### PR TITLE
Refactor discrete closed-loop rollout for JIT/vmap/grad (fix #54)

### DIFF
--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -1,4 +1,5 @@
 __all__ = ["DynamicalSystem"]
+import math
 import warnings
 from abc import abstractmethod
 from collections.abc import Callable
@@ -329,12 +330,10 @@ class DynamicalSystem(eqx.Module):
         initial_state: SystemState,
         controller: Callable[[SystemState], tuple[Array, Any | None]],
         tau_ext: Array | None = None,
-        t1: float | Array = 10.0,
+        duration: float = 10.0,
         solver_dt: float | Array = 1e-4,
-        control_dt: float | Array = 0.01,
-        control_ts: Array | None = None,
-        save_dt: float | Array = 0.01,
-        save_ts: Array | None = None,
+        control_dt: float = 0.01,
+        save_dt: float = 0.01,
         solver: AbstractSolver | None = None,
         stepsize_controller: AbstractStepSizeController | None = ConstantStepSize(),
         max_steps: int | None = None,
@@ -352,32 +351,70 @@ class DynamicalSystem(eqx.Module):
         control state is advanced with a forward-Euler step over the control period;
         otherwise the control state is held constant between controller calls.
 
+        The rollout uses a regular time grid. For static tracing/compilation the
+        following constraints are enforced:
+        - ``duration`` is an integer multiple of ``control_dt``.
+        - ``control_dt`` is an integer multiple of ``save_dt``.
+
         Args:
             initial_state: initial time/state (and optional feedforward actuation/control state).
             controller: callable returning ``(u_control, control_state_dot)``.
             tau_ext: constant external wrench/force applied during the rollout.
-            t1: final time of the simulation.
+            duration: simulation duration in seconds.
             solver_dt: initial step size for the solver.
-            control_dt: sampling period for the controller. Must be positive. Only used if ``control_ts`` is not provided.
-            control_ts: explicit times to evaluate the controller; falls back to uniform spacing with ``control_dt``.
-            save_dt: save interval if ``save_ts`` is not provided.
-            save_ts: explicit times to save; falls back to ``save_dt``.
+            control_dt: sampling period for the controller. Must be positive.
+            save_dt: save interval. Must be positive and evenly divide ``control_dt``.
             solver: Diffrax solver.
             stepsize_controller: Diffrax stepsize controller.
             max_steps: maximum solver steps.
         """
-        if control_dt <= 0.0:
-            raise ValueError("control_dt must be positive.")
-
         if controller is None:
             raise ValueError("A controller must be provided for closed-loop rollouts.")
-        if save_ts is None:
-            save_ts = self._compute_save_times(
-                float(initial_state.t), t1, solver_dt, save_dt, save_ts
-            )
+
+        if not isinstance(duration, (float, int)):
+            raise TypeError("duration must be a float.")
+        if not isinstance(control_dt, (float, int)):
+            raise TypeError("control_dt must be a float.")
+        if not isinstance(save_dt, (float, int)):
+            raise TypeError("save_dt must be a float.")
+
+        duration = float(duration)
+        control_dt = float(control_dt)
+        save_dt = float(save_dt)
+
+        if duration <= 0.0:
+            raise ValueError("duration must be positive.")
+        if control_dt <= 0.0:
+            raise ValueError("control_dt must be positive.")
+        if save_dt <= 0.0:
+            raise ValueError("save_dt must be positive.")
+        if save_dt > control_dt:
+            raise ValueError("save_dt must be less than or equal to control_dt.")
+
+        # Require commensurate, regular control/save grids so the (control, save) sequence
+        # is static and can be traced/compiled without runtime masking.
+        saves_per_control = int(round(control_dt / save_dt))
+        if saves_per_control < 1 or not math.isclose(
+            saves_per_control * save_dt,
+            control_dt,
+            rel_tol=1e-12,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("control_dt must be an integer multiple of save_dt.")
+
+        num_control_steps = int(round(duration / control_dt))
+        if num_control_steps < 1 or not math.isclose(
+            num_control_steps * control_dt,
+            duration,
+            rel_tol=1e-12,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("duration must be an integer multiple of control_dt.")
 
         if solver is None:
             solver = Tsit5()
+
+        term = ODETerm(self._open_loop_forward_dynamics)
 
         base_u = initial_state.u
         if base_u is None:
@@ -388,36 +425,27 @@ class DynamicalSystem(eqx.Module):
         track_control_state = control_state is not None
         zero_control_state_dot = self._zero_like_control_state(control_state)
 
-        if control_ts is None:
-            t_curr = float(initial_state.t)
-            total_horizon = t1 - t_curr
-            num_control_steps = int(jnp.ceil(total_horizon / control_dt))
-            t_starts = t_curr + control_dt * jnp.arange(num_control_steps)
-            t_ends = jnp.minimum(t_starts + control_dt, t1)
-        else:
-            t_starts = control_ts[:-1]
-            t_ends = control_ts[1:]
-
-        max_saves = save_ts.shape[0]
-        max_save_slots = max_saves + 1  # include control interval end time
+        t0 = initial_state.t
+        t0_dtype = jnp.asarray(t0).dtype
+        save_offsets = save_dt * jnp.arange(saves_per_control + 1, dtype=t0_dtype)
+        control_offsets = control_dt * jnp.arange(num_control_steps, dtype=t0_dtype)
+        t_starts = t0 + control_offsets
+        t_ends = t_starts + control_dt
 
         def body(
             carry: tuple[Array, Any | None],
             t_bounds: tuple[Array, Array],
-        ) -> tuple[
-            tuple[Array, Any | None], tuple[Array, Array, Array, Any | None, Array]
-        ]:
+        ) -> tuple[tuple[Array, Any | None], tuple[Array, Array, Array, Any | None]]:
             """
             Advance one control interval: evaluate controller at ``t_start``, hold actuation
-            for the interval, integrate dynamics, and return padded saved trajectories.
+            for the interval, integrate dynamics, and return saved trajectories.
 
             Args:
                 carry: tuple of current state ``y_in`` and current control state ``ctrl_state_in``.
                 t_bounds: tuple of start and end times for this control interval.
             Returns:
                 next_carry: tuple of next state and next control state.
-                outputs: tuple of padded saved times, states, actuations, control states, and count
-                    of valid saved steps.
+                outputs: tuple of saved times, states, actuations, and control states.
             """
             y_in, ctrl_state_in = carry
             t_start, t_end = t_bounds
@@ -438,18 +466,8 @@ class DynamicalSystem(eqx.Module):
 
             u_total = base_u + u_control
 
-            mask = (save_ts >= t_start) & (save_ts <= t_end)
-            count = jnp.sum(mask, dtype=jnp.int32)
-            idxs = jnp.nonzero(mask, size=max_saves, fill_value=0)[0]
-            valid_mask = jnp.arange(max_save_slots - 1) < count
-            ts_control_interval = jnp.where(valid_mask, save_ts[idxs], t_end)
-            ts_control_interval = jnp.concatenate(
-                (ts_control_interval, jnp.array([t_end]))
-            )
-
-            # Use class method to avoid closure overhead
-            term = ODETerm(self._open_loop_forward_dynamics)
-            saveat = SaveAt(ts=ts_control_interval, t1=False)
+            ts_control_interval = t_start + save_offsets
+            saveat = SaveAt(ts=ts_control_interval, t0=False, t1=False)
             sol = diffeqsolve(
                 terms=term,
                 solver=solver,
@@ -463,37 +481,6 @@ class DynamicalSystem(eqx.Module):
                 max_steps=max_steps,
             )
 
-            valid_mask = (jnp.arange(max_save_slots) < (count + 1)).astype(sol.ts.dtype)
-            ts_out = sol.ts * valid_mask
-
-            ys_out = jnp.where(
-                valid_mask[:, None] > 0,
-                sol.ys,
-                jnp.zeros_like(sol.ys),
-            )
-
-            us_out = jnp.where(
-                valid_mask[:, None] > 0,
-                jnp.broadcast_to(u_total, (max_save_slots, u_total.shape[0])),
-                jnp.zeros((max_save_slots, u_total.shape[0]), dtype=u_total.dtype),
-            )
-
-            if track_control_state:
-                cs_segment = jax.tree_util.tree_map(
-                    lambda c: jnp.zeros((max_save_slots,) + c.shape, dtype=c.dtype),
-                    ctrl_state_in,
-                )
-                mask = (jnp.arange(max_save_slots) < (count + 1)).astype(jnp.int32)
-                cs_out = jax.tree_util.tree_map(
-                    lambda arr, c: arr
-                    + mask.reshape((max_save_slots,) + (1,) * c.ndim) * c,
-                    cs_segment,
-                    ctrl_state_in,
-                )
-            else:
-                cs_out = None
-
-            y_next = sol.ys[-1]
             ctrl_state_next = (
                 jax.tree_util.tree_map(
                     lambda c, cdot: c + cdot * (t_end - t_start),
@@ -504,28 +491,57 @@ class DynamicalSystem(eqx.Module):
                 else None
             )
 
-            outputs = (ts_out, ys_out, us_out, cs_out, count + 1)
+            us_out = jnp.broadcast_to(u_total, (sol.ts.shape[0], u_total.shape[0]))
+
+            if track_control_state:
+                # Controller state is held constant over the interval, then advanced at the end.
+                cs_out = jax.tree_util.tree_map(
+                    lambda c, c_next: jnp.concatenate(
+                        [
+                            jnp.broadcast_to(
+                                c, (sol.ts.shape[0] - 1,) + c.shape  # type: ignore[misc]
+                            ),
+                            c_next[None, ...],
+                        ],
+                        axis=0,
+                    ),
+                    ctrl_state_in,
+                    ctrl_state_next,
+                )
+            else:
+                cs_out = None
+
+            y_next = sol.ys[-1]
+
+            outputs = (sol.ts, sol.ys, us_out, cs_out)
             next_carry = (y_next, ctrl_state_next)
             return next_carry, outputs
 
         _, scan_outputs = lax.scan(body, (y_curr, control_state), (t_starts, t_ends))
-        ts_padded, ys_padded, us_padded, cs_padded, counts = scan_outputs
+        ts_segments, ys_segments, us_segments, cs_segments = scan_outputs
 
-        idxs = jnp.arange(max_save_slots)
-        valid_mask = idxs[None, :] < counts[:, None]
-        flat_mask = valid_mask.reshape(-1)
-
-        ts_all = ts_padded.reshape(-1)[flat_mask]
-        ys_all = ys_padded.reshape((-1,) + ys_padded.shape[2:])[flat_mask]
-        us_all = us_padded.reshape((-1, self.num_actuators))[flat_mask]
-
-        if track_control_state and cs_padded is not None:
-            control_state_out = jax.tree_util.tree_map(
-                lambda arr: arr.reshape((-1,) + arr.shape[2:])[flat_mask],
-                cs_padded,
-            )
+        # Drop the first (duplicate) sample of every interval except the first.
+        if num_control_steps == 1:
+            ts_all = ts_segments[0]
+            ys_all = ys_segments[0]
+            us_all = us_segments[0]
+            control_state_out = cs_segments[0] if track_control_state else None
         else:
-            control_state_out = None
+            ts_tail = ts_segments[1:, 1:].reshape(-1)
+            ys_tail = ys_segments[1:, 1:].reshape((-1,) + ys_segments.shape[2:])
+            us_tail = us_segments[1:, 1:].reshape((-1, self.num_actuators))
+            ts_all = jnp.concatenate([ts_segments[0], ts_tail], axis=0)
+            ys_all = jnp.concatenate([ys_segments[0], ys_tail], axis=0)
+            us_all = jnp.concatenate([us_segments[0], us_tail], axis=0)
+            if track_control_state and cs_segments is not None:
+                control_state_out = jax.tree_util.tree_map(
+                    lambda arr: jnp.concatenate(
+                        [arr[0], arr[1:, 1:].reshape((-1,) + arr.shape[2:])], axis=0
+                    ),
+                    cs_segments,
+                )
+            else:
+                control_state_out = None
 
         return SystemState(
             t=ts_all, y=ys_all, u=us_all, control_state=control_state_out

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -467,6 +467,10 @@ class DynamicalSystem(eqx.Module):
             u_total = base_u + u_control
 
             ts_control_interval = t_start + save_offsets
+            # Protect against tiny floating-point drift (especially visible during the
+            # backward pass) that can push the final save time slightly outside
+            # [t_start, t_end].
+            ts_control_interval = jnp.clip(ts_control_interval, t_start, t_end)
             saveat = SaveAt(ts=ts_control_interval, t0=False, t1=False)
             sol = diffeqsolve(
                 terms=term,

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -331,7 +331,8 @@ class DynamicalSystem(eqx.Module):
         tau_ext: Array | None = None,
         t1: float | Array = 10.0,
         solver_dt: float | Array = 1e-4,
-        control_dt: float | Array = 1e-2,
+        control_dt: float | Array = 0.01,
+        control_ts: Array | None = None,
         save_dt: float | Array = 0.01,
         save_ts: Array | None = None,
         solver: AbstractSolver | None = None,
@@ -357,7 +358,8 @@ class DynamicalSystem(eqx.Module):
             tau_ext: constant external wrench/force applied during the rollout.
             t1: final time of the simulation.
             solver_dt: initial step size for the solver.
-            control_dt: sampling period for the controller. Must be positive.
+            control_dt: sampling period for the controller. Must be positive. Only used if ``control_ts`` is not provided.
+            control_ts: explicit times to evaluate the controller; falls back to uniform spacing with ``control_dt``.
             save_dt: save interval if ``save_ts`` is not provided.
             save_ts: explicit times to save; falls back to ``save_dt``.
             solver: Diffrax solver.
@@ -386,11 +388,15 @@ class DynamicalSystem(eqx.Module):
         track_control_state = control_state is not None
         zero_control_state_dot = self._zero_like_control_state(control_state)
 
-        t_curr = float(initial_state.t)
-        total_horizon = t1 - t_curr
-        num_control_steps = int(jnp.ceil(total_horizon / control_dt))
-        t_starts = t_curr + control_dt * jnp.arange(num_control_steps)
-        t_ends = jnp.minimum(t_starts + control_dt, t1)
+        if control_ts is None:
+            t_curr = float(initial_state.t)
+            total_horizon = t1 - t_curr
+            num_control_steps = int(jnp.ceil(total_horizon / control_dt))
+            t_starts = t_curr + control_dt * jnp.arange(num_control_steps)
+            t_ends = jnp.minimum(t_starts + control_dt, t1)
+        else:
+            t_starts = control_ts[:-1]
+            t_ends = control_ts[1:]
 
         max_saves = save_ts.shape[0]
         max_save_slots = max_saves + 1  # include control interval end time

--- a/tests/systems/test_dynamical_system_rollout.py
+++ b/tests/systems/test_dynamical_system_rollout.py
@@ -1,4 +1,5 @@
 import equinox as eqx
+import jax
 from jax import numpy as jnp
 
 from soromox.systems import Pendulum, SystemState
@@ -106,3 +107,93 @@ def test_rollout_discrete_closed_loop_to_tracks_target():
     q_final = trajectory.y[-1, : q0.shape[0]]
     assert jnp.linalg.norm(q_final) < 7e-2
     assert trajectory.control_state is not None
+
+
+def test_rollout_discrete_closed_loop_to_is_jittable():
+    robot = Pendulum(_pendulum_params())
+
+    q0 = jnp.array([0.3, -0.2])
+    qd0 = jnp.zeros_like(q0)
+    initial_state = SystemState(
+        t=0.0,
+        y=jnp.concatenate([q0, qd0]),
+        u=jnp.zeros_like(q0),
+        control_state=jnp.zeros_like(q0),
+    )
+    controller = PIDController(kp=8.0, ki=2.5, kd=1.5, target=jnp.zeros_like(q0))
+
+    def loss_fn(y0: jnp.ndarray) -> jnp.ndarray:
+        init = eqx.tree_at(lambda s: s.y, initial_state, y0)
+        traj = robot.rollout_discrete_closed_loop_to(
+            initial_state=init,
+            controller=controller,
+            duration=0.2,
+            solver_dt=1e-3,
+            control_dt=0.02,
+            save_dt=0.01,
+        )
+        q_final = traj.y[-1, : q0.shape[0]]
+        return jnp.sum(q_final**2)
+
+    y0 = initial_state.y
+    loss = jax.jit(loss_fn)(y0)
+    assert jnp.isfinite(loss)
+
+
+def test_rollout_discrete_closed_loop_to_is_vmappable():
+    robot = Pendulum(_pendulum_params())
+    target = jnp.zeros((2,))
+    controller = PIDController(kp=8.0, ki=2.5, kd=1.5, target=target)
+
+    def run(q0: jnp.ndarray) -> jnp.ndarray:
+        qd0 = jnp.zeros_like(q0)
+        init = SystemState(
+            t=0.0,
+            y=jnp.concatenate([q0, qd0]),
+            u=jnp.zeros_like(q0),
+            control_state=jnp.zeros_like(q0),
+        )
+        traj = robot.rollout_discrete_closed_loop_to(
+            initial_state=init,
+            controller=controller,
+            duration=0.2,
+            solver_dt=1e-3,
+            control_dt=0.02,
+            save_dt=0.01,
+        )
+        return traj.y[-1]
+
+    q0s = jnp.array([[0.3, -0.2], [0.1, 0.05], [-0.25, 0.15]])
+    ys_final = jax.jit(jax.vmap(run))(q0s)
+    assert ys_final.shape == (q0s.shape[0], 2 * q0s.shape[1])
+    assert jnp.all(jnp.isfinite(ys_final))
+
+
+def test_rollout_discrete_closed_loop_to_reverse_mode_grad_works():
+    robot = Pendulum(_pendulum_params())
+
+    q0 = jnp.array([0.3, -0.2])
+    qd0 = jnp.zeros_like(q0)
+    initial_state = SystemState(
+        t=0.0,
+        y=jnp.concatenate([q0, qd0]),
+        u=jnp.zeros_like(q0),
+        control_state=jnp.zeros_like(q0),
+    )
+
+    def loss_fn(kp: jnp.ndarray) -> jnp.ndarray:
+        controller = PIDController(kp=kp, ki=2.5, kd=1.5, target=jnp.zeros_like(q0))
+        traj = robot.rollout_discrete_closed_loop_to(
+            initial_state=initial_state,
+            controller=controller,
+            duration=0.2,
+            solver_dt=1e-3,
+            control_dt=0.02,
+            save_dt=0.01,
+            max_steps=1024,
+        )
+        q_final = traj.y[-1, : q0.shape[0]]
+        return jnp.sum(q_final**2)
+
+    dloss_dkp = jax.grad(loss_fn)(jnp.array(8.0))
+    assert jnp.isfinite(dloss_dkp)

--- a/tests/systems/test_dynamical_system_rollout.py
+++ b/tests/systems/test_dynamical_system_rollout.py
@@ -97,7 +97,7 @@ def test_rollout_discrete_closed_loop_to_tracks_target():
     trajectory = robot.rollout_discrete_closed_loop_to(
         initial_state=initial_state,
         controller=controller,
-        t1=0.6,
+        duration=0.6,
         solver_dt=1e-3,
         control_dt=0.02,
         save_dt=0.02,


### PR DESCRIPTION
## Summary

This PR refactors the discrete closed-loop rollout to be statically traceable (JIT/vmap-friendly) and more robust under reverse-mode differentiation.

- Replace irregular/masked save/control schedules with a strictly regular, commensurate grid.
- API update: remove `t1`, `control_ts`, `save_ts`; add `duration` and require `control_dt`/`save_dt` to be Python floats.
- Avoid runtime masking/`nonzero`/dynamic indexing by using fixed-size per-interval save times and static slicing to remove duplicates.
- Clamp per-interval `SaveAt.ts` to `[t_start, t_end]` to prevent floating-point drift that can surface during the backward pass.
- Add tests verifying that the method can be `jit`-compiled, `vmap`ped, and differentiated with reverse-mode AD.

Fixes #54 .

## Idea / Intuition

The previous implementation built per-interval save times by masking a global `save_ts` array and then flattening variable-length segments. That required dynamic indexing and shape changes, which breaks static tracing and can make compilation/batching fragile.

This PR makes the control and save schedule *regular and static* by enforcing commensurate time steps:

- `duration = N_control * control_dt`
- `control_dt = N_save * save_dt`

This lets us precompute a fixed set of offsets and reuse them in each interval (`t_start + offsets`), so each scan iteration has identical shapes and no masking is needed.

## Example

Below is an example script that can be used to sanity-check the discrete closed-loop rollout and its reverse-mode gradient use in a simple optimization loop.

```python
import jax
import numpy as np
import optax
from jax import Array, jit, value_and_grad, vmap
from jax import numpy as jnp

from soromox.control import (
    OperationalSpaceSynergisticController,
    PIDControl,
    PIDControllerState,
    ReferenceTrajectory,
)
from soromox.coordinate_transformations import OperationalSpaceDynamics
from soromox.systems import SystemState, TendonActuatedPCS

jax.config.update("jax_enable_x64", True)  # double precision
jax.config.update("jax_debug_nans", True)


def evaluate_closed_loop_system(
    opt_vars: dict[str, Array],
    controller: OperationalSpaceSynergisticController,
) -> tuple[Array, dict[str, Array]]:
    # Update optimization parameters
    ctr_params = opt_vars["opt_ctr_params"]
    controller = controller.update_gains(ctr_params)

    # Run simulation
    trajectory = robot.rollout_discrete_closed_loop_to(
        initial_state=initial_state,
        controller=controller,
        duration=float(t1 - t0),
        solver_dt=solver_dt,
        control_dt=control_dt,
        save_dt=save_dt,
        max_steps=num_ts + 1,
    )

    # Extract results
    t_ts = trajectory.t
    q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)

    # Compute loss
    x_ts = vmap(osd.operational_space_poses)(q_ts)[:, task_selector]
    e_ts = jnp.linalg.norm(x_des_ts - x_ts, axis=1)

    loss = 1e7 * jnp.trapezoid(e_ts**2, t_ts)

    # Store auxiliary information
    aux = {"t_ts": t_ts, "q_ts": q_ts, "qd_ts": qd_ts, "u_ts": trajectory.u}

    return loss, aux


# =========================================================================
# Setup
# =========================================================================
num_segments = 2
rho = 1070 * jnp.ones((num_segments,))  # Volumetric density of Dragon Skin 20 [kg/m^3]
L_seg = 0.10  # Segment length [m]
radius = 0.013  # Segment radius [m]
E = 14e4  # [Pa]
G = E / 3  # [Pa]
D = 1e-4  # [?]
params = {
    "p0": jnp.array(
        [jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]
    ),  # Initial position and orientation
    "L": L_seg * jnp.ones((num_segments,)),
    "r": radius * jnp.ones((num_segments,)),
    "rho": rho,
    "g": jnp.array([0.0, 0.0, 9.81]),  # Gravity vector [m/s^2]
    "E": E * jnp.ones((num_segments,)),  # Elastic modulus [Pa]
    "G": G * jnp.ones((num_segments,)),  # Shear modulus [Pa]
}
params["D"] = D * jnp.diag(
    (
        jnp.repeat(jnp.array([[1e0, 1e0, 1e0, 1e3, 1e3, 1e3]]), num_segments, axis=0)
        * params["L"][:, None]
    ).flatten()
)

tendon_distance = 0.8 * radius  # Slightly inside the robot radius
angles_deg = jnp.array([0.0, 120.0, 240.0])
angles_rad = jnp.deg2rad(angles_deg)

active_tendon_routing_params = {
    "ry": tendon_distance * jnp.sin(angles_rad),  # y-coordinate of tendons
    "rz": tendon_distance * jnp.cos(angles_rad),  # z-coordinate of tendons
    "my": jnp.zeros(3),  # Parallel to backbone (no y-slope)
    "mz": jnp.zeros(3),  # Parallel to backbone (no z-slope)
    "idx_seg_att": jnp.array([1, 1, 1]),  # All attached to segment 0 (the only segment)
}

robot = TendonActuatedPCS(
    num_segments=num_segments,
    params=params,
    active_tendon_routing_params=active_tendon_routing_params,
)

num_dofs = robot.num_active_strains
num_actuators = robot.num_actuators
total_length = float(jnp.sum(params["L"]))

# =========================================================================
# Operational Space Definition
# =========================================================================
s_ps = jnp.array([total_length])

task_selector = jnp.array([False, False, False, True, True, True])

# Create operational space dynamics
osd = OperationalSpaceDynamics(
    robot=robot,
    s_ps=s_ps,
    task_selector=task_selector,
)

# =========================================================================
# Find Statically-Feasible Setpoint
# =========================================================================
# Define simulation parameters
solver_dt = 1e-4
control_dt = 1e-2

# Time parameters for closed-loop control
t0, t1 = 0.0, 5.0
duration = float(t1 - t0)

# Saving parameters
save_dt = control_dt / 2

# Start from rest configuration
q0 = jnp.zeros(num_dofs)
qd0 = jnp.zeros(num_dofs)
y0 = jnp.concatenate([q0, qd0])

# Desired configuration
q_des = jnp.array(
    [
        -1.08733113e-06,
        -3.43478909e-01,
        8.49889712e-02,
        4.81709431e-04,
        -1.23489816e-04,
        -4.99077654e-04,
        -4.24568791e-06,
        -9.24797312e-01,
        2.28828013e-01,
        -7.02336829e-03,
        -1.75477402e-04,
        -7.09181336e-04,
    ]
)

x0_full = osd.operational_space_poses(q0)
x_des_full = osd.operational_space_poses(q_des)

# =========================================================================
# Define the Constant Reference
# =========================================================================
save_ts = np.arange(t0, t1 + 0.5 * save_dt, save_dt)
num_ts = save_ts.shape[0]

reference_trajectory = ReferenceTrajectory(
    ts=jnp.asarray(save_ts),
    x_des_fn=lambda t: x_des_full,
    rotation_representation=osd.rotation_representation,
    n_points=osd.n_points,
    is_planar=osd.is_planar,
)
x_des_ts = reference_trajectory.x_des_ts[:, task_selector]

# =========================================================================
# Define the Controller
# =========================================================================
Kp = 40.0 * jnp.ones((osd.n_operational_space,))
Ki = 20.0 * jnp.ones((osd.n_operational_space,))
Kd = 2.0 * jnp.ones((osd.n_operational_space,))

# Define PID controller
pid_control = PIDControl(Kp, Ki, Kd)

# Create the synergistic controller
controller = OperationalSpaceSynergisticController(
    operational_space_dynamics=osd,
    reference_trajectory=reference_trajectory,
    pid_control=pid_control,
)

# =========================================================================
# Initialize Simulation
# =========================================================================
# Initial control state (sized for operational coordinates)
control_state_0 = PIDControllerState.zero(osd.n_operational_space)

# Create initial system state
initial_state = SystemState(
    t=jnp.array(t0),
    y=y0,
    u=jnp.zeros(num_actuators),
    control_state=control_state_0,
)

print("sim_duration      =", duration)
print("control_dt        =", control_dt)
print("solver_dt         =", solver_dt)
print("save_dt           =", save_dt)
print("save_ts.shape     =", save_ts.shape)

print("\nStarting simulation...")
trajectory = robot.rollout_discrete_closed_loop_to(
    initial_state=initial_state,
    controller=controller,
    duration=duration,
    solver_dt=solver_dt,
    control_dt=control_dt,
    save_dt=save_dt,
    max_steps=num_ts + 1,
)
print("Simulation finished.")

# =====================================================
# Optimization
# =====================================================
# Control parameters
control_params = {"Kp": Kp, "Ki": Ki, "Kd": Kd}

# Initialize optimization variables
opt_keys_ctr = ["Kp", "Ki", "Kd"]
opt_keys_atr = []

opt_ctr_params = {k: control_params[k] for k in opt_keys_ctr}
opt_atr_params = {k: active_tendon_routing_params[k] for k in opt_keys_atr}

opt_vars = {"opt_ctr_params": opt_ctr_params, "opt_atr_params": opt_atr_params}

var_to_label_map = {
    "Kp": "P_gain",
    "Ki": "I_gain",
    "Kd": "D_gain",
}
param_labels = {
    "opt_ctr_params": {k: var_to_label_map[k] for k in opt_keys_ctr},
    "opt_atr_params": {k: var_to_label_map[k] for k in opt_keys_atr},
}
optimizer = optax.multi_transform(
    {
        "P_gain": optax.chain(
            optax.clip_by_global_norm(10.0), optax.yogi(learning_rate=0.5)
        ),
        "I_gain": optax.chain(
            optax.clip_by_global_norm(10.0), optax.yogi(learning_rate=0.25)
        ),
        "D_gain": optax.chain(
            optax.clip_by_global_norm(10.0), optax.yogi(learning_rate=0.05)
        ),
    },
    param_labels,
)

# Define box constraints
threshold_box_maps = {
    "opt_ctr_params": {
        "Kp": jnp.array([0.0, 500.0]),
        "Ki": jnp.array([0.0, 150.0]),
        "Kd": jnp.array([0.0, 50.0]),
    },
    "opt_atr_params": {},
}


# Projection function
def clip_params(val, limits):
    return jnp.clip(val, min=limits[0], max=limits[1])


# Initialize the state of the optimizer
opt_state = optimizer.init(opt_vars)

# Gradient function
gradient_fn = jit(value_and_grad(evaluate_closed_loop_system, 0, has_aux=True))


# Update function of the optimization variables
def update(opt_vars, opt_state):
    # Compute gradient
    (loss, aux), grad = gradient_fn(opt_vars, controller)

    # Compute update of the optimization variables
    updates, opt_state = optimizer.update(grad, opt_state, params=opt_vars)

    # Apply update
    opt_vars = optax.apply_updates(opt_vars, updates)

    # Apply constraints
    opt_vars = jax.tree_util.tree_map(clip_params, opt_vars, threshold_box_maps)

    return opt_vars, opt_state, loss, aux


print("\nStarting optimization...")

# Optimization step
opt_vars, opt_state, loss, aux = update(opt_vars, opt_state)

print("Optimization finished.")
```

### Expected Output (Reference)

```bash
(soromox) maximilianstoelzle@MacBook-Pro-2024-by-Maximilian soromox % python ./test2.py
sim_duration      = 5.0
control_dt        = 0.01
solver_dt         = 0.0001
save_dt           = 0.005
save_ts.shape     = (1001,)

Starting simulation...
Simulation finished.

Starting optimization...
Invalid nan value encountered in the output of a jax.jit function. Calling the de-optimized version.
Traceback (most recent call last):
  File "/Users/maximilianstoelzle/Documents/phd/soromox/./test2.py", line 305, in <module>
    opt_vars, opt_state, loss, aux = update(opt_vars, opt_state)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maximilianstoelzle/Documents/phd/soromox/./test2.py", line 288, in update
    (loss, aux), grad = gradient_fn(opt_vars, controller)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maximilianstoelzle/Documents/phd/soromox/./test2.py", line 29, in evaluate_closed_loop_system
    trajectory = robot.rollout_discrete_closed_loop_to(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maximilianstoelzle/Documents/phd/soromox/.venv/lib/python3.12/site-packages/equinox/_module/_prebuilt.py", line 33, in __call__
    return self.__func__(self.__self__, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maximilianstoelzle/Documents/phd/soromox/src/soromox/systems/dynamical_system.py", line 524, in rollout_discrete_closed_loop_to
    _, scan_outputs = lax.scan(body, (y_curr, control_state), (t_starts, t_ends))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FloatingPointError: invalid value (nan) encountered in scan
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
```

## Review Request

@Michele-Martini could you please review this PR and verify that it addresses the issues you encountered with the discrete closed-loop rollout method (JIT/vmap/grad + the `saveat.ts must lie between t0 and t1` backward-pass failure)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rollout API and time-grid semantics, which can break downstream callers and subtly affect saved sample timing; adds validation and new tests to reduce regressions.
> 
> **Overview**
> Refactors `DynamicalSystem.rollout_discrete_closed_loop_to` to use a **static, regular control/save time grid** (no masking/dynamic indexing) so it traces cleanly under `jax.jit`, `vmap`, and reverse-mode `grad`.
> 
> API and behavior changes: replaces `t1` with `duration`, removes support for arbitrary `save_ts`, enforces `duration % control_dt == 0` and `control_dt % save_dt == 0` via runtime validation, and clamps per-interval `SaveAt.ts` to `[t_start, t_end]` to avoid backward-pass floating-point drift errors. Tests are updated and expanded to assert JIT-ability, VMAP-ability, and finite reverse-mode gradients.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03f0467e4dc725f3cd0144328f0f01ec275a834f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>03f0467</u></sup><!-- /BUGBOT_STATUS -->