### PR TITLE
Increase epsilon in SE(2/3) Tangent Computation (fixes #42)

### DIFF
--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -4,7 +4,7 @@ import equinox as eqx
 import jax
 from jax import Array, jit, lax, vmap
 from jax import numpy as jnp
-from typing import Any, Callable, ClassVar, Optional, Tuple
+from typing import Any, Callable, ClassVar, Optional, Tuple, Union
 
 # Diffrax (for time integration helpers)
 from diffrax import (
@@ -23,13 +23,27 @@ from soromox.systems.system_state import SystemState
 class DynamicalSystem(eqx.Module):
     num_actuators: int = eqx.field(static=True)  # Number of actuators
 
-    # Not a dataclass field: avoid default/non-default ordering issues in subclasses
-    global_eps: ClassVar[float] = float(jnp.finfo(jnp.float64).eps)
+    # global epsilon for numerical computations
+    global_eps: float  # Global epsilon for numerical computations
 
     @property
     def tangent_eps(self) -> Array:
         """Epsilon value for Lie algebra tangent computations."""
         return jnp.sqrt(self.global_eps)
+    
+    def __init__(self, eps: Optional[float] = None, **kwargs):
+        """Initialize the DynamicalSystem.
+
+        Args:
+            eps (float): Optional global epsilon value for numerical computations.
+                If not provided, defaults to 10x machine epsilon for float64.
+            **kwargs: Additional keyword arguments for Equinox Module.
+        """
+        super().__init__(**kwargs)
+        if eps is not None:
+            self.global_eps = eps
+        else:
+            self.global_eps = 1e1 * float(jnp.finfo(jnp.float64).eps)
 
     @staticmethod
     def _compute_save_times(

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -4,7 +4,7 @@ import equinox as eqx
 import jax
 from jax import Array, jit, lax, vmap
 from jax import numpy as jnp
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, ClassVar, Optional, Tuple
 
 # Diffrax (for time integration helpers)
 from diffrax import (
@@ -22,6 +22,14 @@ from soromox.systems.system_state import SystemState
 
 class DynamicalSystem(eqx.Module):
     num_actuators: int = eqx.field(static=True)  # Number of actuators
+
+    # Not a dataclass field: avoid default/non-default ordering issues in subclasses
+    global_eps: ClassVar[float] = float(jnp.finfo(jnp.float64).eps)
+
+    @property
+    def tangent_eps(self) -> Array:
+        """Epsilon value for Lie algebra tangent computations."""
+        return jnp.sqrt(self.global_eps)
 
     @staticmethod
     def _compute_save_times(

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -134,8 +134,6 @@ class GVS(DynamicalSystem):
 
     B_select: Array  # Strain basis functions for the robot (6, max_dof)
 
-    global_eps: ClassVar[float] = float(jnp.finfo(jnp.float64).eps)
-
     # Dynamic attributes
     V_L: Array  # List of lengths for each link (num_segments, )
     V_L_cum: Array  # Cumulative lengths of the links (num_segments + 1, )
@@ -1215,7 +1213,7 @@ class GVS(DynamicalSystem):
 
             g_joint_i = lie.exp_gn_SE3(xi_joint_i, self.global_eps)  # shape (4, 4)
             T_g_joint = lie.Tangent_gi_se3(
-                xi_joint_i, 1, self.global_eps
+                xi_joint_i, 1, eps=self.tangent_eps
             )  # shape (6, 6)
 
             T_g_joint_i_B_joint_i = (
@@ -1288,7 +1286,7 @@ class GVS(DynamicalSystem):
 
                 g_step = lie.exp_gn_SE3(Magnus_j, self.global_eps)  # shape (4, 4)
                 T_step = lie.Tangent_gi_se3(
-                    Magnus_j, 1, self.global_eps
+                    Magnus_j, 1, eps=self.tangent_eps
                 )  # shape (6, 6)
 
                 T_step_B_step = (
@@ -1400,7 +1398,7 @@ class GVS(DynamicalSystem):
             xi_joint_i = B_joint_i @ q_joint_i + xi_ref_joint_i
 
             g_joint_i = lie.exp_gn_SE3(xi_joint_i, self.global_eps)  # (4,4)
-            T_g_joint = lie.Tangent_gi_se3(xi_joint_i, 1, self.global_eps)  # (6,6)
+            T_g_joint = lie.Tangent_gi_se3(xi_joint_i, 1, eps=self.tangent_eps)  # (6,6)
 
             # contribution of this joint to its own block
             T_g_joint_i_B_joint_i = (
@@ -1466,7 +1464,7 @@ class GVS(DynamicalSystem):
                 )
 
                 g_step = lie.exp_gn_SE3(Magnus_j, self.global_eps)
-                T_step = lie.Tangent_gi_se3(Magnus_j, 1, self.global_eps)
+                T_step = lie.Tangent_gi_se3(Magnus_j, 1, eps=self.tangent_eps)
 
                 # add contribution for this link block
                 T_step_B_step = (
@@ -1551,7 +1549,7 @@ class GVS(DynamicalSystem):
                 ) * (ad_xi_Z1_j @ Bp[1] - ad_xi_Z2_j @ Bp[0])
 
                 g_step = lie.exp_gn_SE3(Magnus_p, self.global_eps)
-                T_step = lie.Tangent_gi_se3(Magnus_p, 1, self.global_eps)
+                T_step = lie.Tangent_gi_se3(Magnus_p, 1, eps=self.tangent_eps)
 
                 T_block = (
                     jnp.zeros((self.num_segments, 2, 6, self.max_dof))
@@ -1655,10 +1653,10 @@ class GVS(DynamicalSystem):
 
             g_joint_i = lie.exp_gn_SE3(xi_joint_i, self.global_eps)  # shape (4, 4)
             T_g_joint = lie.Tangent_gi_se3(
-                xi_joint_i, 1, self.global_eps
+                xi_joint_i, 1, eps=self.tangent_eps
             )  # shape (6, 6)
             Td_g_joint = lie.Tangent_derivative_gi_se3(
-                xi_joint_i, xid_joint_i, 1, self.global_eps
+                xi_joint_i, xid_joint_i, 1, eps=self.tangent_eps
             )  # shape (6, 6)
 
             Td_g_joint_B_joint_i = (
@@ -1741,10 +1739,10 @@ class GVS(DynamicalSystem):
 
                 g_step = lie.exp_gn_SE3(Magnus_j, self.global_eps)  # shape (4, 4)
                 T_Magnus_j = lie.Tangent_gi_se3(
-                    Magnus_j, 1, self.global_eps
+                    Magnus_j, 1, eps=self.tangent_eps
                 )  # shape (6, 6)
                 Td_Magnus_j = lie.Tangent_derivative_gi_se3(
-                    Magnus_j, Magnusd_j, 1, self.global_eps
+                    Magnus_j, Magnusd_j, 1, eps=self.tangent_eps
                 )  # shape (6, 6)
 
                 T_B_Magnus_step = T_Magnus_j @ B_Magnus_j  # shape (6, max_dof)
@@ -1869,9 +1867,9 @@ class GVS(DynamicalSystem):
             xid_joint_i = B_joint_i @ qd_joint_i  # (6,)
 
             g_joint_i = lie.exp_gn_SE3(xi_joint_i, self.global_eps)  # (4,4)
-            T_g_joint = lie.Tangent_gi_se3(xi_joint_i, 1, self.global_eps)  # (6,6)
+            T_g_joint = lie.Tangent_gi_se3(xi_joint_i, 1, eps=self.tangent_eps)  # (6,6)
             Td_g_joint = lie.Tangent_derivative_gi_se3(
-                xi_joint_i, xid_joint_i, 1, self.global_eps
+                xi_joint_i, xid_joint_i, 1, eps=self.tangent_eps
             )  # (6,6)
 
             # contribution dans le bloc "joint" de ce segment
@@ -1953,9 +1951,9 @@ class GVS(DynamicalSystem):
                 )
 
                 g_step = lie.exp_gn_SE3(Magnus_j, self.global_eps)
-                T_step = lie.Tangent_gi_se3(Magnus_j, 1, self.global_eps)
+                T_step = lie.Tangent_gi_se3(Magnus_j, 1, eps=self.tangent_eps)
                 Td_step = lie.Tangent_derivative_gi_se3(
-                    Magnus_j, Magnusd_j, 1, self.global_eps
+                    Magnus_j, Magnusd_j, 1, eps=self.tangent_eps
                 )
 
                 Td_block_link = (
@@ -2053,9 +2051,9 @@ class GVS(DynamicalSystem):
                 )
 
                 g_step = lie.exp_gn_SE3(Magnus_p, self.global_eps)
-                T_step = lie.Tangent_gi_se3(Magnus_p, 1, self.global_eps)
+                T_step = lie.Tangent_gi_se3(Magnus_p, 1, eps=self.tangent_eps)
                 Td_step = lie.Tangent_derivative_gi_se3(
-                    Magnus_p, Magnusd_p, 1, self.global_eps
+                    Magnus_p, Magnusd_p, 1, eps=self.tangent_eps
                 )
 
                 Td_block_link = (

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -175,6 +175,7 @@ class GVS(DynamicalSystem):
         max_dof: Optional[int] = None,
         max_nGauss: Optional[int] = None,
         p0: Optional[Array] = None,
+        **kwargs,
     ) -> None:
         """
         Initialize the GVS class.
@@ -227,6 +228,10 @@ class GVS(DynamicalSystem):
         p0: (optional) List/Array of shape (6,)
                 Initial orientation angle and position in the inertial frame [rad, m]
                 [ψ, θ, φ, x0, y0, z0]
+        eps (float, optional):
+            Global epsilon for numerical computations.
+            If None, defaults to machine epsilon for float64.
+                
         Raises
         ------
         ValueError
@@ -243,6 +248,8 @@ class GVS(DynamicalSystem):
         - Internal arrays are padded to `max_dof` and `max_nip` to allow vectorized
         batched computations across all segments.
         """
+        super().__init__(**kwargs)
+
         warnings.warn(
             "GVS is not fully validated yet and might not match the behavior of PlanarPCS and PCS."
         )

--- a/src/soromox/systems/pcs.py
+++ b/src/soromox/systems/pcs.py
@@ -84,9 +84,6 @@ class PCS(DynamicalSystem):
     G: Array  # Shear modulus of the segments
     D: Array  # Damping coefficient of the segments
 
-    # Not a dataclass field: avoid default/non-default ordering issues in subclasses
-    global_eps: ClassVar[float] = float(jnp.finfo(jnp.float64).eps)
-
     num_segments: int = eqx.field(static=True)
     num_gauss_points: int = eqx.field(static=True)  #
     num_strains: int = eqx.field(static=True)  # Number of strains (6 * num_segments)
@@ -782,7 +779,7 @@ class PCS(DynamicalSystem):
             arc_len: Array,
         ) -> Array:
             Ad_inv = lie.Adjoint_gi_se3_inv(xi_i, arc_len, eps=self.global_eps)
-            T = lie.Tangent_gi_se3(xi_i, arc_len, eps=self.global_eps)
+            T = lie.Tangent_gi_se3(xi_i, arc_len, eps=self.tangent_eps)
 
             J_rot = jnp.einsum("ij, njk->nik", Ad_inv, J_prev)
             J_next = J_rot.at[i].set(Ad_inv @ T)
@@ -849,7 +846,7 @@ class PCS(DynamicalSystem):
             L_i = lax.dynamic_index_in_dim(self.L, i, axis=0, keepdims=False)
 
             Ad_inv = lie.Adjoint_gi_se3_inv(xi_i, L_i, eps=self.global_eps)
-            T = lie.Tangent_gi_se3(xi_i, L_i, eps=self.global_eps)
+            T = lie.Tangent_gi_se3(xi_i, L_i, eps=self.tangent_eps)
 
             J_rot = jnp.einsum("ij, njk->nik", Ad_inv, J_prev)
             J_next = J_rot.at[i].set(Ad_inv @ T)
@@ -907,7 +904,7 @@ class PCS(DynamicalSystem):
             J_base: Array,
         ) -> Array:
             Ad_inv = lie.Adjoint_gi_se3_inv(xi_i, s_local, eps=self.global_eps)
-            T = lie.Tangent_gi_se3(xi_i, s_local, eps=self.global_eps)
+            T = lie.Tangent_gi_se3(xi_i, s_local, eps=self.tangent_eps)
 
             J_rot = jnp.einsum("ij, njk->nik", Ad_inv, J_base)
             J_next = J_rot.at[i].set(Ad_inv @ T)
@@ -996,9 +993,9 @@ class PCS(DynamicalSystem):
             arc_len: Array,
         ) -> Tuple[Array, Array]:
             Ad_inv = lie.Adjoint_gi_se3_inv(xi_i, arc_len, eps=self.global_eps)
-            T = lie.Tangent_gi_se3(xi_i, arc_len, eps=self.global_eps)
+            T = lie.Tangent_gi_se3(xi_i, arc_len, eps=self.tangent_eps)
             Td = lie.Tangent_derivative_gi_se3(
-                xi_i, xid_i, arc_len, eps=self.global_eps
+                xi_i, xid_i, arc_len, eps=self.tangent_eps
             )
 
             J_rot = jnp.einsum("ij, njk->nik", Ad_inv, J_prev)
@@ -1097,11 +1094,11 @@ class PCS(DynamicalSystem):
             lambda xi_i, L_i: lie.Adjoint_gi_se3_inv(xi_i, L_i, eps=self.global_eps)
         )(xi, self.L)
         T_tips = vmap(
-            lambda xi_i, L_i: lie.Tangent_gi_se3(xi_i, L_i, eps=self.global_eps)
+            lambda xi_i, L_i: lie.Tangent_gi_se3(xi_i, L_i, eps=self.tangent_eps)
         )(xi, self.L)
         Td_tips = vmap(
             lambda xi_i, xid_i, L_i: lie.Tangent_derivative_gi_se3(
-                xi_i, xid_i, L_i, eps=self.global_eps
+                xi_i, xid_i, L_i, eps=self.tangent_eps
             )
         )(xi, xid, self.L)
 
@@ -1204,9 +1201,9 @@ class PCS(DynamicalSystem):
             Jd_base: Array,
         ) -> Tuple[Array, Array]:
             Ad_inv = lie.Adjoint_gi_se3_inv(xi_i, s_local, eps=self.global_eps)
-            T = lie.Tangent_gi_se3(xi_i, s_local, eps=self.global_eps)
+            T = lie.Tangent_gi_se3(xi_i, s_local, eps=self.tangent_eps)
             Td = lie.Tangent_derivative_gi_se3(
-                xi_i, xid_i, s_local, eps=self.global_eps
+                xi_i, xid_i, s_local, eps=self.tangent_eps
             )
 
             J_rot = jnp.einsum("ij, njk->nik", Ad_inv, J_base)

--- a/src/soromox/systems/pcs.py
+++ b/src/soromox/systems/pcs.py
@@ -102,6 +102,7 @@ class PCS(DynamicalSystem):
         order_gauss: int = 5,
         strain_selector: Optional[Array] = None,
         xi_ref: Optional[Array] = None,
+        **kwargs
     ):
         """
         Initialize the PCS class.
@@ -143,8 +144,12 @@ class PCS(DynamicalSystem):
             xi_ref (Optional[Array], optional):
                 Reference strain of shape (6 * num_segments,).
                 Defaults to 0.0 for bending and shear strains, and 1.0 for axial strain (along local x-axis).
-
+            eps (float, optional):
+                Global epsilon for numerical computations.
+                If None, defaults to machine epsilon for float64.
         """
+        super().__init__(**kwargs)
+
         # Number of segments
         if not isinstance(num_segments, int):
             raise TypeError(

--- a/src/soromox/systems/planar_hsa.py
+++ b/src/soromox/systems/planar_hsa.py
@@ -201,9 +201,6 @@ class PlanarHSA(DynamicalSystem):
     # parameters for lambdify
     params_for_lambdify: List[Array]
 
-    # epsilon for numerical stability
-    global_eps: float
-
     def __init__(
         self,
         sym_exp_filepath: Union[str, Path],

--- a/src/soromox/systems/planar_hsa.py
+++ b/src/soromox/systems/planar_hsa.py
@@ -1,15 +1,5 @@
 __all__ = ["PlanarHSA"]
 import equinox as eqx
-import jax
-from diffrax import (
-    diffeqsolve,
-    ODETerm,
-    SaveAt,
-    Tsit5,
-    AbstractStepSizeController,
-    ConstantStepSize,
-    AbstractSolver,
-)
 import dill
 from jax import Array, lax, vmap
 from jax import numpy as jnp

--- a/src/soromox/systems/planar_pcs.py
+++ b/src/soromox/systems/planar_pcs.py
@@ -81,9 +81,6 @@ class PlanarPCS(DynamicalSystem):
     G: Array  # Shear modulus of the segments
     D: Array  # Damping coefficient of the segments
 
-    # Not a dataclass field: avoid default/non-default ordering issues in subclasses
-    global_eps: ClassVar[float] = float(jnp.finfo(jnp.float64).eps)
-
     num_segments: int = eqx.field(static=True)
     num_gauss_points: int = eqx.field(static=True)  #
     num_strains: int = eqx.field(static=True)  # Number of strains (3 * num_segments)
@@ -896,7 +893,7 @@ class PlanarPCS(DynamicalSystem):
             # Map the previous Jacobian into the current segment frame using the inverse adjoint.
             Ad_inv = lie.Adjoint_gi_se2_inv(xi_i, arc_len, eps=self.global_eps)
             # Integrate the local tangent contribution for this segment length.
-            T = lie.Tangent_gi_se2(xi_i, arc_len, eps=self.global_eps)
+            T = lie.Tangent_gi_se2(xi_i, arc_len, eps=self.tangent_eps)
             # Rotate the previous Jacobian into the current frame.
             J_rot = jnp.matmul(Ad_inv, J_prev)
             # Overwrite the slice associated with the active segment.
@@ -997,7 +994,7 @@ class PlanarPCS(DynamicalSystem):
             L_i = lax.dynamic_index_in_dim(self.L, i, axis=0, keepdims=False)
 
             Ad_inv = lie.Adjoint_gi_se2_inv(xi_i, L_i, eps=self.global_eps)
-            T = lie.Tangent_gi_se2(xi_i, L_i, eps=self.global_eps)
+            T = lie.Tangent_gi_se2(xi_i, L_i, eps=self.tangent_eps)
 
             J_rot = jnp.einsum("ij, njk->nik", Ad_inv, J_prev)
             J_next = J_rot.at[i].set(Ad_inv @ T)
@@ -1045,7 +1042,7 @@ class PlanarPCS(DynamicalSystem):
             J_base: Array,
         ) -> Array:
             Ad_inv = lie.Adjoint_gi_se2_inv(xi_i, arc_len, eps=self.global_eps)
-            T = lie.Tangent_gi_se2(xi_i, arc_len, eps=self.global_eps)
+            T = lie.Tangent_gi_se2(xi_i, arc_len, eps=self.tangent_eps)
 
             J_rot = jnp.einsum("ij, njk->nik", Ad_inv, J_base)
             J_next = J_rot.at[i].set(Ad_inv @ T)
@@ -1146,9 +1143,9 @@ class PlanarPCS(DynamicalSystem):
             # Inverse adjoint transformation and tangent integration for the current segment
             Ad_inv = lie.Adjoint_gi_se2_inv(xi_i, arc_len, eps=self.global_eps)
             # Compute the tangent vector and its derivative
-            T = lie.Tangent_gi_se2(xi_i, arc_len, eps=self.global_eps)
+            T = lie.Tangent_gi_se2(xi_i, arc_len, eps=self.tangent_eps)
             Td = lie.Tangent_derivative_gi_se2(
-                xi_i, xid_i, arc_len, eps=self.global_eps
+                xi_i, xid_i, arc_len, eps=self.tangent_eps
             )
 
             # Rotate the previous Jacobian into the current frame and add the local contribution
@@ -1286,11 +1283,11 @@ class PlanarPCS(DynamicalSystem):
             lambda xi_i, L_i: lie.Adjoint_gi_se2_inv(xi_i, L_i, eps=self.global_eps)
         )(xi, self.L)
         T_tips = vmap(
-            lambda xi_i, L_i: lie.Tangent_gi_se2(xi_i, L_i, eps=self.global_eps)
+            lambda xi_i, L_i: lie.Tangent_gi_se2(xi_i, L_i, eps=self.tangent_eps)
         )(xi, self.L)
         Td_tips = vmap(
             lambda xi_i, xid_i, L_i: lie.Tangent_derivative_gi_se2(
-                xi_i, xid_i, L_i, eps=self.global_eps
+                xi_i, xid_i, L_i, eps=self.tangent_eps
             )
         )(xi, xid, self.L)
 
@@ -1377,9 +1374,9 @@ class PlanarPCS(DynamicalSystem):
             Jd_base: Array,
         ) -> Tuple[Array, Array]:
             Ad_inv = lie.Adjoint_gi_se2_inv(xi_i, arc_len, eps=self.global_eps)
-            T = lie.Tangent_gi_se2(xi_i, arc_len, eps=self.global_eps)
+            T = lie.Tangent_gi_se2(xi_i, arc_len, eps=self.tangent_eps)
             Td = lie.Tangent_derivative_gi_se2(
-                xi_i, xid_i, arc_len, eps=self.global_eps
+                xi_i, xid_i, arc_len, eps=self.tangent_eps
             )
 
             J_rot = jnp.einsum("ij, njk->nik", Ad_inv, J_base)

--- a/src/soromox/systems/planar_pcs.py
+++ b/src/soromox/systems/planar_pcs.py
@@ -99,6 +99,7 @@ class PlanarPCS(DynamicalSystem):
         order_gauss: int = 5,
         strain_selector: Optional[Array] = None,
         xi_ref: Optional[Array] = None,
+        **kwargs
     ):
         """
         Initialize the PlanarPCS class.
@@ -134,8 +135,12 @@ class PlanarPCS(DynamicalSystem):
             xi_ref (Optional[Array], optional):
                 Reference strain of shape (3 * num_segments,).
                 Defaults to 0.0 for bending and shear strains, and 1.0 for axial strain (along local x-axis).
-
+            eps (float, optional):
+                Global epsilon for numerical computations.
+                If None, defaults to machine epsilon for float64.
         """
+        super().__init__(**kwargs)
+
         # Number of segments
         if not isinstance(num_segments, int):
             raise TypeError(

--- a/src/soromox/utils/lie_algebra/se2.py
+++ b/src/soromox/utils/lie_algebra/se2.py
@@ -17,6 +17,7 @@ __all__ = [
 import jax
 import jax.numpy as jnp
 from jax import Array, lax
+from typing import Union
 
 
 J = jnp.array([[0, -1], [1, 0]])
@@ -87,12 +88,12 @@ def exp_SE2(vec3: Array) -> Array:
     return g
 
 
-def log_SE2(g: Array, eps: float) -> Array:
+def log_SE2(g: Array, eps: Union[float, Array]) -> Array:
     """Compute the logarithmic map from SE(2) to se(2).
 
     Args:
         g (Array): shape (3, 3) homogeneous transform in SE(2).
-        eps (float): small positive tolerance for angle regularisation.
+        eps (Union[float, Array]): small positive tolerance for angle regularisation.
 
     Returns:
         Array: shape (3,) twist coordinates corresponding to ``g``.
@@ -112,12 +113,12 @@ def log_SE2(g: Array, eps: float) -> Array:
     return jnp.concatenate([jnp.array([theta]), p])
 
 
-def exp_gn_SE2(vec3: Array, eps: float) -> Array:
+def exp_gn_SE2(vec3: Array, eps: Union[float, Array]) -> Array:
     """Compute the exponential map using the Magnus expansion for SE(2).
 
     Args:
         vec3 (Array): shape (3,) screw coordinates.
-        eps (float): threshold for switching to the series expansion.
+        eps (Union[float, Array]): threshold for switching to the series expansion.
 
     Returns:
         Array: shape (3, 3) matrix exponential of ``vec3`` in SE(2).
@@ -262,7 +263,7 @@ def Adjoint_g_inv_SE2(mat3: Array) -> Array:
 def Adjoint_gi_se2(
     xi_i: Array,
     s_i: Array,
-    eps: float,
+    eps: Union[float, Array],
 ) -> Array:
     """
     Computes the adjoint at arclength ``s_i`` for a segment strained by ``xi_i``.
@@ -271,7 +272,7 @@ def Adjoint_gi_se2(
         xi_i (Array): shape (3,) or (3, 1)
             Constant strain vector in the segment, [theta, vx, vy].
         s_i (Array): scalar arclength position along the segment.
-        eps (float): small value to avoid division by zero in the series expansion.
+        eps (Union[float, Array]): small value to avoid division by zero in the series expansion.
 
     Returns:
         Array: shape (3, 3)
@@ -327,7 +328,7 @@ def Adjoint_gi_se2(
 def Adjoint_gi_se2_inv(
     xi_i: Array,
     s_i: Array,
-    eps: float,
+    eps: Union[float, Array],
 ) -> Array:
     """
     Computes the inverse adjoint at arclength ``s_i`` for a segment strained by ``xi_i``.
@@ -336,7 +337,7 @@ def Adjoint_gi_se2_inv(
         xi_i (Array): shape (3,) or (3, 1)
             Constant strain vector in the segment, [theta, vx, vy].
         s_i (Array): scalar arclength position along the segment.
-        eps (float): small value to avoid division by zero in the series expansion.
+        eps (Union[float, Array]): small value to avoid division by zero in the series expansion.
 
     Returns:
         Array: shape (3, 3)
@@ -366,7 +367,7 @@ def Adjoint_gi_se2_inv(
 def Tangent_gi_se2(
     xi_i: Array,
     s_i: Array,
-    eps: float,
+    eps: Union[float, Array],
 ) -> Array:
     """
     Computes the tangent operator accumulated over arclength ``s_i`` for strain ``xi_i``.
@@ -375,7 +376,7 @@ def Tangent_gi_se2(
         xi_i (Array): shape (3,) or (3, 1)
             Constant strain vector in the segment, [theta, vx, vy].
         s_i (Array): scalar arclength position along the segment.
-        eps (float): small value to avoid division by zero in the series expansion.
+        eps (Union[float, Array]): small value to avoid division by zero in the series expansion.
 
     Returns:
         Array: shape (3, 3)
@@ -432,7 +433,7 @@ def Tangent_derivative_gi_se2(
     xi_i: Array,
     xid_i: Array,
     s_i: Array,
-    eps: float,
+    eps: Union[float, Array],
 ) -> Array:
     """
     Computes the time derivative of the tangent operator at arclength ``s_i``.
@@ -443,7 +444,7 @@ def Tangent_derivative_gi_se2(
         xid_i (Array): shape (3,) or (3, 1)
             Time derivative of the strain vector.
         s_i (Array): scalar arclength position along the segment.
-        eps (float): small value to avoid division by zero in the series expansion.
+        eps (Union[float, Array]): small value to avoid division by zero in the series expansion.
 
     Returns:
         Array: shape (3, 3)

--- a/src/soromox/utils/lie_algebra/se3.py
+++ b/src/soromox/utils/lie_algebra/se3.py
@@ -16,9 +16,10 @@ __all__ = [
 import jax
 import jax.numpy as jnp
 from jax import Array, lax
+from typing import Union
 
 
-def _rotational_strain_magnitude(xi: Array, eps: float) -> Array:
+def _rotational_strain_magnitude(xi: Array, eps: Union[float, Array]) -> Array:
     """
     Computes the magnitude of the rotational strain component of a 6D vector.
 
@@ -129,14 +130,14 @@ def exp_SE3(vec6: Array) -> Array:
     return g
 
 
-def log_SE3(g: Array, eps: float) -> Array:
+def log_SE3(g: Array, eps: Union[float, Array]) -> Array:
     """
     Computes the logarithm map from SE(3) to se(3), i.e., extracts the twist from a transformation matrix.
 
     Args:
         g (Array): shape (4, 4)
             Homogeneous transform in SE(3).
-        eps (float): tolerance to avoid division by zero in small angle approximations.
+        eps (Union[float, Array]): tolerance to avoid division by zero in small angle approximations.
 
     Returns:
         log: shape (6,)
@@ -217,14 +218,14 @@ def log_SE3(g: Array, eps: float) -> Array:
     return log
 
 
-def exp_gn_SE3(vec6: Array, eps: float) -> Array:
+def exp_gn_SE3(vec6: Array, eps: Union[float, Array]) -> Array:
     """
     Function to compute the exponential map of the Magnus expansion.
 
     Args:
         vec6 (Array): shape (6,) or (6, 1)
             Screw coordinates used in the Magnus expansion.
-
+        eps (Union[float, Array]): small value to avoid division by zero in the series expansion.
     Returns:
         g (Array): shape (4, 4)
             Homogeneous transform obtained from the Magnus expansion.
@@ -364,7 +365,7 @@ def Adjoint_g_inv_SE3(mat4: Array) -> Array:
 def Adjoint_gi_se3(
     xi_i: Array,
     s_i: Array,
-    eps: float,
+    eps: Union[float, Array],
 ) -> Array:
     """
     Computes the adjoint representation of a position of a points at s_i (local curvilinear coordinate)
@@ -374,7 +375,7 @@ def Adjoint_gi_se3(
         xi_i (Array): shape (6,) or (6, 1)
             Constant strain vector in the segment, [omega, v].
         s_i (Array): scalar arclength position along the segment.
-        eps (float): small value to avoid division by zero in the series expansion.
+        eps (Union[float, Array]): small value to avoid division by zero in the series expansion.
 
     Returns:
         Array: shape (6, 6)
@@ -430,7 +431,7 @@ def Adjoint_gi_se3(
 def Adjoint_gi_se3_inv(
     xi_i: Array,
     s_i: Array,
-    eps: float,
+    eps: Union[float, Array],
 ) -> Array:
     """
     Computes the adjoint representation of a position of a points at s_i (local curvilinear coordinate)
@@ -440,7 +441,7 @@ def Adjoint_gi_se3_inv(
         xi_i (Array): shape (6,) or (6, 1)
             Constant strain vector in the segment, [omega, v].
         s_i (Array): scalar arclength position along the segment.
-        eps (float): small value to avoid division by zero in the series expansion.
+        eps (Union[float, Array]): small value to avoid division by zero in the series expansion.
 
     Returns:
         Array: shape (6, 6)
@@ -466,7 +467,7 @@ def Adjoint_gi_se3_inv(
 def Tangent_gi_se3(
     xi_i: Array,
     s_i: Array,
-    eps: float,
+    eps: Union[float, Array],
 ) -> Array:
     """
     Computes the tangent representation of a position of a points at s_i (local curvilinear coordinate)
@@ -476,7 +477,7 @@ def Tangent_gi_se3(
         xi_i (Array): shape (6,) or (6, 1)
             Constant strain vector in the segment, [omega, v].
         s_i (Array): scalar arclength position along the segment.
-        eps (float): small value to avoid division by zero in the series expansion.
+        eps (Union[float, Array]): small value to avoid division by zero in the series expansion.
 
     Returns:
         T (Array): shape (6, 6)
@@ -533,7 +534,7 @@ def Tangent_derivative_gi_se3(
     xi_i: Array,
     xid_i: Array,
     s_i: Array,
-    eps: float,
+    eps: Union[float, Array],
 ) -> Array:
     """
     Computes the tangent derivative representation of a position of a points at s_i (local curvilinear coordinate)
@@ -545,7 +546,7 @@ def Tangent_derivative_gi_se3(
         xid_i (Array): shape (6,) or (6, 1)
             Time derivative of the strain vector.
         s_i (Array): scalar arclength position along the segment.
-        eps (float): small value to avoid division by zero in the series expansion.
+        eps (Union[float, Array]): small value to avoid division by zero in the series expansion.
 
     Returns:
         Td (Array): shape (6, 6)


### PR DESCRIPTION
This pull request refactors how the epsilon parameter used for numerical stability is handled across all dynamical system classes. Instead of each subclass defining its own `global_eps`, the epsilon is now defined once in the base `DynamicalSystem` class and accessed via a new property, ensuring consistency and reducing redundancy. 
Even more importantly, we are defining a separate `tangent_eps` to be used for SE(2) & SE(3) tangent and tangent derivative computations.
All relevant method calls are updated to use this new approach. Additionally, type annotations are improved for clarity in utility functions.

**Refactoring of epsilon handling across dynamical systems:**

* Introduced `global_eps` as a `ClassVar` and a `tangent_eps` property in `DynamicalSystem`, centralizing the definition of epsilon for all subclasses. (`src/soromox/systems/dynamical_system.py`) [[1]](diffhunk://#diff-01e0052383ed2a1884d67c784069cc19a09b5253ab5ae23fd9e3ed1556bc4522L7-R7) [[2]](diffhunk://#diff-01e0052383ed2a1884d67c784069cc19a09b5253ab5ae23fd9e3ed1556bc4522R26-R33)
* Removed redundant `global_eps` definitions from subclasses `GVS`, `PCS`, `PlanarHSA`, and `PlanarPCS`. (`src/soromox/systems/gvs/core.py`, `src/soromox/systems/pcs.py`, `src/soromox/systems/planar_hsa.py`, `src/soromox/systems/planar_pcs.py`) [[1]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L137-L138) [[2]](diffhunk://#diff-19b0b4a682b4e94d1538d4dd92005bf5c097e7cabb76cb4ddf8c61e55fc851c0L87-L89) [[3]](diffhunk://#diff-b5d02dd98c17946883b02ddb989960fb0b0a280384b0240e91a9c46667e6232cL204-L206) [[4]](diffhunk://#diff-4397bec6ccb864d3bfb2d4a8e482b3312663630e95789bf9d8ada63ffae30b5cL84-L86)

**Consistent usage of epsilon in Lie algebra computations:**

* Updated all calls to `lie.Tangent_gi_se3`, `lie.Tangent_derivative_gi_se3`, `lie.Tangent_gi_se2`, and `lie.Tangent_derivative_gi_se2` to use `self.tangent_eps` instead of `self.global_eps`, ensuring consistent numerical stability across all computations. [[1]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L1218-R1216) [[2]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L1291-R1289) [[3]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L1403-R1401) [[4]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L1469-R1467) [[5]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L1554-R1552) [[6]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L1658-R1659) [[7]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L1744-R1745) [[8]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L1872-R1872) [[9]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L1956-R1956) [[10]](diffhunk://#diff-a09d10506394df2d23096266f1509bdec92074df3b65578f7dddc7aa619083a6L2056-R2056) [[11]](diffhunk://#diff-19b0b4a682b4e94d1538d4dd92005bf5c097e7cabb76cb4ddf8c61e55fc851c0L785-R782) [[12]](diffhunk://#diff-19b0b4a682b4e94d1538d4dd92005bf5c097e7cabb76cb4ddf8c61e55fc851c0L852-R849) [[13]](diffhunk://#diff-19b0b4a682b4e94d1538d4dd92005bf5c097e7cabb76cb4ddf8c61e55fc851c0L910-R907) [[14]](diffhunk://#diff-19b0b4a682b4e94d1538d4dd92005bf5c097e7cabb76cb4ddf8c61e55fc851c0L999-R998) [[15]](diffhunk://#diff-19b0b4a682b4e94d1538d4dd92005bf5c097e7cabb76cb4ddf8c61e55fc851c0L1100-R1101) [[16]](diffhunk://#diff-19b0b4a682b4e94d1538d4dd92005bf5c097e7cabb76cb4ddf8c61e55fc851c0L1207-R1206) Fc11705aL896R894, [[17]](diffhunk://#diff-4397bec6ccb864d3bfb2d4a8e482b3312663630e95789bf9d8ada63ffae30b5cL1000-R997) [[18]](diffhunk://#diff-4397bec6ccb864d3bfb2d4a8e482b3312663630e95789bf9d8ada63ffae30b5cL1048-R1045) [[19]](diffhunk://#diff-4397bec6ccb864d3bfb2d4a8e482b3312663630e95789bf9d8ada63ffae30b5cL1149-R1148) [[20]](diffhunk://#diff-4397bec6ccb864d3bfb2d4a8e482b3312663630e95789bf9d8ada63ffae30b5cL1289-R1290) [[21]](diffhunk://#diff-4397bec6ccb864d3bfb2d4a8e482b3312663630e95789bf9d8ada63ffae30b5cL1380-R1379)

**Type annotation improvements in SE(2) utilities:**

* Updated the type annotation for the `eps` parameter in `log_SE2` to accept both `float` and `Array`, improving flexibility and clarity. (`src/soromox/utils/lie_algebra/se2.py`) [[1]](diffhunk://#diff-7a135597bd290ab5b0ff71144206228e72acd094c018c9c69095527bcb3939a0R20) [[2]](diffhunk://#diff-7a135597bd290ab5b0ff71144206228e72acd094c018c9c69095527bcb3939a0L90-R96)