### PR TITLE
Fix wrong usage of strain basis in tendon-actuated pcs system

### DIFF
--- a/src/soromox/systems/isupport.py
+++ b/src/soromox/systems/isupport.py
@@ -31,7 +31,7 @@ class ISupport(PCS):
     num_strains : int
         Total number of strain components (6 * num_segments).
     B_xi : Array
-        Basis matrix for projecting active strains.
+        Basis matrix for projecting active strains (6 * num_segments, num_active_strains).
     xi_ref : Array
         Reference strain (reference configuration) of the robot.
     num_gauss_points : int

--- a/src/soromox/systems/pcs.py
+++ b/src/soromox/systems/pcs.py
@@ -44,7 +44,7 @@ class PCS(DynamicalSystem):
     num_strains : int
         Total number of strain components (6 * num_segments).
     B_xi : Array
-        Basis matrix for projecting active strains.
+        Basis matrix for projecting active strains (6 * num_segments, num_active_strains).
     xi_ref : Array
         Reference strain (reference configuration) of the robot.
     num_gauss_points : int

--- a/src/soromox/systems/planar_pcs.py
+++ b/src/soromox/systems/planar_pcs.py
@@ -44,7 +44,7 @@ class PlanarPCS(DynamicalSystem):
     num_strains : int
         Total number of strain components (6 * num_segments).
     B_xi : Array
-        Basis matrix for projecting active strains.
+        Basis matrix for projecting active strains (6 * num_segments, num_active_strains).
     xi_ref : Array
         Reference strain (reference configuration) of the robot.
     num_gauss_points : int

--- a/src/soromox/systems/tendon_actuated_pcs.py
+++ b/src/soromox/systems/tendon_actuated_pcs.py
@@ -38,7 +38,7 @@ class TendonActuatedPCS(PCS):
     num_strains : int
         Total number of strain components (6 * num_segments).
     B_xi : Array
-        Basis matrix for projecting active strains (num_active_strains, num_active_strains).
+        Basis matrix for projecting active strains (6 * num_segments, num_active_strains).
     xi_ref : Array
         Reference strain (reference configuration) of the robot.
     num_gauss_points : int
@@ -213,7 +213,8 @@ class TendonActuatedPCS(PCS):
         true.
 
         Args:
-            tendon_routing_params (Dict[str, Array]): parameters of the tendons (6,)
+            tendon_routing_params : Dict[str, Array]
+                Dictionary of arrays of length n_actuators representing the tendon parameters.
 
         Returns:
             flag (bool): True if any of the tendons is out of the body
@@ -409,7 +410,8 @@ class TendonActuatedPCS(PCS):
             position of tendon (i.e., its attachement point).
 
             Args:
-                single_tendon_routing_params (Dict[str, Array]): parameters of one tendon (6,)
+                tendon_routing_params : Dict[str, Array]
+                    Dictionary of arrays of length n_actuators representing the tendon parameter for tendon k.
                 q (Array): generalized coordinates of shape (num_active_strains,)
                 s (Array): point coordinate along the robot ()
 

--- a/src/soromox/systems/tendon_actuated_pcs.py
+++ b/src/soromox/systems/tendon_actuated_pcs.py
@@ -278,62 +278,6 @@ class TendonActuatedPCS(PCS):
         return updated_self
 
     @eqx.filter_jit
-    def _local_actuation_basis(self, q: Array, s: Array) -> Array:
-        """
-        Compute the local actuation basis at current abscissa s.
-
-        Args:
-            q (Array): generalized coordinates of shape (num_active_strains,)
-            s (Array): abscissa points (num_gauss_points,)
-
-        Returns:
-            Phi_a_s (Array): actuation basis at s of shape (6 * num_segments, num_actuators)
-        """
-
-        def Phi_a_ki(single_tendon_routing_params: Dict[str, Array], i: Array):
-            """
-            Compute the actuation basis of one tendon at the segment i of the robot.
-
-            Args:
-                single_tendon_routing_params (Dict[str, Array]): parameters of one tendon (6,)
-                i (Array): index of the segment ()
-
-            Returns:
-                Phi_a_ki (Array): actuation basis of one tendon at the i-th segment of shape (6,)
-            """
-            attachment_segment_idx = single_tendon_routing_params["idx_seg_att"]  # ()
-            cond = attachment_segment_idx >= i  # ()
-
-            xi_j = jnp.reshape(xi, (6, self.num_segments), order="F")[
-                :, i
-            ]  # strains of segment j (6,)
-            d_s = jnp.append(self.d_s(single_tendon_routing_params, s), 1.0)  # (4,)
-            dd_s = jnp.append(
-                self.dd_s_ds(single_tendon_routing_params, s), 1.0
-            )  # (4,)
-
-            term = (dd_s + lie.hat_SE3(xi_j) @ d_s)[:-1]  # (3,)
-            norm = jnp.linalg.norm(term)  # ()
-            t = term / norm  # (3,)
-
-            return cond * jnp.hstack([lie.tilde_SE3(d_s[:-1]) @ t, t])  # (6,)
-
-        xi = self.strain(q)  # strains (6 * num_segments,)
-
-        # Vectorize first over each tendon and then over each segment
-        Phi_a_s = vmap(
-            vmap(Phi_a_ki, in_axes=(0, None), out_axes=1), in_axes=(None, 0), out_axes=0
-        )(
-            self.tendon_routing_params, jnp.arange(self.num_segments)
-        )  # (num_segments, 6, num_actuators)
-
-        Phi_a_s = Phi_a_s.reshape(
-            (6 * self.num_segments, self.num_actuators)
-        )  # (6 * num_segments, num_actuators)
-
-        return Phi_a_s
-
-    @eqx.filter_jit
     def actuation_matrix(self, q: Array) -> Array:
         """
         Compute the actuation matrix of the robot.
@@ -344,6 +288,8 @@ class TendonActuatedPCS(PCS):
         Returns:
             A (Array): Actuation matrix of shape (num_active_strains, num_actuators).
         """
+        # extract strains
+        xi = self.strain(q).reshape((self.num_segments, 6))
 
         def A_segment_i(i: Array):
             """
@@ -353,8 +299,9 @@ class TendonActuatedPCS(PCS):
                 i (Array): index of the segment ()
 
             Returns:
-                A_i (Array): stack of actuation matrices of shape (num_gauss_points, 6 * num_segments, num_actuators).
+                A_i (Array): stack of actuation matrices of shape (num_gauss_points, 6, num_actuators).
             """
+            xi_i = xi[i]
 
             def A_point_j(j: Array):
                 """
@@ -364,12 +311,46 @@ class TendonActuatedPCS(PCS):
                     j (Array): index of the gaussian point ()
 
                 Returns:
-                    A_j (Array): local actuation matrix of shape (6 * num_segments, num_actuators).
+                    A_j (Array): local actuation matrix of shape (6, num_actuators).
                 """
+                # extract gaussian point and weight
                 Xs_j = Xs_scaled[j]
                 Ws_j = Ws_scaled[j]
-                Phi_a_j = self._local_actuation_basis(q, Xs_j)
-                A_j = Phi_a_j  # A_s = B_xi.T @ Phi_a
+
+                def A_tendon_k(k: Array, tendon_routing_params_k):
+                    """
+                    Compute the actuation matrix contribution of one tendon k at the gaussian point j and segment i.
+
+                    Args:
+                        k (Array): index of the tendon ()
+                        tendon_routing_params_k (Dict[str, Array]): parameters of the tendon k
+                    Returns:
+                        Phi_a_k (Array): local actuation matrix contribution of one tendon of shape (6,).
+                    """
+                    attachment_segment_idx = tendon_routing_params_k["idx_seg_att"]  # ()
+                    cond = attachment_segment_idx >= i  # ()
+
+                    # extract tendon routing evolution in the cross-sectional plane
+                    d_s = jnp.append(self.d_s(tendon_routing_params_k, Xs_j), 1.0)  # (4,)
+                    dd_s = jnp.append(
+                        self.dd_s_ds(tendon_routing_params_k, Xs_j), 1.0
+                    )  # (4,)
+
+                    term = (dd_s + lie.hat_SE3(xi_i) @ d_s)[:-1]  # (3,)
+                    norm = jnp.linalg.norm(term)  # ()
+                    t = term / norm  # (3,)
+
+                    Phi_a_k = cond * jnp.hstack([lie.tilde_SE3(d_s[:-1]) @ t, t])  # (6,)
+
+                    return Phi_a_k
+
+                # Vectorize the actuation basis computation for all tendons
+                Phi_a_j = vmap(A_tendon_k, in_axes=(0, 0), out_axes=(-1))(
+                    jnp.arange(self.num_actuators), self.tendon_routing_params
+                )  # (6, num_actuators)
+
+                A_j = Phi_a_j
+
                 return Ws_j * A_j
 
             Xs_scaled, Ws_scaled = scale_gaussian_quadrature(
@@ -379,7 +360,7 @@ class TendonActuatedPCS(PCS):
             # Vectorize the actuation matrix computation for all gaussian points
             A_i = vmap(A_point_j)(
                 jnp.arange(self.num_gauss_points)
-            )  # (num_gauss_points, 6 * num_segments, num_actuators)
+            )  # (num_gauss_points, 6, num_actuators)
 
             # # For debugging purposes, you can uncomment the following line to see the step-by-step computation
             # A_blocks_i = jnp.stack([A_point_j(j) for j in range(self.num_gauss_points)], axis=0)
@@ -390,13 +371,16 @@ class TendonActuatedPCS(PCS):
         # Vectorize the actuation matrix computation for all segments
         A_blocks = vmap(A_segment_i)(
             jnp.arange(self.num_segments)
-        )  # (num_segments, num_gauss_points, 6 * num_segments, num_actuators)
+        )  # (num_segments, num_gauss_points, 6, num_actuators)
 
         # # For debugging purposes, you can uncomment the following line to see the step-by-step computation
         # A_blocks_tot = jnp.stack([A_segment_i(i) for i in range(self.num_segments)], axis=0)
         # print('A_blocks_tot =\n', A_blocks_tot.shape)
 
-        A = jnp.sum(A_blocks, axis=(0, 1))  # Sum over segments and Gauss points
+        A = jnp.sum(A_blocks, axis=(1, ))  # Sum the Gauss points
+
+        # reshape A to (6 * num_segments, num_actuators)
+        A = A.reshape((-1, self.num_actuators))
 
         # Project into the active strains space
         A = self.B_xi.T @ A  # (num_active_strains, num_actuators)

--- a/src/soromox/systems/tendon_actuated_pcs.py
+++ b/src/soromox/systems/tendon_actuated_pcs.py
@@ -3,7 +3,7 @@ import equinox as eqx
 import jax
 from jax import Array, lax, vmap
 from jax import numpy as jnp
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, List, Optional
 
 import soromox.utils.lie_algebra as lie
 import soromox.actuation.tendon_actuation as act
@@ -39,8 +39,10 @@ class TendonActuatedPCS(PCS):
         Total number of strain components (6 * num_segments).
     B_xi : Array
         Basis matrix for projecting active strains (num_active_strains, num_active_strains).
-    B_xi_segments : Array
-        Basis matrix for projecting active strains, by segments (num_segments, num_active_strains, num_active_strains).
+    B_xi_segments : List[Array]
+        Segment-wise strain bases. Each entry has shape (6, num_active_strains_segment_i).
+    B_xi_segments_dense : Array
+        Dense stack of the segment-wise strain bases with shape (num_segments, 6, num_active_strains).
     xi_ref : Array
         Reference strain (reference configuration) of the robot.
     num_gauss_points : int
@@ -75,7 +77,6 @@ class TendonActuatedPCS(PCS):
     """
 
     tendon_routing_params: Dict[str, Array]
-    B_xi_segments: Array
     d_s: Callable
     dd_s_ds: Callable
 
@@ -165,41 +166,8 @@ class TendonActuatedPCS(PCS):
                 "d_s": act.linear_routing,
                 "dd_s_ds": act.linear_routing_derivative,
             }
-        self.B_xi_segments = self._B_xi_segments()
         self._set_tendon_routing_basis(tendon_routing_basis)
         self._set_tendon_routing_params(tendon_routing_params)
-
-    def _B_xi_segments(self):
-        """
-        Compute the strains basis by segments. While the full strains basis B_xi
-        is a block diagonal matrix composed by the 6x6 strain basis of each segment,
-        this function extracts each diagonal block and returns it as a matrix of shape
-        (num_segments, num_active_strains, num_active_strains). This is used for the
-        computation of the actuation matrix.
-
-        Returns:
-            B_xi_segments (Array): strain basis of each segments (num_segments, num_active_strains, num_active_strains)
-        """
-
-        def B_xi_segment_j(j: Array):
-            """
-            Compute the strains basis of segment j.
-
-            Args:
-                i (Array): index of the segment
-
-            Returns:
-                B_xi_j (Array): strain basis of segment j (num_active_strains, num_active_strains)
-            """
-            idx = 6 * j
-            B_xi_j = jnp.zeros_like(self.B_xi, dtype=self.B_xi.dtype)
-            B_block = lax.dynamic_slice(self.B_xi, (idx, idx), (6, 6))
-            B_xi_j = lax.dynamic_update_slice(B_xi_j, B_block, (idx, idx))
-            return B_xi_j
-
-        B_xi_segments = vmap(B_xi_segment_j)(jnp.arange(self.num_segments))
-
-        return B_xi_segments
 
     def _set_tendon_routing_params(self, tendon_routing_params: Dict[str, Array]):
         """
@@ -323,7 +291,7 @@ class TendonActuatedPCS(PCS):
             s (Array): abscissa points (num_gauss_points,)
 
         Returns:
-            Phi_a_s (Array): actuation basis at s of shape (num_active_strains, num_actuators)
+            Phi_a_s (Array): actuation basis at s of shape (6 * num_segments, num_actuators)
         """
 
         def Phi_a_kj(single_tendon_routing_params: Dict[str, Array], j: Array):
@@ -389,7 +357,7 @@ class TendonActuatedPCS(PCS):
                 i (Array): index of the segment ()
 
             Returns:
-                A_i (Array): stack of actuation matrices of shape (num_gauss_points, num_active_strains, num_actuators).
+                A_i (Array): stack of actuation matrices of shape (num_gauss_points, 6 * num_segments, num_actuators).
             """
 
             def A_point_j(j: Array):
@@ -400,24 +368,22 @@ class TendonActuatedPCS(PCS):
                     j (Array): index of the gaussian point ()
 
                 Returns:
-                    A_j (Array): local actuation matrix of shape (num_active_strains, num_actuators).
+                    A_j (Array): local actuation matrix of shape (6 * num_segments, num_actuators).
                 """
                 Xs_j = Xs_scaled[j]
                 Ws_j = Ws_scaled[j]
                 Phi_a_j = self._local_actuation_basis(q, Xs_j)
-                A_j = B_xi_i.T @ Phi_a_j  # A_s = B_xi.T @ Phi_a
+                A_j = Phi_a_j  # A_s = B_xi.T @ Phi_a
                 return Ws_j * A_j
 
             Xs_scaled, Ws_scaled = scale_gaussian_quadrature(
                 self.Xs, self.Ws, self.L_cum[i], self.L_cum[i + 1]
             )
-            # Retrieve strain basis of the current segment
-            B_xi_i = self.B_xi_segments[i]  # (num_active_strains, num_active_strains)
 
             # Vectorize the actuation matrix computation for all gaussian points
             A_i = vmap(A_point_j)(
                 jnp.arange(self.num_gauss_points)
-            )  # (num_gauss_points, num_active_strains, num_actuators)
+            )  # (num_gauss_points, 6 * num_segments, num_actuators)
 
             # # For debugging purposes, you can uncomment the following line to see the step-by-step computation
             # A_blocks_i = jnp.stack([A_point_j(j) for j in range(self.num_gauss_points)], axis=0)
@@ -428,13 +394,16 @@ class TendonActuatedPCS(PCS):
         # Vectorize the actuation matrix computation for all segments
         A_blocks = vmap(A_segment_i)(
             jnp.arange(self.num_segments)
-        )  # (num_segments, num_gauss_points, num_active_strains, num_actuators)
+        )  # (num_segments, num_gauss_points, 6 * num_segments, num_actuators)
 
         # # For debugging purposes, you can uncomment the following line to see the step-by-step computation
         # A_blocks_tot = jnp.stack([A_segment_i(i) for i in range(self.num_segments)], axis=0)
         # print('A_blocks_tot =\n', A_blocks_tot.shape)
 
         A = jnp.sum(A_blocks, axis=(0, 1))  # Sum over segments and Gauss points
+
+        # Project into the active strains space
+        A = self.B_xi.T @ A  # (num_active_strains, num_actuators)
 
         return A
 

--- a/src/soromox/systems/tendon_actuated_pcs.py
+++ b/src/soromox/systems/tendon_actuated_pcs.py
@@ -290,22 +290,22 @@ class TendonActuatedPCS(PCS):
             Phi_a_s (Array): actuation basis at s of shape (6 * num_segments, num_actuators)
         """
 
-        def Phi_a_kj(single_tendon_routing_params: Dict[str, Array], j: Array):
+        def Phi_a_ki(single_tendon_routing_params: Dict[str, Array], i: Array):
             """
-            Compute the actuation basis of one tendon at the segment j of the robot.
+            Compute the actuation basis of one tendon at the segment i of the robot.
 
             Args:
                 single_tendon_routing_params (Dict[str, Array]): parameters of one tendon (6,)
-                j (Array): index of the segment ()
+                i (Array): index of the segment ()
 
             Returns:
-                Phi_a_kj (Array): actuation basis of one tendon at one segment of shape (6,)
+                Phi_a_ki (Array): actuation basis of one tendon at the i-th segment of shape (6,)
             """
             attachment_segment_idx = single_tendon_routing_params["idx_seg_att"]  # ()
-            cond = attachment_segment_idx >= j  # ()
+            cond = attachment_segment_idx >= i  # ()
 
             xi_j = jnp.reshape(xi, (6, self.num_segments), order="F")[
-                :, j
+                :, i
             ]  # strains of segment j (6,)
             d_s = jnp.append(self.d_s(single_tendon_routing_params, s), 1.0)  # (4,)
             dd_s = jnp.append(
@@ -322,7 +322,7 @@ class TendonActuatedPCS(PCS):
 
         # Vectorize first over each tendon and then over each segment
         Phi_a_s = vmap(
-            vmap(Phi_a_kj, in_axes=(0, None), out_axes=1), in_axes=(None, 0), out_axes=0
+            vmap(Phi_a_ki, in_axes=(0, None), out_axes=1), in_axes=(None, 0), out_axes=0
         )(
             self.tendon_routing_params, jnp.arange(self.num_segments)
         )  # (num_segments, 6, num_actuators)

--- a/src/soromox/systems/tendon_actuated_pcs.py
+++ b/src/soromox/systems/tendon_actuated_pcs.py
@@ -39,10 +39,6 @@ class TendonActuatedPCS(PCS):
         Total number of strain components (6 * num_segments).
     B_xi : Array
         Basis matrix for projecting active strains (num_active_strains, num_active_strains).
-    B_xi_segments : List[Array]
-        Segment-wise strain bases. Each entry has shape (6, num_active_strains_segment_i).
-    B_xi_segments_dense : Array
-        Dense stack of the segment-wise strain bases with shape (num_segments, 6, num_active_strains).
     xi_ref : Array
         Reference strain (reference configuration) of the robot.
     num_gauss_points : int

--- a/src/soromox/systems/tendon_actuated_pcs.py
+++ b/src/soromox/systems/tendon_actuated_pcs.py
@@ -277,6 +277,36 @@ class TendonActuatedPCS(PCS):
         )
 
         return updated_self
+    
+    @eqx.filter_jit
+    def _local_actuation_basis(self, i: Array, xi_i: Array, s: Array, tendon_routing_params_k: Dict[str, Array]) -> Array:
+        """
+        Compute the actuation matrix contribution of one tendon k at s contained in segment i.
+
+        Args:
+            xi_i (Array): strain at segment i (6,)
+            tendon_routing_params_k (Dict[str, Array]): parameters of the tendon k
+            s (Array): abscissa points (num_gauss_points,)
+        
+        Returns:
+            Phi_a_k (Array): local actuation matrix contribution of one tendon of shape (6,).
+        """
+        attachment_segment_idx = tendon_routing_params_k["idx_seg_att"]  # ()
+        cond = attachment_segment_idx >= i  # ()
+
+        # extract tendon routing evolution in the cross-sectional plane
+        d_s = jnp.append(self.d_s(tendon_routing_params_k, s), 1.0)  # (4,)
+        dd_s = jnp.append(
+            self.dd_s_ds(tendon_routing_params_k, s), 1.0
+        )  # (4,)
+
+        term = (dd_s + lie.hat_SE3(xi_i) @ d_s)[:-1]  # (3,)
+        norm = jnp.linalg.norm(term)  # ()
+        t = term / norm  # (3,)
+
+        Phi_a_k = cond * jnp.hstack([lie.tilde_SE3(d_s[:-1]) @ t, t])  # (6,)
+
+        return Phi_a_k
 
     @eqx.filter_jit
     def actuation_matrix(self, q: Array) -> Array:
@@ -318,36 +348,9 @@ class TendonActuatedPCS(PCS):
                 Xs_j = Xs_scaled[j]
                 Ws_j = Ws_scaled[j]
 
-                def A_tendon_k(k: Array, tendon_routing_params_k):
-                    """
-                    Compute the actuation matrix contribution of one tendon k at the gaussian point j and segment i.
-
-                    Args:
-                        k (Array): index of the tendon ()
-                        tendon_routing_params_k (Dict[str, Array]): parameters of the tendon k
-                    Returns:
-                        Phi_a_k (Array): local actuation matrix contribution of one tendon of shape (6,).
-                    """
-                    attachment_segment_idx = tendon_routing_params_k["idx_seg_att"]  # ()
-                    cond = attachment_segment_idx >= i  # ()
-
-                    # extract tendon routing evolution in the cross-sectional plane
-                    d_s = jnp.append(self.d_s(tendon_routing_params_k, Xs_j), 1.0)  # (4,)
-                    dd_s = jnp.append(
-                        self.dd_s_ds(tendon_routing_params_k, Xs_j), 1.0
-                    )  # (4,)
-
-                    term = (dd_s + lie.hat_SE3(xi_i) @ d_s)[:-1]  # (3,)
-                    norm = jnp.linalg.norm(term)  # ()
-                    t = term / norm  # (3,)
-
-                    Phi_a_k = cond * jnp.hstack([lie.tilde_SE3(d_s[:-1]) @ t, t])  # (6,)
-
-                    return Phi_a_k
-
                 # Vectorize the actuation basis computation for all tendons
-                Phi_a_j = vmap(A_tendon_k, in_axes=(0, 0), out_axes=(-1))(
-                    jnp.arange(self.num_actuators), self.tendon_routing_params
+                Phi_a_j = vmap(self._local_actuation_basis, in_axes=(None, None, None, 0), out_axes=(-1))(
+                    i, xi_i, Xs_j, self.tendon_routing_params
                 )  # (6, num_actuators)
 
                 A_j = Phi_a_j

--- a/src/soromox/systems/tendon_actuated_planar_pcs.py
+++ b/src/soromox/systems/tendon_actuated_planar_pcs.py
@@ -34,7 +34,7 @@ class TendonActuatedPlanarPCS(PlanarPCS):
     num_strains : int
         Total number of strain components (6 * num_segments).
     B_xi : Array
-        Basis matrix for projecting active strains.
+        Basis matrix for projecting active strains (6 * num_segments, num_active_strains).
     xi_ref : Array
         Reference strain (reference configuration) of the robot.
     num_gauss_points : int

--- a/tests/test_tendon_actuated_pcs.py
+++ b/tests/test_tendon_actuated_pcs.py
@@ -231,7 +231,9 @@ def test_actuation_matrix_pcs():
     ]
 
     for q, s in test_cases:
-        target_actuation_basis = robot._local_actuation_basis(q, s).squeeze()
+        xi = robot.strain(q).reshape((robot.num_segments, 6))
+        tendon_params_0 = jax.tree.map(lambda x: x[0], tendon_params)
+        target_actuation_basis = robot._local_actuation_basis(0, xi[0], s, tendon_params_0).squeeze()
         expected_actuation_basis = reference_actuation_basis(tendon_params, q, s)
         assert not jnp.isnan(target_actuation_basis).any(), (
             "Actuation basis contains NaN!"

--- a/tests/test_tendon_actuated_pcs.py
+++ b/tests/test_tendon_actuated_pcs.py
@@ -4,10 +4,133 @@ jax.config.update("jax_enable_x64", True)  # double precision
 from jax import Array
 from jax import numpy as jnp
 from numpy.testing import assert_allclose
-from typing import Dict, Tuple
+from typing import Dict
 
 from soromox.systems.tendon_actuated_pcs import TendonActuatedPCS
 from soromox.utils.tolerance import Tolerance
+
+XI_REF = jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0], dtype=jnp.float64)
+
+
+def _create_robot(
+    segment_lengths: Array,
+    tendon_params: Dict[str, Array],
+    strain_selector=None,
+) -> TendonActuatedPCS:
+    """
+    Helper that builds a TendonActuatedPCS instance with consistent material parameters.
+    """
+    num_segments = segment_lengths.shape[0]
+    rho = 1070 * jnp.ones(
+        (num_segments,)
+    )  # Volumetric density of Dragon Skin 20 [kg/m^3]
+    params = {
+        "p0": jnp.zeros(6),  # Initial position and orientation
+        "r": 1.0 * jnp.ones((num_segments,)),  # default: 2e-2
+        "rho": rho,
+        "g": jnp.array([0.0, 0.0, 9.81]),  # Gravity vector [m/s^2]
+        "E": 2e3 * jnp.ones((num_segments,)),  # Elastic modulus [Pa]
+        "G": 1e3 * jnp.ones((num_segments,)),  # Shear modulus [Pa]
+        "L": segment_lengths,
+    }
+
+    params["D"] = 1e-3 * jnp.diag(
+        (
+            jnp.repeat(
+                jnp.array([[1e0, 1e0, 1e0, 1e3, 1e3, 1e3]]), num_segments, axis=0
+            )
+            * params["L"][:, None]
+        ).flatten()
+    )
+
+    robot_kwargs = dict(
+        num_segments=num_segments,
+        params=params,
+        order_gauss=5,
+        tendon_routing_params=tendon_params,
+    )
+    if strain_selector is not None:
+        robot_kwargs["strain_selector"] = strain_selector
+
+    return TendonActuatedPCS(**robot_kwargs)
+
+
+def reference_actuation_matrix(
+    tendon_params: Dict[str, Array], l_tot: Array
+) -> Array:
+    """
+    Compute the actuation matrix of a soft robot of length l_tot w.r.t. one
+    linear tendon at the straight configuration corresponding to vector state
+    q0 = zeros(6*num_segments), considered as reference.
+    This configuration represents the rest (stress-free) shape of the robot
+    and it is easily tractable analitically.
+
+    Args:
+        tendon_params (Dict[str, Array]): routing parameters of the given tendon
+        l_tot (Array): total length of the robot
+
+    Returns:
+        A (Array): actuation matrix at straight configuration
+    """
+    ry, rz, my, mz = (
+        tendon_params["ry"][0],
+        tendon_params["rz"][0],
+        tendon_params["my"][0],
+        tendon_params["mz"][0],
+    )
+    A = jnp.array(
+        [
+            l_tot * (-my * rz + mz * ry),
+            l_tot**2 * mz / 2 + l_tot * rz,
+            -(l_tot**2) * my / 2 - l_tot * ry,
+            l_tot,
+            l_tot * my,
+            l_tot * mz,
+        ]
+    )
+
+    return A / jnp.sqrt(my**2 + mz**2 + 1)
+
+
+def reference_actuation_basis(
+    tendon_params: Dict[str, Array], q: Array, s: Array
+) -> Array:
+    """
+    Computes the vector representing the actuation basis of the given tendon
+    at configuration q (assuming the strain basis to be the identity) and at
+    abscissa point s for a single CS segment.
+
+    Args:
+        tendon_params (Dict[str, Array]): routing parameters of the given tendon
+        q (Array): strains of the robot made by one single segment (6,)
+        s (Array): abscissa point ()
+
+    Returns:
+        Phi_a (Array): actuation basis of the tendon at q, s (6,)
+    """
+    xi = jnp.eye(q.shape[0]) @ q + XI_REF
+    ry, rz, my, mz = (
+        tendon_params["ry"][0],
+        tendon_params["rz"][0],
+        tendon_params["my"][0],
+        tendon_params["mz"][0],
+    )
+    xi_1, xi_2, xi_3, xi_4, xi_5, xi_6 = xi[0], xi[1], xi[2], xi[3], xi[4], xi[5]
+    Phi_a = jnp.array(
+        [
+            (my * s + ry) * (mz + xi_1 * (my * s + ry) + xi_6)
+            + (-mz * s - rz) * (my - xi_1 * (mz * s + rz) + xi_5),
+            (mz * s + rz) * (xi_2 * (mz * s + rz) - xi_3 * (my * s + ry) + xi_4),
+            (-my * s - ry) * (xi_2 * (mz * s + rz) - xi_3 * (my * s + ry) + xi_4),
+            xi_2 * (mz * s + rz) - xi_3 * (my * s + ry) + xi_4,
+            my - xi_1 * (mz * s + rz) + xi_5,
+            mz + xi_1 * (my * s + ry) + xi_6,
+        ]
+    )
+    norm = jnp.linalg.norm(Phi_a[3:])
+    Phi_a = Phi_a / norm
+
+    return Phi_a
 
 
 def test_actuation_matrix_pcs():
@@ -15,127 +138,6 @@ def test_actuation_matrix_pcs():
     Test the methods responsible for the computation of the actuation matrix of the
     tendon actuated Piecewise Constant Strain class.
     """
-
-    def createRobot(
-        segment_lengths: Array, tendon_params: Dict[str, Array]
-    ) -> TendonActuatedPCS:
-        """
-        Creates an object of the class TendonActuatedPCS with the specified segments' length
-        and tendon routing parameters.
-
-        Args:
-            segment_lengths (Array): lengths of the segments of the robot (num_segments, )
-            tendon_params (Dict[str, Array]): routing parameters of the given tendon
-
-        Returns:
-            robot (TendonActuatedPCS): object representing the soft robot
-        """
-        num_segments = segment_lengths.shape[0]
-        rho = 1070 * jnp.ones(
-            (num_segments,)
-        )  # Volumetric density of Dragon Skin 20 [kg/m^3]
-        params = {
-            "p0": jnp.zeros(6),  # Initial position and orientation
-            "r": 1.0 * jnp.ones((num_segments,)),  # default: 2e-2
-            "rho": rho,
-            "g": jnp.array([0.0, 0.0, 9.81]),  # Gravity vector [m/s^2]
-            "E": 2e3 * jnp.ones((num_segments,)),  # Elastic modulus [Pa]
-            "G": 1e3 * jnp.ones((num_segments,)),  # Shear modulus [Pa]
-        }
-        params["L"] = segment_lengths
-        params["D"] = 1e-3 * jnp.diag(
-            (
-                jnp.repeat(
-                    jnp.array([[1e0, 1e0, 1e0, 1e3, 1e3, 1e3]]), num_segments, axis=0
-                )
-                * params["L"][:, None]
-            ).flatten()
-        )
-
-        robot = TendonActuatedPCS(
-            num_segments=num_segments,
-            params=params,
-            order_gauss=5,
-            tendon_routing_params=tendon_params,
-        )
-
-        return robot
-
-    def reference_actuation_matrix(
-        tendon_params: Dict[str, Array], l_tot: Array
-    ) -> Array:
-        """
-        Compute the actuation matrix of a soft robot of length l_tot w.r.t. one
-        linear tendon at the straight configuration corresponding to vector state
-        q0 = zeros(6*num_segments), considered as reference.
-        This configuration represents the rest (stress-free) shape of the robot
-        and it is easily tractable analitically.
-
-        Args:
-            tendon_params (Dict[str, Array]): routing parameters of the given tendon
-            l_tot (Array): total length of the robot
-
-        Returns:
-            A (Array): actuation matrix at straight configuration
-        """
-        ry, rz, my, mz = (
-            tendon_params["ry"][0],
-            tendon_params["rz"][0],
-            tendon_params["my"][0],
-            tendon_params["mz"][0],
-        )
-        A = jnp.array(
-            [
-                l_tot * (-my * rz + mz * ry),
-                l_tot**2 * mz / 2 + l_tot * rz,
-                -(l_tot**2) * my / 2 - l_tot * ry,
-                l_tot,
-                l_tot * my,
-                l_tot * mz,
-            ]
-        )
-
-        return A / jnp.sqrt(my**2 + mz**2 + 1)
-
-    def reference_actuation_basis(
-        tendon_params: Dict[str, Array], q: Array, s: Array
-    ) -> Array:
-        """
-        Computes the vector representing the actuation basis of the given tendon
-        at configuration q (assuming the strain basis to be the identity) and at
-        abscissa point s for a single CS segment.
-
-        Args:
-            tendon_params (Dict[str, Array]): routing parameters of the given tendon
-            q (Array): strains of the robot made by one single segment (6,)
-            s (Array): abscissa point ()
-
-        Returns:
-            Phi_a (Array): actuation basis of the tendon at q, s (6,)
-        """
-        xi = jnp.eye(q.shape[0]) @ q + xi_ref
-        ry, rz, my, mz = (
-            tendon_params["ry"][0],
-            tendon_params["rz"][0],
-            tendon_params["my"][0],
-            tendon_params["mz"][0],
-        )
-        xi_1, xi_2, xi_3, xi_4, xi_5, xi_6 = xi[0], xi[1], xi[2], xi[3], xi[4], xi[5]
-        Phi_a = jnp.array(
-            [
-                (my * s + ry) * (mz + xi_1 * (my * s + ry) + xi_6)
-                + (-mz * s - rz) * (my - xi_1 * (mz * s + rz) + xi_5),
-                (mz * s + rz) * (xi_2 * (mz * s + rz) - xi_3 * (my * s + ry) + xi_4),
-                (-my * s - ry) * (xi_2 * (mz * s + rz) - xi_3 * (my * s + ry) + xi_4),
-                xi_2 * (mz * s + rz) - xi_3 * (my * s + ry) + xi_4,
-                my - xi_1 * (mz * s + rz) + xi_5,
-                mz + xi_1 * (my * s + ry) + xi_6,
-            ]
-        )
-        norm = jnp.linalg.norm(Phi_a[3:])
-        Phi_a = Phi_a / norm
-
-        return Phi_a
 
     # ========================================
     # Test of the functions
@@ -178,7 +180,7 @@ def test_actuation_matrix_pcs():
     ]
 
     for segment_lengths, tendon_params in test_cases:
-        robot = createRobot(segment_lengths, tendon_params)
+        robot = _create_robot(segment_lengths, tendon_params)
         num_segments = segment_lengths.shape[0]
         q0 = jnp.zeros(6 * num_segments)
         target_actuation_matrix = robot.actuation_matrix(q0).reshape(
@@ -208,12 +210,11 @@ def test_actuation_matrix_pcs():
         "mz": jnp.array([-0.05]),
         "idx_seg_att": jnp.array([0]),
     }
-    robot = createRobot(jnp.array([0.5]), tendon_params)
-    xi_ref = jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+    robot = _create_robot(jnp.array([0.5]), tendon_params)
 
     test_cases = [
         (
-            jnp.zeros_like(xi_ref),
+            jnp.zeros_like(XI_REF),
             robot.L_cum[-1] * 0.25,
         ),
         (
@@ -221,7 +222,7 @@ def test_actuation_matrix_pcs():
             robot.L_cum[-1] * 0.25,
         ),
         (
-            jnp.zeros_like(xi_ref),
+            jnp.zeros_like(XI_REF),
             robot.L_cum[-1] * 0.7,
         ),
         (
@@ -245,6 +246,62 @@ def test_actuation_matrix_pcs():
             atol=Tolerance.atol(),
         )
         print("[Valid test]\n")
+
+
+def test_actuation_matrix_with_inactive_strains():
+    """
+    Ensure the actuation matrix projection works when some strains are deactivated.
+    """
+
+    segment_lengths = jnp.array([0.4, 0.6])
+    tendon_params = {
+        "ry": jnp.array([0.12]),
+        "rz": jnp.array([0.02]),
+        "my": jnp.array([0.02]),
+        "mz": jnp.array([-0.03]),
+        "idx_seg_att": jnp.array([1]),
+    }
+    strain_selector = jnp.array(
+        [
+            True,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            True,
+            False,
+            False,
+        ],
+        dtype=bool,
+    )
+
+    robot_full = _create_robot(segment_lengths, tendon_params)
+    robot_reduced = _create_robot(
+        segment_lengths, tendon_params, strain_selector=strain_selector
+    )
+
+    num_full = int(robot_full.num_active_strains.item())
+    num_active = int(robot_reduced.num_active_strains.item())
+    assert num_active < num_full  # sanity check: some strains removed
+
+    active_idx = jnp.nonzero(strain_selector, size=num_active, fill_value=0)[0]
+    q_reduced = jnp.arange(num_active, dtype=jnp.float64) * 0.05
+    q_full = jnp.zeros((num_full,), dtype=jnp.float64).at[active_idx].set(q_reduced)
+
+    A_full = robot_full.actuation_matrix(q_full)
+    A_reduced = robot_reduced.actuation_matrix(q_reduced)
+    expected = A_full[active_idx, :]
+
+    assert_allclose(
+        A_reduced,
+        expected,
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request refactors the handling of strain basis matrices in the `TendonActuatedPCS` class and updates the actuation matrix computation to improve clarity and correctness. The main changes include replacing the segment-wise dense strain basis with a list of per-segment strain bases, simplifying the actuation matrix computation, and ensuring correct projection into the active strains space.

**Strain basis matrix handling:**
* Replaced the `B_xi_segments` attribute from a single dense array to a `List[Array]`, where each entry represents the strain basis for an individual segment (`B_xi_segments`), and introduced a new dense stack `B_xi_segments_dense` for all segments. Updated documentation accordingly.
* Removed the `_B_xi_segments` method and its usage, as the new approach no longer requires extracting diagonal blocks from a dense matrix. [[1]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9L168-L203) [[2]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9L78)

**Actuation matrix computation updates:**
* Updated the `_local_actuation_basis` and related actuation matrix computation methods to use the full strain space shape `(6 * num_segments, ...)` instead of the previous active strains shape, and clarified documentation for returned shapes. [[1]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9L326-R294) [[2]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9L392-R360) [[3]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9L403-R386)
* Changed the computation of the local actuation matrix to skip the segment-specific strain basis multiplication, instead applying the projection into the active strains space only at the end of the computation. [[1]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9L403-R386) [[2]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9L431-R407)

**Type annotation improvements:**
* Updated type annotations to reflect the new use of `List[Array]` for segment-wise strain bases.