### PR TITLE
Add closed-loop control utils

### DIFF
--- a/docs/api/pendulum/tendon-actuated-pendulum.md
+++ b/docs/api/pendulum/tendon-actuated-pendulum.md
@@ -147,6 +147,7 @@ robot_updated = robot.update_tendon_params(new_tendon_params)
 
 ```python
 from diffrax import Tsit5
+from soromox.systems.system_state import SystemState
 
 # Simulation setup
 q0 = jnp.array([jnp.pi/8, -jnp.pi/4])       # Initial angles
@@ -154,15 +155,16 @@ qd0 = jnp.zeros_like(q0)                    # Initial velocities
 u = jnp.array([2.0])                        # Constant motor input
 
 # Time integration
-ts, qs, qds, us = robot.resolve_upon_time(
-    q0=q0,
-    qd0=qd0,
-    u=u,
-    t0=0.0,
+initial_state = SystemState(t=0.0, y=jnp.concatenate([q0, qd0]), u=u)
+trajectory = robot.resolve_upon_time(
+    initial_state=initial_state,
     t1=5.0,
     dt=1e-3,
     solver=Tsit5()
 )
+ts = trajectory.t
+qs, qds = jnp.split(trajectory.y, 2, axis=1)
+us = trajectory.u
 ```
 
 ## Configuration Guidelines

--- a/docs/api/pendulum/tendon-actuated-pendulum.md
+++ b/docs/api/pendulum/tendon-actuated-pendulum.md
@@ -160,7 +160,7 @@ trajectory = robot.rollout_to(
     initial_state=initial_state,
     u=u,
     t1=5.0,
-    dt=1e-3,
+    solver_dt=1e-3,
     solver=Tsit5()
 )
 ts = trajectory.t

--- a/docs/api/pendulum/tendon-actuated-pendulum.md
+++ b/docs/api/pendulum/tendon-actuated-pendulum.md
@@ -154,7 +154,7 @@ qd0 = jnp.zeros_like(q0)                    # Initial velocities
 u = jnp.array([2.0])                        # Constant motor input
 
 # Time integration
-ts, qs, qds = robot.resolve_upon_time(
+ts, qs, qds, us = robot.resolve_upon_time(
     q0=q0,
     qd0=qd0,
     u=u,

--- a/docs/api/pendulum/tendon-actuated-pendulum.md
+++ b/docs/api/pendulum/tendon-actuated-pendulum.md
@@ -155,9 +155,10 @@ qd0 = jnp.zeros_like(q0)                    # Initial velocities
 u = jnp.array([2.0])                        # Constant motor input
 
 # Time integration
-initial_state = SystemState(t=0.0, y=jnp.concatenate([q0, qd0]), u=u)
-trajectory = robot.resolve_upon_time(
+initial_state = SystemState(t=0.0, y=jnp.concatenate([q0, qd0]))
+trajectory = robot.rollout_to(
     initial_state=initial_state,
+    u=u,
     t1=5.0,
     dt=1e-3,
     solver=Tsit5()

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -29,7 +29,7 @@ python tools/benchmarks/benchmark_system_methods.py \
   --systems pendulum planar_pcs pcs \
   --segment-counts 1 3 5 7 \
   --duration 2.0 \
-  --dt 5e-4 \
+  --solver-dt 5e-4 \
   --execution-repeats 5 \
   --csv benchmarks/methods.csv \
   --plot benchmarks/methods.png
@@ -39,7 +39,7 @@ python tools/benchmarks/benchmark_system_methods.py \
 
 - `--systems`: subset of available robots (defaults to all registered systems).
 - `--segment-counts`: link/segment sweep; a fresh system instance is created per value.
-- `--duration`, `--dt`, `--save-dt`: integration controls when benchmarking
+- `--duration`, `--solver-dt` (`--dt` alias), `--save-dt`: integration controls when benchmarking
   `rollout_to`.
 - `--execution-repeats`: number of warm calls to average after the cold run.
 - `--json` / `--csv`: export raw results for regression tracking.
@@ -73,7 +73,7 @@ python tools/benchmarks/benchmark_simulation_batch_scaling.py \
   --segment-counts 1 3 5 \
   --batch-sizes 1 2 4 8 16 32 64 \
   --duration 2.0 \
-  --dt 5e-4 \
+  --solver-dt 5e-4 \
   --csv benchmarks/batch-scaling.csv \
   --plot benchmarks/batch-scaling.png \
   --log-x --log-y
@@ -82,7 +82,7 @@ python tools/benchmarks/benchmark_simulation_batch_scaling.py \
 ### Key options
 
 - `--batch-sizes`: number of environments to launch per measurement.
-- Shared `--systems`, `--segment-counts`, `--duration`, `--dt`, `--save-dt`.
+- Shared `--systems`, `--segment-counts`, `--duration`, `--solver-dt` (`--dt` alias), `--save-dt`.
 - `--noise-scale`: per-environment perturbation applied to `q`/`qd` to avoid feeding
   identical states to all replicas (helps stress vectorisation paths).
 - `--repeats`, `--warmup-runs`: control timing stability.

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -40,7 +40,7 @@ python tools/benchmarks/benchmark_system_methods.py \
 - `--systems`: subset of available robots (defaults to all registered systems).
 - `--segment-counts`: link/segment sweep; a fresh system instance is created per value.
 - `--duration`, `--dt`, `--save-dt`: integration controls when benchmarking
-  `resolve_upon_time`.
+  `rollout_to`.
 - `--execution-repeats`: number of warm calls to average after the cold run.
 - `--json` / `--csv`: export raw results for regression tracking.
 - `--plot` / `--show-plot`: render Matplotlib summaries (compile vs. exec time).
@@ -95,7 +95,7 @@ For each combination of system, segment count, and number of environments the sc
 
 - Wall-clock time averaged over the requested repeats.
 - Mean simulated time per environment (i.e., the final timestamp returned by
-  `resolve_upon_time`).
+  `rollout_to`).
 - Per-environment speed ratio `simulated_time / wall_time`, total throughput
   `number_of_environments * simulated_time / wall_time`, and per-environment wall time. Ratios > 1
   indicate faster-than-real-time performance.
@@ -112,7 +112,7 @@ To revisit stored measurements (JSON or CSV) without re-running the benchmarks, 
 ```bash
 python tools/benchmarks/visualize_benchmarks.py benchmarks/methods.json \
   --systems planar_pcs pcs \
-  --functions resolve_upon_time forward_dynamics \
+  --functions rollout_to forward_dynamics \
   --output benchmarks/methods-focus.png
 ```
 

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -46,7 +46,7 @@ Let's dive right in with a classic example - simulating a double pendulum to und
     ```python
     # Configure simulation
     t_span = (0.0, 5.0)  # 5 seconds
-    dt = 0.01           # 10ms timestep
+    solver_dt = 0.01    # 10ms timestep
 
     # Zero control torques
     u = jnp.zeros((num_links,))
@@ -57,8 +57,8 @@ Let's dive right in with a classic example - simulating a double pendulum to und
         initial_state=initial_state,
         u=u,
         t1=t_span[1],
-        dt=dt,
-        save_dt=dt,
+        solver_dt=solver_dt,
+        save_dt=solver_dt,
     )
     ts = trajectory.t
     qs, qds = jnp.split(trajectory.y, 2, axis=1)

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -16,6 +16,7 @@ Let's dive right in with a classic example - simulating a double pendulum to und
     import jax.numpy as jnp
     import matplotlib.pyplot as plt
     from soromox.systems import pendulum
+    from soromox.systems.system_state import SystemState
 
     # Define parameters for a double pendulum
     num_links = 2
@@ -51,15 +52,16 @@ Let's dive right in with a classic example - simulating a double pendulum to und
     u = jnp.zeros((num_links,))
 
     # Integrate using the class helper (Diffrax under the hood)
-    ts, qs, qds, us = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u=u,
-        t0=t_span[0],
+    initial_state = SystemState(t=t_span[0], y=jnp.concatenate([q0, qd0]), u=u)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=t_span[1],
         dt=dt,
-        save_dt=1,
+        save_dt=dt,
     )
+    ts = trajectory.t
+    qs, qds = jnp.split(trajectory.y, 2, axis=1)
+    us = trajectory.u
     ```
 
 === "📊 Analyze"

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -51,7 +51,7 @@ Let's dive right in with a classic example - simulating a double pendulum to und
     u = jnp.zeros((num_links,))
 
     # Integrate using the class helper (Diffrax under the hood)
-    ts, qs, qds = robot.resolve_upon_time(
+    ts, qs, qds, us = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u=u,

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -52,9 +52,10 @@ Let's dive right in with a classic example - simulating a double pendulum to und
     u = jnp.zeros((num_links,))
 
     # Integrate using the class helper (Diffrax under the hood)
-    initial_state = SystemState(t=t_span[0], y=jnp.concatenate([q0, qd0]), u=u)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=t_span[0], y=jnp.concatenate([q0, qd0]))
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=u,
         t1=t_span[1],
         dt=dt,
         save_dt=dt,

--- a/examples/simulation/gvs/simulate_gvs.py
+++ b/examples/simulation/gvs/simulate_gvs.py
@@ -244,16 +244,16 @@ if __name__ == "__main__":
     # Simulation time parameters
     t0 = 0.0
     t1 = 2.0
-    dt = 1e-4
+    solver_dt = 1e-4
     skip_step = 100  # how many time steps to skip in between video frames
-    save_dt = dt * skip_step
+    save_dt = solver_dt * skip_step
 
     initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]))
     trajectory = robot.rollout_to(
         initial_state=initial_state,
         u=u,
         t1=t1,
-        dt=dt,
+        solver_dt=solver_dt,
         save_dt=save_dt,
         max_steps=None,
     )

--- a/examples/simulation/gvs/simulate_gvs.py
+++ b/examples/simulation/gvs/simulate_gvs.py
@@ -248,9 +248,10 @@ if __name__ == "__main__":
     skip_step = 100  # how many time steps to skip in between video frames
     save_dt = dt * skip_step
 
-    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]))
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=u,
         t1=t1,
         dt=dt,
         save_dt=save_dt,

--- a/examples/simulation/gvs/simulate_gvs.py
+++ b/examples/simulation/gvs/simulate_gvs.py
@@ -246,7 +246,7 @@ if __name__ == "__main__":
     dt = 1e-4
     skip_step = 100  # how many time steps to skip in between video frames
 
-    ts, q_ts, qd_ts = robot.resolve_upon_time(
+    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u=u,

--- a/examples/simulation/gvs/simulate_gvs.py
+++ b/examples/simulation/gvs/simulate_gvs.py
@@ -11,6 +11,7 @@ from typing import List
 
 jax.config.update("jax_enable_x64", True)  # double precision
 from soromox.systems.gvs import *
+from soromox.systems.system_state import SystemState
 
 jnp.set_printoptions(
     threshold=jnp.inf,
@@ -245,17 +246,18 @@ if __name__ == "__main__":
     t1 = 2.0
     dt = 1e-4
     skip_step = 100  # how many time steps to skip in between video frames
+    save_dt = dt * skip_step
 
-    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u=u,
-        t0=t0,
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=t1,
         dt=dt,
-        skip_steps=skip_step,
+        save_dt=save_dt,
         max_steps=None,
     )
+    ts = trajectory.t
+    q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)
     print(f"Simulation completed with {len(ts)} time steps.")
 
     # =====================================================

--- a/examples/simulation/hsa/simulate_planar_hsa.py
+++ b/examples/simulation/hsa/simulate_planar_hsa.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     # Simulation time parameters
     t0 = 0.0
     t1 = 5.0
-    dt = 5e-5  # time step
+    solver_dt = 5e-5  # time step
     save_dt = 0.01
 
     initial_state = SystemState(t=t0, y=y0)
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         initial_state=initial_state,
         u=phi,
         t1=t1,
-        dt=dt,
+        solver_dt=solver_dt,
         save_dt=save_dt,
         max_steps=None,
     )

--- a/examples/simulation/hsa/simulate_planar_hsa.py
+++ b/examples/simulation/hsa/simulate_planar_hsa.py
@@ -95,9 +95,10 @@ if __name__ == "__main__":
     dt = 5e-5  # time step
     save_dt = 0.01
 
-    initial_state = SystemState(t=t0, y=y0, u=phi)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=t0, y=y0)
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=phi,
         t1=t1,
         dt=dt,
         save_dt=save_dt,

--- a/examples/simulation/hsa/simulate_planar_hsa.py
+++ b/examples/simulation/hsa/simulate_planar_hsa.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     dt = 5e-5  # time step
     save_dt = 0.01
 
-    ts, q_ts, qd_ts = robot.resolve_upon_time(
+    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u0=phi,

--- a/examples/simulation/hsa/simulate_planar_hsa.py
+++ b/examples/simulation/hsa/simulate_planar_hsa.py
@@ -10,6 +10,7 @@ from soromox.parameters.hsa_params import (
     PARAMS_FPU_HYSTERESIS_CONTROL,
 )
 from soromox.systems.planar_hsa import PlanarHSA
+from soromox.systems.system_state import SystemState
 from soromox.rendering.planar_hsa.opencv_renderer import draw_robot, animate_robot
 
 
@@ -66,6 +67,12 @@ if __name__ == "__main__":
     qd0 = jnp.zeros_like(q0)
     # Motor actuation angles
     phi = jnp.array([jnp.pi, jnp.pi / 2])
+    # initial hysteresis state
+    if consider_hysteresis:
+        z0 = jnp.zeros((robot.num_hysteresis,))
+    else:
+        z0 = jnp.array([])
+    y0 = jnp.concatenate([q0, qd0, z0])
 
     # Displaying the image
     window_name = f"Planar HSA with {num_segments} segments"
@@ -88,16 +95,16 @@ if __name__ == "__main__":
     dt = 5e-5  # time step
     save_dt = 0.01
 
-    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u0=phi,
-        t0=t0,
+    initial_state = SystemState(t=t0, y=y0, u=phi)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=t1,
         dt=dt,
         save_dt=save_dt,
         max_steps=None,
     )
+    ts = trajectory.t
+    q_ts, qd_ts, _ = jnp.split(trajectory.y, [robot.num_dofs, 2 * robot.num_dofs], axis=1)
 
     # create video
     video_width, video_height = 700, 700  # img height and width
@@ -124,7 +131,7 @@ if __name__ == "__main__":
             if not ret:
                 break
             cv2.imshow("Animation Planar HSA", frame)
-            key = cv2.waitKey(int(1000 / (1 / dt / skip_step)))
+            key = cv2.waitKey(int(1000 / (1 / save_dt)))
             if key in (27, ord("q")):
                 break
         cap.release()

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -211,9 +211,10 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]))
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=u,
         t1=t1,
         dt=dt,
         save_dt=save_dt,

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -18,6 +18,7 @@ import numpy as onp
 
 jax.config.update("jax_enable_x64", True)  # double precision
 from soromox.systems.isupport import ISupport
+from soromox.systems.system_state import SystemState
 
 jnp.set_printoptions(
     threshold=jnp.inf,
@@ -210,17 +211,17 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u=u,
-        t0=t0,
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=t1,
         dt=dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,
     )
+    ts = trajectory.t
+    q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)
 
     q1 = q_ts[-1]
     print("q1:\n", q1)

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    ts, q_ts, qd_ts = robot.resolve_upon_time(
+    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u=u,

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     # Simulation time parameters
     t0 = 0.0
     t1 = 2.0
-    dt = 5e-5
+    solver_dt = 5e-5
     save_dt = 0.01
 
     # Solver
@@ -216,7 +216,7 @@ if __name__ == "__main__":
         initial_state=initial_state,
         u=u,
         t1=t1,
-        dt=dt,
+        solver_dt=solver_dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,

--- a/examples/simulation/pcs/simulate_pcs.py
+++ b/examples/simulation/pcs/simulate_pcs.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    ts, q_ts, qd_ts = robot.resolve_upon_time(
+    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u=u,

--- a/examples/simulation/pcs/simulate_pcs.py
+++ b/examples/simulation/pcs/simulate_pcs.py
@@ -192,9 +192,10 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]))
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=u,
         t1=t1,
         dt=dt,
         save_dt=save_dt,

--- a/examples/simulation/pcs/simulate_pcs.py
+++ b/examples/simulation/pcs/simulate_pcs.py
@@ -186,7 +186,7 @@ if __name__ == "__main__":
     # Simulation time parameters
     t0 = 0.0
     t1 = 2.0
-    dt = 1e-4
+    solver_dt = 1e-4
     save_dt = 0.01
 
     # Solver
@@ -197,7 +197,7 @@ if __name__ == "__main__":
         initial_state=initial_state,
         u=u,
         t1=t1,
-        dt=dt,
+        solver_dt=solver_dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,

--- a/examples/simulation/pcs/simulate_pcs.py
+++ b/examples/simulation/pcs/simulate_pcs.py
@@ -13,6 +13,7 @@ from typing import Callable
 
 jax.config.update("jax_enable_x64", True)  # double precision
 from soromox.systems.pcs import PCS
+from soromox.systems.system_state import SystemState
 
 jnp.set_printoptions(
     threshold=jnp.inf,
@@ -191,17 +192,17 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u=u,
-        t0=t0,
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=t1,
         dt=dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,
     )
+    ts = trajectory.t
+    q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)
 
     # =====================================================
     # End-effector position upon time

--- a/examples/simulation/pcs/simulate_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_planar_pcs.py
@@ -189,7 +189,7 @@ if __name__ == "__main__":
     # Simulation time parameters
     t0 = 0.0
     t1 = 2.0
-    dt = 1e-4
+    solver_dt = 1e-4
     save_dt = 0.01
 
     # Solver
@@ -200,7 +200,7 @@ if __name__ == "__main__":
         initial_state=initial_state,
         u=u,
         t1=t1,
-        dt=dt,
+        solver_dt=solver_dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,

--- a/examples/simulation/pcs/simulate_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_planar_pcs.py
@@ -11,6 +11,7 @@ import numpy as onp
 
 jax.config.update("jax_enable_x64", True)  # double precision
 from soromox.systems.planar_pcs import PlanarPCS
+from soromox.systems.system_state import SystemState
 
 jnp.set_printoptions(
     threshold=jnp.inf,
@@ -194,17 +195,17 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u=u,
-        t0=t0,
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=t1,
         dt=dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,
     )
+    ts = trajectory.t
+    q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)
 
     # =====================================================
     # End-effector position upon time

--- a/examples/simulation/pcs/simulate_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_planar_pcs.py
@@ -194,7 +194,7 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    ts, q_ts, qd_ts = robot.resolve_upon_time(
+    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u=u,

--- a/examples/simulation/pcs/simulate_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_planar_pcs.py
@@ -195,9 +195,10 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]))
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=u,
         t1=t1,
         dt=dt,
         save_dt=save_dt,

--- a/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
@@ -351,7 +351,7 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    ts, q_ts, qd_ts = robot.resolve_upon_time(
+    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u=u,

--- a/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
@@ -352,9 +352,10 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]))
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=u,
         t1=t1,
         dt=dt,
         save_dt=save_dt,

--- a/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
@@ -16,6 +16,7 @@ jax.config.update("jax_enable_x64", True)  # double precision
 from soromox.systems.pneumatic_actuated_planar_pcs import (
     PneumaticActuatedPlanarPCS,
 )
+from soromox.systems.system_state import SystemState
 
 
 def draw_robot(
@@ -351,17 +352,17 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u=u,
-        t0=t0,
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=t1,
         dt=dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,
     )
+    ts = trajectory.t
+    q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)
 
     # =====================================================
     # End-effector position upon time

--- a/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
@@ -346,7 +346,7 @@ if __name__ == "__main__":
     # Simulation time parameters
     t0 = 0.0
     t1 = 7.0
-    dt = 5e-5
+    solver_dt = 5e-5
     save_dt = 0.01
 
     # Solver
@@ -357,7 +357,7 @@ if __name__ == "__main__":
         initial_state=initial_state,
         u=u,
         t1=t1,
-        dt=dt,
+        solver_dt=solver_dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,

--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -340,9 +340,10 @@ if __name__ == "__main__":
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
     initial_time = time.time()
-    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]))
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=u,
         t1=t1,
         dt=dt,
         save_dt=save_dt,

--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -339,7 +339,7 @@ if __name__ == "__main__":
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
     initial_time = time.time()
-    ts, q_ts, qd_ts = robot.resolve_upon_time(
+    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u=u,

--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -333,7 +333,7 @@ if __name__ == "__main__":
     # Simulation time parameters
     t0 = 0.0
     t1 = 2.0
-    dt = 1e-4
+    solver_dt = 1e-4
     save_dt = 0.01
 
     # Solver
@@ -345,7 +345,7 @@ if __name__ == "__main__":
         initial_state=initial_state,
         u=u,
         t1=t1,
-        dt=dt,
+        solver_dt=solver_dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,
@@ -353,7 +353,9 @@ if __name__ == "__main__":
     ts = trajectory.t
     q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)
     end_time = time.time()
-    print(f"Total simulation time = {round(end_time - initial_time, ndigits=3)} s  |  t0 = {t0}, t1 = {t1}, dt0 = {dt}")
+    print(
+        f"Total simulation time = {round(end_time - initial_time, ndigits=3)} s  |  t0 = {t0}, t1 = {t1}, solver_dt0 = {solver_dt}"
+    )
 
     # =====================================================
     # End-effector position upon time

--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -16,6 +16,7 @@ from functools import partial
 import time
 
 from soromox.systems.tendon_actuated_pcs import TendonActuatedPCS
+from soromox.systems.system_state import SystemState
 
 jax.config.update("jax_enable_x64", True)  # double precision
 
@@ -339,17 +340,17 @@ if __name__ == "__main__":
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
     initial_time = time.time()
-    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u=u,
-        t0=t0,
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=t1,
         dt=dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,
     )
+    ts = trajectory.t
+    q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)
     end_time = time.time()
     print(f"Total simulation time = {round(end_time - initial_time, ndigits=3)} s  |  t0 = {t0}, t1 = {t1}, dt0 = {dt}")
 

--- a/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
@@ -264,7 +264,7 @@ if __name__ == "__main__":
     # Simulation time parameters
     t0 = 0.0
     t1 = 10.0
-    dt = 1e-4
+    solver_dt = 1e-4
     save_dt = 0.01
 
     # Solver
@@ -275,7 +275,7 @@ if __name__ == "__main__":
         initial_state=initial_state,
         u=u,
         t1=t1,
-        dt=dt,
+        solver_dt=solver_dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,

--- a/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
@@ -270,9 +270,10 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]))
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=u,
         t1=t1,
         dt=dt,
         save_dt=save_dt,

--- a/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
@@ -269,7 +269,7 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    ts, q_ts, qd_ts = robot.resolve_upon_time(
+    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u=u,

--- a/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
@@ -17,6 +17,7 @@ jax.config.update("jax_enable_x64", True)  # double precision
 from soromox.rendering.animation import animate_cv2
 from soromox.rendering.planar_pcs.opencv_renderer import render_planar_pcs
 from soromox.systems.tendon_actuated_planar_pcs import TendonActuatedPlanarPCS
+from soromox.systems.system_state import SystemState
 
 
 videos_dir = Path("videos")
@@ -269,17 +270,17 @@ if __name__ == "__main__":
     # Solver
     solver = Tsit5()  # Runge-Kutta 5(4) method
 
-    ts, q_ts, qd_ts, _ = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u=u,
-        t0=t0,
+    initial_state = SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=t1,
         dt=dt,
         save_dt=save_dt,
         solver=solver,
         max_steps=None,
     )
+    ts = trajectory.t
+    q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)
     print("Final configuration q(t1) =\n", q_ts[-1])
 
     # =====================================================

--- a/examples/simulation/pendulum/simulate_pendulum.py
+++ b/examples/simulation/pendulum/simulate_pendulum.py
@@ -12,6 +12,7 @@ from typing import Callable, Dict
 
 import soromox
 from soromox.systems import pendulum
+from soromox.systems.system_state import SystemState
 
 num_links = 2
 params = {
@@ -85,15 +86,15 @@ if __name__ == "__main__":
     print("yd0:\n", yd)
 
     # Integrate using the model's built-in solver
-    ts_out, q_ts, qd_ts, _ = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u=u,
-        t0=ts[0],
+    initial_state = SystemState(t=ts[0], y=jnp.concatenate([q0, qd0]), u=u)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=ts[-1],
         dt=dt,
         save_dt=save_dt,
     )
+    ts_out = trajectory.t
+    q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)
     video_ts = ts_out
     print("Final configuration:\n", q_ts[-1])
 

--- a/examples/simulation/pendulum/simulate_pendulum.py
+++ b/examples/simulation/pendulum/simulate_pendulum.py
@@ -86,9 +86,10 @@ if __name__ == "__main__":
     print("yd0:\n", yd)
 
     # Integrate using the model's built-in solver
-    initial_state = SystemState(t=ts[0], y=jnp.concatenate([q0, qd0]), u=u)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=ts[0], y=jnp.concatenate([q0, qd0]))
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=u,
         t1=ts[-1],
         dt=dt,
         save_dt=save_dt,

--- a/examples/simulation/pendulum/simulate_pendulum.py
+++ b/examples/simulation/pendulum/simulate_pendulum.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     print("yd0:\n", yd)
 
     # Integrate using the model's built-in solver
-    ts_out, q_ts, qd_ts = robot.resolve_upon_time(
+    ts_out, q_ts, qd_ts, _ = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u=u,

--- a/examples/simulation/pendulum/simulate_pendulum.py
+++ b/examples/simulation/pendulum/simulate_pendulum.py
@@ -28,8 +28,8 @@ q0 = jnp.zeros((num_links,))
 q0 = jnp.array([jnp.pi / 8, -jnp.pi / 4])
 
 # set simulation parameters
-dt = 1e-4  # time step
-ts = jnp.arange(0.0, 5, dt)  # time steps
+solver_dt = 1e-4  # time step
+ts = jnp.arange(0.0, 5, solver_dt)  # time steps
 save_dt = 0.01
 
 # video settings
@@ -91,7 +91,7 @@ if __name__ == "__main__":
         initial_state=initial_state,
         u=u,
         t1=ts[-1],
-        dt=dt,
+        solver_dt=solver_dt,
         save_dt=save_dt,
     )
     ts_out = trajectory.t
@@ -176,7 +176,7 @@ if __name__ == "__main__":
     video = cv2.VideoWriter(
         str(video_path),
         fourcc,
-        1 / (save_dt * dt),  # fps
+        1 / (save_dt * solver_dt),  # fps
         (video_width, video_height),
     )
 

--- a/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
+++ b/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
@@ -12,6 +12,7 @@ from functools import partial
 
 import soromox
 from soromox.systems.tendon_actuated_pendulum import TendonActuatedPendulum
+from soromox.systems.system_state import SystemState
 
 import matplotlib.pyplot as plt
 
@@ -207,15 +208,15 @@ if __name__ == "__main__":
     print(robot.passive_tendon_length(q0))
 
     # Integrate using the model's built-in solver
-    ts_out, qs, qds, _ = robot.resolve_upon_time(
-        q0=q0,
-        qd0=qd0,
-        u=u,
-        t0=ts[0],
+    initial_state = SystemState(t=ts[0], y=jnp.concatenate([q0, qd0]), u=u)
+    trajectory = robot.resolve_upon_time(
+        initial_state=initial_state,
         t1=ts[-1],
         dt=dt,
         save_dt=save_dt,
     )
+    ts_out = trajectory.t
+    qs, qds = jnp.split(trajectory.y, 2, axis=1)
     video_ts = ts_out
     print("Final configuration:\n", qs[-1])
 

--- a/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
+++ b/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     print(robot.passive_tendon_length(q0))
 
     # Integrate using the model's built-in solver
-    ts_out, qs, qds = robot.resolve_upon_time(
+    ts_out, qs, qds, _ = robot.resolve_upon_time(
         q0=q0,
         qd0=qd0,
         u=u,

--- a/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
+++ b/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
@@ -39,9 +39,9 @@ q0 = jnp.zeros((num_links,))
 # q0 = jnp.array([jnp.pi / 8, -jnp.pi / 4])
 
 # set simulation parameters
-dt = 1e-4  # time step
-ts = jnp.arange(0.0, 5, dt)  # time steps
-save_dt = dt * 100
+solver_dt = 1e-4  # time step
+ts = jnp.arange(0.0, 5, solver_dt)  # time steps
+save_dt = solver_dt * 100
 
 # video settings
 video_width, video_height = 1080, 1080  # img height and width
@@ -213,7 +213,7 @@ if __name__ == "__main__":
         initial_state=initial_state,
         u=u,
         t1=ts[-1],
-        dt=dt,
+        solver_dt=solver_dt,
         save_dt=save_dt,
     )
     ts_out = trajectory.t

--- a/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
+++ b/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
@@ -208,9 +208,10 @@ if __name__ == "__main__":
     print(robot.passive_tendon_length(q0))
 
     # Integrate using the model's built-in solver
-    initial_state = SystemState(t=ts[0], y=jnp.concatenate([q0, qd0]), u=u)
-    trajectory = robot.resolve_upon_time(
+    initial_state = SystemState(t=ts[0], y=jnp.concatenate([q0, qd0]))
+    trajectory = robot.rollout_to(
         initial_state=initial_state,
+        u=u,
         t1=ts[-1],
         dt=dt,
         save_dt=save_dt,

--- a/src/soromox/systems/__init__.py
+++ b/src/soromox/systems/__init__.py
@@ -1,0 +1,3 @@
+from soromox.systems.system_state import SystemState
+
+__all__ = ["SystemState"]

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -2,7 +2,7 @@ __all__ = ["DynamicalSystem"]
 import warnings
 import equinox as eqx
 import jax
-from jax import Array, jit, vmap
+from jax import Array, jit, lax, vmap
 from jax import numpy as jnp
 from typing import Any, Callable, Optional, Tuple
 
@@ -252,3 +252,179 @@ class DynamicalSystem(eqx.Module):
         us = u_controls + base_u
 
         return SystemState(t=ts, y=y_out, u=us, control_state=controller_state_out)
+
+    def rollout_discrete_closed_loop_to(
+        self,
+        initial_state: SystemState,
+        controller: Callable[[SystemState], Tuple[Array, Optional[Any]]],
+        tau_ext: Optional[Array] = None,
+        t1: Optional[float] = 10.0,
+        dt: Optional[float] = 1e-4,
+        control_dt: Optional[float] = 1e-2,
+        save_ts: Optional[Array] = None,
+        save_dt: Optional[float] = 0.01,
+        solver: Optional[AbstractSolver] = Tsit5(),
+        stepsize_controller: Optional[AbstractStepSizeController] = ConstantStepSize(),
+        max_steps: Optional[int] = None,
+    ) -> SystemState:
+        """
+        Roll out the system in discrete-time closed loop.
+
+        The controller is evaluated every ``control_dt`` seconds. Between control
+        evaluations the actuation is held constant and the system is integrated
+        with Diffrax (equivalent to repeatedly calling ``rollout_to`` over each
+        control interval).
+
+        The controller signature mirrors ``rollout_closed_loop_to``. If it returns a
+        ``control_state_dot`` and ``initial_state.control_state`` is provided, the
+        control state is advanced with a forward-Euler step over the control period;
+        otherwise the control state is held constant between controller calls.
+
+        Args:
+            initial_state: initial time/state (and optional feedforward actuation/control state).
+            controller: callable returning ``(u_control, control_state_dot)``.
+            tau_ext: constant external wrench/force applied during the rollout.
+            t1: final time of the simulation.
+            dt: initial step size for the solver.
+            control_dt: sampling period for the controller. Must be positive.
+            save_ts: explicit times to save; falls back to ``save_dt``.
+            save_dt: save interval if ``save_ts`` is not provided.
+            solver: Diffrax solver.
+            stepsize_controller: Diffrax stepsize controller.
+            max_steps: maximum solver steps.
+        """
+        if control_dt <= 0.0:
+            raise ValueError("control_dt must be positive.")
+
+        if controller is None:
+            raise ValueError("A controller must be provided for closed-loop rollouts.")
+        if save_ts is None:
+            save_ts = self._compute_save_times(float(initial_state.t), t1, dt, save_ts, save_dt)
+
+        base_u = initial_state.u
+        if base_u is None:
+            base_u = jnp.zeros((self.num_actuators,))
+
+        y_curr = initial_state.y
+        control_state = initial_state.control_state
+        track_control_state = control_state is not None
+        zero_control_state_dot = self._zero_like_control_state(control_state)
+
+        t_curr = float(initial_state.t)
+        total_horizon = t1 - t_curr
+        num_control_steps = int(jnp.ceil(total_horizon / control_dt))
+        t_starts = t_curr + control_dt * jnp.arange(num_control_steps)
+        t_ends = jnp.minimum(t_starts + control_dt, t1)
+
+        max_saves = save_ts.shape[0]
+
+        def body(
+            carry: Tuple[Array, Optional[Any]],
+            t_bounds: Tuple[Array, Array],
+        ) -> Tuple[Tuple[Array, Optional[Any]], Tuple[Array, Array, Array, Optional[Any], Array]]:
+            """
+            Advance one control interval: evaluate controller at ``t_start``, hold actuation
+            for the interval, integrate dynamics, and return padded saved trajectories.
+            
+            Args:
+                carry: tuple of current state ``y_in`` and current control state ``ctrl_state_in``.
+                t_bounds: tuple of start and end times for this control interval.
+            Returns:
+                next_carry: tuple of next state and next control state.
+                outputs: tuple of padded saved times, states, actuations, control states, and count
+                    of valid saved steps.
+            """
+            y_in, ctrl_state_in = carry
+            t_start, t_end = t_bounds
+
+            system_state = SystemState(t=t_start, y=y_in, u=base_u, control_state=ctrl_state_in)
+            u_control, control_state_dot = controller(system_state)
+            if control_state_dot is not None and not track_control_state:
+                raise ValueError(
+                    "Controller returned a control_state derivative but no initial control_state was provided."
+                )
+            control_state_dot = control_state_dot if control_state_dot is not None else zero_control_state_dot
+
+            u_total = base_u + u_control
+
+            mask = (save_ts >= t_start) & (save_ts <= t_end)
+            count = jnp.sum(mask, dtype=jnp.int32)
+            idxs = jnp.nonzero(mask, size=max_saves, fill_value=0)[0]
+
+            @jit
+            def open_loop_forward_dynamics(t: Array, y: Array, actuation_args: Tuple[Array, Array]):
+                base_u_val, base_tau_ext = actuation_args
+                return self.forward_dynamics(t, y, (base_u_val, base_tau_ext))
+
+            term = ODETerm(open_loop_forward_dynamics)
+            saveat = SaveAt(ts=save_ts[idxs[:count]], t1=True)
+            sol = diffeqsolve(
+                terms=term,
+                solver=solver,
+                t0=t_start,
+                t1=t_end,
+                dt0=dt,
+                y0=y_in,
+                args=(u_total, tau_ext),
+                saveat=saveat,
+                stepsize_controller=stepsize_controller,
+                max_steps=max_steps,
+            )
+
+            ts_out = jnp.zeros((max_saves,), dtype=sol.ts.dtype)
+            ts_out = ts_out.at[:count].set(sol.ts[:count])
+
+            ys_out = jnp.zeros((max_saves,) + y_in.shape, dtype=sol.ys.dtype)
+            ys_out = ys_out.at[:count].set(sol.ys[:count])
+
+            us_out = jnp.zeros((max_saves, self.num_actuators), dtype=u_total.dtype)
+            us_out = us_out.at[:count].set(jnp.broadcast_to(u_total, (count, u_total.shape[0])))
+
+            if track_control_state:
+                cs_segment = jax.tree_util.tree_map(
+                    lambda c: jnp.zeros((max_saves,) + c.shape, dtype=c.dtype),
+                    ctrl_state_in,
+                )
+                mask = (jnp.arange(max_saves) < count).astype(jnp.int32)
+                cs_out = jax.tree_util.tree_map(
+                    lambda arr, c: arr
+                    + mask.reshape((max_saves,) + (1,) * c.ndim) * c,
+                    cs_segment,
+                    ctrl_state_in,
+                )
+            else:
+                cs_out = None
+
+            y_next = sol.ys[-1]
+            ctrl_state_next = (
+                jax.tree_util.tree_map(
+                    lambda c, cdot: c + cdot * (t_end - t_start), ctrl_state_in, control_state_dot
+                )
+                if track_control_state
+                else None
+            )
+
+            outputs = (ts_out, ys_out, us_out, cs_out, count)
+            next_carry = (y_next, ctrl_state_next)
+            return next_carry, outputs
+
+        _, scan_outputs = lax.scan(body, (y_curr, control_state), (t_starts, t_ends))
+        ts_padded, ys_padded, us_padded, cs_padded, counts = scan_outputs
+
+        idxs = jnp.arange(max_saves)
+        valid_mask = idxs[None, :] < counts[:, None]
+        flat_mask = valid_mask.reshape(-1)
+
+        ts_all = ts_padded.reshape(-1)[flat_mask]
+        ys_all = ys_padded.reshape((-1,) + ys_padded.shape[2:])[flat_mask]
+        us_all = us_padded.reshape((-1, self.num_actuators))[flat_mask]
+
+        if track_control_state and cs_padded is not None:
+            control_state_out = jax.tree_util.tree_map(
+                lambda arr: arr.reshape((-1,) + arr.shape[2:])[flat_mask],
+                cs_padded,
+            )
+        else:
+            control_state_out = None
+
+        return SystemState(t=ts_all, y=ys_all, u=us_all, control_state=control_state_out)

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -319,6 +319,7 @@ class DynamicalSystem(eqx.Module):
         t_ends = jnp.minimum(t_starts + control_dt, t1)
 
         max_saves = save_ts.shape[0]
+        max_save_slots = max_saves + 1  # include control interval end time
 
         def body(
             carry: Tuple[Array, Optional[Any]],
@@ -352,6 +353,9 @@ class DynamicalSystem(eqx.Module):
             mask = (save_ts >= t_start) & (save_ts <= t_end)
             count = jnp.sum(mask, dtype=jnp.int32)
             idxs = jnp.nonzero(mask, size=max_saves, fill_value=0)[0]
+            valid_mask = jnp.arange(max_save_slots - 1) < count
+            ts_control_interval = jnp.where(valid_mask, save_ts[idxs], t_end)
+            ts_control_interval = jnp.concatenate((ts_control_interval, jnp.array([t_end])))
 
             @jit
             def open_loop_forward_dynamics(t: Array, y: Array, actuation_args: Tuple[Array, Array]):
@@ -359,7 +363,7 @@ class DynamicalSystem(eqx.Module):
                 return self.forward_dynamics(t, y, (base_u_val, base_tau_ext))
 
             term = ODETerm(open_loop_forward_dynamics)
-            saveat = SaveAt(ts=save_ts[idxs[:count]], t1=True)
+            saveat = SaveAt(ts=ts_control_interval, t1=False)
             sol = diffeqsolve(
                 terms=term,
                 solver=solver,
@@ -373,24 +377,30 @@ class DynamicalSystem(eqx.Module):
                 max_steps=max_steps,
             )
 
-            ts_out = jnp.zeros((max_saves,), dtype=sol.ts.dtype)
-            ts_out = ts_out.at[:count].set(sol.ts[:count])
+            valid_mask = (jnp.arange(max_save_slots) < (count + 1)).astype(sol.ts.dtype)
+            ts_out = sol.ts * valid_mask
 
-            ys_out = jnp.zeros((max_saves,) + y_in.shape, dtype=sol.ys.dtype)
-            ys_out = ys_out.at[:count].set(sol.ys[:count])
+            ys_out = jnp.where(
+                valid_mask[:, None] > 0,
+                sol.ys,
+                jnp.zeros_like(sol.ys),
+            )
 
-            us_out = jnp.zeros((max_saves, self.num_actuators), dtype=u_total.dtype)
-            us_out = us_out.at[:count].set(jnp.broadcast_to(u_total, (count, u_total.shape[0])))
+            us_out = jnp.where(
+                valid_mask[:, None] > 0,
+                jnp.broadcast_to(u_total, (max_save_slots, u_total.shape[0])),
+                jnp.zeros((max_save_slots, u_total.shape[0]), dtype=u_total.dtype),
+            )
 
             if track_control_state:
                 cs_segment = jax.tree_util.tree_map(
-                    lambda c: jnp.zeros((max_saves,) + c.shape, dtype=c.dtype),
+                    lambda c: jnp.zeros((max_save_slots,) + c.shape, dtype=c.dtype),
                     ctrl_state_in,
                 )
-                mask = (jnp.arange(max_saves) < count).astype(jnp.int32)
+                mask = (jnp.arange(max_save_slots) < (count + 1)).astype(jnp.int32)
                 cs_out = jax.tree_util.tree_map(
                     lambda arr, c: arr
-                    + mask.reshape((max_saves,) + (1,) * c.ndim) * c,
+                    + mask.reshape((max_save_slots,) + (1,) * c.ndim) * c,
                     cs_segment,
                     ctrl_state_in,
                 )
@@ -406,14 +416,14 @@ class DynamicalSystem(eqx.Module):
                 else None
             )
 
-            outputs = (ts_out, ys_out, us_out, cs_out, count)
+            outputs = (ts_out, ys_out, us_out, cs_out, count + 1)
             next_carry = (y_next, ctrl_state_next)
             return next_carry, outputs
 
         _, scan_outputs = lax.scan(body, (y_curr, control_state), (t_starts, t_ends))
         ts_padded, ys_padded, us_padded, cs_padded, counts = scan_outputs
 
-        idxs = jnp.arange(max_saves)
+        idxs = jnp.arange(max_save_slots)
         valid_mask = idxs[None, :] < counts[:, None]
         flat_mask = valid_mask.reshape(-1)
 

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -1,4 +1,5 @@
 __all__ = ["DynamicalSystem"]
+import warnings
 import equinox as eqx
 import jax
 from jax import Array, jit, vmap
@@ -22,12 +23,34 @@ from soromox.systems.system_state import SystemState
 class DynamicalSystem(eqx.Module):
     num_actuators: int = eqx.field(static=True)  # Number of actuators
 
-    def resolve_upon_time(
+    @staticmethod
+    def _compute_save_times(
+        t0: float,
+        t1: float,
+        dt: float,
+        save_ts: Optional[Array],
+        save_dt: Optional[float],
+    ) -> Array:
+        """Build the array of time stamps to save during integration."""
+        if save_ts is not None:
+            return save_ts
+
+        assert save_dt is not None, "Either save_ts or save_dt must be provided."
+        assert save_dt > 0.0, "save_dt must be positive."
+        assert save_dt >= dt, "save_dt must be greater than or equal to the simulation dt."
+        return jnp.arange(t0, t1 + save_dt, save_dt)
+
+    @staticmethod
+    def _zero_like_control_state(control_state: Optional[Any]) -> Optional[Any]:
+        """Create a zero-structured control_state derivative matching the provided PyTree."""
+        if control_state is None:
+            return None
+        return jax.tree_util.tree_map(jnp.zeros_like, control_state)
+
+    def rollout_to(
         self,
         initial_state: SystemState,
-        controller: Optional[
-            Callable[[SystemState], Tuple[Array, Optional[Any]]]
-        ] = None,
+        u: Optional[Array] = None,
         tau_ext: Optional[Array] = None,
         t1: Optional[float] = 10.0,
         dt: Optional[float] = 1e-4,
@@ -38,15 +61,14 @@ class DynamicalSystem(eqx.Module):
         max_steps: Optional[int] = None,
     ) -> SystemState:
         """
-        Resolve the system dynamics over time using Diffrax.
+        Roll out the system dynamics in open loop using Diffrax.
 
         Args:
             initial_state: Dataclass holding the initial time, system state vector (y),
-                optional actuation (u), and optional controller state.
-            controller: Callable that accepts a `SystemState` and returns a tuple
-                `(u_control, control_state_dot)`. `u_control` is added to the base
-                actuation from the initial state.
-            tau_ext: External forces/torques applied to the system.
+                optional actuation (u), and optional control state.
+            u: Constant actuation to apply throughout the rollout. If not provided,
+                falls back to `initial_state.u`, then zeros.
+            tau_ext: External forces/torques applied to the system (broadcast as constant).
             t1: Final time of the simulation, included in the saved trajectory.
             dt: Time step for the solver.
             save_ts: Explicit time points to be saved in the output. Must be within
@@ -59,86 +81,142 @@ class DynamicalSystem(eqx.Module):
 
         Returns:
             SystemState PyTree containing time samples, system state trajectory,
-            actuation at each saved step, and (optionally) the controller state
-            trajectory. Each leaf has a leading time dimension aligned with
-            `save_ts`.
+            actuation at each saved step, and (optionally) the control state
+            trajectory. Each leaf has a leading time dimension aligned with `save_ts`.
         """
-        base_u = initial_state.u
+        if initial_state.control_state is not None:
+            warnings.warn(
+                "control_state provided to rollout_to is ignored for open-loop rollouts.",
+                UserWarning,
+                stacklevel=2,
+            )
+        base_u = u if u is not None else initial_state.u
         if base_u is None:
             base_u = jnp.zeros((self.num_actuators,))
 
         y0 = initial_state.y  # initial state vector
+        t0 = float(initial_state.t)
+        save_ts = self._compute_save_times(t0, t1, dt, save_ts, save_dt)
+
+        @jit
+        def open_loop_forward_dynamics(
+            t: Array, ode_state, actuation_args: Tuple[Array, Array]
+        ):
+            base_u_val, base_tau_ext = actuation_args
+            y = ode_state
+            return self.forward_dynamics(t, y, (base_u_val, base_tau_ext))
+
+        forward_dynamics = open_loop_forward_dynamics
+
+        term = ODETerm(forward_dynamics)
+        saveat = SaveAt(ts=save_ts)  # Save at specified time points
+
+        sol = diffeqsolve(
+            terms=term,
+            solver=solver,
+            t0=t0,
+            t1=t1 + dt,
+            dt0=dt,
+            y0=y0,
+            args=(base_u, tau_ext),
+            saveat=saveat,
+            stepsize_controller=stepsize_controller,
+            max_steps=max_steps,
+        )
+
+        ts = sol.ts
+        y_out = sol.ys
+
+        us = jnp.broadcast_to(base_u, (ts.shape[0], base_u.shape[0]))
+
+        return SystemState(t=ts, y=y_out, u=us, control_state=None)
+
+    def rollout_closed_loop_to(
+        self,
+        initial_state: SystemState,
+        controller: Callable[[SystemState], Tuple[Array, Optional[Any]]],
+        tau_ext: Optional[Array] = None,
+        t1: Optional[float] = 10.0,
+        dt: Optional[float] = 1e-4,
+        save_ts: Optional[Array] = None,
+        save_dt: Optional[float] = 0.01,
+        solver: Optional[AbstractSolver] = Tsit5(),
+        stepsize_controller: Optional[AbstractStepSizeController] = ConstantStepSize(),
+        max_steps: Optional[int] = None,
+    ) -> SystemState:
+        """
+        Roll out the system dynamics in closed loop using Diffrax.
+
+        The provided controller is queried at every integration step with the current
+        system state (and optional control_state). Its actuation output is added to any
+        feed-forward actuation contained in `initial_state.u`.
+
+        Args:
+            initial_state: Dataclass holding the initial time, system state vector (y),
+                optional actuation (u), and optional control state.
+            controller: Callable that accepts a `SystemState` and returns a tuple
+                `(u_control, control_state_dot)`. `u_control` is added to the base
+                actuation from the initial state.
+            tau_ext: External forces/torques applied to the system (broadcast as constant).
+            t1: Final time of the simulation, included in the saved trajectory.
+            dt: Time step for the solver.
+            save_ts: Explicit time points to be saved in the output. Must be within
+                [initial_state.t, t1]. Falls back to `save_dt` if None.
+            save_dt: Time interval at which to save the solution when `save_ts` is
+                not provided.
+            solver: Solver to use for the ODE integration.
+            stepsize_controller: Stepsize controller for the solver.
+            max_steps: Maximum number of steps for the solver.
+
+        Returns:
+            SystemState PyTree containing time samples, system state trajectory,
+            actuation at each saved step, and controller state trajectory. Each
+            leaf has a leading time dimension aligned with `save_ts`.
+        """
+        if controller is None:
+            raise ValueError("A controller must be provided for closed-loop rollouts.")
+
+        base_u = initial_state.u
+        if base_u is None:
+            base_u = jnp.zeros((self.num_actuators,))
+
+        y0 = initial_state.y
 
         controller_state0 = initial_state.control_state
         track_control_state = controller_state0 is not None
-        zero_control_state_dot = (
-            None
-            if not track_control_state
-            else jnp.zeros_like(controller_state0)
-            if isinstance(controller_state0, Array)
-            else jax.tree_util.tree_map(jnp.zeros_like, controller_state0)
-        )
+        zero_control_state_dot = self._zero_like_control_state(controller_state0)
 
         t0 = float(initial_state.t)
+        save_ts = self._compute_save_times(t0, t1, dt, save_ts, save_dt)
 
-        if save_ts is None:
-            assert save_dt is not None, "Either save_ts or save_dt must be provided."
-            assert save_dt > 0.0, "save_dt must be positive."
-            assert save_dt >= dt, "save_dt must be greater than or equal to the simulation dt."
-            save_ts = jnp.arange(t0, t1 + save_dt, save_dt)
+        @jit
+        def closed_loop_forward_dynamics(
+            t: Array, ode_state, actuation_args: Tuple[Array, Array]
+        ):
+            """
+            Evaluate the controller at (t, y[, control_state]) and apply it to the forward dynamics.
+            """
+            base_u_val, base_tau_ext = actuation_args
+            if track_control_state:
+                y, ctrl_state = ode_state
+            else:
+                y = ode_state
+                ctrl_state = None
 
+            system_state = SystemState(t=t, y=y, u=base_u_val, control_state=ctrl_state)
+            u_control, control_state_dot = controller(system_state)
+            if control_state_dot is not None and not track_control_state:
+                raise ValueError(
+                    "Controller returned a control_state derivative but no initial control_state was provided."
+                )
+            u_total = base_u_val + u_control
+            yd = self.forward_dynamics(t, y, (u_total, base_tau_ext))
+            if track_control_state:
+                control_state_dot = control_state_dot if control_state_dot is not None else zero_control_state_dot
+                return yd, control_state_dot
+            return yd
 
-        if controller is not None:
-
-            @jit
-            def closed_loop_forward_dynamics(
-                t: Array, ode_state, actuation_args: Tuple[Array, Array]
-            ):
-                """
-                Evaluate the controller at (t, y[, control_state]) and apply it to the forward dynamics.
-                """
-                base_u_val, base_tau_ext = actuation_args
-                if track_control_state:
-                    y, ctrl_state = ode_state
-                else:
-                    y = ode_state
-                    ctrl_state = None
-
-                system_state = SystemState(t=t, y=y, u=base_u_val, control_state=ctrl_state)
-                u_control, control_state_dot = controller(system_state)
-                if control_state_dot is not None and not track_control_state:
-                    raise ValueError(
-                        "Controller returned a control_state derivative but no initial control_state was provided."
-                    )
-                u_total = base_u_val + u_control
-                yd = self.forward_dynamics(t, y, (u_total, base_tau_ext))
-                if track_control_state:
-                    control_state_dot = (
-                        control_state_dot if control_state_dot is not None else zero_control_state_dot
-                    )
-                    return yd, control_state_dot
-                return yd
-
-            forward_dynamics = closed_loop_forward_dynamics
-        else:
-
-            @jit
-            def open_loop_forward_dynamics(
-                t: Array, ode_state, actuation_args: Tuple[Array, Array]
-            ):
-                base_u_val, base_tau_ext = actuation_args
-                if track_control_state:
-                    y, _ = ode_state
-                else:
-                    y = ode_state
-                yd = self.forward_dynamics(t, y, (base_u_val, base_tau_ext))
-                if track_control_state:
-                    return yd, zero_control_state_dot
-                return yd
-
-            forward_dynamics = open_loop_forward_dynamics
-
-        term = ODETerm(forward_dynamics)
+        term = ODETerm(closed_loop_forward_dynamics)
         saveat = SaveAt(ts=save_ts)  # Save at specified time points
 
         y0_for_solver = (y0, controller_state0) if track_control_state else y0
@@ -163,20 +241,14 @@ class DynamicalSystem(eqx.Module):
             y_out = sol.ys
             controller_state_out = None
 
-        # Compute controller outputs on the saved trajectory
-        if controller is None:
-            us = jnp.broadcast_to(base_u, (ts.shape[0], base_u.shape[0]))
+        if track_control_state:
+            u_controls = vmap(
+                lambda t_i, y_i, c_i: controller(SystemState(t=t_i, y=y_i, u=base_u, control_state=c_i))[0]
+            )(ts, y_out, controller_state_out)
         else:
-            if track_control_state:
-                u_controls = vmap(
-                    lambda t_i, y_i, c_i: controller(
-                        SystemState(t=t_i, y=y_i, u=base_u, control_state=c_i)
-                    )[0]
-                )(ts, y_out, controller_state_out)
-            else:
-                u_controls = vmap(
-                    lambda t_i, y_i: controller(SystemState(t=t_i, y=y_i, u=base_u, control_state=None))[0]
-                )(ts, y_out)
-            us = u_controls + base_u
+            u_controls = vmap(
+                lambda t_i, y_i: controller(SystemState(t=t_i, y=y_i, u=base_u, control_state=None))[0]
+            )(ts, y_out)
+        us = u_controls + base_u
 
         return SystemState(t=ts, y=y_out, u=us, control_state=controller_state_out)

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -27,7 +27,7 @@ class DynamicalSystem(eqx.Module):
     def _compute_save_times(
         t0: float,
         t1: float,
-        dt: float,
+        solver_dt: float,
         save_ts: Optional[Array],
         save_dt: Optional[float],
     ) -> Array:
@@ -37,7 +37,9 @@ class DynamicalSystem(eqx.Module):
 
         assert save_dt is not None, "Either save_ts or save_dt must be provided."
         assert save_dt > 0.0, "save_dt must be positive."
-        assert save_dt >= dt, "save_dt must be greater than or equal to the simulation dt."
+        assert (
+            save_dt >= solver_dt
+        ), "save_dt must be greater than or equal to the solver step size."
         return jnp.arange(t0, t1 + save_dt, save_dt)
 
     @staticmethod
@@ -53,7 +55,7 @@ class DynamicalSystem(eqx.Module):
         u: Optional[Array] = None,
         tau_ext: Optional[Array] = None,
         t1: Optional[float] = 10.0,
-        dt: Optional[float] = 1e-4,
+        solver_dt: Optional[float] = 1e-4,
         save_ts: Optional[Array] = None,
         save_dt: Optional[float] = 0.01,
         solver: Optional[AbstractSolver] = Tsit5(),
@@ -70,7 +72,7 @@ class DynamicalSystem(eqx.Module):
                 falls back to `initial_state.u`, then zeros.
             tau_ext: External forces/torques applied to the system (broadcast as constant).
             t1: Final time of the simulation, included in the saved trajectory.
-            dt: Time step for the solver.
+            solver_dt: Time step for the solver.
             save_ts: Explicit time points to be saved in the output. Must be within
                 [initial_state.t, t1]. Falls back to `save_dt` if None.
             save_dt: Time interval at which to save the solution when `save_ts` is
@@ -96,7 +98,7 @@ class DynamicalSystem(eqx.Module):
 
         y0 = initial_state.y  # initial state vector
         t0 = float(initial_state.t)
-        save_ts = self._compute_save_times(t0, t1, dt, save_ts, save_dt)
+        save_ts = self._compute_save_times(t0, t1, solver_dt, save_ts, save_dt)
 
         @jit
         def open_loop_forward_dynamics(
@@ -115,8 +117,8 @@ class DynamicalSystem(eqx.Module):
             terms=term,
             solver=solver,
             t0=t0,
-            t1=t1 + dt,
-            dt0=dt,
+            t1=t1 + solver_dt,
+            dt0=solver_dt,
             y0=y0,
             args=(base_u, tau_ext),
             saveat=saveat,
@@ -137,7 +139,7 @@ class DynamicalSystem(eqx.Module):
         controller: Callable[[SystemState], Tuple[Array, Optional[Any]]],
         tau_ext: Optional[Array] = None,
         t1: Optional[float] = 10.0,
-        dt: Optional[float] = 1e-4,
+        solver_dt: Optional[float] = 1e-4,
         save_ts: Optional[Array] = None,
         save_dt: Optional[float] = 0.01,
         solver: Optional[AbstractSolver] = Tsit5(),
@@ -159,7 +161,7 @@ class DynamicalSystem(eqx.Module):
                 actuation from the initial state.
             tau_ext: External forces/torques applied to the system (broadcast as constant).
             t1: Final time of the simulation, included in the saved trajectory.
-            dt: Time step for the solver.
+            solver_dt: Time step for the solver.
             save_ts: Explicit time points to be saved in the output. Must be within
                 [initial_state.t, t1]. Falls back to `save_dt` if None.
             save_dt: Time interval at which to save the solution when `save_ts` is
@@ -187,7 +189,7 @@ class DynamicalSystem(eqx.Module):
         zero_control_state_dot = self._zero_like_control_state(controller_state0)
 
         t0 = float(initial_state.t)
-        save_ts = self._compute_save_times(t0, t1, dt, save_ts, save_dt)
+        save_ts = self._compute_save_times(t0, t1, solver_dt, save_ts, save_dt)
 
         @jit
         def closed_loop_forward_dynamics(
@@ -225,8 +227,8 @@ class DynamicalSystem(eqx.Module):
             terms=term,
             solver=solver,
             t0=t0,
-            t1=t1 + dt,
-            dt0=dt,
+            t1=t1 + solver_dt,
+            dt0=solver_dt,
             y0=y0_for_solver,
             args=(base_u, tau_ext),
             saveat=saveat,
@@ -259,7 +261,7 @@ class DynamicalSystem(eqx.Module):
         controller: Callable[[SystemState], Tuple[Array, Optional[Any]]],
         tau_ext: Optional[Array] = None,
         t1: Optional[float] = 10.0,
-        dt: Optional[float] = 1e-4,
+        solver_dt: Optional[float] = 1e-4,
         control_dt: Optional[float] = 1e-2,
         save_ts: Optional[Array] = None,
         save_dt: Optional[float] = 0.01,
@@ -285,7 +287,7 @@ class DynamicalSystem(eqx.Module):
             controller: callable returning ``(u_control, control_state_dot)``.
             tau_ext: constant external wrench/force applied during the rollout.
             t1: final time of the simulation.
-            dt: initial step size for the solver.
+            solver_dt: initial step size for the solver.
             control_dt: sampling period for the controller. Must be positive.
             save_ts: explicit times to save; falls back to ``save_dt``.
             save_dt: save interval if ``save_ts`` is not provided.
@@ -299,7 +301,7 @@ class DynamicalSystem(eqx.Module):
         if controller is None:
             raise ValueError("A controller must be provided for closed-loop rollouts.")
         if save_ts is None:
-            save_ts = self._compute_save_times(float(initial_state.t), t1, dt, save_ts, save_dt)
+            save_ts = self._compute_save_times(float(initial_state.t), t1, solver_dt, save_ts, save_dt)
 
         base_u = initial_state.u
         if base_u is None:
@@ -363,7 +365,7 @@ class DynamicalSystem(eqx.Module):
                 solver=solver,
                 t0=t_start,
                 t1=t_end,
-                dt0=dt,
+                dt0=solver_dt,
                 y0=y_in,
                 args=(u_total, tau_ext),
                 saveat=saveat,

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -28,8 +28,8 @@ class DynamicalSystem(eqx.Module):
         t0: float,
         t1: float,
         solver_dt: float,
-        save_ts: Optional[Array],
         save_dt: Optional[float],
+        save_ts: Optional[Array],
     ) -> Array:
         """Build the array of time stamps to save during integration."""
         if save_ts is not None:
@@ -56,8 +56,8 @@ class DynamicalSystem(eqx.Module):
         tau_ext: Optional[Array] = None,
         t1: Optional[float] = 10.0,
         solver_dt: Optional[float] = 1e-4,
-        save_ts: Optional[Array] = None,
         save_dt: Optional[float] = 0.01,
+        save_ts: Optional[Array] = None,
         solver: Optional[AbstractSolver] = Tsit5(),
         stepsize_controller: Optional[AbstractStepSizeController] = ConstantStepSize(),
         max_steps: Optional[int] = None,
@@ -73,10 +73,10 @@ class DynamicalSystem(eqx.Module):
             tau_ext: External forces/torques applied to the system (broadcast as constant).
             t1: Final time of the simulation, included in the saved trajectory.
             solver_dt: Time step for the solver.
-            save_ts: Explicit time points to be saved in the output. Must be within
-                [initial_state.t, t1]. Falls back to `save_dt` if None.
             save_dt: Time interval at which to save the solution when `save_ts` is
                 not provided.
+            save_ts: Explicit time points to be saved in the output. Must be within
+                [initial_state.t, t1]. Falls back to `save_dt` if None.
             solver: Solver to use for the ODE integration.
             stepsize_controller: Stepsize controller for the solver.
             max_steps: Maximum number of steps for the solver.
@@ -98,7 +98,7 @@ class DynamicalSystem(eqx.Module):
 
         y0 = initial_state.y  # initial state vector
         t0 = float(initial_state.t)
-        save_ts = self._compute_save_times(t0, t1, solver_dt, save_ts, save_dt)
+        save_ts = self._compute_save_times(t0, t1, solver_dt, save_dt, save_ts)
 
         @jit
         def open_loop_forward_dynamics(
@@ -140,8 +140,8 @@ class DynamicalSystem(eqx.Module):
         tau_ext: Optional[Array] = None,
         t1: Optional[float] = 10.0,
         solver_dt: Optional[float] = 1e-4,
-        save_ts: Optional[Array] = None,
         save_dt: Optional[float] = 0.01,
+        save_ts: Optional[Array] = None,
         solver: Optional[AbstractSolver] = Tsit5(),
         stepsize_controller: Optional[AbstractStepSizeController] = ConstantStepSize(),
         max_steps: Optional[int] = None,
@@ -162,10 +162,10 @@ class DynamicalSystem(eqx.Module):
             tau_ext: External forces/torques applied to the system (broadcast as constant).
             t1: Final time of the simulation, included in the saved trajectory.
             solver_dt: Time step for the solver.
-            save_ts: Explicit time points to be saved in the output. Must be within
-                [initial_state.t, t1]. Falls back to `save_dt` if None.
             save_dt: Time interval at which to save the solution when `save_ts` is
                 not provided.
+            save_ts: Explicit time points to be saved in the output. Must be within
+                [initial_state.t, t1]. Falls back to `save_dt` if None.
             solver: Solver to use for the ODE integration.
             stepsize_controller: Stepsize controller for the solver.
             max_steps: Maximum number of steps for the solver.
@@ -189,7 +189,7 @@ class DynamicalSystem(eqx.Module):
         zero_control_state_dot = self._zero_like_control_state(controller_state0)
 
         t0 = float(initial_state.t)
-        save_ts = self._compute_save_times(t0, t1, solver_dt, save_ts, save_dt)
+        save_ts = self._compute_save_times(t0, t1, solver_dt, save_dt, save_ts)
 
         @jit
         def closed_loop_forward_dynamics(
@@ -263,8 +263,8 @@ class DynamicalSystem(eqx.Module):
         t1: Optional[float] = 10.0,
         solver_dt: Optional[float] = 1e-4,
         control_dt: Optional[float] = 1e-2,
-        save_ts: Optional[Array] = None,
         save_dt: Optional[float] = 0.01,
+        save_ts: Optional[Array] = None,
         solver: Optional[AbstractSolver] = Tsit5(),
         stepsize_controller: Optional[AbstractStepSizeController] = ConstantStepSize(),
         max_steps: Optional[int] = None,
@@ -289,8 +289,8 @@ class DynamicalSystem(eqx.Module):
             t1: final time of the simulation.
             solver_dt: initial step size for the solver.
             control_dt: sampling period for the controller. Must be positive.
-            save_ts: explicit times to save; falls back to ``save_dt``.
             save_dt: save interval if ``save_ts`` is not provided.
+            save_ts: explicit times to save; falls back to ``save_dt``.
             solver: Diffrax solver.
             stepsize_controller: Diffrax stepsize controller.
             max_steps: maximum solver steps.
@@ -301,7 +301,7 @@ class DynamicalSystem(eqx.Module):
         if controller is None:
             raise ValueError("A controller must be provided for closed-loop rollouts.")
         if save_ts is None:
-            save_ts = self._compute_save_times(float(initial_state.t), t1, solver_dt, save_ts, save_dt)
+            save_ts = self._compute_save_times(float(initial_state.t), t1, solver_dt, save_dt, save_ts)
 
         base_u = initial_state.u
         if base_u is None:

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -1,9 +1,9 @@
 __all__ = ["DynamicalSystem"]
 import equinox as eqx
-from jax import Array, jit, lax, vmap
+import jax
+from jax import Array, jit, vmap
 from jax import numpy as jnp
-from pathlib import Path
-from typing import Callable, Dict, List, Tuple, Type, Union, Optional
+from typing import Any, Callable, Optional, Tuple
 
 # Diffrax (for time integration helpers)
 from diffrax import (
@@ -16,100 +16,132 @@ from diffrax import (
     AbstractSolver,
 )
 
+from soromox.systems.system_state import SystemState
+
 
 class DynamicalSystem(eqx.Module):
     num_actuators: int = eqx.field(static=True)  # Number of actuators
 
     def resolve_upon_time(
         self,
-        q0: Array,
-        qd0: Array,
-        u: Optional[Array] = None,
-        controller: Optional[Callable[[Array, Array, Array], Array]] = None,
+        initial_state: SystemState,
+        controller: Optional[
+            Callable[[SystemState], Tuple[Array, Optional[Any]]]
+        ] = None,
         tau_ext: Optional[Array] = None,
-        t0: Optional[float] = 0.0,
         t1: Optional[float] = 10.0,
         dt: Optional[float] = 1e-4,
-        saveat_ts: Optional[Array] = None,
+        save_ts: Optional[Array] = None,
         save_dt: Optional[float] = 0.01,
         solver: Optional[AbstractSolver] = Tsit5(),
         stepsize_controller: Optional[AbstractStepSizeController] = ConstantStepSize(),
         max_steps: Optional[int] = None,
-    ) -> Tuple[Array, Array, Array, Array]:
+    ) -> SystemState:
         """
         Resolve the system dynamics over time using Diffrax.
 
         Args:
-            q0 (Array): Initial configuration (strains).
-            qd0 (Array): Initial velocity (strains).
-            u (Array, optional): Actuation/control input.
-                Default is None (no actuation).
-            controller (Callable, optional): Control function/object that takes in time, configuration, and velocity,
-                and returns the actuation input. If provided, it is added to the `u` argument.
-                    => controller(t: Array, q: Array, qd: Array) -> Array
-            tau_ext (Array, optional): External forces/torques applied to the system.
-            t0 (float, optional): Initial time of the simuation, included.
-                It represents the first time step resolved by the solver. Default is 0.0.
-            t1 (float, optional): Final time of the simulation, included.
-                It represents the last time step resolved by the solver, so that the solution of the system at
-                time t1 is included in the output (we include t1 by adding dt to the interval in diffeqsolve).
-                Default is 10.0.
-            dt (float, optional): Time step for the solver.
-                Default is 1e-4.
-            saveat_ts (Array, optional): Array of time steps to be saved in the output. Must be within t0 and t1.
-                If not provided, falls back to `save_dt`.
-            save_dt (float, optional): Time interval at which to save the solution.
-                If saveat_ts is provided, this is ignored. Default is 0.01 (i.e., save every 10 ms).
-            solver (AbstractSolver, optional): Solver to use for the ODE integration.
-                Default is Tsit5() (Runge-Kutta 5(4) method).
-            stepsize_controller (PIDController, optional): Stepsize controller for the solver.
-                Default is ConstantStepSize().
-            max_steps (int, optional): Maximum number of steps for the solver.
-                Default is None (no limit).
+            initial_state: Dataclass holding the initial time, system state vector (y),
+                optional actuation (u), and optional controller state.
+            controller: Callable that accepts a `SystemState` and returns a tuple
+                `(u_control, control_state_dot)`. `u_control` is added to the base
+                actuation from the initial state.
+            tau_ext: External forces/torques applied to the system.
+            t1: Final time of the simulation, included in the saved trajectory.
+            dt: Time step for the solver.
+            save_ts: Explicit time points to be saved in the output. Must be within
+                [initial_state.t, t1]. Falls back to `save_dt` if None.
+            save_dt: Time interval at which to save the solution when `save_ts` is
+                not provided.
+            solver: Solver to use for the ODE integration.
+            stepsize_controller: Stepsize controller for the solver.
+            max_steps: Maximum number of steps for the solver.
 
         Returns:
-            ts (Array): Time points at which the solution is saved.
-            qs (Array): Configuration (strains) at the saved time points.
-            qds (Array): Velocity (strains) at the saved time points.
-            us (Array): Actuation applied at each saved time step.
+            SystemState PyTree containing time samples, system state trajectory,
+            actuation at each saved step, and (optionally) the controller state
+            trajectory. Each leaf has a leading time dimension aligned with
+            `save_ts`.
         """
-        y0 = jnp.concatenate([q0, qd0])  # Initial state vector
-        if u is None:
-            u = jnp.zeros((self.num_actuators,))
-        if tau_ext is None:
-            tau_ext = jnp.zeros((q0.shape[-1],))
-        if saveat_ts is None:
-            assert save_dt is not None, "Either saveat_ts or save_dt must be provided."
+        base_u = initial_state.u
+        if base_u is None:
+            base_u = jnp.zeros((self.num_actuators,))
+
+        y0 = initial_state.y  # initial state vector
+
+        controller_state0 = initial_state.control_state
+        track_control_state = controller_state0 is not None
+        zero_control_state_dot = (
+            None
+            if not track_control_state
+            else jnp.zeros_like(controller_state0)
+            if isinstance(controller_state0, Array)
+            else jax.tree_util.tree_map(jnp.zeros_like, controller_state0)
+        )
+
+        t0 = float(initial_state.t)
+
+        if save_ts is None:
+            assert save_dt is not None, "Either save_ts or save_dt must be provided."
             assert save_dt > 0.0, "save_dt must be positive."
             assert save_dt >= dt, "save_dt must be greater than or equal to the simulation dt."
-            saveat_ts = jnp.arange(t0, t1 + save_dt, save_dt)
+            save_ts = jnp.arange(t0, t1 + save_dt, save_dt)
+
 
         if controller is not None:
+
             @jit
             def closed_loop_forward_dynamics(
-                t: Array, y: Array, actuation_args: Tuple[Array, Array]
-            ) -> Array:
+                t: Array, ode_state, actuation_args: Tuple[Array, Array]
+            ):
                 """
-                Evaluate controller at (t, q, qd) and apply it to the forward dynamics.
-                Args:
-                    t: Current time
-                    y: Current state vector (configuration and velocity)
-                    actuation_args: Tuple containing base actuation and external torques
-                Returns:
-                    yd: Time derivative of the state vector
+                Evaluate the controller at (t, y[, control_state]) and apply it to the forward dynamics.
                 """
-                base_u, base_tau_ext = actuation_args
-                q, qd = jnp.split(y, 2)
-                u_control = controller(t, q, qd)
-                u = base_u + u_control
-                yd = self.forward_dynamics(t, y, (u, base_tau_ext))
+                base_u_val, base_tau_ext = actuation_args
+                if track_control_state:
+                    y, ctrl_state = ode_state
+                else:
+                    y = ode_state
+                    ctrl_state = None
+
+                system_state = SystemState(t=t, y=y, u=base_u_val, control_state=ctrl_state)
+                u_control, control_state_dot = controller(system_state)
+                if control_state_dot is not None and not track_control_state:
+                    raise ValueError(
+                        "Controller returned a control_state derivative but no initial control_state was provided."
+                    )
+                u_total = base_u_val + u_control
+                yd = self.forward_dynamics(t, y, (u_total, base_tau_ext))
+                if track_control_state:
+                    control_state_dot = (
+                        control_state_dot if control_state_dot is not None else zero_control_state_dot
+                    )
+                    return yd, control_state_dot
                 return yd
 
             forward_dynamics = closed_loop_forward_dynamics
         else:
-            forward_dynamics = self.forward_dynamics
+
+            @jit
+            def open_loop_forward_dynamics(
+                t: Array, ode_state, actuation_args: Tuple[Array, Array]
+            ):
+                base_u_val, base_tau_ext = actuation_args
+                if track_control_state:
+                    y, _ = ode_state
+                else:
+                    y = ode_state
+                yd = self.forward_dynamics(t, y, (base_u_val, base_tau_ext))
+                if track_control_state:
+                    return yd, zero_control_state_dot
+                return yd
+
+            forward_dynamics = open_loop_forward_dynamics
+
         term = ODETerm(forward_dynamics)
-        saveat = SaveAt(ts=saveat_ts)  # Save at specified time points
+        saveat = SaveAt(ts=save_ts)  # Save at specified time points
+
+        y0_for_solver = (y0, controller_state0) if track_control_state else y0
 
         sol = diffeqsolve(
             terms=term,
@@ -117,22 +149,34 @@ class DynamicalSystem(eqx.Module):
             t0=t0,
             t1=t1 + dt,
             dt0=dt,
-            y0=y0,
-            args=(u, tau_ext),
+            y0=y0_for_solver,
+            args=(base_u, tau_ext),
             saveat=saveat,
             stepsize_controller=stepsize_controller,
             max_steps=max_steps,
         )
 
         ts = sol.ts
-        # Extract the configuration and velocity from the solution
-        y_out = sol.ys
-        qs, qds = jnp.split(y_out, 2, axis=1)
-
-        if controller is None:
-            us = jnp.broadcast_to(u, (ts.shape[0], u.shape[0]))
+        if track_control_state:
+            y_out, controller_state_out = sol.ys
         else:
-            u_controls = vmap(lambda t_i, q_i, qd_i: controller(t_i, q_i, qd_i))(ts, qs, qds)
-            us = u_controls + u
+            y_out = sol.ys
+            controller_state_out = None
 
-        return ts, qs, qds, us
+        # Compute controller outputs on the saved trajectory
+        if controller is None:
+            us = jnp.broadcast_to(base_u, (ts.shape[0], base_u.shape[0]))
+        else:
+            if track_control_state:
+                u_controls = vmap(
+                    lambda t_i, y_i, c_i: controller(
+                        SystemState(t=t_i, y=y_i, u=base_u, control_state=c_i)
+                    )[0]
+                )(ts, y_out, controller_state_out)
+            else:
+                u_controls = vmap(
+                    lambda t_i, y_i: controller(SystemState(t=t_i, y=y_i, u=base_u, control_state=None))[0]
+                )(ts, y_out)
+            us = u_controls + base_u
+
+        return SystemState(t=ts, y=y_out, u=us, control_state=controller_state_out)

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -1,6 +1,6 @@
 __all__ = ["DynamicalSystem"]
 import equinox as eqx
-from jax import Array, jit, lax
+from jax import Array, jit, lax, vmap
 from jax import numpy as jnp
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple, Type, Union, Optional
@@ -25,16 +25,17 @@ class DynamicalSystem(eqx.Module):
         q0: Array,
         qd0: Array,
         u: Optional[Array] = None,
+        controller: Optional[Callable[[Array, Array, Array], Array]] = None,
         tau_ext: Optional[Array] = None,
         t0: Optional[float] = 0.0,
         t1: Optional[float] = 10.0,
         dt: Optional[float] = 1e-4,
         saveat_ts: Optional[Array] = None,
-        save_dt: Optional[Union[float]] = 0.01,
+        save_dt: Optional[float] = 0.01,
         solver: Optional[AbstractSolver] = Tsit5(),
         stepsize_controller: Optional[AbstractStepSizeController] = ConstantStepSize(),
         max_steps: Optional[int] = None,
-    ) -> Tuple[Array, Array, Array]:
+    ) -> Tuple[Array, Array, Array, Array]:
         """
         Resolve the system dynamics over time using Diffrax.
 
@@ -43,6 +44,9 @@ class DynamicalSystem(eqx.Module):
             qd0 (Array): Initial velocity (strains).
             u (Array, optional): Actuation/control input.
                 Default is None (no actuation).
+            controller (Callable, optional): Control function/object that takes in time, configuration, and velocity,
+                and returns the actuation input. If provided, it is added to the `u` argument.
+                    => controller(t: Array, q: Array, qd: Array) -> Array
             tau_ext (Array, optional): External forces/torques applied to the system.
             t0 (float, optional): Initial time of the simuation, included.
                 It represents the first time step resolved by the solver. Default is 0.0.
@@ -67,6 +71,7 @@ class DynamicalSystem(eqx.Module):
             ts (Array): Time points at which the solution is saved.
             qs (Array): Configuration (strains) at the saved time points.
             qds (Array): Velocity (strains) at the saved time points.
+            us (Array): Actuation applied at each saved time step.
         """
         y0 = jnp.concatenate([q0, qd0])  # Initial state vector
         if u is None:
@@ -79,14 +84,38 @@ class DynamicalSystem(eqx.Module):
             assert save_dt >= dt, "save_dt must be greater than or equal to the simulation dt."
             saveat_ts = jnp.arange(t0, t1 + save_dt, save_dt)
 
-        term = ODETerm(self.forward_dynamics)
+        if controller is not None:
+            @jit
+            def closed_loop_forward_dynamics(
+                t: Array, y: Array, actuation_args: Tuple[Array, Array]
+            ) -> Array:
+                """
+                Evaluate controller at (t, q, qd) and apply it to the forward dynamics.
+                Args:
+                    t: Current time
+                    y: Current state vector (configuration and velocity)
+                    actuation_args: Tuple containing base actuation and external torques
+                Returns:
+                    yd: Time derivative of the state vector
+                """
+                base_u, base_tau_ext = actuation_args
+                q, qd = jnp.split(y, 2)
+                u_control = controller(t, q, qd)
+                u = base_u + u_control
+                yd = self.forward_dynamics(t, y, (u, base_tau_ext))
+                return yd
+
+            forward_dynamics = closed_loop_forward_dynamics
+        else:
+            forward_dynamics = self.forward_dynamics
+        term = ODETerm(forward_dynamics)
         saveat = SaveAt(ts=saveat_ts)  # Save at specified time points
 
         sol = diffeqsolve(
             terms=term,
             solver=solver,
             t0=t0,
-            t1=t1 + dt, 
+            t1=t1 + dt,
             dt0=dt,
             y0=y0,
             args=(u, tau_ext),
@@ -100,4 +129,10 @@ class DynamicalSystem(eqx.Module):
         y_out = sol.ys
         qs, qds = jnp.split(y_out, 2, axis=1)
 
-        return ts, qs, qds
+        if controller is None:
+            us = jnp.broadcast_to(u, (ts.shape[0], u.shape[0]))
+        else:
+            u_controls = vmap(lambda t_i, q_i, qd_i: controller(t_i, q_i, qd_i))(ts, qs, qds)
+            us = u_controls + u
+
+        return ts, qs, qds, us

--- a/src/soromox/systems/planar_hsa.py
+++ b/src/soromox/systems/planar_hsa.py
@@ -10,7 +10,7 @@ from diffrax import (
     AbstractSolver,
 )
 import dill
-from jax import Array, lax
+from jax import Array, lax, vmap
 from jax import numpy as jnp
 import sympy as sp
 from pathlib import Path
@@ -1492,7 +1492,7 @@ class PlanarHSA(DynamicalSystem):
 
     @eqx.filter_jit
     def forward_dynamics(
-        self, t: Array, y: Array, actuation_args: Tuple[Array, Callable]
+        self, t: Array, y: Array, actuation_args: Tuple[Array, Optional[Callable]]
     ) -> Array:
         """
         Forward dynamics function.
@@ -1507,14 +1507,14 @@ class PlanarHSA(DynamicalSystem):
                     motor positions / twist angles of the proximal end of the rods.
                     If consider_underactuation is False, this is an array of shape (num_dofs, ) with
                     the configuration-space torques.
-                - control_fn (Callable): Callable that returns the forcing function of the form control_fn(t, x) -> phi. If consider_underactuation is True,
+                - controller (Callable): Callable that returns the forcing function of the form controller(t, x) -> phi. If consider_underactuation is True,
                     then phi is an array of shape (num_dofs, ) with the configuration-space torques. If consider_underactuation is False,
                     then phi is an array of shape (num_hysteresis, ) with the motor positions / twist angles of the proximal end of the rods.
 
         Returns:
             yd: Time derivative of the state vector of shape (2 * num_dofs + num_hysteresis, ).
         """
-        u, control_fn = actuation_args
+        u, controller = actuation_args
 
         q, qd, z = jnp.split(y, [self.num_dofs, 2 * self.num_dofs])
 
@@ -1524,8 +1524,8 @@ class PlanarHSA(DynamicalSystem):
             * (self.hyst_gamma + self.hyst_beta * jnp.sign((self.B_hyst.T @ qd) * z))
         )
 
-        if control_fn is not None:
-            u = u + control_fn(t, y)
+        if controller is not None:
+            u = u + controller(t, y)
 
         if self.consider_underactuation is True:
             phi = u
@@ -1563,7 +1563,7 @@ class PlanarHSA(DynamicalSystem):
         q0: Array,
         qd0: Array,
         u0: Array,
-        control_fn: Optional[Callable] = None,
+        controller: Optional[Callable] = None,
         t0: Optional[float] = 0.0,
         t1: Optional[float] = 10.0,
         dt: Optional[float] = 1e-4,
@@ -1571,7 +1571,7 @@ class PlanarHSA(DynamicalSystem):
         solver: Optional[AbstractSolver] = Tsit5(),
         stepsize_controller: Optional[AbstractStepSizeController] = ConstantStepSize(),
         max_steps: Optional[int] = None,
-    ) -> Tuple[Array, Array, Array]:
+    ) -> Tuple[Array, Array, Array, Array]:
         """
         Resolve the system dynamics over time using Diffrax.
 
@@ -1585,7 +1585,7 @@ class PlanarHSA(DynamicalSystem):
                 If consider_underactuation is False,
                     array of shape (num_dofs, ) with
                     the configuration-space torques.
-            control_fn (Callable, optional): Callable that returns the forcing function of the form control_fn(t, [q, qd]) -> phi.
+            controller (Callable, optional): Callable that returns the forcing function of the form controller(t, [q, qd]) -> phi.
                 If consider_underactuation is True,
                     then phi is an array of shape (num_actuators, )
                     with the configuration-space torques.
@@ -1613,6 +1613,7 @@ class PlanarHSA(DynamicalSystem):
             ts (Array): Time points at which the solution is saved.
             qs (Array): Configuration (strains) at the saved time points.
             qds (Array): Velocity (strains) at the saved time points.
+            us (Array): Actuation applied at each saved time step.
         """
         y0 = jnp.concatenate([q0, qd0, jnp.zeros((self.num_hysteresis,))])
 
@@ -1625,7 +1626,7 @@ class PlanarHSA(DynamicalSystem):
         saveat = SaveAt(ts=t[::save_dt])  # Save at specified time points
 
         # Prepare the actuation arguments
-        actuation_args = (u0, control_fn)
+        actuation_args = (u0, controller)
 
         sol = diffeqsolve(
             terms=term,
@@ -1645,4 +1646,10 @@ class PlanarHSA(DynamicalSystem):
         y_out = sol.ys
         qs, qds, zs = jnp.split(y_out, [self.num_dofs, 2 * self.num_dofs], axis=1)
 
-        return ts, qs, qds
+        if controller is None:
+            us = jnp.broadcast_to(u0, (ts.shape[0], u0.shape[0]))
+        else:
+            u_controls = vmap(controller)(ts, y_out)
+            us = u0 + u_controls
+
+        return ts, qs, qds, us

--- a/src/soromox/systems/planar_hsa.py
+++ b/src/soromox/systems/planar_hsa.py
@@ -1,5 +1,6 @@
 __all__ = ["PlanarHSA"]
 import equinox as eqx
+import jax
 from diffrax import (
     diffeqsolve,
     ODETerm,
@@ -14,9 +15,10 @@ from jax import Array, lax, vmap
 from jax import numpy as jnp
 import sympy as sp
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from soromox.systems.dynamical_system import DynamicalSystem
+from soromox.systems.system_state import SystemState
 from soromox.utils.basic import (
     concatenate_params_syms,
     compute_strain_basis,
@@ -1492,7 +1494,7 @@ class PlanarHSA(DynamicalSystem):
 
     @eqx.filter_jit
     def forward_dynamics(
-        self, t: Array, y: Array, actuation_args: Tuple[Array, Optional[Callable]]
+        self, t: Array, y: Array, actuation_args: Tuple[Array, Optional[Array]]
     ) -> Array:
         """
         Forward dynamics function.
@@ -1502,30 +1504,34 @@ class PlanarHSA(DynamicalSystem):
             y (Array): State vector containing configuration, velocity, and possibly hysteresis state.
                 Shape is (2 * num_dofs + num_hysteresis,).
             actuation_args (Tuple): Additional arguments for the actuation function.
-                - u (Array): Initial actuation input.
-                    If consider_underactuation is True, this is an array of shape (num_hysteresis, ) with
-                    motor positions / twist angles of the proximal end of the rods.
-                    If consider_underactuation is False, this is an array of shape (num_dofs, ) with
-                    the configuration-space torques.
-                - controller (Callable): Callable that returns the forcing function of the form controller(t, x) -> phi. If consider_underactuation is True,
-                    then phi is an array of shape (num_dofs, ) with the configuration-space torques. If consider_underactuation is False,
-                    then phi is an array of shape (num_hysteresis, ) with the motor positions / twist angles of the proximal end of the rods.
+                - u (Array): Actuation input.
+                    If consider_underactuation is True, this is an array of shape (num_actuators, )
+                    with motor positions / twist angles of the proximal end of the rods.
+                    If consider_underactuation is False, this is an array of shape (num_dofs, )
+                    with the configuration-space torques.
+                - tau_ext (Array, optional): External generalized forces, shape (num_dofs,).
 
         Returns:
             yd: Time derivative of the state vector of shape (2 * num_dofs + num_hysteresis, ).
         """
-        u, controller = actuation_args
+        u, tau_ext = actuation_args
+        if tau_ext is None:
+            tau_ext = jnp.zeros((self.num_dofs,), dtype=y.dtype)
 
-        q, qd, z = jnp.split(y, [self.num_dofs, 2 * self.num_dofs])
+        if self.consider_hysteresis:
+            q, qd, z = jnp.split(y, [self.num_dofs, 2 * self.num_dofs])
+        else:
+            q, qd = jnp.split(y, [self.num_dofs])
+            z = jnp.zeros((self.num_hysteresis,), dtype=y.dtype)
 
-        zd = (self.B_hyst.T @ qd) * (
-            self.hyst_A
-            - jnp.abs(z) ** self.hyst_n
-            * (self.hyst_gamma + self.hyst_beta * jnp.sign((self.B_hyst.T @ qd) * z))
-        )
-
-        if controller is not None:
-            u = u + controller(t, y)
+        if self.consider_hysteresis:
+            zd = (self.B_hyst.T @ qd) * (
+                self.hyst_A
+                - jnp.abs(z) ** self.hyst_n
+                * (self.hyst_gamma + self.hyst_beta * jnp.sign((self.B_hyst.T @ qd) * z))
+            )
+        else:
+            zd = jnp.zeros((self.num_hysteresis,), dtype=y.dtype)
 
         if self.consider_underactuation is True:
             phi = u
@@ -1551,105 +1557,11 @@ class PlanarHSA(DynamicalSystem):
         B_inv = jnp.linalg.inv(B)
 
         # Compute the acceleration
-        qdd = B_inv @ (-C @ qd - G - tau_el - D @ qd + alpha)
+        qdd = B_inv @ (-C @ qd - G - tau_el - D @ qd + alpha + tau_ext)
 
-        yd = jnp.concatenate([qd, qdd, zd])
+        if self.consider_hysteresis:
+            yd = jnp.concatenate([qd, qdd, zd])
+        else:
+            yd = jnp.concatenate([qd, qdd])
 
         return yd
-
-    @eqx.filter_jit
-    def resolve_upon_time(
-        self,
-        q0: Array,
-        qd0: Array,
-        u0: Array,
-        controller: Optional[Callable] = None,
-        t0: Optional[float] = 0.0,
-        t1: Optional[float] = 10.0,
-        dt: Optional[float] = 1e-4,
-        save_dt: int = 1,
-        solver: Optional[AbstractSolver] = Tsit5(),
-        stepsize_controller: Optional[AbstractStepSizeController] = ConstantStepSize(),
-        max_steps: Optional[int] = None,
-    ) -> Tuple[Array, Array, Array, Array]:
-        """
-        Resolve the system dynamics over time using Diffrax.
-
-        Args:
-            q0 (Array): Initial configuration (strains).
-            qd0 (Array): Initial velocity (strains).
-            u0 (Array): Initial actuation input.
-                If consider_underactuation is True,
-                    array of shape (num_actuators, ) with
-                    motor positions / twist angles of the proximal end of the rods.
-                If consider_underactuation is False,
-                    array of shape (num_dofs, ) with
-                    the configuration-space torques.
-            controller (Callable, optional): Callable that returns the forcing function of the form controller(t, [q, qd]) -> phi.
-                If consider_underactuation is True,
-                    then phi is an array of shape (num_actuators, )
-                    with the configuration-space torques.
-                If consider_underactuation is False,
-                    then phi is an array of shape (num_dofs, )
-                    with the motor positions / twist angles of the proximal end of the rods.
-            t0 (float, optionnal): Initial time.
-                Default is 0.0.
-            t1 (float, optionnal): Final time.
-                Default is 10.0.
-            dt (float, optionnal): Time step for the solver.
-                Default is 1e-4.
-            save_dt (int, optional): Determines how many time steps to skip
-                when saving the output. For example, if set to 1, every time step is saved;
-                if set to 10, every 10th time step is saved.
-                Default is 1 (save every step).
-            solver (AbstractSolver, optional): Solver to use for the ODE integration.
-                Default is Tsit5() (Runge-Kutta 5(4) method).
-            stepsize_controller (PIDController, optional): Stepsize controller for the solver.
-                Default is ConstantStepSize().
-            max_steps (int, optional): Maximum number of steps for the solver.
-                Default is None (no limit).
-
-        Returns:
-            ts (Array): Time points at which the solution is saved.
-            qs (Array): Configuration (strains) at the saved time points.
-            qds (Array): Velocity (strains) at the saved time points.
-            us (Array): Actuation applied at each saved time step.
-        """
-        y0 = jnp.concatenate([q0, qd0, jnp.zeros((self.num_hysteresis,))])
-
-        term = ODETerm(self.forward_dynamics)
-
-        t = jnp.arange(t0, t1, dt)  # Time points for the solution
-        
-        assert save_dt > 0, "save_dt must be a positive integer."
-        assert isinstance(save_dt, int), "save_dt must be an integer."
-        saveat = SaveAt(ts=t[::save_dt])  # Save at specified time points
-
-        # Prepare the actuation arguments
-        actuation_args = (u0, controller)
-
-        sol = diffeqsolve(
-            terms=term,
-            solver=solver,
-            t0=t[0],
-            t1=t[-1],
-            dt0=dt,
-            y0=y0,
-            args=actuation_args,
-            saveat=saveat,
-            stepsize_controller=stepsize_controller,
-            max_steps=max_steps,
-        )
-
-        ts = sol.ts
-        # Extract the configuration and velocity from the solution
-        y_out = sol.ys
-        qs, qds, zs = jnp.split(y_out, [self.num_dofs, 2 * self.num_dofs], axis=1)
-
-        if controller is None:
-            us = jnp.broadcast_to(u0, (ts.shape[0], u0.shape[0]))
-        else:
-            u_controls = vmap(controller)(ts, y_out)
-            us = u0 + u_controls
-
-        return ts, qs, qds, us

--- a/src/soromox/systems/system_state.py
+++ b/src/soromox/systems/system_state.py
@@ -1,0 +1,52 @@
+__all__ = ["SystemState"]
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import jax
+from jax import Array
+
+
+@jax.tree_util.register_pytree_node_class
+@dataclass
+class SystemState:
+    """
+    Container for the system state and optional controller state.
+
+    Attributes
+    ----------
+    t : Array
+        Current simulation time.
+    y : Array
+        Robot state vector, typically concatenated configuration and velocity.
+    u : Optional[Array]
+        Actuation input applied at the current time.
+    control_state : Optional[Any]
+        Additional controller state as a PyTree (e.g., integrator terms).
+    """
+
+    t: Array
+    y: Array
+    u: Optional[Array] = None
+    control_state: Optional[Any] = None
+
+    def tree_flatten(self):
+        children = [self.t, self.y]
+        aux = {
+            "has_u": self.u is not None,
+            "has_control_state": self.control_state is not None,
+        }
+        if self.u is not None:
+            children.append(self.u)
+        if self.control_state is not None:
+            children.append(self.control_state)
+        return tuple(children), aux
+
+    @classmethod
+    def tree_unflatten(cls, aux, children):
+        t, y, *rest = children
+        idx = 0
+        u = rest[idx] if aux["has_u"] else None
+        if aux["has_u"]:
+            idx += 1
+        control_state = rest[idx] if aux["has_control_state"] else None
+        return cls(t=t, y=y, u=u, control_state=control_state)

--- a/tests/test_dynamical_system_rollout.py
+++ b/tests/test_dynamical_system_rollout.py
@@ -1,0 +1,109 @@
+import equinox as eqx
+from jax import numpy as jnp
+
+from soromox.systems import pendulum
+from soromox.systems.system_state import SystemState
+
+
+def _pendulum_params():
+    # Gravity set to zero so the zero configuration is an equilibrium for zero actuation.
+    return {
+        "L": jnp.array([0.5, 0.3]),
+        "Lc": jnp.array([0.25, 0.15]),
+        "m": jnp.array([1.0, 0.5]),
+        "I": jnp.array([0.1, 0.05]),
+        "g": jnp.array([0.0, 0.0]),
+    }
+
+
+class PIDController(eqx.Module):
+    kp: float
+    ki: float
+    kd: float
+    target: jnp.ndarray
+
+    def __call__(self, state: SystemState):
+        q_len = self.target.shape[0]
+        q, qd = jnp.split(state.y, [q_len], axis=0)
+        integ = state.control_state
+
+        error = self.target - q
+        d_error = -qd  # derivative of (target - q) when target is constant
+
+        u = self.kp * error + self.ki * integ + self.kd * d_error
+        control_state_dot = error
+        return u, control_state_dot
+
+
+def test_rollout_to_keeps_equilibrium():
+    robot = pendulum.Pendulum(_pendulum_params())
+
+    q0 = jnp.zeros((2,))
+    qd0 = jnp.zeros_like(q0)
+    initial_state = SystemState(t=0.0, y=jnp.concatenate([q0, qd0]))
+
+    trajectory = robot.rollout_to(
+        initial_state=initial_state,
+        u=jnp.zeros_like(q0),
+        t1=0.1,
+        solver_dt=1e-3,
+        save_dt=0.01,
+    )
+
+    assert trajectory.control_state is None
+    assert jnp.allclose(trajectory.y, 0.0, atol=1e-6)
+
+
+def test_rollout_closed_loop_to_tracks_target():
+    robot = pendulum.Pendulum(_pendulum_params())
+
+    q0 = jnp.array([0.2, -0.1])
+    qd0 = jnp.zeros_like(q0)
+    initial_state = SystemState(
+        t=0.0,
+        y=jnp.concatenate([q0, qd0]),
+        u=jnp.zeros_like(q0),
+        control_state=jnp.zeros_like(q0),  # integral term
+    )
+
+    controller = PIDController(kp=10.0, ki=3.0, kd=2.0, target=jnp.zeros_like(q0))
+
+    trajectory = robot.rollout_closed_loop_to(
+        initial_state=initial_state,
+        controller=controller,
+        t1=0.4,
+        solver_dt=1e-3,
+        save_dt=0.02,
+    )
+
+    q_final = trajectory.y[-1, : q0.shape[0]]
+    assert jnp.linalg.norm(q_final) < 5e-2
+    assert trajectory.control_state is not None
+
+
+def test_rollout_discrete_closed_loop_to_tracks_target():
+    robot = pendulum.Pendulum(_pendulum_params())
+
+    q0 = jnp.array([0.3, -0.2])
+    qd0 = jnp.zeros_like(q0)
+    initial_state = SystemState(
+        t=0.0,
+        y=jnp.concatenate([q0, qd0]),
+        u=jnp.zeros_like(q0),
+        control_state=jnp.zeros_like(q0),
+    )
+
+    controller = PIDController(kp=8.0, ki=2.5, kd=1.5, target=jnp.zeros_like(q0))
+
+    trajectory = robot.rollout_discrete_closed_loop_to(
+        initial_state=initial_state,
+        controller=controller,
+        t1=0.6,
+        solver_dt=1e-3,
+        control_dt=0.02,
+        save_dt=0.02,
+    )
+
+    q_final = trajectory.y[-1, : q0.shape[0]]
+    assert jnp.linalg.norm(q_final) < 7e-2
+    assert trajectory.control_state is not None

--- a/tools/benchmarks/_benchmark_common.py
+++ b/tools/benchmarks/_benchmark_common.py
@@ -254,7 +254,7 @@ def add_integration_args(
     parser: argparse.ArgumentParser,
     *,
     duration_default: float = 1.0,
-    dt_default: float = 1e-4,
+    solver_dt_default: float = 1e-4,
     save_dt_default: float = 0.01,
 ) -> None:
     """Attach shared integration arguments to a parser."""
@@ -266,16 +266,18 @@ def add_integration_args(
         help="Simulation duration (seconds)",
     )
     parser.add_argument(
+        "--solver-dt",
         "--dt",
+        dest="solver_dt",
         type=float,
-        default=dt_default,
+        default=solver_dt_default,
         help="Integration step size",
     )
     parser.add_argument(
         "--save-dt",
         type=float,
         default=save_dt_default,
-        help="Save the system state every `save_dt` seconds (must be >= dt)",
+        help="Save the system state every `save_dt` seconds (must be >= solver_dt)",
     )
 
 

--- a/tools/benchmarks/benchmark_simulation_batch_scaling.py
+++ b/tools/benchmarks/benchmark_simulation_batch_scaling.py
@@ -65,9 +65,10 @@ def _build_batched_solver(system: DynamicalSystem, runtime: RuntimeConfig) -> Ca
     t1 = runtime.t0 + runtime.duration
 
     def single_env(q0: Array, qd0: Array, u: Array, tau_ext: Array) -> Tuple[Array, Array, Array]:
-        initial_state = SystemState(t=runtime.t0, y=jnp.concatenate([q0, qd0]), u=u)
-        trajectory = system.resolve_upon_time(
+        initial_state = SystemState(t=runtime.t0, y=jnp.concatenate([q0, qd0]))
+        trajectory = system.rollout_to(
             initial_state=initial_state,
+            u=u,
             tau_ext=tau_ext,
             t1=t1,
             dt=runtime.dt,

--- a/tools/benchmarks/benchmark_simulation_batch_scaling.py
+++ b/tools/benchmarks/benchmark_simulation_batch_scaling.py
@@ -22,6 +22,7 @@ import jax.numpy as jnp
 jax.config.update("jax_enable_x64", True)
 
 from soromox.systems.dynamical_system import DynamicalSystem
+from soromox.systems.system_state import SystemState
 from tools.benchmarks._benchmark_common import (
     add_integration_args,
     add_system_selection_args,
@@ -64,17 +65,16 @@ def _build_batched_solver(system: DynamicalSystem, runtime: RuntimeConfig) -> Ca
     t1 = runtime.t0 + runtime.duration
 
     def single_env(q0: Array, qd0: Array, u: Array, tau_ext: Array) -> Tuple[Array, Array, Array]:
-        ts, qs, qds, _ = system.resolve_upon_time(
-            q0=q0,
-            qd0=qd0,
-            u=u,
+        initial_state = SystemState(t=runtime.t0, y=jnp.concatenate([q0, qd0]), u=u)
+        trajectory = system.resolve_upon_time(
+            initial_state=initial_state,
             tau_ext=tau_ext,
-            t0=runtime.t0,
             t1=t1,
             dt=runtime.dt,
             save_dt=runtime.save_dt,
         )
-        return ts[-1], qs[-1], qds[-1]
+        qs, qds = jnp.split(trajectory.y, 2, axis=1)
+        return trajectory.t[-1], qs[-1], qds[-1]
 
     vmapped = jax.jit(jax.vmap(single_env, in_axes=(0, 0, 0, 0)))
     return vmapped

--- a/tools/benchmarks/benchmark_simulation_batch_scaling.py
+++ b/tools/benchmarks/benchmark_simulation_batch_scaling.py
@@ -36,7 +36,7 @@ Array = jax.Array
 @dataclass
 class RuntimeConfig:
     duration: float
-    dt: float
+    solver_dt: float
     save_dt: float
     t0: float = 0.0
 
@@ -71,7 +71,7 @@ def _build_batched_solver(system: DynamicalSystem, runtime: RuntimeConfig) -> Ca
             u=u,
             tau_ext=tau_ext,
             t1=t1,
-            dt=runtime.dt,
+            solver_dt=runtime.solver_dt,
             save_dt=runtime.save_dt,
         )
         qs, qds = jnp.split(trajectory.y, 2, axis=1)
@@ -119,7 +119,7 @@ def _write_csv(results: Sequence[Mapping[str, Any]], path: Path) -> None:
         "dof",
         "batch_size",
         "duration_s",
-        "dt",
+        "solver_dt",
         "save_dt",
         "wall_time_s",
         "per_env_wall_time_s",
@@ -299,10 +299,10 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
 
     if args.duration <= 0.0:
         parser.error("--duration must be positive.")
-    if args.dt <= 0.0:
-        parser.error("--dt must be positive.")
-    if args.save_dt < args.dt:
-        parser.error("--save-dt must be greater than or equal to --dt.")
+    if args.solver_dt <= 0.0:
+        parser.error("--solver-dt/--dt must be positive.")
+    if args.save_dt < args.solver_dt:
+        parser.error("--save-dt must be greater than or equal to --solver-dt/--dt.")
     if any(bs < 1 for bs in args.batch_sizes):
         parser.error("All --batch-sizes entries must be >= 1.")
     if any(seg < 1 for seg in args.segment_counts):
@@ -321,7 +321,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
     runtime = RuntimeConfig(
         duration=args.duration,
-        dt=args.dt,
+        solver_dt=args.solver_dt,
         save_dt=args.save_dt,
     )
     registry = get_system_registry()
@@ -381,7 +381,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "dof": dof,
                         "batch_size": batch,
                         "duration_s": args.duration,
-                        "dt": args.dt,
+                        "solver_dt": args.solver_dt,
                         "save_dt": args.save_dt,
                         "wall_time_s": wall_time,
                         "per_env_wall_time_s": per_env_wall,

--- a/tools/benchmarks/benchmark_simulation_batch_scaling.py
+++ b/tools/benchmarks/benchmark_simulation_batch_scaling.py
@@ -64,7 +64,7 @@ def _build_batched_solver(system: DynamicalSystem, runtime: RuntimeConfig) -> Ca
     t1 = runtime.t0 + runtime.duration
 
     def single_env(q0: Array, qd0: Array, u: Array, tau_ext: Array) -> Tuple[Array, Array, Array]:
-        ts, qs, qds = system.resolve_upon_time(
+        ts, qs, qds, _ = system.resolve_upon_time(
             q0=q0,
             qd0=qd0,
             u=u,

--- a/tools/benchmarks/benchmark_system_methods.py
+++ b/tools/benchmarks/benchmark_system_methods.py
@@ -138,10 +138,11 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             builder=lambda sys, ctx, _: (sys.total_energy, (ctx["q"], ctx["qd"])),
         ),
         BenchmarkCase(
-            name="resolve_upon_time",
+            name="rollout_to",
             builder=lambda sys, ctx, runtime: (
-                lambda q0, qd0, u, tau, t0, t1, dt, save_dt: sys.resolve_upon_time(
-                    initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u),
+                lambda q0, qd0, u, tau, t0, t1, dt, save_dt: sys.rollout_to(
+                    initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0])),
+                    u=u,
                     tau_ext=tau,
                     t1=t1,
                     dt=dt,
@@ -194,10 +195,11 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             builder=lambda sys, ctx, _: (sys.total_energy, (ctx["q"], ctx["qd"])),
         ),
         BenchmarkCase(
-            name="resolve_upon_time",
+            name="rollout_to",
             builder=lambda sys, ctx, runtime: (
-                lambda q0, qd0, u, tau, t0, t1, dt, save_dt: sys.resolve_upon_time(
-                    initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u),
+                lambda q0, qd0, u, tau, t0, t1, dt, save_dt: sys.rollout_to(
+                    initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0])),
+                    u=u,
                     tau_ext=tau,
                     t1=t1,
                     dt=dt,
@@ -257,10 +259,11 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             builder=lambda sys, ctx, _: (sys.total_energy, (ctx["q"], ctx["qd"])),
         ),
         BenchmarkCase(
-            name="resolve_upon_time",
+            name="rollout_to",
             builder=lambda sys, ctx, runtime: (
-                lambda q0, qd0, u, tau, t0, t1, dt, save_n: sys.resolve_upon_time(
-                    initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u),
+                lambda q0, qd0, u, tau, t0, t1, dt, save_n: sys.rollout_to(
+                    initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0])),
+                    u=u,
                     tau_ext=tau,
                     t1=t1,
                     dt=dt,

--- a/tools/benchmarks/benchmark_system_methods.py
+++ b/tools/benchmarks/benchmark_system_methods.py
@@ -50,7 +50,7 @@ class RuntimeConfig:
     """Holds runtime controls shared across benchmark cases."""
 
     duration: float
-    dt: float
+    solver_dt: float
     save_dt: float
     execution_repeats: int
 
@@ -140,12 +140,12 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
         BenchmarkCase(
             name="rollout_to",
             builder=lambda sys, ctx, runtime: (
-                lambda q0, qd0, u, tau, t0, t1, dt, save_dt: sys.rollout_to(
+                lambda q0, qd0, u, tau, t0, t1, solver_dt, save_dt: sys.rollout_to(
                     initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0])),
                     u=u,
                     tau_ext=tau,
                     t1=t1,
-                    dt=dt,
+                    solver_dt=solver_dt,
                     save_dt=save_dt,
                 ),
                 (
@@ -155,7 +155,7 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
                     ctx["tau_ext"],
                     jnp.array(0.0),
                     jnp.array(runtime.duration),
-                    jnp.array(runtime.dt),
+                    jnp.array(runtime.solver_dt),
                     runtime.save_dt,
                 ),
             ),
@@ -197,12 +197,12 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
         BenchmarkCase(
             name="rollout_to",
             builder=lambda sys, ctx, runtime: (
-                lambda q0, qd0, u, tau, t0, t1, dt, save_dt: sys.rollout_to(
+                lambda q0, qd0, u, tau, t0, t1, solver_dt, save_dt: sys.rollout_to(
                     initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0])),
                     u=u,
                     tau_ext=tau,
                     t1=t1,
-                    dt=dt,
+                    solver_dt=solver_dt,
                     save_dt=save_dt,
                 ),
                 (
@@ -212,7 +212,7 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
                     ctx["tau_ext"],
                     jnp.array(0.0),
                     jnp.array(runtime.duration),
-                    jnp.array(runtime.dt),
+                    jnp.array(runtime.solver_dt),
                     runtime.save_dt,
                 ),
             ),
@@ -261,12 +261,12 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
         BenchmarkCase(
             name="rollout_to",
             builder=lambda sys, ctx, runtime: (
-                lambda q0, qd0, u, tau, t0, t1, dt, save_n: sys.rollout_to(
+                lambda q0, qd0, u, tau, t0, t1, solver_dt, save_n: sys.rollout_to(
                     initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0])),
                     u=u,
                     tau_ext=tau,
                     t1=t1,
-                    dt=dt,
+                    solver_dt=solver_dt,
                     save_dt=save_n,
                 ),
                 (
@@ -276,7 +276,7 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
                     ctx["tau_ext"],
                     jnp.array(0.0),
                     jnp.array(runtime.duration),
-                    jnp.array(runtime.dt),
+                    jnp.array(runtime.solver_dt),
                     runtime.save_dt,
                 ),
             ),
@@ -368,7 +368,7 @@ def _write_csv(results: Sequence[Mapping[str, Any]], path: Path) -> None:
         "jit_compile_time_s",
         "jit_execution_time_s",
         "duration",
-        "dt",
+        "solver_dt",
         "save_dt",
         "execution_repeats",
     ]
@@ -423,7 +423,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     runtime = RuntimeConfig(
         duration=args.duration,
-        dt=args.dt,
+        solver_dt=args.solver_dt,
         save_dt=max(0.0, args.save_dt),
         execution_repeats=args.execution_repeats,
     )
@@ -468,7 +468,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "jit_compile_time_s": compile_time,
                         "jit_execution_time_s": exec_time,
                         "duration": runtime.duration,
-                        "dt": runtime.dt,
+                        "solver_dt": runtime.solver_dt,
                         "save_dt": runtime.save_dt,
                         "execution_repeats": runtime.execution_repeats,
                     }

--- a/tools/benchmarks/benchmark_system_methods.py
+++ b/tools/benchmarks/benchmark_system_methods.py
@@ -39,6 +39,7 @@ from tools.benchmarks._benchmark_common import (
     block_until_ready,
     get_system_registry,
 )
+from soromox.systems.system_state import SystemState
 
 Array = jax.Array
 Tree = Any
@@ -50,7 +51,7 @@ class RuntimeConfig:
 
     duration: float
     dt: float
-    save_dt: int
+    save_dt: float
     execution_repeats: int
 
 
@@ -140,11 +141,8 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             name="resolve_upon_time",
             builder=lambda sys, ctx, runtime: (
                 lambda q0, qd0, u, tau, t0, t1, dt, save_dt: sys.resolve_upon_time(
-                    q0=q0,
-                    qd0=qd0,
-                    u=u,
+                    initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u),
                     tau_ext=tau,
-                    t0=t0,
                     t1=t1,
                     dt=dt,
                     save_dt=save_dt,
@@ -199,11 +197,8 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             name="resolve_upon_time",
             builder=lambda sys, ctx, runtime: (
                 lambda q0, qd0, u, tau, t0, t1, dt, save_dt: sys.resolve_upon_time(
-                    q0=q0,
-                    qd0=qd0,
-                    u=u,
+                    initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u),
                     tau_ext=tau,
-                    t0=t0,
                     t1=t1,
                     dt=dt,
                     save_dt=save_dt,
@@ -265,11 +260,8 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             name="resolve_upon_time",
             builder=lambda sys, ctx, runtime: (
                 lambda q0, qd0, u, tau, t0, t1, dt, save_n: sys.resolve_upon_time(
-                    q0=q0,
-                    qd0=qd0,
-                    u=u,
+                    initial_state=SystemState(t=t0, y=jnp.concatenate([q0, qd0]), u=u),
                     tau_ext=tau,
-                    t0=t0,
                     t1=t1,
                     dt=dt,
                     save_dt=save_n,


### PR DESCRIPTION
This pull request updates all simulation examples and documentation to use the new `SystemState` class and the `rollout_to` method instead of the previous `resolve_upon_time` approach. It also standardizes the naming of time step parameters from `dt` to `solver_dt` across code and documentation, and updates relevant CLI options and descriptions. These changes improve clarity, consistency, and alignment with the updated simulation API. The main improvement, however, is to add methods for closed-loop simulation - both in continuous and discrete time.

**Migration to new simulation API:**

* All simulation scripts now import and use the `SystemState` class to initialize the system state, replacing separate `q0` and `qd0` arguments. (`examples/simulation/gvs/simulate_gvs.py`, `examples/simulation/hsa/simulate_planar_hsa.py`, `examples/simulation/pcs/simulate_isupport.py`, `examples/simulation/pcs/simulate_pcs.py`, `examples/simulation/pcs/simulate_planar_pcs.py`, `examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py`, `examples/simulation/pcs/simulate_tendon_actuated_pcs.py`, `examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py`, `examples/simulation/pendulum/simulate_pendulum.py`, [[1]](diffhunk://#diff-0d73fe3ecb0e5efabd0e895c32e07a46aa35733bcffa3f1d9e9d45b480fd7dfaR14) [[2]](diffhunk://#diff-cfa88be8febba17c3e6bdcad05fbabe3cf6e1490ce65cc319561dcc0274b6bc4R13) [[3]](diffhunk://#diff-2e2e224fa1e6f19e4d950aca7e67c6b5985f65591e0abd6fd074dc4b30c766f6R21) [[4]](diffhunk://#diff-6c954ff34451b86543d409233de6311135cdfa2b2c86c2835033b4b45687b509R16) [[5]](diffhunk://#diff-f2b62366de7f162555361c1e849e811a58701e7f0a30c903a0c382f47a66c9e4R14) [[6]](diffhunk://#diff-46f972f82b1ab4bd444bc104a9750c6dd9823d9c7e4f239c130fc7fb85814b34R19) [[7]](diffhunk://#diff-fc73f5bf08c3bc2b2b174b550f85187edfa24f0df4627a48ca8263609230c391R19) [[8]](diffhunk://#diff-9854d8decb403603098ceeb4ddf2c2d291b768b41e20ae770f84bbac7f32bc75R20) [[9]](diffhunk://#diff-a9251f57397fdbf1146b6e67cab09c965d154d685b362076df94cb0b38e0bcd2R15)

* All simulation scripts now use the `rollout_to` method for time integration, replacing `resolve_upon_time`. This includes updating how simulation outputs are extracted from the returned trajectory object. [[1]](diffhunk://#diff-0d73fe3ecb0e5efabd0e895c32e07a46aa35733bcffa3f1d9e9d45b480fd7dfaL246-R261) [[2]](diffhunk://#diff-cfa88be8febba17c3e6bdcad05fbabe3cf6e1490ce65cc319561dcc0274b6bc4L88-R108) [[3]](diffhunk://#diff-2e2e224fa1e6f19e4d950aca7e67c6b5985f65591e0abd6fd074dc4b30c766f6L207-R225) [[4]](diffhunk://#diff-6c954ff34451b86543d409233de6311135cdfa2b2c86c2835033b4b45687b509L188-R206) [[5]](diffhunk://#diff-f2b62366de7f162555361c1e849e811a58701e7f0a30c903a0c382f47a66c9e4L191-R209) [[6]](diffhunk://#diff-46f972f82b1ab4bd444bc104a9750c6dd9823d9c7e4f239c130fc7fb85814b34L348-R366) [[7]](diffhunk://#diff-fc73f5bf08c3bc2b2b174b550f85187edfa24f0df4627a48ca8263609230c391L335-R358) [[8]](diffhunk://#diff-9854d8decb403603098ceeb4ddf2c2d291b768b41e20ae770f84bbac7f32bc75L266-R284) [[9]](diffhunk://#diff-a9251f57397fdbf1146b6e67cab09c965d154d685b362076df94cb0b38e0bcd2L30-R32) [[10]](diffhunk://#diff-b1fcf19669445924e993b523bab6fef1be6c60d0d09c10fde9895de2ec9ca153R150-R168)

**Standardization of time step parameter:**

* The simulation time step variable is renamed from `dt` to `solver_dt` throughout all scripts and documentation for clarity and consistency with the new API. [[1]](diffhunk://#diff-0d73fe3ecb0e5efabd0e895c32e07a46aa35733bcffa3f1d9e9d45b480fd7dfaL246-R261) [[2]](diffhunk://#diff-cfa88be8febba17c3e6bdcad05fbabe3cf6e1490ce65cc319561dcc0274b6bc4L88-R108) [[3]](diffhunk://#diff-2e2e224fa1e6f19e4d950aca7e67c6b5985f65591e0abd6fd074dc4b30c766f6L207-R225) [[4]](diffhunk://#diff-6c954ff34451b86543d409233de6311135cdfa2b2c86c2835033b4b45687b509L188-R206) [[5]](diffhunk://#diff-f2b62366de7f162555361c1e849e811a58701e7f0a30c903a0c382f47a66c9e4L191-R209) [[6]](diffhunk://#diff-46f972f82b1ab4bd444bc104a9750c6dd9823d9c7e4f239c130fc7fb85814b34L348-R366) [[7]](diffhunk://#diff-fc73f5bf08c3bc2b2b174b550f85187edfa24f0df4627a48ca8263609230c391L335-R358) [[8]](diffhunk://#diff-9854d8decb403603098ceeb4ddf2c2d291b768b41e20ae770f84bbac7f32bc75L266-R284) [[9]](diffhunk://#diff-a9251f57397fdbf1146b6e67cab09c965d154d685b362076df94cb0b38e0bcd2L30-R32) [[10]](diffhunk://#diff-b1fcf19669445924e993b523bab6fef1be6c60d0d09c10fde9895de2ec9ca153R150-R168) [[11]](diffhunk://#diff-2791c7e4727d3756553151e882bab8c32fb2d05c062550740f6e91c59e26412aL48-R65)

* All CLI documentation and code examples now use the `--solver-dt` argument instead of `--dt`, with notes about `--dt` as an alias for backward compatibility. [[1]](diffhunk://#diff-89b03c4bfee716fcc9fdc12b39d844f0dbee242bce8add6b60fef2c6cf60e9f9L32-R32) [[2]](diffhunk://#diff-89b03c4bfee716fcc9fdc12b39d844f0dbee242bce8add6b60fef2c6cf60e9f9L42-R43) [[3]](diffhunk://#diff-89b03c4bfee716fcc9fdc12b39d844f0dbee242bce8add6b60fef2c6cf60e9f9L76-R76) [[4]](diffhunk://#diff-89b03c4bfee716fcc9fdc12b39d844f0dbee242bce8add6b60fef2c6cf60e9f9L85-R85)

**Documentation updates:**

* All documentation and quick start guides are updated to use `SystemState`, `rollout_to`, and the new time step naming. Example code snippets and explanations now match the updated API. [[1]](diffhunk://#diff-2791c7e4727d3756553151e882bab8c32fb2d05c062550740f6e91c59e26412aR19) [[2]](diffhunk://#diff-2791c7e4727d3756553151e882bab8c32fb2d05c062550740f6e91c59e26412aL48-R65) [[3]](diffhunk://#diff-b1fcf19669445924e993b523bab6fef1be6c60d0d09c10fde9895de2ec9ca153R150-R168) [[4]](diffhunk://#diff-89b03c4bfee716fcc9fdc12b39d844f0dbee242bce8add6b60fef2c6cf60e9f9L32-R32) [[5]](diffhunk://#diff-89b03c4bfee716fcc9fdc12b39d844f0dbee242bce8add6b60fef2c6cf60e9f9L42-R43) [[6]](diffhunk://#diff-89b03c4bfee716fcc9fdc12b39d844f0dbee242bce8add6b60fef2c6cf60e9f9L76-R76) [[7]](diffhunk://#diff-89b03c4bfee716fcc9fdc12b39d844f0dbee242bce8add6b60fef2c6cf60e9f9L85-R85) [[8]](diffhunk://#diff-89b03c4bfee716fcc9fdc12b39d844f0dbee242bce8add6b60fef2c6cf60e9f9L98-R98) [[9]](diffhunk://#diff-89b03c4bfee716fcc9fdc12b39d844f0dbee242bce8add6b60fef2c6cf60e9f9L115-R115)

**Minor improvements:**

* Adjustments to animation frame timing and handling of additional state variables (e.g., hysteresis state in HSA example) to ensure compatibility with the new API. [[1]](diffhunk://#diff-cfa88be8febba17c3e6bdcad05fbabe3cf6e1490ce65cc319561dcc0274b6bc4R70-R75) [[2]](diffhunk://#diff-cfa88be8febba17c3e6bdcad05fbabe3cf6e1490ce65cc319561dcc0274b6bc4L127-R135)

These changes collectively modernize the simulation interface and ensure consistency across the codebase and documentation.