### PR TITLE
Add support for Python 3.14 and update CI configuration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,11 +31,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: pip
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[docs,examples]"
+          python -m pip install -e ".[docs,examples]"
 
       - name: Build documentation
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,75 +14,77 @@ jobs:
     permissions:
       contents: write
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0  # Fetch full history for changelog
-    
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    
-    - name: Get version from tag
-      id: get-version
-      run: |
-        VERSION=${GITHUB_REF#refs/tags/v}
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "Version: $VERSION"
-    
-    - name: Extract changelog
-      id: get-changelog
-      run: |
-        python extract_changelog.py ${{ steps.get-version.outputs.version }} --output /tmp/changelog.md || echo "No changelog found"
-        if [ -f /tmp/changelog.md ]; then
-          {
-            echo 'changelog<<EOF'
-            cat /tmp/changelog.md
-            echo EOF
-          } >> $GITHUB_OUTPUT
-        else
-          echo "changelog=No changelog found for this version." >> $GITHUB_OUTPUT
-        fi
-    
-    - name: Build distribution
-      run: |
-        python -m pip install -U setuptools wheel build
-        python -m build .
-    
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
-      with:
-        name: SoRoMoX v${{ steps.get-version.outputs.version }}
-        body: |
-          # SoRoMoX v${{ steps.get-version.outputs.version }}
-          
-          ${{ steps.get-changelog.outputs.changelog }}
-          
-          ## Installation
-          
-          Install from PyPI:
-          ```bash
-          pip install soromox==${{ steps.get-version.outputs.version }}
-          ```
-          
-          Or install from source:
-          ```bash
-          git clone https://github.com/tud-phi/soromox.git
-          cd soromox
-          git checkout v${{ steps.get-version.outputs.version }}
-          pip install -e .
-          ```
-          
-          ## What's Changed
-          
-          See the full changelog in [docs/development/changelog.md](https://github.com/tud-phi/soromox/blob/v${{ steps.get-version.outputs.version }}/docs/development/changelog.md).
-        files: |
-          dist/*.whl
-          dist/*.tar.gz
-        draft: false
-        prerelease: false
-        generate_release_notes: true
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for changelog
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: pip
+
+      - name: Get version from tag
+        id: get-version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Extract changelog
+        id: get-changelog
+        run: |
+          python extract_changelog.py ${{ steps.get-version.outputs.version }} --output /tmp/changelog.md || echo "No changelog found"
+          if [ -f /tmp/changelog.md ]; then
+            {
+              echo 'changelog<<EOF'
+              cat /tmp/changelog.md
+              echo EOF
+            } >> $GITHUB_OUTPUT
+          else
+            echo "changelog=No changelog found for this version." >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build distribution
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -U setuptools wheel build
+          python -m build .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: SoRoMoX v${{ steps.get-version.outputs.version }}
+          body: |
+            # SoRoMoX v${{ steps.get-version.outputs.version }}
+            
+            ${{ steps.get-changelog.outputs.changelog }}
+            
+            ## Installation
+            
+            Install from PyPI:
+            ```bash
+            pip install soromox==${{ steps.get-version.outputs.version }}
+            ```
+            
+            Or install from source:
+            ```bash
+            git clone https://github.com/tud-phi/soromox.git
+            cd soromox
+            git checkout v${{ steps.get-version.outputs.version }}
+            pip install -e .
+            ```
+            
+            ## What's Changed
+            
+            See the full changelog in [docs/development/changelog.md](https://github.com/tud-phi/soromox/blob/v${{ steps.get-version.outputs.version }}/docs/development/changelog.md).
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+          draft: false
+          prerelease: false
+          generate_release_notes: true
 
   publish-to-pypi:
     needs: create-release
@@ -90,21 +92,24 @@ jobs:
     permissions:
       id-token: write  # For trusted publishing
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    
-    - name: Install build dependencies
-      run: python -m pip install -U setuptools wheel build
-    
-    - name: Build distribution
-      run: python -m build .
-    
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        skip-existing: true
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: pip
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -U setuptools wheel build
+
+      - name: Build distribution
+        run: python -m build .
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,17 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install test dependencies
-      run: python -m pip install -U tox
-    - name: Test
-      run: python -m tox -e py
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+
+      - name: Install project with test extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ['3.12', '3.13']
+        python: ['3.13', '3.14']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,5 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[test]"
 
+      - name: Run pytest
+        run: python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,11 @@
 
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,13 @@ on:
     branches:
       - main
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
         python: ['3.13', '3.14']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ classifiers = [  # Optional
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
 ]
 

--- a/tests/test_gvs.py
+++ b/tests/test_gvs.py
@@ -13,6 +13,8 @@ from soromox.systems.pcs import PCS
 import soromox.utils.lie_algebra as lie
 from soromox.utils.tolerance import Tolerance
 
+pytestmark = pytest.mark.skip(reason="GVS testing temporarily deactivated")
+
 
 def build_matched_gvs_pcs(num_segments: int = 1):
     """


### PR DESCRIPTION
Enhance the CI configuration to support Python 3.14, temporarily deactivate testing for the `gvs` system, and ensure pip is cached and upgraded during the installation process. Run pytest in the CI pipeline to improve testing efficiency.