### PR TITLE
Add `tendon_length` method to `TendonActuatedPlanarPCS` and `TendonActuatedPCS`

### DIFF
--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -274,7 +274,8 @@ if __name__ == "__main__":
         num_segments,
         axis=0,
     ).flatten()
-    #q0 = jnp.array([0.9143,-0.0292,0.6006,-0.7162,-0.1565,0.8315,0.5844,0.9190,0.3115,-0.9286,0.6983,0.8680])
+    # q0 = jnp.array([0.9143,-0.0292,0.6006,-0.7162,-0.1565,0.8315,0.5844,0.9190,0.3115,-0.9286,0.6983,0.8680])
+    # q0 = jnp.zeros_like(q0)
 
     # Initial velocities
     qd0 = jnp.zeros_like(q0)
@@ -287,6 +288,11 @@ if __name__ == "__main__":
     A = robot.actuation_matrix(q0)
     print("A =\n", A.shape)
     print(A)
+
+    # tendon lengths
+    l = robot.tendon_length(q0)
+    print("l =\n", l.shape)
+    print(l)
 
     # Tendons' position
     t_s = robot.forward_kinematics_tendons(q0, robot.L_cum[-1])

--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -274,14 +274,13 @@ if __name__ == "__main__":
         num_segments,
         axis=0,
     ).flatten()
-    # q0 = jnp.array([0.9143,-0.0292,0.6006,-0.7162,-0.1565,0.8315,0.5844,0.9190,0.3115,-0.9286,0.6983,0.8680])
     # q0 = jnp.zeros_like(q0)
 
     # Initial velocities
     qd0 = jnp.zeros_like(q0)
 
     # Actuation parameters
-    u = jnp.array([-1.0, 0.0])
+    u = jnp.array([-0.5, -1.0])
     print("u =\n", u)
 
     # Actuation matrix

--- a/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
@@ -151,7 +151,7 @@ def animate_robot_matplotlib(
 
 
 if __name__ == "__main__":
-    num_segments = 3  # number of segments in the robot
+    num_segments = 2  # number of segments in the robot
     rho = 1070 * jnp.ones(
         (num_segments,)
     )  # Volumetric density of Dragon Skin 20 [kg/m^3]
@@ -160,7 +160,7 @@ if __name__ == "__main__":
         "L": 1e-1 * jnp.ones((num_segments,)),
         "r": 2e-2 * jnp.ones((num_segments,)),
         "rho": rho,
-        "g": 1 * jnp.array([0.0, 9.81]),  # gravitational acceleration [m/s^2] UP!
+        "g": 0 * jnp.array([0.0, 9.81]),  # gravitational acceleration [m/s^2] UP!
         "E": 5e3 * jnp.ones((num_segments,)),  # Elastic modulus [Pa]
         "G": 1e3 * jnp.ones((num_segments,)),  # Shear modulus [Pa]
         "d": 2e-2
@@ -209,7 +209,7 @@ if __name__ == "__main__":
     # ).flatten()
     # q0 = jnp.zeros_like(q0)
     # randomly sample initial configuration
-    key = jax.random.PRNGKey(0)
+    key = jax.random.PRNGKey(4)
     q0 = jax.random.normal(key, shape=int(robot.num_active_strains)) * jnp.repeat(
         jnp.array([5.0 * jnp.pi, 0.1, 0.05])[None, :], num_segments, axis=0
     ).flatten()
@@ -227,17 +227,34 @@ if __name__ == "__main__":
     qd0 = jnp.zeros_like(q0)
 
     # Actuation parameters
-    # u = (
-    #     jnp.array([1.0, 0.0])[None].repeat(num_segments, axis=0).flatten()
-    # )  # tendon tensions
     # u = jnp.zeros((robot.num_actuators,))  # no actuation
+    # u = (
+    #     jnp.array([0.0, -0.3])[None].repeat(num_segments, axis=0).flatten()
+    # )  # tendon tensions
     # randomly sample actuation
-    u = jax.random.uniform(
-        key,
-        shape=(robot.num_actuators,),
-        minval=0.0,
-        maxval=2e0,
+    # u = jax.random.uniform(
+    #     key,
+    #     shape=(robot.num_actuators,),
+    #     minval=-0.5,
+    #     maxval=0.0,
+    # )
+    # alternating tendon tensions
+    base_tension = jnp.array(-0.3, dtype=q0.dtype)
+    segment_ids = jnp.arange(num_segments)
+    segment_tensions = base_tension / (segment_ids.astype(q0.dtype) + 1.0)
+    even_segments = (segment_ids % 2) == 0
+    tendon_pattern = jnp.zeros((num_segments, 2), dtype=q0.dtype)
+    tendon_pattern = tendon_pattern.at[:, 0].set(
+        jnp.where(even_segments, segment_tensions, 0.0)
     )
+    tendon_pattern = tendon_pattern.at[:, 1].set(
+        jnp.where(~even_segments, segment_tensions, 0.0)
+    )
+    u = jnp.take(
+        tendon_pattern,
+        robot.segment_indices_to_actuate,
+        axis=0,
+    ).reshape(-1)
     print("u =\n", u)
 
     # call the actuation mapping function
@@ -266,6 +283,7 @@ if __name__ == "__main__":
         solver=solver,
         max_steps=None,
     )
+    print("Final configuration q(t1) =\n", q_ts[-1])
 
     # =====================================================
     # End-effector position upon time

--- a/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
@@ -372,6 +372,5 @@ if __name__ == "__main__":
         width=w,
         height=h,
         speed_up=1.0,
-        skip_step=save_dt,
         rgb_to_bgr=False,
     )

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -91,6 +91,11 @@ class GVS(DynamicalSystem):
     - Link cross-section geometry can vary along the length and supports circular,
       rectangular, and elliptical shapes.
 
+    References:
+    ----------
+    - Renda, F., Armanini, C., Lebastard, V., Candelier, F., & Boyer, F. (2020). A geometric variable-strain approach for static modeling of soft manipulators with tendon and fluidic actuation. IEEE Robotics and Automation Letters, 5(3), 4006-4013.
+    - Boyer, F., Lebastard, V., Candelier, F., & Renda, F. (2020). Dynamics of continuum and soft robots: A strain parameterization based approach. IEEE Transactions on Robotics, 37(3), 847-863.
+    - Mathew, A. T., Feliu-Talegon, D., Alkayas, A. Y., Boyer, F., & Renda, F. (2025). Reduced order modeling of hybrid soft-rigid robots using global, local, and state-dependent strain parameterization. The International Journal of Robotics Research, 44(1), 129-154.
     """
 
     # Static attributes

--- a/src/soromox/systems/isupport.py
+++ b/src/soromox/systems/isupport.py
@@ -49,19 +49,17 @@ class ISupport(PCS):
         Angular offset of the first actuator from the local segment frame [rad].
 
     References:
-    -----
-    This implementation builds upon the findings of:
-
-    Arleo et al. (2021): Arleo, L., Stano, G., Percoco, G., & Cianchetti, M. (2021).
+    ----------
+    - Arleo et al. (2021): Arleo, L., Stano, G., Percoco, G., & Cianchetti, M. (2021).
         I-support soft arm for assistance tasks: a new manufacturing approach based on 3D printing and characterization.
         Progress in Additive Manufacturing, 6(2), 243-256.
         https://link.springer.com/article/10.1007/s40964-020-00158-y
 
-    Alessi et al. (2023): Alessi, C., Falotico, E., & Lucantonio, A. (2023).
+    - Alessi et al. (2023): Alessi, C., Falotico, E., & Lucantonio, A. (2023).
         Ablation study of a dynamic model for a 3d-printed pneumatic soft robotic arm. IEEE Access, 11, 37840-37853.
         https://ieeexplore.ieee.org/abstract/document/10098800
 
-    Alessi, C., Bianchi, D., Stano, G., Cianchetti, M., & Falotico, E. (2024).
+    - Alessi, C., Bianchi, D., Stano, G., Cianchetti, M., & Falotico, E. (2024).
         Pushing with soft robotic arms via deep reinforcement learning. Advanced Intelligent Systems, 6(8), 2300899.
         https://advanced.onlinelibrary.wiley.com/doi/full/10.1002/aisy.202300899
 

--- a/src/soromox/systems/pcs.py
+++ b/src/soromox/systems/pcs.py
@@ -66,6 +66,10 @@ class PCS(DynamicalSystem):
                 - sigma_y corresponds to shear along the y-axis,
                 - sigma_z corresponds to shear along the z-axis.
 
+    References:
+    ----------
+    - Renda, Federico, Frédéric Boyer, Jorge Dias, and Lakmal Seneviratne. "Discrete cosserat approach for multisection soft manipulator dynamics." IEEE Transactions on Robotics 34, no. 6 (2018): 1518-1533.
+
     """
 
     # Robot parameters

--- a/src/soromox/systems/planar_hsa.py
+++ b/src/soromox/systems/planar_hsa.py
@@ -139,6 +139,10 @@ class PlanarHSA(DynamicalSystem):
       rod mapping for accurate modeling of HSA mechanics.
     - Hysteresis modeling is optional and uses the Bouc-Wen model
       when consider_hysteresis=True.
+
+    References:
+    ----------
+    - Stölzle, M., Rus, D., & Della Santina, C. (2023, November). An experimental study of model-based control for planar handed shearing auxetics robots. In International Symposium on Experimental Robotics (pp. 153-167). Cham: Springer Nature Switzerland.
     """
     # static settings
     num_segments: int = eqx.field(static=True)

--- a/src/soromox/systems/planar_pcs.py
+++ b/src/soromox/systems/planar_pcs.py
@@ -63,6 +63,10 @@ class PlanarPCS(DynamicalSystem):
                 - sigma_x corresponds to axial strain along the x-axis,
                 - sigma_y corresponds to shear along the y-axis.
 
+    References:
+    ----------
+    - Renda, Federico, Frédéric Boyer, Jorge Dias, and Lakmal Seneviratne. "Discrete cosserat approach for multisection soft manipulator dynamics." IEEE Transactions on Robotics 34, no. 6 (2018): 1518-1533.
+
     """
 
     # Robot parameters

--- a/src/soromox/systems/tendon_actuated_pcs.py
+++ b/src/soromox/systems/tendon_actuated_pcs.py
@@ -289,6 +289,7 @@ class TendonActuatedPCS(PCS):
         Compute the actuation matrix contribution of one tendon k at s contained in segment i.
 
         Args:
+            i (Array): index of the segment ()
             xi_i (Array): strain at segment i (6,)
             tendon_routing_params_k (Dict[str, Array]): parameters of the tendon k
             s (Array): abscissa points (num_gauss_points,)
@@ -397,6 +398,107 @@ class TendonActuatedPCS(PCS):
         A = self.B_xi.T @ A  # (num_active_strains, num_actuators)
 
         return A
+    
+    @eqx.filter_jit
+    def tendon_length(self, q: Array) -> Array:
+        """
+        Compute the length of all tendons of the robot.
+        This implementation is based on the formulation presented in:
+        Pustina, P., Della Santina, C., Boyer, F., De Luca, A., & Renda, F. (2024). Input decoupling of lagrangian systems via coordinate transformation: General characterization and its application to soft robotics. IEEE transactions on robotics, 40, 2098-2110.
+
+        Args:
+            q (Array): generalized coordinates of shape (num_active_strains,).
+
+        Returns:
+            l (Array): Lengths of all tendons of shape (num_actuators,).
+        """
+        # extract strains
+        xi = self.strain(q).reshape((self.num_segments, 6))
+
+        def tendon_length_delta_segment_i(i: Array):
+            """
+            Compute the actuation matrix at the gaussian points of segment i of the robot.
+
+            Args:
+                i (Array): index of the segment ()
+
+            Returns:
+                dl_ds_i (Array): tendon length density at gaussian points of shape (num_gauss_points, num_actuators) at segment i.
+            """
+            xi_i = xi[i]
+
+            def tendon_length_delta_point_j(j: Array):
+                """
+                Compute the actuation matrix at the abscissa point corresponding to the gaussian point j.
+
+                Args:
+                    j (Array): index of the gaussian point ()
+
+                Returns:
+                    dl_ds_j (Array): local tendon length density of shape (num_actuators, ) at gaussian point j.
+                """
+                # extract gaussian point and weight
+                Xs_j = Xs_scaled[j]
+                Ws_j = Ws_scaled[j]
+
+                def tendon_length_delta_tendon_k(tendon_routing_params_k: Dict[str, Array]) -> Array:
+                    """
+                    Compute the actuation matrix contribution of one tendon k at s contained in segment i.
+
+                    Args:
+                        tendon_routing_params_k (Dict[str, Array]): parameters of the tendon k
+                    
+                    Returns:
+                        dl_ds_k (Array): local tendon length density contribution of one tendon of shape ().
+                    """
+                    # evaluate condition if the tendon is routed through segment i
+                    attachment_segment_idx = tendon_routing_params_k["idx_seg_att"]  # ()
+                    cond = attachment_segment_idx >= i  # ()
+
+                    # extract tendon routing evolution in the cross-sectional plane
+                    dd_s = jnp.append(
+                        self.dd_s_ds(tendon_routing_params_k, Xs_j), 1.0
+                    )  # (4,)
+
+                    # compute local actuation basis
+                    Phi_a_k = self._local_actuation_basis(
+                        i, xi_i, Xs_j, tendon_routing_params_k
+                    )  # (6,)
+
+                    # compute tendon length density contribution
+                    dl_ds_k = jnp.dot(Phi_a_k.T, xi_i + jnp.concat([jnp.zeros((3,)), dd_s[:3]], axis=-1))  # ()
+
+                    # apply condition
+                    dl_ds_k = cond * dl_ds_k  # ()
+
+                    return dl_ds_k
+
+                # Vectorize the actuation basis computation for all tendons
+                dl_ds_j = vmap(tendon_length_delta_tendon_k)(
+                    self.tendon_routing_params
+                )  # (num_actuators,)
+
+                return Ws_j * dl_ds_j
+            
+            Xs_scaled, Ws_scaled = scale_gaussian_quadrature(
+                self.Xs, self.Ws, self.L_cum[i], self.L_cum[i + 1]
+            )
+
+            # Vectorize the actuation matrix computation for all gaussian points
+            dl_ds_i = vmap(tendon_length_delta_point_j)(
+                jnp.arange(self.num_gauss_points)
+            )  # (num_gauss_points, num_actuators)
+
+            return dl_ds_i
+
+        # Vectorize the actuation matrix computation for all segments
+        dl_ds_blocks = vmap(tendon_length_delta_segment_i)(
+            jnp.arange(self.num_segments)
+        )  # (num_segments, num_gauss_points, num_actuators)
+
+        l = jnp.sum(dl_ds_blocks, axis=(0, 1))  # Sum over the segments and Gauss points
+
+        return l
 
     @eqx.filter_jit
     def forward_kinematics_tendons(self, q: Array, s: Array) -> Array:

--- a/src/soromox/systems/tendon_actuated_pcs.py
+++ b/src/soromox/systems/tendon_actuated_pcs.py
@@ -14,7 +14,7 @@ from soromox.utils.integration import scale_gaussian_quadrature
 
 class TendonActuatedPCS(PCS):
     """
-    Piecewise Constant Strain (PCS) model for 3D soft continuum robots.
+    Piecewise Constant Strain (PCS) model for 3D soft continuum robots with tendon actuation.
 
     This class implements the geometric and dynamic modeling of a 3D soft robot
     using the Cosserat rod theory and piecewise constant strain assumption.
@@ -72,6 +72,11 @@ class TendonActuatedPCS(PCS):
                 - sigma_y corresponds to shear along the y-axis,
                 - sigma_z corresponds to shear along the z-axis.
 
+    References:
+    ----------
+    - [PCS model] Renda, Federico, Frédéric Boyer, Jorge Dias, and Lakmal Seneviratne. "Discrete cosserat approach for multisection soft manipulator dynamics." IEEE Transactions on Robotics 34, no. 6 (2018): 1518-1533.
+    - [Actuation matrix for tendon-actuated soft robots] Renda, F., Armanini, C., Lebastard, V., Candelier, F., & Boyer, F. (2020). A geometric variable-strain approach for static modeling of soft manipulators with tendon and fluidic actuation. IEEE Robotics and Automation Letters, 5(3), 4006-4013.
+    - [Tendon lengths] Pustina, P., Della Santina, C., Boyer, F., De Luca, A., & Renda, F. (2024). Input decoupling of lagrangian systems via coordinate transformation: General characterization and its application to soft robotics. IEEE transactions on robotics, 40, 2098-2110.
     """
 
     tendon_routing_params: Dict[str, Array]
@@ -373,6 +378,8 @@ class TendonActuatedPCS(PCS):
     def actuation_matrix(self, q: Array) -> Array:
         """
         Compute the actuation matrix of the robot.
+        This implementation is based on the formulation presented in:
+        Renda, F., Armanini, C., Lebastard, V., Candelier, F., & Boyer, F. (2020). A geometric variable-strain approach for static modeling of soft manipulators with tendon and fluidic actuation. IEEE Robotics and Automation Letters, 5(3), 4006-4013.
 
         Args:
             q (Array): generalized coordinates of shape (num_active_strains,).

--- a/src/soromox/systems/tendon_actuated_pcs.py
+++ b/src/soromox/systems/tendon_actuated_pcs.py
@@ -298,7 +298,7 @@ class TendonActuatedPCS(PCS):
             Phi_a_k (Array): local actuation matrix contribution of one tendon of shape (6,).
         """
         attachment_segment_idx = tendon_routing_params_k["idx_seg_att"]  # ()
-        cond = attachment_segment_idx >= i  # ()
+        is_tendon_active = attachment_segment_idx >= i  # ()
 
         # extract tendon routing evolution in the cross-sectional plane
         d_s = jnp.append(self.d_s(tendon_routing_params_k, s), 1.0)  # (4,)
@@ -310,7 +310,7 @@ class TendonActuatedPCS(PCS):
         norm = jnp.linalg.norm(term)  # ()
         t = term / norm  # (3,)
 
-        Phi_a_k = cond * jnp.hstack([lie.tilde_SE3(d_s[:-1]) @ t, t])  # (6,)
+        Phi_a_k = is_tendon_active * jnp.hstack([lie.tilde_SE3(d_s[:-1]) @ t, t])  # (6,)
 
         return Phi_a_k
 
@@ -415,46 +415,47 @@ class TendonActuatedPCS(PCS):
         # extract strains
         xi = self.strain(q).reshape((self.num_segments, 6))
 
-        def tendon_length_delta_segment_i(i: Array):
+        def tendon_length_density_segment_i(i: Array):
             """
-            Compute the actuation matrix at the gaussian points of segment i of the robot.
+            Compute the tendon length density at all Gauss points of segment i.
 
             Args:
-                i (Array): index of the segment ()
+                i (Array): segment index.
 
             Returns:
-                dl_ds_i (Array): tendon length density at gaussian points of shape (num_gauss_points, num_actuators) at segment i.
+                dl_ds_i (Array): tendon length density values at Gauss points,
+                    shape (num_gauss_points, num_actuators).
             """
             xi_i = xi[i]
 
-            def tendon_length_delta_point_j(j: Array):
+            def tendon_length_density_point_j(j: Array):
                 """
-                Compute the actuation matrix at the abscissa point corresponding to the gaussian point j.
+                Evaluate the tendon length density at the Gauss point j inside segment i.
 
                 Args:
-                    j (Array): index of the gaussian point ()
+                    j (Array): Gauss point index.
 
                 Returns:
-                    dl_ds_j (Array): local tendon length density of shape (num_actuators, ) at gaussian point j.
+                    dl_ds_j (Array): local tendon length density of shape (num_actuators,)
+                        at Gauss point j.
                 """
                 # extract gaussian point and weight
                 Xs_j = Xs_scaled[j]
                 Ws_j = Ws_scaled[j]
 
-                def tendon_length_delta_tendon_k(tendon_routing_params_k: Dict[str, Array]) -> Array:
+                def tendon_length_density_tendon_k(
+                    tendon_routing_params_k: Dict[str, Array]
+                ) -> Array:
                     """
-                    Compute the actuation matrix contribution of one tendon k at s contained in segment i.
+                    Compute the tendon length density contribution of one tendon at the
+                    current Gauss point.
 
                     Args:
-                        tendon_routing_params_k (Dict[str, Array]): parameters of the tendon k
+                        tendon_routing_params_k (Dict[str, Array]): parameters of the tendon.
                     
                     Returns:
-                        dl_ds_k (Array): local tendon length density contribution of one tendon of shape ().
+                        dl_ds_k (Array): scalar tendon length density contribution.
                     """
-                    # evaluate condition if the tendon is routed through segment i
-                    attachment_segment_idx = tendon_routing_params_k["idx_seg_att"]  # ()
-                    cond = attachment_segment_idx >= i  # ()
-
                     # extract tendon routing evolution in the cross-sectional plane
                     dd_s = jnp.append(
                         self.dd_s_ds(tendon_routing_params_k, Xs_j), 1.0
@@ -468,13 +469,10 @@ class TendonActuatedPCS(PCS):
                     # compute tendon length density contribution
                     dl_ds_k = jnp.dot(Phi_a_k.T, xi_i + jnp.concat([jnp.zeros((3,)), dd_s[:3]], axis=-1))  # ()
 
-                    # apply condition
-                    dl_ds_k = cond * dl_ds_k  # ()
-
                     return dl_ds_k
 
-                # Vectorize the actuation basis computation for all tendons
-                dl_ds_j = vmap(tendon_length_delta_tendon_k)(
+                # Vectorize the tendon length density computation for all tendons
+                dl_ds_j = vmap(tendon_length_density_tendon_k)(
                     self.tendon_routing_params
                 )  # (num_actuators,)
 
@@ -484,15 +482,15 @@ class TendonActuatedPCS(PCS):
                 self.Xs, self.Ws, self.L_cum[i], self.L_cum[i + 1]
             )
 
-            # Vectorize the actuation matrix computation for all gaussian points
-            dl_ds_i = vmap(tendon_length_delta_point_j)(
+            # Vectorize the tendon length density evaluation for all Gauss points
+            dl_ds_i = vmap(tendon_length_density_point_j)(
                 jnp.arange(self.num_gauss_points)
             )  # (num_gauss_points, num_actuators)
 
             return dl_ds_i
 
-        # Vectorize the actuation matrix computation for all segments
-        dl_ds_blocks = vmap(tendon_length_delta_segment_i)(
+        # Vectorize the tendon length density evaluation for all segments
+        dl_ds_blocks = vmap(tendon_length_density_segment_i)(
             jnp.arange(self.num_segments)
         )  # (num_segments, num_gauss_points, num_actuators)
 

--- a/src/soromox/systems/tendon_actuated_pcs.py
+++ b/src/soromox/systems/tendon_actuated_pcs.py
@@ -70,6 +70,16 @@ class TendonActuatedPCS(PCS):
                 - sigma_y corresponds to shear along the y-axis,
                 - sigma_z corresponds to shear along the z-axis.
 
+    References:
+    ----------
+    This implementation builds upon the findings of:
+    - Renda, F., Armanini, C., Lebastard, V., Candelier, F., & Boyer, F. (2020). A geometric variable-strain approach 
+        for static modeling of soft manipulators with tendon and fluidic actuation. IEEE Robotics and Automation Letters, 
+        5(3), 4006-4013.
+    - Pustina, P., Della Santina, C., Boyer, F., De Luca, A., & Renda, F. (2024). Input decoupling of lagrangian systems
+        via coordinate transformation: General characterization and its application to soft robotics. 
+        IEEE transactions on robotics, 40, 2098-2110.    
+
     """
 
     tendon_routing_params: Dict[str, Array]

--- a/src/soromox/systems/tendon_actuated_pendulum.py
+++ b/src/soromox/systems/tendon_actuated_pendulum.py
@@ -106,6 +106,10 @@ class TendonActuatedPendulum(Pendulum):
         Transformation matrix from actuation to configuration coordinates, such that q = h_q(y) (identity if omitted).
     h_q_inv: Array (shape (N, N))
         Transformation matrix from configuration to actuation coordinates, such that y = h_q_inv(q) (identity if omitted).
+
+    References:
+    ----------
+    - [Tendon-driven actuation of an articulated link system] Murray, Richard M., Zexiang Li, and S. Shankar Sastry. A mathematical introduction to robotic manipulation. CRC press, 2017. (Chapter 6)
     """
 
     R_at: Array

--- a/src/soromox/systems/tendon_actuated_pendulum.py
+++ b/src/soromox/systems/tendon_actuated_pendulum.py
@@ -391,6 +391,8 @@ class TendonActuatedPendulum(Pendulum):
         l0_p = jnp.sum(self.L * mask * cond, axis=1)
         l_tot_p = self.passive_tendon_displacement(q) + l0_p
         return l_tot_p
+    
+    tendon_length = active_tendon_length  # Alias for compatibility
 
     # -------------------------------
     # Standardized dynamics interface

--- a/src/soromox/systems/tendon_actuated_pendulum.py
+++ b/src/soromox/systems/tendon_actuated_pendulum.py
@@ -106,6 +106,11 @@ class TendonActuatedPendulum(Pendulum):
         Transformation matrix from actuation to configuration coordinates, such that q = h_q(y) (identity if omitted).
     h_q_inv: Array (shape (N, N))
         Transformation matrix from configuration to actuation coordinates, such that y = h_q_inv(q) (identity if omitted).
+
+    References:
+    ----------
+    This implementation builds upon the findings of:
+    - Murray, R. M., Li, Z., & Sastry, S. S. (2017). A mathematical introduction to robotic manipulation. CRC press.
     """
 
     R_at: Array

--- a/src/soromox/systems/tendon_actuated_planar_pcs.py
+++ b/src/soromox/systems/tendon_actuated_planar_pcs.py
@@ -246,18 +246,14 @@ class TendonActuatedPlanarPCS(PlanarPCS):
                 A_sm: actuation matrix of shape (n_xi, num_segment_tendons)
             """
 
-            def compute_A_d(d: Array) -> Array:
+            def compute_A_d(d_k: Array) -> Array:
                 """
                 Compute the actuation matrix for a single actuator/tendon with respect to the soft robot's strains.
                 Args:
-                    d: distance of the tendon from the centerline
+                    d_k: distance of the k-th tendon from the centerline as array of shape ()
                 Returns:
                     A_d: actuation matrix of shape (n_xi, ) where n_xi is the number of strains
                 """
-                kappa_0 = xi[0]  # bending strain
-                axial_0 = xi[1]  # axial strain
-                shear_0 = xi[2]  # shear strain
-                square_root_term = jnp.sqrt(shear_0**2 + (axial_0 + d * kappa_0) ** 2)
 
                 def compute_A_d_wrt_xi_i(i: Array, L_i: Array, xi_i: Array) -> Array:
                     """
@@ -273,14 +269,18 @@ class TendonActuatedPlanarPCS(PlanarPCS):
                     axial_i = xi_i[1]  # axial strain
                     shear_i = xi_i[2]  # shear strain
 
-                    A_d_wrt_xi_i = -jnp.array(
+                    square_root_term = jnp.sqrt(
+                        shear_i**2 + (axial_i + d_k * kappa_i) ** 2
+                    )
+
+                    A_d_wrt_xi_i = jnp.array(
                         [
                             L_i
-                            * d
-                            * (d * kappa_i + axial_i)
+                            * d_k
+                            * (d_k * kappa_i + axial_i)
                             / square_root_term,  # actuation on the bending
                             L_i
-                            * (d * kappa_i + axial_i)
+                            * (d_k * kappa_i + axial_i)
                             / square_root_term,  # actuation on the axial strain
                             L_i
                             * shear_i
@@ -320,4 +320,43 @@ class TendonActuatedPlanarPCS(PlanarPCS):
         # reshape the actuation matrix to have shape (n_xi, n_act)
         A = jnp.concatenate(A, axis=1)  # concatenate along the second axis
 
+        # project onto the active strain basis to match the generalized coordinates
+        A = self.B_xi.T @ A
+
         return A
+
+    @eqx.filter_jit
+    def tendon_length(self, q: Array) -> Array:
+        """
+        Compute the cumulative tendon length for each actuator.
+
+        Each tendon is assumed to be routed along the backbone and attached at the distal
+        end of the corresponding actuated segment. The tendon length is obtained by
+        integrating the local stretch along every traversed segment, which depends on
+        shear and axial strains and on the tendon offset d.
+
+        Args:
+            q (Array): generalized coordinates of shape (num_active_strains,).
+
+        Returns:
+            l (Array): tendon lengths of shape (num_actuators,).
+        """
+
+        xi = self.strain(q).reshape(self.num_segments, 3)
+        kappa = xi[:, 0:1]
+        axial = xi[:, 1:2]
+        shear = xi[:, 2:3]  # ensure 2D for broadcasting
+
+        d = self.d
+        if d.ndim == 1:
+            d = d[:, None]
+
+        local_extension = axial + d * kappa
+        segment_lengths = self.L[:, None] * jnp.sqrt(
+            shear**2 + local_extension**2
+        )
+
+        cumulative_lengths = jnp.cumsum(segment_lengths, axis=0)
+        tendon_lengths = cumulative_lengths[self.segment_indices_to_actuate]
+
+        return tendon_lengths.reshape(-1)

--- a/tests/test_tendon_actuated_pcs.py
+++ b/tests/test_tendon_actuated_pcs.py
@@ -330,38 +330,36 @@ def test_actuation_matrix_with_inactive_strains():
     )
 
 
-def test_tendon_length_gradient_matches_actuation_matrix_random_configs():
-    """
-    Ensure the tendon_length Jacobian equals the transpose of the actuation matrix
-    across different robot sizes and random configurations.
-    """
+@pytest.mark.parametrize("num_tendons", [1, 2, 4])
+@pytest.mark.parametrize("num_segments", [1, 2, 3])
+def test_tendon_length_gradient_matches_actuation_matrix_random_configs(
+    num_segments: int, num_tendons: int
+):
+    """Ensure tendon_length Jacobian equals actuation matrix transpose."""
 
-    segment_options = [1, 2, 3]
-    tendon_options = [1, 2, 4]
-    key = jax.random.PRNGKey(42)
+    segment_lengths = jnp.linspace(
+        0.2, 0.2 + 0.05 * (num_segments - 1), num_segments, dtype=jnp.float64
+    )
+    tendon_params = _stacked_tendon_params(num_segments, num_tendons)
+    robot = _create_robot(segment_lengths, tendon_params)
 
-    for num_segments in segment_options:
-        segment_lengths = jnp.linspace(
-            0.2, 0.2 + 0.05 * (num_segments - 1), num_segments, dtype=jnp.float64
+    key = jax.random.PRNGKey(42 + num_segments * 10 + num_tendons)
+
+    for _ in range(10):
+        key, subkey = jax.random.split(key)
+        q = 0.05 * jax.random.normal(
+            subkey, (robot.num_active_strains,), dtype=jnp.float64
         )
-        for num_tendons in tendon_options:
-            tendon_params = _stacked_tendon_params(num_segments, num_tendons)
-            robot = _create_robot(segment_lengths, tendon_params)
-            for _ in range(10):
-                key, subkey = jax.random.split(key)
-                q = 0.05 * jax.random.normal(
-                    subkey, (robot.num_active_strains,), dtype=jnp.float64
-                )
-                lengths = robot.tendon_length(q)
-                assert lengths.shape == (robot.num_actuators,)
-                jac = jax.jacrev(robot.tendon_length)(q)
-                A = robot.actuation_matrix(q)
-                assert_allclose(
-                    jac,
-                    A.T,
-                    rtol=Tolerance.rtol(),
-                    atol=Tolerance.atol(),
-                )
+        lengths = robot.tendon_length(q)
+        assert lengths.shape == (robot.num_actuators,)
+        jac = jax.jacrev(robot.tendon_length)(q)
+        A = robot.actuation_matrix(q)
+        assert_allclose(
+            jac,
+            A.T,
+            rtol=Tolerance.rtol(),
+            atol=Tolerance.atol(),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_tendon_actuated_pcs.py
+++ b/tests/test_tendon_actuated_pcs.py
@@ -1,4 +1,5 @@
 import jax
+import pytest
 
 jax.config.update("jax_enable_x64", True)  # double precision
 from jax import Array
@@ -53,6 +54,31 @@ def _create_robot(
         robot_kwargs["strain_selector"] = strain_selector
 
     return TendonActuatedPCS(**robot_kwargs)
+
+
+def _stacked_tendon_params(num_segments: int, num_tendons: int) -> Dict[str, Array]:
+    """
+    Build a set of tendon routing parameters covering multiple attachments and slopes.
+    """
+    if num_tendons < 1:
+        raise ValueError("num_tendons must be at least 1.")
+    idx = jnp.arange(num_tendons, dtype=jnp.int32)
+    attachment = jnp.minimum(idx % num_segments, num_segments - 1)
+    base = idx.astype(jnp.float64) + 1.0
+    alternating = jnp.where(idx % 2 == 0, 1.0, -1.0)
+
+    ry = 0.02 * base * alternating
+    rz = -0.015 * (base + 0.5)
+    my = 0.01 * (jnp.mod(idx, 3).astype(jnp.float64) - 1.0)
+    mz = 0.012 * (jnp.mod(idx + 1, 3).astype(jnp.float64) - 1.0)
+
+    return {
+        "ry": ry,
+        "rz": rz,
+        "my": my,
+        "mz": mz,
+        "idx_seg_att": attachment,
+    }
 
 
 def reference_actuation_matrix(
@@ -304,6 +330,40 @@ def test_actuation_matrix_with_inactive_strains():
     )
 
 
+def test_tendon_length_gradient_matches_actuation_matrix_random_configs():
+    """
+    Ensure the tendon_length Jacobian equals the transpose of the actuation matrix
+    across different robot sizes and random configurations.
+    """
+
+    segment_options = [1, 2, 3]
+    tendon_options = [1, 2, 4]
+    key = jax.random.PRNGKey(42)
+
+    for num_segments in segment_options:
+        segment_lengths = jnp.linspace(
+            0.2, 0.2 + 0.05 * (num_segments - 1), num_segments, dtype=jnp.float64
+        )
+        for num_tendons in tendon_options:
+            tendon_params = _stacked_tendon_params(num_segments, num_tendons)
+            robot = _create_robot(segment_lengths, tendon_params)
+            for _ in range(10):
+                key, subkey = jax.random.split(key)
+                q = 0.05 * jax.random.normal(
+                    subkey, (robot.num_active_strains,), dtype=jnp.float64
+                )
+                lengths = robot.tendon_length(q)
+                assert lengths.shape == (robot.num_actuators,)
+                jac = jax.jacrev(robot.tendon_length)(q)
+                A = robot.actuation_matrix(q)
+                assert_allclose(
+                    jac,
+                    A.T,
+                    rtol=Tolerance.rtol(),
+                    atol=Tolerance.atol(),
+                )
+
+
 if __name__ == "__main__":
-    print("Running tests for tendon actuated Piecewise Constant Strain...")
-    test_actuation_matrix_pcs()
+    # run pytest with activated stdout
+    pytest.main([__file__])

--- a/tests/test_tendon_actuated_pcs.py
+++ b/tests/test_tendon_actuated_pcs.py
@@ -327,6 +327,121 @@ def test_actuation_matrix_with_inactive_strains():
         expected,
         rtol=Tolerance.rtol(),
         atol=Tolerance.atol(),
+        )
+
+
+def test_constant_curvature_segment_actuation_matches_closed_form_expression_from_pustina2024():
+    """
+    Validate Equation (15) and the following y expression from
+    Pustina et al. (2024) for a single-segment constant-curvature rod.
+
+    For a single segment with only bending (kappa_y, kappa_z) and axial strain
+    active, Eq. (15) predicts a constant actuation matrix whose entries depend
+    only on the tendon radius d and the segment length L. The subsequent
+    expression for y states that tendon lengths equal the rest length plus
+    A(q)^T q. We check both statements here.
+
+    The PCC coordinates (kappa_i, phi_i, delta_L_i) used in the paper relate
+    to SoRoMoX strains (kappa_y, kappa_z, sigma_x) as
+        kappa_i = sqrt(kappa_y^2 + kappa_z^2),
+        phi_i   = atan2(kappa_y, -kappa_z)   (bending angle measured from +z),
+        delta_L_i = (sigma_x - 1) * L,
+    where L is the segment length (also the tendon rest length in this test).
+    """
+
+    segment_lengths = jnp.array([1.0], dtype=jnp.float64)
+    d = 1.0e-2  # tendon distance/radius from centerline
+    tendon_angles = jnp.array([0.0, 2 * jnp.pi / 3, 4 * jnp.pi / 3], dtype=jnp.float64)
+    tendon_params = {
+        "ry": d * jnp.cos(tendon_angles),
+        "rz": d * jnp.sin(tendon_angles),
+        "my": jnp.zeros_like(tendon_angles),
+        "mz": jnp.zeros_like(tendon_angles),
+        "idx_seg_att": jnp.zeros((3,), dtype=jnp.int32),
+    }
+    # activate bending about y and z plus axial elongation
+    strain_selector = jnp.array(
+        [False, True, True, True, False, False], dtype=bool
+    )
+
+    robot = _create_robot(
+        segment_lengths, tendon_params, strain_selector=strain_selector
+    )
+    q = jnp.array([0.12, -0.07, 0.03], dtype=jnp.float64)
+
+    A_numeric = robot.actuation_matrix(q)
+
+    segment_length = segment_lengths[0]
+    sqrt_three = jnp.sqrt(3.0)
+    expected_A = jnp.array(
+        [
+            [
+                0.0,
+                (sqrt_three * d * segment_length) / 2.0,
+                -(sqrt_three * d * segment_length) / 2.0,
+            ],
+            [
+                -d * segment_length,
+                0.5 * d * segment_length,
+                0.5 * d * segment_length,
+            ],
+            [
+                segment_length,
+                segment_length,
+                segment_length,
+            ],
+        ],
+        dtype=jnp.float64,
+    )
+
+    assert_allclose(
+        A_numeric,
+        expected_A,
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
+
+    tendon_lengths = robot.tendon_length(q)
+
+    # Map SoRoMoX strains (kappa_y, kappa_z, sigma_x) to the PCC coordinates
+    # used in Pustina et al. (2024), Example 5.
+    kappa_y, kappa_z = q[0], q[1]
+    sigma_x = q[2] + 1.0  # xi_ref adds 1.0 to axial strain
+    kappa_mag = jnp.sqrt(kappa_y**2 + kappa_z**2)
+    # Paper’s bending direction is measured from +z, so swapping arctan2
+    # arguments guarantees cos(q2) = -kappa_z / kappa_mag and sin(q2) =
+    # kappa_y / kappa_mag as in Eq. (15).
+    phi = jnp.arctan2(kappa_y, -kappa_z)
+    delta_L = (sigma_x - 1.0) * segment_length
+    # q1 stores kappa_i * L to match the notation in the paper.
+    q1, q2, q3 = segment_length * kappa_mag, phi, delta_L
+    q4 = q5 = q6 = 0.0  # Only one segment is active in this scenario.
+    cos_q2, sin_q2 = jnp.cos(q2), jnp.sin(q2)
+    cos_q5, sin_q5 = jnp.cos(q5), jnp.sin(q5)
+
+    common_cos = q1 * cos_q2 + q4 * cos_q5
+    common_sin = q1 * sin_q2 + q4 * sin_q5
+    y_expr = jnp.array(
+        [
+            q3 + q6 + d * common_cos,
+            q3
+            + q6
+            - 0.5 * d * common_cos
+            + (jnp.sqrt(3.0) / 2.0) * d * common_sin,
+            q3
+            + q6
+            - 0.5 * d * common_cos
+            - (jnp.sqrt(3.0) / 2.0) * d * common_sin,
+        ],
+        dtype=jnp.float64,
+    )
+    expected_lengths = segment_length + y_expr
+
+    assert_allclose(
+        tendon_lengths,
+        expected_lengths,
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
     )
 
 

--- a/tests/test_tendon_actuated_planar_pcs.py
+++ b/tests/test_tendon_actuated_planar_pcs.py
@@ -1,0 +1,52 @@
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+from jax import numpy as jnp
+from numpy.testing import assert_allclose
+
+from soromox.systems.tendon_actuated_planar_pcs import TendonActuatedPlanarPCS
+from soromox.utils.tolerance import Tolerance
+
+
+def _build_planar_robot(num_segments: int = 3) -> TendonActuatedPlanarPCS:
+    rho = 1070.0 * jnp.ones((num_segments,))
+    params = {
+        "th0": jnp.array(jnp.pi / 2),
+        "L": 1e-1 * jnp.ones((num_segments,)),
+        "r": 2e-2 * jnp.ones((num_segments,)),
+        "rho": rho,
+        "g": jnp.array([0.0, 9.81]),
+        "E": 5e3 * jnp.ones((num_segments,)),
+        "G": 1e3 * jnp.ones((num_segments,)),
+        "d": 2e-2 * jnp.array([[1.0, -1.0]]).repeat(num_segments, axis=0),
+    }
+    params["D"] = 1e-3 * jnp.diag(
+        (
+            jnp.repeat(jnp.array([[1e0, 1e3, 1e3]]), num_segments, axis=0)
+            * params["L"][:, None]
+        ).flatten()
+    )
+
+    return TendonActuatedPlanarPCS(
+        num_segments=num_segments,
+        params=params,
+    )
+
+
+def test_tendon_length_gradient_matches_actuation_matrix():
+    robot = _build_planar_robot(num_segments=3)
+    q = jnp.linspace(-0.05, 0.05, robot.num_active_strains, dtype=jnp.float64)
+
+    lengths = robot.tendon_length(q)
+    assert lengths.shape == (robot.num_actuators,)
+
+    jac_lengths = jax.jacrev(robot.tendon_length)(q)
+    A = robot.actuation_matrix(q)
+
+    assert_allclose(
+        jac_lengths,
+        A.T,
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )


### PR DESCRIPTION
This pull request introduces several improvements and additions to the tendon-actuated soft robot simulation and modeling codebase. The key changes include the implementation of a new method for computing tendon lengths in the `TendonActuatedPCS` class, updates to the simulation scripts for tendon-actuated robots (both 3D and planar), and the addition of relevant literature references throughout the codebase for improved documentation and traceability. There are also minor bug fixes, code cleanups, and improvements to actuation matrix calculations.

**Major new features and improvements:**

*Implementation of tendon length computation:*
- Added a new `tendon_length` method to the `TendonActuatedPCS` class, enabling the calculation of all tendon lengths based on the current robot configuration, following the formulation from Pustina et al. (2024). This improves the modeling of tendon-driven soft robots and provides a standardized interface for tendon length computation.

*Simulation script updates:*
- In `simulate_tendon_actuated_pcs.py`, updated the actuation input `u` and added a call to the new `tendon_length` method, with corresponding debug printouts for improved simulation insight.
- In `simulate_tendon_actuated_planar_pcs.py`, made several changes: reduced the number of segments to 2, set gravity to zero, changed the random seed for initial configuration, and introduced an alternating tendon tension pattern for actuation. Also added a printout of the final configuration and removed the unused `skip_step` parameter in the animation call. [[1]](diffhunk://#diff-9854d8decb403603098ceeb4ddf2c2d291b768b41e20ae770f84bbac7f32bc75L154-R154) [[2]](diffhunk://#diff-9854d8decb403603098ceeb4ddf2c2d291b768b41e20ae770f84bbac7f32bc75L163-R163) [[3]](diffhunk://#diff-9854d8decb403603098ceeb4ddf2c2d291b768b41e20ae770f84bbac7f32bc75L212-R212) [[4]](diffhunk://#diff-9854d8decb403603098ceeb4ddf2c2d291b768b41e20ae770f84bbac7f32bc75R230-R257) [[5]](diffhunk://#diff-9854d8decb403603098ceeb4ddf2c2d291b768b41e20ae770f84bbac7f32bc75R286) [[6]](diffhunk://#diff-9854d8decb403603098ceeb4ddf2c2d291b768b41e20ae770f84bbac7f32bc75L375)

**Documentation and reference improvements:**

*Addition of literature references:*
- Added or improved references in the docstrings for the following classes: `TendonActuatedPCS`, `PlanarPCS`, `PCS`, `PlanarHSA`, `GVS`, `ISupport`, and `TendonActuatedPendulum`, providing users with direct links to relevant foundational and recent research papers. [[1]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9R73-R77) [[2]](diffhunk://#diff-4397bec6ccb864d3bfb2d4a8e482b3312663630e95789bf9d8ada63ffae30b5cR66-R69) [[3]](diffhunk://#diff-19b0b4a682b4e94d1538d4dd92005bf5c097e7cabb76cb4ddf8c61e55fc851c0R69-R72) [[4]](diffhunk://#diff-b5d02dd98c17946883b02ddb989960fb0b0a280384b0240e91a9c46667e6232cR142-R145) [[5]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6R94-R98) [[6]](diffhunk://#diff-2daacc7cdf8e4a771a49c0ee6275b2a397bf0774f76ea8a1f5845e2907741bdfL52-R62) [[7]](diffhunk://#diff-445b713c2772619ff10413abb52d037f02afe5a1a15ed07374f0e32461722f7fR109-R112)

*Minor documentation and code clarity:*
- Improved docstring descriptions and argument names for clarity in several methods, such as `_local_actuation_basis` in `TendonActuatedPCS`. [[1]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9R292) [[2]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9L295-R301) [[3]](diffhunk://#diff-b0093925a979f4790787ab7cb6ea560470a8b9f434306ea38565c8a3afc83fa9L307-R322)
- Updated the class docstring for `TendonActuatedPCS` to clarify its tendon actuation capability.

**Bug fixes and code cleanups:**

*Actuation matrix calculation:*
- Fixed and clarified variable names and computation logic in the actuation matrix calculation for planar tendon-actuated robots, ensuring correct use of tendon distance variables and square root computation. [[1]](diffhunk://#diff-18e6effc8ff3eda048a9c1cda3013c5701debacf400ee283bd255646136ecd91L249-L260) [[2]](diffhunk://#diff-18e6effc8ff3eda048a9c1cda3013c5701debacf400ee283bd255646136ecd91L276-R283)

*Compatibility and utility:*
- Added an alias `tendon_length = active_tendon_length` in `TendonActuatedPendulum` for compatibility with other parts of the codebase.