### PR TITLE
Optimize PCS forward dynamics assembly and caching mechanisms

### DIFF
--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -85,6 +85,11 @@ class PCS(SoftRobot):
 
     Xs: Array  # Gauss nodes
     Ws: Array  # Gauss weights
+    M_segments: Array  # Cached per-segment mass matrices
+    K_full: Array  # Cached full stiffness matrix
+    K: Array  # Cached active-coordinate stiffness matrix
+    D_full: Array  # Cached full damping matrix
+    D_active: Array  # Cached active-coordinate damping matrix
 
     def __init__(
         self,
@@ -213,6 +218,14 @@ class PCS(SoftRobot):
 
         # Number of actuators
         self.num_actuators = int(self.num_active_strains.item())
+
+        (
+            self.M_segments,
+            self.K_full,
+            self.K,
+            self.D_full,
+            self.D_active,
+        ) = self._compute_constant_matrices()
 
     @property
     def is_planar(self) -> bool:
@@ -490,7 +503,26 @@ class PCS(SoftRobot):
                 raise ValueError(f"D must have shape {expected_D_shape}, got {D.shape}")
             updated_self = eqx.tree_at(lambda m: m.D, updated_self, D)
 
-        return updated_self
+        return updated_self._with_refreshed_constant_matrices()
+
+    def _compute_constant_matrices(self) -> tuple[Array, Array, Array, Array, Array]:
+        """Compute state-independent matrices cached by the model."""
+        M_segments = vmap(self._compute_local_mass_matrix)(
+            jnp.arange(self.num_segments)
+        )
+        K_full = self._compute_stiffness_full_matrix()
+        K = self.B_xi.T @ K_full @ self.B_xi
+        D_full = self.D
+        D_active = self.B_xi.T @ D_full @ self.B_xi
+        return M_segments, K_full, K, D_full, D_active
+
+    def _with_refreshed_constant_matrices(self) -> "PCS":
+        """Return a copy with cached state-independent matrices refreshed."""
+        return eqx.tree_at(
+            lambda m: (m.M_segments, m.K_full, m.K, m.D_full, m.D_active),
+            self,
+            self._compute_constant_matrices(),
+        )
 
     @eqx.filter_jit
     def classify_segment(self, s: Array) -> tuple[Array, Array]:
@@ -1129,7 +1161,6 @@ class PCS(SoftRobot):
             J_prev, Jd_prev = carry
 
             # extract the current segment variables
-            xi_i = lax.dynamic_index_in_dim(xi, i, axis=0, keepdims=False)
             xid_i = lax.dynamic_index_in_dim(xid, i, axis=0, keepdims=False)
             Ad_inv_i = lax.dynamic_index_in_dim(Ad_inv_tips, i, axis=0, keepdims=False)
             T_i = lax.dynamic_index_in_dim(T_tips, i, axis=0, keepdims=False)
@@ -1391,8 +1422,7 @@ class PCS(SoftRobot):
         )
         return I_i
 
-    @eqx.filter_jit
-    def _local_mass_matrix(self, i: Array) -> Array:
+    def _compute_local_mass_matrix(self, i: Array) -> Array:
         """
         Compute the local mass matrix for the i-th segment.
 
@@ -1409,6 +1439,19 @@ class PCS(SoftRobot):
 
         M_i = rho_i * jnp.diag(jnp.array([I_i[0], I_i[1], I_i[2], A_i, A_i, A_i]))
         return M_i
+
+    @eqx.filter_jit
+    def _local_mass_matrix(self, i: Array) -> Array:
+        """
+        Return the cached local mass matrix for the i-th segment.
+
+        Args:
+            i (Array): index of the segment as array of shape ()
+
+        Returns:
+            M_i (Array): local mass matrix of shape (6, 6) for the i-th segment
+        """
+        return self.M_segments[i]
 
     # ===========================================
     # Dynamical matrices computation
@@ -1691,17 +1734,19 @@ class PCS(SoftRobot):
 
         return S_i
 
-    @eqx.filter_jit
-    def _stiffness(self, formulate_in_strain_space: bool = False) -> Array:
+    def _compute_stiffness_full_matrix(self) -> Array:
+        """Compute the uncached full stiffness matrix from current parameters."""
         # stiffness matrix of shape (num_segments, 6, 6)
         S_sms = vmap(self._local_stiffness_matrix)(jnp.arange(self.num_segments))
         # we define the elastic matrix of shape (num_strains, num_strains) as K(xi) = K @ xi where K is equal to
-        S = blk_diag(S_sms)
+        return blk_diag(S_sms)
 
-        if not formulate_in_strain_space:
-            S = self.B_xi.T @ S @ self.B_xi
+    @eqx.filter_jit
+    def _stiffness(self, formulate_in_strain_space: bool = False) -> Array:
+        if formulate_in_strain_space:
+            return self.K_full
 
-        return S
+        return self.K
 
     @eqx.filter_jit
     def _stiffness_full_matrix(self) -> Array:
@@ -1711,9 +1756,7 @@ class PCS(SoftRobot):
         Returns:
             K_full (Array): Full stiffness matrix of shape (num_strains, num_strains).
         """
-        K_full = self._stiffness(formulate_in_strain_space=True)
-
-        return K_full
+        return self.K_full
 
     @eqx.filter_jit
     def stiffness_matrix(self) -> Array:
@@ -1723,9 +1766,7 @@ class PCS(SoftRobot):
         Returns:
             K (Array): Stiffness matrix of shape (num_active_strains, num_active_strains).
         """
-        K = self._stiffness(formulate_in_strain_space=False)
-
-        return K
+        return self.K
 
     @eqx.filter_jit
     def elastic_force(self, q: Array) -> Array:
@@ -1738,10 +1779,7 @@ class PCS(SoftRobot):
         Returns:
             tau_el (Array): Elastic force of shape (num_active_strains,).
         """
-        K = self.stiffness_matrix()
-        tau_el = K @ q
-
-        return tau_el
+        return self.K @ q
 
     @eqx.filter_jit
     def _damping_full_matrix(self) -> Array:
@@ -1754,9 +1792,7 @@ class PCS(SoftRobot):
         Returns:
             D (Array): Full damping matrix of shape (num_strains, num_strains).
         """
-        D_full = self.D
-
-        return D_full
+        return self.D_full
 
     @eqx.filter_jit
     def damping_matrix(self, q: Array) -> Array:
@@ -1769,11 +1805,7 @@ class PCS(SoftRobot):
         Returns:
             D (Array): Damping matrix of shape (num_active_strains, num_active_strains).
         """
-        D_full = self._damping_full_matrix()
-
-        D = self.B_xi.T @ D_full @ self.B_xi
-
-        return D
+        return self.D_active
 
     @eqx.filter_jit
     def actuation_matrix(self, q: Array) -> Array:
@@ -1875,33 +1907,139 @@ class PCS(SoftRobot):
         return U_G
 
     @eqx.filter_jit
-    def _active_quadrature_dynamics_terms(
-        self, q: Array, qd: Array
-    ) -> tuple[Array, Array, Array]:
-        """
-        Assemble active-coordinate inertia, Coriolis, and gravity terms over quadrature.
+    def _active_J_Jd_local_tips_from_strain(
+        self, xi: Array, xid: Array, B_segments: Array
+    ) -> tuple[Array, Array]:
+        """Compute active-coordinate local Jacobians at all segment tips."""
+        Ad_inv_tips = vmap(
+            lambda xi_i, L_i: lie.Adjoint_gi_se3_inv(xi_i, L_i, eps=self.global_eps)
+        )(xi, self.L)
+        T_tips = vmap(
+            lambda xi_i, L_i: lie.Tangent_gi_se3(xi_i, L_i, eps=self.tangent_eps)
+        )(xi, self.L)
+        Td_tips = vmap(
+            lambda xi_i, xid_i, L_i: lie.Tangent_derivative_gi_se3(
+                xi_i, xid_i, L_i, eps=self.tangent_eps
+            )
+        )(xi, xid, self.L)
 
-        The endpoint quadrature nodes have zero weight and are dropped before the
-        kinematics/Jacobian batch evaluation. Jacobians are projected to the active
-        strain coordinates before forming the matrix/vector integrands.
-        """
+        zeros = jnp.zeros((6, self.num_dofs), dtype=xi.dtype)
+
+        def scan_body(
+            carry: tuple[Array, Array], i: Array
+        ) -> tuple[tuple[Array, Array], tuple[Array, Array]]:
+            J_prev, Jd_prev = carry
+
+            xid_i = lax.dynamic_index_in_dim(xid, i, axis=0, keepdims=False)
+            B_i = lax.dynamic_index_in_dim(B_segments, i, axis=0, keepdims=False)
+            Ad_inv_i = lax.dynamic_index_in_dim(Ad_inv_tips, i, axis=0, keepdims=False)
+            T_i = lax.dynamic_index_in_dim(T_tips, i, axis=0, keepdims=False)
+            Td_i = lax.dynamic_index_in_dim(Td_tips, i, axis=0, keepdims=False)
+
+            Ad_inv_T_i = Ad_inv_i @ T_i
+            J_segment = Ad_inv_T_i @ B_i
+            J_next = Ad_inv_i @ J_prev + J_segment
+
+            eta = Ad_inv_T_i @ xid_i
+            Ad_inv_dot = -lie.adjoint_se3(eta) @ Ad_inv_i
+
+            Jd_segment = (Ad_inv_dot @ T_i + Ad_inv_i @ Td_i) @ B_i
+            Jd_next = Ad_inv_i @ Jd_prev + Ad_inv_dot @ J_prev + Jd_segment
+
+            return (J_next, Jd_next), (J_next, Jd_next)
+
+        indices = jnp.arange(self.num_segments, dtype=jnp.int32)
+        (_, _), (J_tips, Jd_tips) = lax.scan(scan_body, (zeros, zeros), indices)
+
+        return J_tips, Jd_tips
+
+    @eqx.filter_jit
+    def _active_quadrature_kinematics(
+        self, q: Array, qd: Array
+    ) -> tuple[Array, Array, Array, Array]:
+        """Return weights, poses, active Jacobians, and derivatives at quadrature points."""
+        xi = self.strain(q).reshape(self.num_segments, 6)
+        xid = (self.B_xi @ qd).reshape(self.num_segments, 6)
+        B_segments = self.B_xi.reshape(self.num_segments, 6, self.num_dofs)
+
         Xs_inner, Ws_inner = vmap(
             scale_interior_gaussian_quadrature, in_axes=(None, None, 0, 0)
         )(self.Xs, self.Ws, self.L_cum[:-1], self.L_cum[1:])
+        s_local = Xs_inner - self.L_cum[:-1, None]
+
+        def scan_fk(g_base: Array, i: Array) -> tuple[Array, Array]:
+            xi_i = lax.dynamic_index_in_dim(xi, i, axis=0, keepdims=False)
+            L_i = lax.dynamic_index_in_dim(self.L, i, axis=0, keepdims=False)
+            g_tip = g_base @ lie.exp_gn_SE3(L_i * xi_i, eps=self.global_eps)
+            return g_tip, g_base
+
+        indices = jnp.arange(self.num_segments, dtype=jnp.int32)
+        _, g_bases = lax.scan(scan_fk, self.g0, indices)
+
+        def segment_poses(g_base_i: Array, xi_i: Array, s_local_i: Array) -> Array:
+            def pose_at_s(s_local_ij: Array) -> Array:
+                g_rel = lie.exp_gn_SE3(s_local_ij * xi_i, eps=self.global_eps)
+                return g_base_i @ g_rel
+
+            return vmap(pose_at_s)(s_local_i)
+
+        g_ps = vmap(segment_poses)(g_bases, xi, s_local)
+
+        J_tips, Jd_tips = self._active_J_Jd_local_tips_from_strain(xi, xid, B_segments)
+        zeros_tip = jnp.zeros_like(J_tips[:1])
+        J_bases = jnp.concatenate([zeros_tip, J_tips[:-1]], axis=0)
+        Jd_bases = jnp.concatenate([zeros_tip, Jd_tips[:-1]], axis=0)
+
+        def segment_jacobians(
+            xi_i: Array,
+            xid_i: Array,
+            B_i: Array,
+            J_base_i: Array,
+            Jd_base_i: Array,
+            s_local_i: Array,
+        ) -> tuple[Array, Array]:
+            def jacobian_at_s(s_local_ij: Array) -> tuple[Array, Array]:
+                Ad_inv = lie.Adjoint_gi_se3_inv(xi_i, s_local_ij, eps=self.global_eps)
+                T = lie.Tangent_gi_se3(xi_i, s_local_ij, eps=self.tangent_eps)
+                Td = lie.Tangent_derivative_gi_se3(
+                    xi_i, xid_i, s_local_ij, eps=self.tangent_eps
+                )
+
+                Ad_inv_T = Ad_inv @ T
+                J_segment = Ad_inv_T @ B_i
+                J_next = Ad_inv @ J_base_i + J_segment
+
+                eta = Ad_inv_T @ xid_i
+                Ad_inv_dot = -lie.adjoint_se3(eta) @ Ad_inv
+
+                Jd_segment = (Ad_inv_dot @ T + Ad_inv @ Td) @ B_i
+                Jd_next = Ad_inv @ Jd_base_i + Ad_inv_dot @ J_base_i + Jd_segment
+
+                return J_next, Jd_next
+
+            return vmap(jacobian_at_s)(s_local_i)
+
+        J_ps, Jd_ps = vmap(segment_jacobians)(
+            xi, xid, B_segments, J_bases, Jd_bases, s_local
+        )
+
+        return Ws_inner, g_ps, J_ps, Jd_ps
+
+    @eqx.filter_jit
+    def _active_quadrature_forward_dynamics_terms(
+        self, q: Array, qd: Array
+    ) -> tuple[Array, Array, Array]:
+        """
+        Assemble active-coordinate inertia, Coriolis-vector, and gravity terms.
+
+        The endpoint quadrature nodes have zero weight and are dropped before the
+        kinematics/Jacobian batch evaluation.
+        """
+        Ws_inner, g_ps, J_ps, Jd_ps = self._active_quadrature_kinematics(q, qd)
         num_inner_points = self.num_gauss_points - 2
-        s_inner = Xs_inner.reshape(-1)
-
-        g_ps = self.forward_kinematics_batched(q, s_inner)
-        g_ps = g_ps.reshape(self.num_segments, num_inner_points, 4, 4)
-
-        J_ps, Jd_ps = self._J_Jd_local_batched(q, qd, s_inner)
-        J_ps = jnp.einsum("ijk,kl->ijl", J_ps, self.B_xi)
-        Jd_ps = jnp.einsum("ijk,kl->ijl", Jd_ps, self.B_xi)
-        J_ps = J_ps.reshape(self.num_segments, num_inner_points, *J_ps.shape[1:])
-        Jd_ps = Jd_ps.reshape(self.num_segments, num_inner_points, *Jd_ps.shape[1:])
 
         def dynamical_terms_i(i: Array) -> tuple[Array, Array, Array]:
-            M_i = self._local_mass_matrix(i)
+            M_i = self.M_segments[i]
 
             def dynamical_terms_ij(j: Array) -> tuple[Array, Array, Array]:
                 Ws_ij = Ws_inner[i][j]
@@ -1913,24 +2051,25 @@ class PCS(SoftRobot):
                 Ad_g_inv_ij = lie.Adjoint_g_inv_SE3(g_ij)
 
                 B_ij = Ws_ij * J_ij.T @ M_i @ J_ij
-                C_ij = Ws_ij * (
-                    J_ij.T @ (M_i @ Jd_ij + lie.coadjoint_se3(eta_ij) @ M_i @ J_ij)
+                Cqd_ij = Ws_ij * (
+                    J_ij.T
+                    @ (M_i @ (Jd_ij @ qd) + lie.coadjoint_se3(eta_ij) @ M_i @ eta_ij)
                 )
                 G_ij = -Ws_ij * J_ij.T @ M_i @ Ad_g_inv_ij @ self.g
 
-                return B_ij, C_ij, G_ij
+                return B_ij, Cqd_ij, G_ij
 
             return vmap(dynamical_terms_ij)(jnp.arange(num_inner_points))
 
-        B_blocks_tot, C_blocks_tot, G_blocks_tot = vmap(dynamical_terms_i)(
+        B_blocks_tot, Cqd_blocks_tot, G_blocks_tot = vmap(dynamical_terms_i)(
             jnp.arange(self.num_segments)
         )
 
         B = jnp.sum(B_blocks_tot, axis=(0, 1))
-        C = jnp.sum(C_blocks_tot, axis=(0, 1))
+        Cqd = jnp.sum(Cqd_blocks_tot, axis=(0, 1))
         G = jnp.sum(G_blocks_tot, axis=(0, 1))
 
-        return B, C, G
+        return B, Cqd, G
 
     @eqx.filter_jit
     def forward_dynamics(
@@ -1967,12 +2106,11 @@ class PCS(SoftRobot):
         if tau_ext is None:
             tau_ext = jnp.zeros((q.shape[-1],))
 
-        B, C, G = self._active_quadrature_dynamics_terms(q, qd)
-        D = self.damping_matrix(q)
+        B, Cqd, G = self._active_quadrature_forward_dynamics_terms(q, qd)
         tau_el = self.elastic_force(q)
         tau_u = self.actuation_force(q, u)
 
-        rhs = tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
+        rhs = tau_u + tau_ext - Cqd - G - tau_el - self.damping_matrix(q) @ qd
         qdd = jnp.linalg.solve(B, rhs)
 
         yd = jnp.concatenate([qd, qdd])

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -16,6 +16,7 @@ from soromox.utils.basic import (
 from soromox.utils.integration import (
     gauss_quadrature,
     scale_gaussian_quadrature,
+    scale_interior_gaussian_quadrature,
 )
 
 
@@ -1874,6 +1875,64 @@ class PCS(SoftRobot):
         return U_G
 
     @eqx.filter_jit
+    def _active_quadrature_dynamics_terms(
+        self, q: Array, qd: Array
+    ) -> tuple[Array, Array, Array]:
+        """
+        Assemble active-coordinate inertia, Coriolis, and gravity terms over quadrature.
+
+        The endpoint quadrature nodes have zero weight and are dropped before the
+        kinematics/Jacobian batch evaluation. Jacobians are projected to the active
+        strain coordinates before forming the matrix/vector integrands.
+        """
+        Xs_inner, Ws_inner = vmap(
+            scale_interior_gaussian_quadrature, in_axes=(None, None, 0, 0)
+        )(self.Xs, self.Ws, self.L_cum[:-1], self.L_cum[1:])
+        num_inner_points = self.num_gauss_points - 2
+        s_inner = Xs_inner.reshape(-1)
+
+        g_ps = self.forward_kinematics_batched(q, s_inner)
+        g_ps = g_ps.reshape(self.num_segments, num_inner_points, 4, 4)
+
+        J_ps, Jd_ps = self._J_Jd_local_batched(q, qd, s_inner)
+        J_ps = jnp.einsum("ijk,kl->ijl", J_ps, self.B_xi)
+        Jd_ps = jnp.einsum("ijk,kl->ijl", Jd_ps, self.B_xi)
+        J_ps = J_ps.reshape(self.num_segments, num_inner_points, *J_ps.shape[1:])
+        Jd_ps = Jd_ps.reshape(self.num_segments, num_inner_points, *Jd_ps.shape[1:])
+
+        def dynamical_terms_i(i: Array) -> tuple[Array, Array, Array]:
+            M_i = self._local_mass_matrix(i)
+
+            def dynamical_terms_ij(j: Array) -> tuple[Array, Array, Array]:
+                Ws_ij = Ws_inner[i][j]
+                g_ij = g_ps[i, j]
+                J_ij = J_ps[i, j]
+                Jd_ij = Jd_ps[i, j]
+
+                eta_ij = J_ij @ qd
+                Ad_g_inv_ij = lie.Adjoint_g_inv_SE3(g_ij)
+
+                B_ij = Ws_ij * J_ij.T @ M_i @ J_ij
+                C_ij = Ws_ij * (
+                    J_ij.T @ (M_i @ Jd_ij + lie.coadjoint_se3(eta_ij) @ M_i @ J_ij)
+                )
+                G_ij = -Ws_ij * J_ij.T @ M_i @ Ad_g_inv_ij @ self.g
+
+                return B_ij, C_ij, G_ij
+
+            return vmap(dynamical_terms_ij)(jnp.arange(num_inner_points))
+
+        B_blocks_tot, C_blocks_tot, G_blocks_tot = vmap(dynamical_terms_i)(
+            jnp.arange(self.num_segments)
+        )
+
+        B = jnp.sum(B_blocks_tot, axis=(0, 1))
+        C = jnp.sum(C_blocks_tot, axis=(0, 1))
+        G = jnp.sum(G_blocks_tot, axis=(0, 1))
+
+        return B, C, G
+
+    @eqx.filter_jit
     def forward_dynamics(
         self, t: Array, y: Array, actuation_args: tuple | None = None
     ) -> Array:
@@ -1908,107 +1967,13 @@ class PCS(SoftRobot):
         if tau_ext is None:
             tau_ext = jnp.zeros((q.shape[-1],))
 
-        # compute the gauss quadrature points and weights for each segment
-        Xs_scaled, Ws_scaled = vmap(
-            scale_gaussian_quadrature, in_axes=(None, None, 0, 0)
-        )(
-            self.Xs, self.Ws, self.L_cum[:-1], self.L_cum[1:]
-        )  # shape (num_segments, num_gauss_points) for both Xs_scaled and Ws_scaled
-
-        # compute the forward kinematics for each quadrature point
-        g_ps = self.forward_kinematics_batched(
-            q, Xs_scaled.flatten()
-        )  # shape (num_segments * num_gauss_points, 4, 4)
-        g_ps = g_ps.reshape(
-            self.num_segments, self.num_gauss_points, 4, 4
-        )  # shape (num_segments, num_gauss_points, 4, 4)
-
-        # compute the jacobian and its time-derivative for each quadrature point
-        J_ps, Jd_ps = self._J_Jd_local_batched(
-            q, qd, Xs_scaled.flatten()
-        )  # shape (num_segments * num_gauss_points, 6, num_active_strains)
-        J_ps = J_ps.reshape(
-            self.num_segments, self.num_gauss_points, *J_ps.shape[1:]
-        )  # shape (num_segments, num_gauss_points, 6, num_active_strains)
-        Jd_ps = Jd_ps.reshape(
-            self.num_segments, self.num_gauss_points, *Jd_ps.shape[1:]
-        )  # shape (num_segments, num_gauss_points, 6, num_active_strains)
-
-        def dynamical_matrices_i(i: Array) -> tuple[Array, Array, Array]:
-            """
-            Compute the integrand for the dynamical matrices at the i-th segment.
-            Args:
-                i (Array): index of the segment
-            Returns:
-                tuple[Array, Array, Array]: The inertia matrix, Coriolis matrix, and gravitational force integrands.
-            """
-            M_i = self._local_mass_matrix(i)
-
-            def dynamical_matrices_ij(j: Array) -> tuple[Array, Array, Array]:
-                """
-                Compute the integrand for the dynamical matrices at the j-th quadrature point of the i-th segment.
-                Args:
-                    j (Array): index of the quadrature point
-                Returns:
-                    tuple[Array, Array, Array]: The inertia matrix, Coriolis matrix, and gravitational force integrands.
-                """
-                # select the j-th quadrature weight
-                Ws_ij = Ws_scaled[i][j]
-                # select the j-th Cartesian pose
-                g_ij = g_ps[i, j]
-                # select the j-th jacobian and its time-derivative
-                J_ij = J_ps[i, j]
-                Jd_ij = Jd_ps[i, j]
-
-                # compute the lie algebra expressions.
-                Ad_g_inv_ij = lie.Adjoint_g_inv_SE3(g_ij)
-
-                # compute the inertia matrix integrand
-                B_ij = Ws_ij * J_ij.T @ M_i @ J_ij
-
-                # compute the coriolis matrix integrand
-                C_ij = Ws_ij * (
-                    J_ij.T
-                    @ (
-                        M_i @ Jd_ij
-                        + lie.coadjoint_se3(J_ij @ self.B_xi @ qd) @ M_i @ J_ij
-                    )
-                )
-
-                # compute the gravitational force integrand
-                G_ij = -Ws_ij * J_ij.T @ M_i @ Ad_g_inv_ij @ self.g
-
-                return B_ij, C_ij, G_ij
-
-            # we can skip the first and last quadrature points since their weight is zero
-            B_blocks_i, C_blocks_i, G_blocks_i = vmap(dynamical_matrices_ij)(
-                jnp.arange(1, self.num_gauss_points - 1)
-            )
-
-            return B_blocks_i, C_blocks_i, G_blocks_i
-
-        # compute the dynamical matrices for each segment
-        B_blocks_tot, C_blocks_tot, G_blocks_tot = vmap(dynamical_matrices_i)(
-            jnp.arange(self.num_segments)
-        )
-
-        # sum over segments and Gauss points
-        B_full = jnp.sum(B_blocks_tot, axis=(0, 1))
-        C_full = jnp.sum(C_blocks_tot, axis=(0, 1))
-        G_full = jnp.sum(G_blocks_tot, axis=(0, 1))
-
-        # construct the dynamical matrices
-        B = self.B_xi.T @ B_full @ self.B_xi
-        C = self.B_xi.T @ C_full @ self.B_xi
-        G = self.B_xi.T @ G_full
+        B, C, G = self._active_quadrature_dynamics_terms(q, qd)
         D = self.damping_matrix(q)
         tau_el = self.elastic_force(q)
         tau_u = self.actuation_force(q, u)
 
-        B_inv = jnp.linalg.inv(B)  # Inverse of the inertia matrix
-        qdd = B_inv @ (
-            tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
-        )  # Compute the acceleration
+        rhs = tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
+        qdd = jnp.linalg.solve(B, rhs)
 
         yd = jnp.concatenate([qd, qdd])
 

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -82,6 +82,11 @@ class PlanarPCS(SoftRobot):
 
     Xs: Array  # Gauss nodes
     Ws: Array  # Gauss weights
+    M_segments: Array  # Cached per-segment mass matrices
+    K_full: Array  # Cached full stiffness matrix
+    K: Array  # Cached active-coordinate stiffness matrix
+    D_full: Array  # Cached full damping matrix
+    D_active: Array  # Cached active-coordinate damping matrix
 
     def __init__(
         self,
@@ -203,6 +208,14 @@ class PlanarPCS(SoftRobot):
 
         # Number of actuators
         self.num_actuators = int(self.num_active_strains.item())
+
+        (
+            self.M_segments,
+            self.K_full,
+            self.K,
+            self.D_full,
+            self.D_active,
+        ) = self._compute_constant_matrices()
 
     @property
     def is_planar(self) -> bool:
@@ -473,7 +486,26 @@ class PlanarPCS(SoftRobot):
                 raise ValueError(f"D must have shape {expected_D_shape}, got {D.shape}")
             updated_self = eqx.tree_at(lambda m: m.D, updated_self, D)
 
-        return updated_self
+        return updated_self._with_refreshed_constant_matrices()
+
+    def _compute_constant_matrices(self) -> tuple[Array, Array, Array, Array, Array]:
+        """Compute state-independent matrices cached by the model."""
+        M_segments = vmap(self._compute_local_mass_matrix)(
+            jnp.arange(self.num_segments)
+        )
+        K_full = self._compute_stiffness_full_matrix()
+        K = self.B_xi.T @ K_full @ self.B_xi
+        D_full = self.D
+        D_active = self.B_xi.T @ D_full @ self.B_xi
+        return M_segments, K_full, K, D_full, D_active
+
+    def _with_refreshed_constant_matrices(self) -> "PlanarPCS":
+        """Return a copy with cached state-independent matrices refreshed."""
+        return eqx.tree_at(
+            lambda m: (m.M_segments, m.K_full, m.K, m.D_full, m.D_active),
+            self,
+            self._compute_constant_matrices(),
+        )
 
     @eqx.filter_jit
     def classify_segment(self, s: Array) -> tuple[Array, Array]:
@@ -1317,7 +1349,6 @@ class PlanarPCS(SoftRobot):
             Ad_inv_i = lax.dynamic_index_in_dim(Ad_inv_tips, i, axis=0, keepdims=False)
             T_i = lax.dynamic_index_in_dim(T_tips, i, axis=0, keepdims=False)
             Td_i = lax.dynamic_index_in_dim(Td_tips, i, axis=0, keepdims=False)
-            xi_i = lax.dynamic_index_in_dim(xi, i, axis=0, keepdims=False)
             xid_i = lax.dynamic_index_in_dim(xid, i, axis=0, keepdims=False)
 
             J_rot = jnp.einsum("ij, njk->nik", Ad_inv_i, J_prev)
@@ -1556,8 +1587,7 @@ class PlanarPCS(SoftRobot):
         I_i = jnp.pi * self.r[i] ** 4 / 4
         return I_i
 
-    @eqx.filter_jit
-    def _local_mass_matrix(self, i: Array) -> Array:
+    def _compute_local_mass_matrix(self, i: Array) -> Array:
         """
         Compute the local mass matrix for the i-th segment.
 
@@ -1572,6 +1602,19 @@ class PlanarPCS(SoftRobot):
 
         M_i = rho_i * jnp.diag(jnp.array([I_i, A_i, A_i]))
         return M_i
+
+    @eqx.filter_jit
+    def _local_mass_matrix(self, i: Array) -> Array:
+        """
+        Return the cached local mass matrix for the i-th segment.
+
+        Args:
+            i (Array): index of the segment
+
+        Returns:
+            M_i (Array): Local mass matrix of shape (3, 3) for the i-th segment.
+        """
+        return self.M_segments[i]
 
     # ===========================================
     # Dynamical matrices computation
@@ -1788,18 +1831,20 @@ class PlanarPCS(SoftRobot):
 
         return S_i
 
-    @eqx.filter_jit
-    def _stiffness(self, formulate_in_strain_space: bool = False) -> Array:
+    def _compute_stiffness_full_matrix(self) -> Array:
+        """Compute the uncached full stiffness matrix from current parameters."""
         # stiffness matrix of shape (num_segments, 3, 3)
         S_sms = vmap(self._local_stiffness_matrix)(jnp.arange(self.num_segments))
 
         # we define the elastic matrix of shape (num_strains, num_strains) as K(xi) = K @ xi where K is equal to
-        S = blk_diag(S_sms)
+        return blk_diag(S_sms)
 
-        if not formulate_in_strain_space:
-            S = self.B_xi.T @ S @ self.B_xi
+    @eqx.filter_jit
+    def _stiffness(self, formulate_in_strain_space: bool = False) -> Array:
+        if formulate_in_strain_space:
+            return self.K_full
 
-        return S
+        return self.K
 
     @eqx.filter_jit
     def _stiffness_full_matrix(self) -> Array:
@@ -1809,9 +1854,7 @@ class PlanarPCS(SoftRobot):
         Returns:
             K_full (Array): Full stiffness matrix of shape (num_strains, num_strains).
         """
-        K_full = self._stiffness(formulate_in_strain_space=True)
-
-        return K_full
+        return self.K_full
 
     @eqx.filter_jit
     def stiffness_matrix(self) -> Array:
@@ -1821,9 +1864,7 @@ class PlanarPCS(SoftRobot):
         Returns:
             K (Array): Stiffness matrix of shape (num_active_strains, num_active_strains).
         """
-        K = self._stiffness(formulate_in_strain_space=False)
-
-        return K
+        return self.K
 
     @eqx.filter_jit
     def elastic_force(self, q: Array) -> Array:
@@ -1836,10 +1877,7 @@ class PlanarPCS(SoftRobot):
         Returns:
             tau_el (Array): Elastic force of shape (num_active_strains,).
         """
-        K = self.stiffness_matrix()
-        tau_el = K @ q
-
-        return tau_el
+        return self.K @ q
 
     @eqx.filter_jit
     def _damping_full_matrix(self) -> Array:
@@ -1852,9 +1890,7 @@ class PlanarPCS(SoftRobot):
         Returns:
             D (Array): Full damping matrix of shape (num_strains, num_strains).
         """
-        D_full = self.D
-
-        return D_full
+        return self.D_full
 
     @eqx.filter_jit
     def damping_matrix(self, q: Array) -> Array:
@@ -1867,11 +1903,7 @@ class PlanarPCS(SoftRobot):
         Returns:
             D (Array): Damping matrix of shape (num_active_strains, num_active_strains).
         """
-        D_full = self._damping_full_matrix()
-
-        D = self.B_xi.T @ D_full @ self.B_xi
-
-        return D
+        return self.D_active
 
     @eqx.filter_jit
     def actuation_matrix(self, q: Array) -> Array:
@@ -1949,38 +1981,153 @@ class PlanarPCS(SoftRobot):
         return U_G
 
     @eqx.filter_jit
-    def _active_quadrature_dynamics_terms(
+    def _active_J_Jd_local_tips_from_strain(
+        self, xi: Array, xid: Array, B_segments: Array
+    ) -> tuple[Array, Array]:
+        """Compute active-coordinate local Jacobians at all segment tips."""
+        Ad_inv_tips = vmap(
+            lambda xi_i, L_i: lie.Adjoint_gi_se2_inv(xi_i, L_i, eps=self.global_eps)
+        )(xi, self.L)
+        T_tips = vmap(
+            lambda xi_i, L_i: lie.Tangent_gi_se2(xi_i, L_i, eps=self.tangent_eps)
+        )(xi, self.L)
+        Td_tips = vmap(
+            lambda xi_i, xid_i, L_i: lie.Tangent_derivative_gi_se2(
+                xi_i, xid_i, L_i, eps=self.tangent_eps
+            )
+        )(xi, xid, self.L)
+
+        zeros = jnp.zeros((3, self.num_dofs), dtype=xi.dtype)
+
+        def scan_body(
+            carry: tuple[Array, Array], i: Array
+        ) -> tuple[tuple[Array, Array], tuple[Array, Array]]:
+            J_prev, Jd_prev = carry
+
+            xid_i = lax.dynamic_index_in_dim(xid, i, axis=0, keepdims=False)
+            B_i = lax.dynamic_index_in_dim(B_segments, i, axis=0, keepdims=False)
+            Ad_inv_i = lax.dynamic_index_in_dim(Ad_inv_tips, i, axis=0, keepdims=False)
+            T_i = lax.dynamic_index_in_dim(T_tips, i, axis=0, keepdims=False)
+            Td_i = lax.dynamic_index_in_dim(Td_tips, i, axis=0, keepdims=False)
+
+            Ad_inv_T_i = Ad_inv_i @ T_i
+            J_segment = Ad_inv_T_i @ B_i
+            J_next = Ad_inv_i @ J_prev + J_segment
+
+            eta = Ad_inv_T_i @ xid_i
+            Ad_inv_dot = -lie.adjoint_se2(eta) @ Ad_inv_i
+
+            Jd_segment = (Ad_inv_dot @ T_i + Ad_inv_i @ Td_i) @ B_i
+            Jd_next = Ad_inv_i @ Jd_prev + Ad_inv_dot @ J_prev + Jd_segment
+
+            return (J_next, Jd_next), (J_next, Jd_next)
+
+        indices = jnp.arange(self.num_segments, dtype=jnp.int32)
+        (_, _), (J_tips, Jd_tips) = lax.scan(scan_body, (zeros, zeros), indices)
+
+        return J_tips, Jd_tips
+
+    @eqx.filter_jit
+    def _active_quadrature_kinematics(
+        self, q: Array, qd: Array
+    ) -> tuple[Array, Array, Array, Array]:
+        """Return weights, poses, active Jacobians, and derivatives at quadrature points."""
+        xi = self.strain(q).reshape(self.num_segments, 3)
+        xid = (self.B_xi @ qd).reshape(self.num_segments, 3)
+        B_segments = self.B_xi.reshape(self.num_segments, 3, self.num_dofs)
+
+        Xs_scaled, Ws_scaled = vmap(
+            scale_interior_gaussian_quadrature, in_axes=(None, None, 0, 0)
+        )(self.Xs, self.Ws, self.L_cum[:-1], self.L_cum[1:])
+        s_local = Xs_scaled - self.L_cum[:-1, None]
+
+        th0 = jnp.asarray(self.th0, dtype=xi.dtype)
+        g0 = lie.exp_SE2(
+            jnp.stack(
+                [
+                    th0,
+                    jnp.zeros((), dtype=xi.dtype),
+                    jnp.zeros((), dtype=xi.dtype),
+                ]
+            )
+        )
+
+        def scan_fk(g_base: Array, i: Array) -> tuple[Array, Array]:
+            xi_i = lax.dynamic_index_in_dim(xi, i, axis=0, keepdims=False)
+            L_i = lax.dynamic_index_in_dim(self.L, i, axis=0, keepdims=False)
+            g_tip = g_base @ lie.exp_gn_SE2(L_i * xi_i, eps=self.global_eps)
+            return g_tip, g_base
+
+        indices = jnp.arange(self.num_segments, dtype=jnp.int32)
+        _, g_bases = lax.scan(scan_fk, g0, indices)
+
+        def segment_poses(g_base_i: Array, xi_i: Array, s_local_i: Array) -> Array:
+            def pose_at_s(s_local_ij: Array) -> Array:
+                g_rel = lie.exp_gn_SE2(s_local_ij * xi_i, eps=self.global_eps)
+                return g_base_i @ g_rel
+
+            return vmap(pose_at_s)(s_local_i)
+
+        g_ps = vmap(segment_poses)(g_bases, xi, s_local)
+
+        J_tips, Jd_tips = self._active_J_Jd_local_tips_from_strain(xi, xid, B_segments)
+        zeros_tip = jnp.zeros_like(J_tips[:1])
+        J_bases = jnp.concatenate([zeros_tip, J_tips[:-1]], axis=0)
+        Jd_bases = jnp.concatenate([zeros_tip, Jd_tips[:-1]], axis=0)
+
+        def segment_jacobians(
+            xi_i: Array,
+            xid_i: Array,
+            B_i: Array,
+            J_base_i: Array,
+            Jd_base_i: Array,
+            s_local_i: Array,
+        ) -> tuple[Array, Array]:
+            def jacobian_at_s(s_local_ij: Array) -> tuple[Array, Array]:
+                Ad_inv = lie.Adjoint_gi_se2_inv(xi_i, s_local_ij, eps=self.global_eps)
+                T = lie.Tangent_gi_se2(xi_i, s_local_ij, eps=self.tangent_eps)
+                Td = lie.Tangent_derivative_gi_se2(
+                    xi_i, xid_i, s_local_ij, eps=self.tangent_eps
+                )
+
+                Ad_inv_T = Ad_inv @ T
+                J_segment = Ad_inv_T @ B_i
+                J_next = Ad_inv @ J_base_i + J_segment
+
+                eta = Ad_inv_T @ xid_i
+                Ad_inv_dot = -lie.adjoint_se2(eta) @ Ad_inv
+
+                Jd_segment = (Ad_inv_dot @ T + Ad_inv @ Td) @ B_i
+                Jd_next = Ad_inv @ Jd_base_i + Ad_inv_dot @ J_base_i + Jd_segment
+
+                return J_next, Jd_next
+
+            return vmap(jacobian_at_s)(s_local_i)
+
+        J_ps, Jd_ps = vmap(segment_jacobians)(
+            xi, xid, B_segments, J_bases, Jd_bases, s_local
+        )
+
+        return Ws_scaled, g_ps, J_ps, Jd_ps
+
+    @eqx.filter_jit
+    def _active_quadrature_forward_dynamics_terms(
         self, q: Array, qd: Array
     ) -> tuple[Array, Array, Array]:
         """
-        Assemble active-coordinate dynamics terms from quadrature samples.
+        Assemble active-coordinate inertia, Coriolis-vector, and gravity terms.
 
         Returns:
             B (Array): Inertia matrix of shape
                 (num_active_strains, num_active_strains).
-            C (Array): Coriolis matrix of shape
-                (num_active_strains, num_active_strains).
+            Cqd (Array): Coriolis/centrifugal force of shape (num_active_strains,).
             G (Array): Gravitational force of shape (num_active_strains,).
         """
-        Xs_scaled, Ws_scaled = vmap(
-            scale_interior_gaussian_quadrature, in_axes=(None, None, 0, 0)
-        )(self.Xs, self.Ws, self.L_cum[:-1], self.L_cum[1:])
+        Ws_scaled, g_ps, J_ps, Jd_ps = self._active_quadrature_kinematics(q, qd)
         num_quad = self.num_gauss_points - 2
 
-        s_ps = Xs_scaled.reshape(-1)
-
-        chi_ps = self.forward_kinematics_batched(q, s_ps)
-        g_ps = vmap(lie.exp_SE2)(chi_ps.reshape(-1, 3))
-        g_ps = g_ps.reshape(self.num_segments, num_quad, 3, 3)
-
-        J_ps_full, Jd_ps_full = self._J_Jd_local_batched(q, qd, s_ps)
-        J_ps = jnp.einsum("ijk, kl->ijl", J_ps_full, self.B_xi)
-        Jd_ps = jnp.einsum("ijk, kl->ijl", Jd_ps_full, self.B_xi)
-        J_ps = J_ps.reshape(self.num_segments, num_quad, *J_ps.shape[1:])
-        Jd_ps = Jd_ps.reshape(self.num_segments, num_quad, *Jd_ps.shape[1:])
-
         def dynamical_terms_i(i: Array) -> tuple[Array, Array, Array]:
-            M_i = self._local_mass_matrix(i)
+            M_i = self.M_segments[i]
 
             def dynamical_terms_ij(j: Array) -> tuple[Array, Array, Array]:
                 Ws_ij = Ws_scaled[i, j]
@@ -1992,24 +2139,25 @@ class PlanarPCS(SoftRobot):
                 eta_ij = J_ij @ qd
 
                 B_ij = Ws_ij * J_ij.T @ M_i @ J_ij
-                C_ij = Ws_ij * (
-                    J_ij.T @ (M_i @ Jd_ij + lie.coadjoint_se2(eta_ij) @ M_i @ J_ij)
+                Cqd_ij = Ws_ij * (
+                    J_ij.T
+                    @ (M_i @ (Jd_ij @ qd) + lie.coadjoint_se2(eta_ij) @ M_i @ eta_ij)
                 )
                 G_ij = -Ws_ij * J_ij.T @ M_i @ Ad_g_inv_ij @ self.g
 
-                return B_ij, C_ij, G_ij
+                return B_ij, Cqd_ij, G_ij
 
             return vmap(dynamical_terms_ij)(jnp.arange(num_quad))
 
-        B_blocks_tot, C_blocks_tot, G_blocks_tot = vmap(dynamical_terms_i)(
+        B_blocks_tot, Cqd_blocks_tot, G_blocks_tot = vmap(dynamical_terms_i)(
             jnp.arange(self.num_segments)
         )
 
         B = jnp.sum(B_blocks_tot, axis=(0, 1))
-        C = jnp.sum(C_blocks_tot, axis=(0, 1))
+        Cqd = jnp.sum(Cqd_blocks_tot, axis=(0, 1))
         G = jnp.sum(G_blocks_tot, axis=(0, 1))
 
-        return B, C, G
+        return B, Cqd, G
 
     @eqx.filter_jit
     def forward_dynamics(
@@ -2046,12 +2194,11 @@ class PlanarPCS(SoftRobot):
         if tau_ext is None:
             tau_ext = jnp.zeros((q.shape[-1],))
 
-        B, C, G = self._active_quadrature_dynamics_terms(q, qd)
-        D = self.damping_matrix(q)
+        B, Cqd, G = self._active_quadrature_forward_dynamics_terms(q, qd)
         tau_el = self.elastic_force(q)
         tau_u = self.actuation_force(q, u)
 
-        rhs = tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
+        rhs = tau_u + tau_ext - Cqd - G - tau_el - self.damping_matrix(q) @ qd
         qdd = jnp.linalg.solve(B, rhs)
 
         yd = jnp.concatenate([qd, qdd])

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -16,6 +16,7 @@ from soromox.utils.basic import (
 from soromox.utils.integration import (
     gauss_quadrature,
     scale_gaussian_quadrature,
+    scale_interior_gaussian_quadrature,
 )
 
 
@@ -1948,6 +1949,69 @@ class PlanarPCS(SoftRobot):
         return U_G
 
     @eqx.filter_jit
+    def _active_quadrature_dynamics_terms(
+        self, q: Array, qd: Array
+    ) -> tuple[Array, Array, Array]:
+        """
+        Assemble active-coordinate dynamics terms from quadrature samples.
+
+        Returns:
+            B (Array): Inertia matrix of shape
+                (num_active_strains, num_active_strains).
+            C (Array): Coriolis matrix of shape
+                (num_active_strains, num_active_strains).
+            G (Array): Gravitational force of shape (num_active_strains,).
+        """
+        Xs_scaled, Ws_scaled = vmap(
+            scale_interior_gaussian_quadrature, in_axes=(None, None, 0, 0)
+        )(self.Xs, self.Ws, self.L_cum[:-1], self.L_cum[1:])
+        num_quad = self.num_gauss_points - 2
+
+        s_ps = Xs_scaled.reshape(-1)
+
+        chi_ps = self.forward_kinematics_batched(q, s_ps)
+        g_ps = vmap(lie.exp_SE2)(chi_ps.reshape(-1, 3))
+        g_ps = g_ps.reshape(self.num_segments, num_quad, 3, 3)
+
+        J_ps_full, Jd_ps_full = self._J_Jd_local_batched(q, qd, s_ps)
+        J_ps = jnp.einsum("ijk, kl->ijl", J_ps_full, self.B_xi)
+        Jd_ps = jnp.einsum("ijk, kl->ijl", Jd_ps_full, self.B_xi)
+        J_ps = J_ps.reshape(self.num_segments, num_quad, *J_ps.shape[1:])
+        Jd_ps = Jd_ps.reshape(self.num_segments, num_quad, *Jd_ps.shape[1:])
+
+        def dynamical_terms_i(i: Array) -> tuple[Array, Array, Array]:
+            M_i = self._local_mass_matrix(i)
+
+            def dynamical_terms_ij(j: Array) -> tuple[Array, Array, Array]:
+                Ws_ij = Ws_scaled[i, j]
+                g_ij = g_ps[i, j]
+                J_ij = J_ps[i, j]
+                Jd_ij = Jd_ps[i, j]
+
+                Ad_g_inv_ij = lie.Adjoint_g_inv_SE2(g_ij)
+                eta_ij = J_ij @ qd
+
+                B_ij = Ws_ij * J_ij.T @ M_i @ J_ij
+                C_ij = Ws_ij * (
+                    J_ij.T @ (M_i @ Jd_ij + lie.coadjoint_se2(eta_ij) @ M_i @ J_ij)
+                )
+                G_ij = -Ws_ij * J_ij.T @ M_i @ Ad_g_inv_ij @ self.g
+
+                return B_ij, C_ij, G_ij
+
+            return vmap(dynamical_terms_ij)(jnp.arange(num_quad))
+
+        B_blocks_tot, C_blocks_tot, G_blocks_tot = vmap(dynamical_terms_i)(
+            jnp.arange(self.num_segments)
+        )
+
+        B = jnp.sum(B_blocks_tot, axis=(0, 1))
+        C = jnp.sum(C_blocks_tot, axis=(0, 1))
+        G = jnp.sum(G_blocks_tot, axis=(0, 1))
+
+        return B, C, G
+
+    @eqx.filter_jit
     def forward_dynamics(
         self, t: Array, y: Array, actuation_args: tuple | None = None
     ) -> Array:
@@ -1982,64 +2046,13 @@ class PlanarPCS(SoftRobot):
         if tau_ext is None:
             tau_ext = jnp.zeros((q.shape[-1],))
 
-        Xs_scaled, Ws_scaled = vmap(
-            scale_gaussian_quadrature, in_axes=(None, None, 0, 0)
-        )(self.Xs, self.Ws, self.L_cum[:-1], self.L_cum[1:])
-
-        chi_ps = self.forward_kinematics_batched(q, Xs_scaled.flatten())
-        g_ps = vmap(lie.exp_SE2)(chi_ps.reshape(-1, 3))
-        g_ps = g_ps.reshape(self.num_segments, self.num_gauss_points, 3, 3)
-
-        J_ps, Jd_ps = self._J_Jd_local_batched(q, qd, Xs_scaled.flatten())
-        J_ps = J_ps.reshape(self.num_segments, self.num_gauss_points, *J_ps.shape[1:])
-        Jd_ps = Jd_ps.reshape(
-            self.num_segments, self.num_gauss_points, *Jd_ps.shape[1:]
-        )
-
-        def dynamical_matrices_i(i: Array) -> tuple[Array, Array, Array]:
-            M_i = self._local_mass_matrix(i)
-
-            def dynamical_matrices_ij(j: Array) -> tuple[Array, Array, Array]:
-                Ws_ij = Ws_scaled[i][j]
-                g_ij = g_ps[i, j]
-                J_ij = J_ps[i, j]
-                Jd_ij = Jd_ps[i, j]
-
-                Ad_g_inv_ij = lie.Adjoint_g_inv_SE2(g_ij)
-
-                B_ij = Ws_ij * J_ij.T @ M_i @ J_ij
-                C_ij = Ws_ij * (
-                    J_ij.T
-                    @ (
-                        M_i @ Jd_ij
-                        + lie.coadjoint_se2(J_ij @ self.B_xi @ qd) @ M_i @ J_ij
-                    )
-                )
-                G_ij = -Ws_ij * J_ij.T @ M_i @ Ad_g_inv_ij @ self.g
-
-                return B_ij, C_ij, G_ij
-
-            return vmap(dynamical_matrices_ij)(jnp.arange(1, self.num_gauss_points - 1))
-
-        B_blocks_tot, C_blocks_tot, G_blocks_tot = vmap(dynamical_matrices_i)(
-            jnp.arange(self.num_segments)
-        )
-
-        B_full = jnp.sum(B_blocks_tot, axis=(0, 1))
-        C_full = jnp.sum(C_blocks_tot, axis=(0, 1))
-        G_full = jnp.sum(G_blocks_tot, axis=(0, 1))
-
-        B = self.B_xi.T @ B_full @ self.B_xi
-        C = self.B_xi.T @ C_full @ self.B_xi
-        G = self.B_xi.T @ G_full
+        B, C, G = self._active_quadrature_dynamics_terms(q, qd)
         D = self.damping_matrix(q)
         tau_el = self.elastic_force(q)
         tau_u = self.actuation_force(q, u)
 
-        B_inv = jnp.linalg.inv(B)  # Inverse of the inertia matrix
-        qdd = B_inv @ (
-            tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
-        )  # Compute the acceleration
+        rhs = tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
+        qdd = jnp.linalg.solve(B, rhs)
 
         yd = jnp.concatenate([qd, qdd])
 

--- a/src/soromox/utils/integration.py
+++ b/src/soromox/utils/integration.py
@@ -1,4 +1,8 @@
-__all__ = ["gauss_quadrature", "scale_gaussian_quadrature"]
+__all__ = [
+    "gauss_quadrature",
+    "scale_gaussian_quadrature",
+    "scale_interior_gaussian_quadrature",
+]
 
 # For documentation purposes
 from jax import Array, lax
@@ -124,3 +128,26 @@ def scale_gaussian_quadrature(
     Xs_scaled = a + (b - a) * Xs
     Ws_scaled = Ws * (b - a)
     return Xs_scaled, Ws_scaled
+
+
+def scale_interior_gaussian_quadrature(
+    Xs: Array, Ws: Array, a: Array = jnp.zeros(()), b: Array = jnp.ones(())
+) -> tuple[Array, Array]:
+    """
+    Scale only the non-zero weighted Gauss nodes and weights to ``[a, b]``.
+
+    The PCS quadrature convention includes the interval endpoints with zero
+    weights. Dynamics integrals do not need those nodes, so this helper drops
+    them before scaling.
+
+    Args:
+        Xs (Array): Gauss nodes including zero-weight endpoints.
+        Ws (Array): Gauss weights including zero-weight endpoints.
+        a (Array): The lower bound of the interval.
+        b (Array): The upper bound of the interval.
+
+    Returns:
+        Xs_scaled (Array): Scaled interior Gauss nodes on ``[a, b]``.
+        Ws_scaled (Array): Scaled interior Gauss weights on ``[a, b]``.
+    """
+    return scale_gaussian_quadrature(Xs[1:-1], Ws[1:-1], a, b)

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -7,6 +7,7 @@ import pytest
 from typing import List, Optional
 
 from soromox.systems import PCS
+from soromox.utils.integration import scale_interior_gaussian_quadrature
 from soromox.utils.lie_algebra.se3 import Adjoint_g_SE3, log_SE3
 from soromox.utils.tolerance import Tolerance
 
@@ -821,11 +822,142 @@ def test_forward_dynamics_matches_manual_computation(num_segments: int):
         tau_el = model.elastic_force(q)
         tau_u = model.actuation_force(q, u)
 
-        B_inv = jnp.linalg.inv(B)
-        qdd_expected = B_inv @ (tau_u + tau_ext - C @ qd - G - tau_el - D @ qd)
+        qdd_expected = jnp.linalg.solve(
+            B, tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
+        )
         yd_expected = jnp.concatenate([qd, qdd_expected])
 
         assert_allclose(yd, yd_expected, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize("num_segments", [1, 3])
+@pytest.mark.parametrize(
+    "selector_per_segment",
+    [
+        None,
+        (False, False, True, True, False, False),
+        (False, False, False, True, False, False),
+    ],
+)
+def test_active_quadrature_kinematics_matches_existing_batched_path(
+    num_segments: int, selector_per_segment: tuple[bool, ...] | None
+):
+    strain_selector = (
+        None
+        if selector_per_segment is None
+        else jnp.tile(jnp.asarray(selector_per_segment, dtype=bool), num_segments)
+    )
+    model, _ = make_pcs(num_segments=num_segments, strain_selector=strain_selector)
+    dof = int(model.num_active_strains.item())
+
+    key_q, key_qd = jax.random.split(jax.random.PRNGKey(6123))
+    q = random_q(model, key_q, scale=0.05)
+    qd = random_q(model, key_qd, scale=0.1)
+
+    weights, g_quads, J_quads, Jd_quads = model._active_quadrature_kinematics(q, qd)
+    Xs_scaled, weights_expected = jax.vmap(
+        scale_interior_gaussian_quadrature, in_axes=(None, None, 0, 0)
+    )(model.Xs, model.Ws, model.L_cum[:-1], model.L_cum[1:])
+    s_points = Xs_scaled.reshape(-1)
+    num_inner = model.num_gauss_points - 2
+
+    g_expected = model.forward_kinematics_batched(q, s_points).reshape(
+        num_segments, num_inner, 4, 4
+    )
+    J_full, Jd_full = model._J_Jd_local_batched(q, qd, s_points)
+    J_expected = (J_full @ model.B_xi).reshape(num_segments, num_inner, 6, dof)
+    Jd_expected = (Jd_full @ model.B_xi).reshape(num_segments, num_inner, 6, dof)
+
+    assert_allclose(weights, weights_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(g_quads, g_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(J_quads, J_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(Jd_quads, Jd_expected, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize("num_segments", [1, 3])
+@pytest.mark.parametrize(
+    "selector_per_segment",
+    [
+        None,
+        (False, False, True, True, False, False),
+        (False, False, False, True, False, False),
+    ],
+)
+def test_active_quadrature_forward_dynamics_terms_match_public_matrices(
+    num_segments: int, selector_per_segment: tuple[bool, ...] | None
+):
+    strain_selector = (
+        None
+        if selector_per_segment is None
+        else jnp.tile(jnp.asarray(selector_per_segment, dtype=bool), num_segments)
+    )
+    model, _ = make_pcs(num_segments=num_segments, strain_selector=strain_selector)
+    dof = int(model.num_active_strains.item())
+
+    zero_q = jnp.zeros((dof,), dtype=jnp.float64)
+    zero_qd = jnp.zeros((dof,), dtype=jnp.float64)
+    key_q, key_qd, key_u, key_tau = jax.random.split(jax.random.PRNGKey(6124), 4)
+    random_q_ = random_q(model, key_q, scale=0.05)
+    random_qd = random_q(model, key_qd, scale=0.1)
+    u = random_q(model, key_u, scale=0.2)
+    tau_ext = random_q(model, key_tau, scale=0.03)
+
+    for q, qd in ((zero_q, zero_qd), (random_q_, random_qd)):
+        B, Cqd, G = model._active_quadrature_forward_dynamics_terms(q, qd)
+        C = model.coriolis_matrix(q, qd)
+
+        assert_allclose(B, model.inertia_matrix(q), rtol=RTOL, atol=ATOL)
+        assert_allclose(Cqd, C @ qd, rtol=RTOL, atol=ATOL)
+        assert_allclose(G, model.gravitational_force(q), rtol=RTOL, atol=ATOL)
+
+        y = jnp.concatenate([q, qd])
+        yd = model.forward_dynamics(0.0, y, (u, tau_ext))
+        tau_el = model.elastic_force(q)
+        tau_u = model.actuation_force(q, u)
+        D = model.damping_matrix(q)
+        qdd_expected = jnp.linalg.solve(
+            B, tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
+        )
+        assert_allclose(yd, jnp.concatenate([qd, qdd_expected]), rtol=RTOL, atol=ATOL)
+
+
+def test_cached_constant_matrices_refresh_after_update_params():
+    selector_per_segment = jnp.array(
+        [False, False, True, True, False, False], dtype=bool
+    )
+    model, _ = make_pcs(
+        num_segments=2,
+        strain_selector=jnp.tile(selector_per_segment, 2),
+    )
+
+    updated = model.update_params(
+        {
+            "r": 1.1 * model.r,
+            "rho": 0.9 * model.rho,
+            "E": 1.25 * model.E,
+            "G": 0.75 * model.G,
+            "D": 2.0 * model.D,
+        }
+    )
+    segment_ids = jnp.arange(updated.num_segments)
+    expected_M = jax.vmap(updated._compute_local_mass_matrix)(segment_ids)
+    expected_K_full = updated._compute_stiffness_full_matrix()
+    expected_K = updated.B_xi.T @ expected_K_full @ updated.B_xi
+    expected_D_full = updated.D
+    expected_D = updated.B_xi.T @ expected_D_full @ updated.B_xi
+
+    assert_allclose(updated.M_segments, expected_M, rtol=RTOL, atol=ATOL)
+    assert_allclose(updated.K_full, expected_K_full, rtol=RTOL, atol=ATOL)
+    assert_allclose(updated.K, expected_K, rtol=RTOL, atol=ATOL)
+    assert_allclose(updated.D_full, expected_D_full, rtol=RTOL, atol=ATOL)
+    assert_allclose(updated.D_active, expected_D, rtol=RTOL, atol=ATOL)
+    assert_allclose(updated.stiffness_matrix(), expected_K, rtol=RTOL, atol=ATOL)
+    assert_allclose(
+        updated.damping_matrix(jnp.zeros(updated.num_dofs)),
+        expected_D,
+        rtol=RTOL,
+        atol=ATOL,
+    )
 
 
 # ======================================================================================

--- a/tests/systems/test_planar_pcs.py
+++ b/tests/systems/test_planar_pcs.py
@@ -7,6 +7,7 @@ import pytest
 from typing import List, Optional
 
 from soromox.systems import PlanarPCS
+from soromox.utils.integration import scale_interior_gaussian_quadrature
 from soromox.utils.lie_algebra.se2 import Adjoint_g_SE2, exp_SE2
 from soromox.utils.tolerance import Tolerance
 
@@ -934,8 +935,6 @@ def test_coriolis_force_with_christoffel_symbols(num_segments):
         def B_of_q(q_):
             return robot.inertia_matrix(q_)
 
-        B = B_of_q(q)
-
         # dB_dq[i, j, k] = ∂B_{ij}/∂q_k
         dB_dq = jax.jacfwd(B_of_q)(q)
 
@@ -1032,11 +1031,154 @@ def test_forward_dynamics_matches_manual_computation(num_segments: int):
         tau_el = model.elastic_force(q)
         tau_u = model.actuation_force(q, u)
 
-        B_inv = jnp.linalg.inv(B)
-        qdd_expected = B_inv @ (tau_u + tau_ext - C @ qd - G - tau_el - D @ qd)
+        qdd_expected = jnp.linalg.solve(
+            B, tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
+        )
         yd_expected = jnp.concatenate([qd, qdd_expected])
 
         assert_allclose(yd, yd_expected, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize("num_segments", [1, 3])
+@pytest.mark.parametrize(
+    "selector_per_segment",
+    [
+        None,
+        (True, True, False),
+        (False, True, False),
+    ],
+)
+def test_active_quadrature_kinematics_matches_existing_batched_path_planar(
+    num_segments: int, selector_per_segment: tuple[bool, ...] | None
+):
+    base_model, params = make_planar_pcs(num_segments=num_segments)
+    strain_selector = (
+        None
+        if selector_per_segment is None
+        else jnp.tile(jnp.asarray(selector_per_segment, dtype=bool), num_segments)
+    )
+    model = PlanarPCS(
+        num_segments=num_segments,
+        params=params,
+        xi_ref=base_model.xi_ref,
+        strain_selector=strain_selector,
+    )
+    dof = int(model.num_active_strains.item())
+
+    key_q, key_qd = jax.random.split(jax.random.PRNGKey(7123))
+    q = random_q(model, key_q, scale=0.05)
+    qd = random_q(model, key_qd, scale=0.1)
+
+    weights, g_quads, J_quads, Jd_quads = model._active_quadrature_kinematics(q, qd)
+    Xs_scaled, weights_expected = jax.vmap(
+        scale_interior_gaussian_quadrature, in_axes=(None, None, 0, 0)
+    )(model.Xs, model.Ws, model.L_cum[:-1], model.L_cum[1:])
+    s_points = Xs_scaled.reshape(-1)
+    num_inner = model.num_gauss_points - 2
+
+    chi_expected = model.forward_kinematics_batched(q, s_points)
+    g_expected = jax.vmap(exp_SE2)(chi_expected).reshape(num_segments, num_inner, 3, 3)
+    J_full, Jd_full = model._J_Jd_local_batched(q, qd, s_points)
+    J_expected = (J_full @ model.B_xi).reshape(num_segments, num_inner, 3, dof)
+    Jd_expected = (Jd_full @ model.B_xi).reshape(num_segments, num_inner, 3, dof)
+
+    assert_allclose(weights, weights_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(g_quads, g_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(J_quads, J_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(Jd_quads, Jd_expected, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize("num_segments", [1, 3])
+@pytest.mark.parametrize(
+    "selector_per_segment",
+    [
+        None,
+        (True, True, False),
+        (False, True, False),
+    ],
+)
+def test_active_quadrature_forward_dynamics_terms_match_public_matrices_planar(
+    num_segments: int, selector_per_segment: tuple[bool, ...] | None
+):
+    base_model, params = make_planar_pcs(num_segments=num_segments)
+    strain_selector = (
+        None
+        if selector_per_segment is None
+        else jnp.tile(jnp.asarray(selector_per_segment, dtype=bool), num_segments)
+    )
+    model = PlanarPCS(
+        num_segments=num_segments,
+        params=params,
+        xi_ref=base_model.xi_ref,
+        strain_selector=strain_selector,
+    )
+    dof = int(model.num_active_strains.item())
+
+    zero_q = jnp.zeros((dof,), dtype=jnp.float64)
+    zero_qd = jnp.zeros((dof,), dtype=jnp.float64)
+    key_q, key_qd, key_u, key_tau = jax.random.split(jax.random.PRNGKey(7124), 4)
+    random_q_ = random_q(model, key_q, scale=0.05)
+    random_qd = random_q(model, key_qd, scale=0.1)
+    u = random_q(model, key_u, scale=0.2)
+    tau_ext = random_q(model, key_tau, scale=0.03)
+
+    for q, qd in ((zero_q, zero_qd), (random_q_, random_qd)):
+        B, Cqd, G = model._active_quadrature_forward_dynamics_terms(q, qd)
+        C = model.coriolis_matrix(q, qd)
+
+        assert_allclose(B, model.inertia_matrix(q), rtol=RTOL, atol=ATOL)
+        assert_allclose(Cqd, C @ qd, rtol=RTOL, atol=ATOL)
+        assert_allclose(G, model.gravitational_force(q), rtol=RTOL, atol=ATOL)
+
+        y = jnp.concatenate([q, qd])
+        yd = model.forward_dynamics(0.0, y, (u, tau_ext))
+        tau_el = model.elastic_force(q)
+        tau_u = model.actuation_force(q, u)
+        D = model.damping_matrix(q)
+        qdd_expected = jnp.linalg.solve(
+            B, tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
+        )
+        assert_allclose(yd, jnp.concatenate([qd, qdd_expected]), rtol=RTOL, atol=ATOL)
+
+
+def test_cached_constant_matrices_refresh_after_update_params_planar():
+    selector_per_segment = jnp.array([True, True, False], dtype=bool)
+    base_model, params = make_planar_pcs(num_segments=2)
+    model = PlanarPCS(
+        num_segments=2,
+        params=params,
+        xi_ref=base_model.xi_ref,
+        strain_selector=jnp.tile(selector_per_segment, 2),
+    )
+
+    updated = model.update_params(
+        {
+            "r": 1.1 * model.r,
+            "rho": 0.9 * model.rho,
+            "E": 1.25 * model.E,
+            "G": 0.75 * model.G,
+            "D": 2.0 * model.D,
+        }
+    )
+    segment_ids = jnp.arange(updated.num_segments)
+    expected_M = jax.vmap(updated._compute_local_mass_matrix)(segment_ids)
+    expected_K_full = updated._compute_stiffness_full_matrix()
+    expected_K = updated.B_xi.T @ expected_K_full @ updated.B_xi
+    expected_D_full = updated.D
+    expected_D = updated.B_xi.T @ expected_D_full @ updated.B_xi
+
+    assert_allclose(updated.M_segments, expected_M, rtol=RTOL, atol=ATOL)
+    assert_allclose(updated.K_full, expected_K_full, rtol=RTOL, atol=ATOL)
+    assert_allclose(updated.K, expected_K, rtol=RTOL, atol=ATOL)
+    assert_allclose(updated.D_full, expected_D_full, rtol=RTOL, atol=ATOL)
+    assert_allclose(updated.D_active, expected_D, rtol=RTOL, atol=ATOL)
+    assert_allclose(updated.stiffness_matrix(), expected_K, rtol=RTOL, atol=ATOL)
+    assert_allclose(
+        updated.damping_matrix(jnp.zeros(updated.num_dofs)),
+        expected_D,
+        rtol=RTOL,
+        atol=ATOL,
+    )
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])


### PR DESCRIPTION
## Summary

This PR speeds up `PCS` and `PlanarPCS` forward dynamics assembly while preserving the public APIs and numerical outputs.

The two commits together:
- Skip zero-weight quadrature endpoints earlier via `scale_interior_gaussian_quadrature`.
- Assemble forward-dynamics quadrature terms through a private quadrature-specific path.
- Project Jacobians to active coordinates before dynamics assembly.
- Use `jnp.linalg.solve(B, rhs)` instead of explicitly forming `jnp.linalg.inv(B) @ rhs`.
- Compute the Coriolis/centrifugal vector `Cqd` directly in `forward_dynamics`.
- Add private active-coordinate quadrature kinematics helpers.
- Cache constant per-segment mass matrices and full/active stiffness and damping matrices.
- Refresh cached constants in `update_params()`.
- Keep public methods such as `inertia_matrix`, `coriolis_matrix`, `gravitational_force`, `stiffness_matrix`, and `damping_matrix` API-compatible.
- Add tests for the new private helpers and cache refresh behavior.

## Benchmarks

Median runtime over 50 post-JIT `forward_dynamics` calls, comparing current `HEAD` against `HEAD~2`, i.e. before both PCS optimization commits.

### Total Speedup vs Pre-Optimization Baseline

| System / active strains | 1 seg | 2 seg | 4 seg | 8 seg | 12 seg | 16 seg | 20 seg |
|---|---:|---:|---:|---:|---:|---:|---:|
| PCS all | 21.6% | 34.6% | 40.5% | 46.3% | 56.5% | 61.6% | 65.2% |
| PCS 2 / segment | 17.7% | 30.3% | 43.7% | 63.7% | 67.9% | 77.4% | 75.9% |
| PCS 1 / segment | 10.2% | 26.5% | 46.3% | 67.5% | 72.4% | 81.1% | 79.8% |
| PlanarPCS all | -0.4% | 6.5% | 17.3% | 31.6% | 42.0% | 57.0% | 50.1% |
| PlanarPCS 2 / segment | 4.3% | 19.4% | 18.8% | 31.8% | 55.9% | 55.6% | 60.6% |
| PlanarPCS 1 / segment | 46.4% | 13.7% | 26.0% | 27.2% | 58.5% | 69.7% | 75.7% |

Small low-segment cases are sub-0.1 ms and are therefore more sensitive to fixed overhead and scheduler noise. The scaling benefit is most visible from roughly 8 segments onward.

### Commit-Level Ablation at 20 Segments

Speedup vs `HEAD~2` baseline:

| System / active strains | after `eef7065` | after `652599b` | additional from `652599b` |
|---|---:|---:|---:|
| PCS all | 4.4% | 65.2% | +60.8% |
| PCS 2 / segment | 48.3% | 75.9% | +27.5% |
| PCS 1 / segment | 54.7% | 79.8% | +25.1% |
| PlanarPCS all | -2.1% | 50.1% | +52.2% |
| PlanarPCS 2 / segment | 29.4% | 60.6% | +31.2% |
| PlanarPCS 1 / segment | 40.8% | 75.7% | +34.9% |

Interpretation:
- `eef7065` contributes the first round of speedups by improving quadrature handling, active projection, and solve-based dynamics.
- `652599b` contributes the larger scaling gain by computing `Cqd` directly, using active-coordinate quadrature kinematics, fusing the quadrature layout, and caching constant matrices.

The maximum absolute output differences versus `HEAD~2` remained at floating-point roundoff scale:
- PCS: up to `8.8e-6`
- PlanarPCS: up to `4.0e-6`

## Tests

```bash
uv run pytest tests/systems/test_pcs.py
uv run pytest tests/systems/test_planar_pcs.py
uv run pytest tests/systems/test_pcs_2d_vs_3d_coherence.py -k forward_dynamics
