### PR TITLE
Fix typos and improve parameter naming in `resolve_upon_time`

### DIFF
--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -58,7 +58,7 @@ Let's dive right in with a classic example - simulating a double pendulum to und
         t0=t_span[0],
         t1=t_span[1],
         dt=dt,
-        skip_steps=1,
+        save_every_n_steps=1,
     )
     ```
 

--- a/examples/simulate_pcs.py
+++ b/examples/simulate_pcs.py
@@ -189,7 +189,7 @@ if __name__ == "__main__":
     t0 = 0.0
     t1 = 2.0
     dt = 1e-4
-    skip_step = 100  # how many time steps to skip in between video frames
+    save_every_n_steps = 100
 
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
@@ -201,7 +201,7 @@ if __name__ == "__main__":
         t0=t0,
         t1=t1,
         dt=dt,
-        skip_steps=skip_step,
+        save_every_n_steps=save_every_n_steps,
         solver=solver,
         max_steps=None,
     )

--- a/examples/simulate_pendulum.py
+++ b/examples/simulate_pendulum.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
     video = cv2.VideoWriter(
         str(video_path),
         fourcc,
-        1 / (skip_steps * dt),  # fps
+        1 / (save_every_n_steps * dt),  # fps
         (video_width, video_height),
     )
 

--- a/examples/simulate_pendulum.py
+++ b/examples/simulate_pendulum.py
@@ -29,7 +29,7 @@ q0 = jnp.array([jnp.pi / 8, -jnp.pi / 4])
 # set simulation parameters
 dt = 1e-4  # time step
 ts = jnp.arange(0.0, 5, dt)  # time steps
-skip_step = 100  # how many time steps to skip in between video frames
+save_every_n_steps = 100
 
 # video settings
 video_width, video_height = 700, 700  # img height and width
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         t0=ts[0],
         t1=ts[-1],
         dt=dt,
-        skip_steps=skip_step,
+        save_every_n_steps=save_every_n_steps,
     )
     video_ts = ts_out
     print("Final configuration:\n", q_ts[-1])
@@ -174,7 +174,7 @@ if __name__ == "__main__":
     video = cv2.VideoWriter(
         str(video_path),
         fourcc,
-        1 / (skip_step * dt),  # fps
+        1 / (skip_steps * dt),  # fps
         (video_width, video_height),
     )
 

--- a/examples/simulate_planar_hsa.py
+++ b/examples/simulate_planar_hsa.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     t0 = 0.0
     t1 = 5.0
     dt = 5e-5  # time step
-    skip_step = 100  # how many time steps to skip in between video frames
+    save_every_n_steps = 100
 
     actuation_args = (phi, None, True)  # actuation arguments
 
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         t0=t0,
         t1=t1,
         dt=dt,
-        skip_steps=skip_step,
+        output_skip_steps=save_every_n_steps,
         max_steps=None,
     )
 

--- a/examples/simulate_planar_hsa.py
+++ b/examples/simulate_planar_hsa.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         t0=t0,
         t1=t1,
         dt=dt,
-        output_skip_steps=save_every_n_steps,
+        save_every_n_steps=save_every_n_steps,
         max_steps=None,
     )
 

--- a/examples/simulate_planar_pcs.py
+++ b/examples/simulate_planar_pcs.py
@@ -193,7 +193,7 @@ if __name__ == "__main__":
     t0 = 0.0
     t1 = 2.0
     dt = 1e-4
-    skip_step = 100  # how many time steps to skip in between video frames
+    save_every_n_steps = 100
 
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
@@ -205,7 +205,7 @@ if __name__ == "__main__":
         t0=t0,
         t1=t1,
         dt=dt,
-        skip_steps=skip_step,
+        save_every_n_steps=save_every_n_steps,
         solver=solver,
         max_steps=None,
     )

--- a/examples/simulate_pneumatic_actuated_planar_pcs.py
+++ b/examples/simulate_pneumatic_actuated_planar_pcs.py
@@ -349,7 +349,7 @@ if __name__ == "__main__":
     t0 = 0.0
     t1 = 7.0
     dt = 5e-5
-    skip_step = 100  # how many time steps to skip in between video frames
+    save_every_n_steps = 100
 
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
@@ -361,7 +361,7 @@ if __name__ == "__main__":
         t0=t0,
         t1=t1,
         dt=dt,
-        skip_steps=skip_step,
+        save_every_n_steps=save_every_n_steps,
         solver=solver,
         max_steps=None,
     )

--- a/examples/simulate_tendon_actuated_pcs.py
+++ b/examples/simulate_tendon_actuated_pcs.py
@@ -298,7 +298,7 @@ if __name__ == "__main__":
     t0 = 0.0
     t1 = 2.0
     dt = 1e-4
-    skip_step = 100  # how many time steps to skip in between video frames
+    save_every_n_steps = 100
 
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
@@ -310,7 +310,7 @@ if __name__ == "__main__":
         t0=t0,
         t1=t1,
         dt=dt,
-        skip_steps=skip_step,
+        save_every_n_steps=save_every_n_steps,
         solver=solver,
         max_steps=None,
     )

--- a/examples/simulate_tendon_actuated_pendulum.py
+++ b/examples/simulate_tendon_actuated_pendulum.py
@@ -41,7 +41,7 @@ q0 = jnp.array([jnp.pi / 8, -jnp.pi / 4])
 # set simulation parameters
 dt = 1e-4  # time step
 ts = jnp.arange(0.0, 5, dt)  # time steps
-skip_step = 100  # how many time steps to skip in between video frames
+save_every_n_steps = 100
 
 # video settings
 video_width, video_height = 700, 700  # img height and width
@@ -154,7 +154,7 @@ if __name__ == "__main__":
         t0=ts[0],
         t1=ts[-1],
         dt=dt,
-        skip_steps=skip_step,
+        save_every_n_steps=save_every_n_steps,
     )
     video_ts = ts_out
     print("Final configuration:\n", qs[-1])
@@ -189,7 +189,7 @@ if __name__ == "__main__":
     video = cv2.VideoWriter(
         str(video_path),
         fourcc,
-        1 / (skip_step * dt),  # fps
+        1 / (save_every_n_steps * dt),  # fps
         (video_width, video_height),
     )
 

--- a/examples/simulate_tendon_actuated_planar_pcs.py
+++ b/examples/simulate_tendon_actuated_planar_pcs.py
@@ -250,7 +250,7 @@ if __name__ == "__main__":
     t0 = 0.0
     t1 = 10.0
     dt = 1e-4
-    skip_step = 10  # how many time steps to skip in between video frames
+    save_every_n_steps = 10
 
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
@@ -262,7 +262,7 @@ if __name__ == "__main__":
         t0=t0,
         t1=t1,
         dt=dt,
-        skip_steps=skip_step,
+        save_every_n_steps=save_every_n_steps,
         solver=solver,
         max_steps=None,
     )
@@ -372,6 +372,6 @@ if __name__ == "__main__":
         width=w,
         height=h,
         speed_up=1.0,
-        skip_step=skip_step,
+        skip_step=save_every_n_steps,
         rgb_to_bgr=False,
     )

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -42,13 +42,13 @@ class DynamicalSystem(eqx.Module):
             u (Array, optional): Actuation/control input.
                 Default is None (no actuation).
             tau_ext (Array, optional): External forces/torques applied to the system.
-            t0 (float, optionnal): Initial time.
+            t0 (float, optional): Initial time.
                 Default is 0.0.
-            t1 (float, optionnal): Final time.
+            t1 (float, optional): Final time.
                 Default is 10.0.
-            dt (float, optionnal): Time step for the solver.
+            dt (float, optional): Time step for the solver.
                 Default is 1e-4.
-            skip_steps (int, optionnal): Number of steps to skip in the output.
+            skip_steps (int, optional): Number of steps to skip in the output.
                 This allows to reduce the number of saved time points.
                 Default is 0.
             solver (AbstractSolver, optional): Solver to use for the ODE integration.

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -28,7 +28,7 @@ class DynamicalSystem(eqx.Module):
         t0: Optional[float] = 0.0,
         t1: Optional[float] = 10.0,
         dt: Optional[float] = 1e-4,
-        skip_steps: Optional[int] = 0,
+        save_every_n_steps: int = 1,
         solver: Optional[AbstractSolver] = Tsit5(),
         stepsize_controller: Optional[AbstractStepSizeController] = ConstantStepSize(),
         max_steps: Optional[int] = None,
@@ -48,9 +48,10 @@ class DynamicalSystem(eqx.Module):
                 Default is 10.0.
             dt (float, optional): Time step for the solver.
                 Default is 1e-4.
-            skip_steps (int, optional): Number of steps to skip in the output.
-                This allows to reduce the number of saved time points.
-                Default is 0.
+            save_every_n_steps (int, optional): Determines how many time steps to skip
+                when saving the output. For example, if set to 1, every time step is saved;
+                if set to 10, every 10th time step is saved.
+                Default is 1 (save every step).
             solver (AbstractSolver, optional): Solver to use for the ODE integration.
                 Default is Tsit5() (Runge-Kutta 5(4) method).
             stepsize_controller (PIDController, optional): Stepsize controller for the solver.
@@ -72,7 +73,10 @@ class DynamicalSystem(eqx.Module):
         term = ODETerm(self.forward_dynamics)
 
         t = jnp.arange(t0, t1, dt)  # Time points for the solution
-        saveat = SaveAt(ts=t[::skip_steps])  # Save at specified time points
+        
+        assert save_every_n_steps > 0, "save_every_n_steps must be a positive integer."
+        assert isinstance(save_every_n_steps, int), "save_every_n_steps must be an integer."
+        saveat = SaveAt(ts=t[::save_every_n_steps])  # Save at specified time points
 
         sol = diffeqsolve(
             terms=term,

--- a/src/soromox/systems/planar_hsa.py
+++ b/src/soromox/systems/planar_hsa.py
@@ -1546,7 +1546,7 @@ class PlanarHSA(DynamicalSystem):
         t0: Optional[float] = 0.0,
         t1: Optional[float] = 10.0,
         dt: Optional[float] = 1e-4,
-        skip_steps: Optional[int] = 0,
+        save_every_n_steps: int = 1,
         solver: Optional[AbstractSolver] = Tsit5(),
         stepsize_controller: Optional[PIDController] = ConstantStepSize(),
         max_steps: Optional[int] = None,
@@ -1580,9 +1580,10 @@ class PlanarHSA(DynamicalSystem):
                 Default is 10.0.
             dt (float, optionnal): Time step for the solver.
                 Default is 1e-4.
-            skip_steps (int, optionnal): Number of steps to skip in the output.
-                This allows to reduce the number of saved time points.
-                Default is 0.
+            save_every_n_steps (int, optional): Determines how many time steps to skip
+                when saving the output. For example, if set to 1, every time step is saved;
+                if set to 10, every 10th time step is saved.
+                Default is 1 (save every step).
             solver (AbstractSolver, optional): Solver to use for the ODE integration.
                 Default is Tsit5() (Runge-Kutta 5(4) method).
             stepsize_controller (PIDController, optional): Stepsize controller for the solver.
@@ -1600,7 +1601,10 @@ class PlanarHSA(DynamicalSystem):
         term = ODETerm(self.forward_dynamics)
 
         t = jnp.arange(t0, t1, dt)  # Time points for the solution
-        saveat = SaveAt(ts=t[::skip_steps])  # Save at specified time points
+        
+        assert save_every_n_steps > 0, "save_every_n_steps must be a positive integer."
+        assert isinstance(save_every_n_steps, int), "save_every_n_steps must be an integer."
+        saveat = SaveAt(ts=t[::save_every_n_steps])  # Save at specified time points
 
         # Prepare the actuation arguments
         actuation_args = (u0, control_fn, consider_underactuation_model)


### PR DESCRIPTION
Correct typos in the docstring of `resolve_upon_time` and rename `skip_steps` to `save_every_n_steps` for clarity and consistency across the codebase.