### PR TITLE
Use convective-only Jd in forward dynamics

### DIFF
--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -3313,6 +3313,8 @@ class GVS(SoftRobot):
                 ``(self.num_dofs,)``.
             qd: Active generalized velocities, shape
                 ``(self.num_dofs,)``.
+            convective_only_jd: If true, compute a Jacobian derivative that is
+                only guaranteed to be equivalent after multiplication by ``qd``.
 
         Returns:
             Tuple ``(weights, g_quads, J_quads, Jd_quads)``. ``weights`` has

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -3294,7 +3294,7 @@ class GVS(SoftRobot):
 
     @eqx.filter_jit
     def _active_quadrature_kinematics(
-        self, q: Array, qd: Array
+        self, q: Array, qd: Array, convective_only_jd: bool = False
     ) -> tuple[Array, Array, Array, Array]:
         """
         Return active kinematic data at interior quadrature nodes.
@@ -3302,7 +3302,11 @@ class GVS(SoftRobot):
         This is the active-coordinate counterpart of the public/full Gauss
         kinematics path. It keeps the segment and quadrature axes explicit,
         projects local joint/link contributions into active coordinates as they
-        are assembled, and drops zero-weight endpoint outputs.
+        are assembled, and drops zero-weight endpoint outputs. When
+        ``convective_only_jd`` is true, the returned derivative is only
+        guaranteed to be equivalent after multiplication by ``qd``. This is
+        sufficient for the forward-dynamics ``C(q, qd) @ qd`` path and avoids
+        assembling terms that vanish in that product.
 
         Args:
             q: Active generalized coordinates, shape
@@ -3350,9 +3354,15 @@ class GVS(SoftRobot):
 
             g_j = g_tip @ g_joint_i
             J_j = Ad_g_joint_inv @ (J_tip + T_joint_active)
-            Jd_j = Ad_g_joint_inv @ (Jd_tip + Td_joint_active) + Ad_g_joint_inv_dot @ (
-                J_tip + T_joint_active
-            )
+            if convective_only_jd:
+                Jd_j = (
+                    Ad_g_joint_inv @ (Jd_tip + Td_joint_active)
+                    + Ad_g_joint_inv_dot @ J_tip
+                )
+            else:
+                Jd_j = Ad_g_joint_inv @ (
+                    Jd_tip + Td_joint_active
+                ) + Ad_g_joint_inv_dot @ (J_tip + T_joint_active)
 
             Xs_i = self.integration_points[i_segment]
             xi_ref_Z1_i = self.xi_ref_Z1[i_segment]
@@ -3400,9 +3410,15 @@ class GVS(SoftRobot):
 
                 g_next = g_prev @ g_step
                 J_next = Ad_step_inv @ (J_prev + T_active)
-                Jd_next = Ad_step_inv @ (Jd_prev + Td_active) + Ad_step_inv_dot @ (
-                    J_prev + T_active
-                )
+                if convective_only_jd:
+                    Jd_next = (
+                        Ad_step_inv @ (Jd_prev + Td_active)
+                        + Ad_step_inv_dot @ J_prev
+                    )
+                else:
+                    Jd_next = Ad_step_inv @ (
+                        Jd_prev + Td_active
+                    ) + Ad_step_inv_dot @ (J_prev + T_active)
 
                 return (g_next, J_next, Jd_next, eta_next), (
                     g_next,
@@ -3466,7 +3482,9 @@ class GVS(SoftRobot):
             ``G`` is the active generalized gravity vector with shape
             ``(self.num_dofs,)``.
         """
-        weights, g_quads, J_quads, Jd_quads = self._active_quadrature_kinematics(q, qd)
+        weights, g_quads, J_quads, Jd_quads = self._active_quadrature_kinematics(
+            q, qd, convective_only_jd=True
+        )
         Ms_inner = self._inner_mass_matrices()
 
         def segment_terms(i: Array) -> tuple[Array, Array, Array]:

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -2099,6 +2099,12 @@ class PCS(SoftRobot):
         """
         Return weights, poses, active Jacobians, and derivatives at quadrature points.
 
+        Args:
+            q: Active generalized coordinates, shape ``(self.num_dofs,)``.
+            qd: Active generalized velocities, shape ``(self.num_dofs,)``.
+            convective_only_jd: If true, compute a Jacobian derivative that is
+                only guaranteed to be equivalent after multiplication by ``qd``.
+
         When ``convective_only_jd`` is true, the returned derivative is only
         guaranteed to be equivalent after multiplication by ``qd``. This is
         sufficient for the forward-dynamics ``C(q, qd) @ qd`` path and avoids

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -2040,7 +2040,11 @@ class PCS(SoftRobot):
 
     @eqx.filter_jit
     def _active_J_Jd_local_tips_from_strain(
-        self, xi: Array, xid: Array, B_segments: Array
+        self,
+        xi: Array,
+        xid: Array,
+        B_segments: Array,
+        convective_only_jd: bool = False,
     ) -> tuple[Array, Array]:
         """Compute active-coordinate local Jacobians at all segment tips."""
         Ad_inv_tips = vmap(
@@ -2075,7 +2079,10 @@ class PCS(SoftRobot):
             eta = Ad_inv_T_i @ xid_i
             Ad_inv_dot = -lie.adjoint_se3(eta) @ Ad_inv_i
 
-            Jd_segment = (Ad_inv_dot @ T_i + Ad_inv_i @ Td_i) @ B_i
+            if convective_only_jd:
+                Jd_segment = (Ad_inv_i @ Td_i) @ B_i
+            else:
+                Jd_segment = (Ad_inv_dot @ T_i + Ad_inv_i @ Td_i) @ B_i
             Jd_next = Ad_inv_i @ Jd_prev + Ad_inv_dot @ J_prev + Jd_segment
 
             return (J_next, Jd_next), (J_next, Jd_next)
@@ -2087,9 +2094,16 @@ class PCS(SoftRobot):
 
     @eqx.filter_jit
     def _active_quadrature_kinematics(
-        self, q: Array, qd: Array
+        self, q: Array, qd: Array, convective_only_jd: bool = False
     ) -> tuple[Array, Array, Array, Array]:
-        """Return weights, poses, active Jacobians, and derivatives at quadrature points."""
+        """
+        Return weights, poses, active Jacobians, and derivatives at quadrature points.
+
+        When ``convective_only_jd`` is true, the returned derivative is only
+        guaranteed to be equivalent after multiplication by ``qd``. This is
+        sufficient for the forward-dynamics ``C(q, qd) @ qd`` path and avoids
+        assembling terms that vanish in that product.
+        """
         xi = self.strain(q).reshape(self.num_segments, 6)
         xid = (self.B_xi @ qd).reshape(self.num_segments, 6)
         B_segments = self.B_xi.reshape(self.num_segments, 6, self.num_dofs)
@@ -2122,7 +2136,9 @@ class PCS(SoftRobot):
 
         g_ps = vmap(segment_poses)(g_bases, xi, s_local)
 
-        J_tips, Jd_tips = self._active_J_Jd_local_tips_from_strain(xi, xid, B_segments)
+        J_tips, Jd_tips = self._active_J_Jd_local_tips_from_strain(
+            xi, xid, B_segments, convective_only_jd=convective_only_jd
+        )
         zeros_tip = jnp.zeros_like(J_tips[:1])
         J_bases = jnp.concatenate([zeros_tip, J_tips[:-1]], axis=0)
         Jd_bases = jnp.concatenate([zeros_tip, Jd_tips[:-1]], axis=0)
@@ -2149,7 +2165,10 @@ class PCS(SoftRobot):
                 eta = Ad_inv_T @ xid_i
                 Ad_inv_dot = -lie.adjoint_se3(eta) @ Ad_inv
 
-                Jd_segment = (Ad_inv_dot @ T + Ad_inv @ Td) @ B_i
+                if convective_only_jd:
+                    Jd_segment = (Ad_inv @ Td) @ B_i
+                else:
+                    Jd_segment = (Ad_inv_dot @ T + Ad_inv @ Td) @ B_i
                 Jd_next = Ad_inv @ Jd_base_i + Ad_inv_dot @ J_base_i + Jd_segment
 
                 return J_next, Jd_next
@@ -2172,7 +2191,9 @@ class PCS(SoftRobot):
         The endpoint quadrature nodes have zero weight and are dropped before the
         kinematics/Jacobian batch evaluation.
         """
-        Ws_inner, g_ps, J_ps, Jd_ps = self._active_quadrature_kinematics(q, qd)
+        Ws_inner, g_ps, J_ps, Jd_ps = self._active_quadrature_kinematics(
+            q, qd, convective_only_jd=True
+        )
         num_inner_points = self.num_gauss_points
 
         def dynamical_terms_i(i: Array) -> tuple[Array, Array, Array]:

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -1989,7 +1989,11 @@ class PlanarPCS(SoftRobot):
 
     @eqx.filter_jit
     def _active_J_Jd_local_tips_from_strain(
-        self, xi: Array, xid: Array, B_segments: Array
+        self,
+        xi: Array,
+        xid: Array,
+        B_segments: Array,
+        convective_only_jd: bool = False,
     ) -> tuple[Array, Array]:
         """Compute active-coordinate local Jacobians at all segment tips."""
         Ad_inv_tips = vmap(
@@ -2024,7 +2028,10 @@ class PlanarPCS(SoftRobot):
             eta = Ad_inv_T_i @ xid_i
             Ad_inv_dot = -lie.adjoint_se2(eta) @ Ad_inv_i
 
-            Jd_segment = (Ad_inv_dot @ T_i + Ad_inv_i @ Td_i) @ B_i
+            if convective_only_jd:
+                Jd_segment = (Ad_inv_i @ Td_i) @ B_i
+            else:
+                Jd_segment = (Ad_inv_dot @ T_i + Ad_inv_i @ Td_i) @ B_i
             Jd_next = Ad_inv_i @ Jd_prev + Ad_inv_dot @ J_prev + Jd_segment
 
             return (J_next, Jd_next), (J_next, Jd_next)
@@ -2036,9 +2043,16 @@ class PlanarPCS(SoftRobot):
 
     @eqx.filter_jit
     def _active_quadrature_kinematics(
-        self, q: Array, qd: Array
+        self, q: Array, qd: Array, convective_only_jd: bool = False
     ) -> tuple[Array, Array, Array, Array]:
-        """Return weights, poses, active Jacobians, and derivatives at quadrature points."""
+        """
+        Return weights, poses, active Jacobians, and derivatives at quadrature points.
+
+        When ``convective_only_jd`` is true, the returned derivative is only
+        guaranteed to be equivalent after multiplication by ``qd``. This is
+        sufficient for the forward-dynamics ``C(q, qd) @ qd`` path and avoids
+        assembling terms that vanish in that product.
+        """
         xi = self.strain(q).reshape(self.num_segments, 3)
         xid = (self.B_xi @ qd).reshape(self.num_segments, 3)
         B_segments = self.B_xi.reshape(self.num_segments, 3, self.num_dofs)
@@ -2082,7 +2096,9 @@ class PlanarPCS(SoftRobot):
 
         g_ps = vmap(segment_poses)(g_bases, xi, s_local)
 
-        J_tips, Jd_tips = self._active_J_Jd_local_tips_from_strain(xi, xid, B_segments)
+        J_tips, Jd_tips = self._active_J_Jd_local_tips_from_strain(
+            xi, xid, B_segments, convective_only_jd=convective_only_jd
+        )
         zeros_tip = jnp.zeros_like(J_tips[:1])
         J_bases = jnp.concatenate([zeros_tip, J_tips[:-1]], axis=0)
         Jd_bases = jnp.concatenate([zeros_tip, Jd_tips[:-1]], axis=0)
@@ -2109,7 +2125,10 @@ class PlanarPCS(SoftRobot):
                 eta = Ad_inv_T @ xid_i
                 Ad_inv_dot = -lie.adjoint_se2(eta) @ Ad_inv
 
-                Jd_segment = (Ad_inv_dot @ T + Ad_inv @ Td) @ B_i
+                if convective_only_jd:
+                    Jd_segment = (Ad_inv @ Td) @ B_i
+                else:
+                    Jd_segment = (Ad_inv_dot @ T + Ad_inv @ Td) @ B_i
                 Jd_next = Ad_inv @ Jd_base_i + Ad_inv_dot @ J_base_i + Jd_segment
 
                 return J_next, Jd_next
@@ -2135,7 +2154,9 @@ class PlanarPCS(SoftRobot):
             Cqd (Array): Coriolis/centrifugal force of shape (num_active_strains,).
             G (Array): Gravitational force of shape (num_active_strains,).
         """
-        Ws_scaled, g_ps, J_ps, Jd_ps = self._active_quadrature_kinematics(q, qd)
+        Ws_scaled, g_ps, J_ps, Jd_ps = self._active_quadrature_kinematics(
+            q, qd, convective_only_jd=True
+        )
         num_quad = self.num_gauss_points
 
         def dynamical_terms_i(i: Array) -> tuple[Array, Array, Array]:

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -2048,6 +2048,12 @@ class PlanarPCS(SoftRobot):
         """
         Return weights, poses, active Jacobians, and derivatives at quadrature points.
 
+        Args:
+            q: Active generalized coordinates, shape ``(self.num_dofs,)``.
+            qd: Active generalized velocities, shape ``(self.num_dofs,)``.
+            convective_only_jd: If true, compute a Jacobian derivative that is
+                only guaranteed to be equivalent after multiplication by ``qd``.
+
         When ``convective_only_jd`` is true, the returned derivative is only
         guaranteed to be equivalent after multiplication by ``qd``. This is
         sufficient for the forward-dynamics ``C(q, qd) @ qd`` path and avoids

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1322,6 +1322,20 @@ def test_active_quadrature_kinematics_matches_existing_batched_path(
     assert J_quads.shape[:2] == weights.shape
     assert Jd_quads.shape == J_quads.shape
 
+    weights_fast, g_fast, J_fast, Jd_fast = robot._active_quadrature_kinematics(
+        q, qd, convective_only_jd=True
+    )
+
+    assert_allclose(weights_fast, weights, rtol=RTOL, atol=ATOL)
+    assert_allclose(g_fast, g_quads, rtol=RTOL, atol=ATOL)
+    assert_allclose(J_fast, J_quads, rtol=RTOL, atol=ATOL)
+    assert_allclose(
+        jnp.einsum("ijkl,l->ijk", Jd_fast, qd),
+        jnp.einsum("ijkl,l->ijk", Jd_quads, qd),
+        rtol=RTOL,
+        atol=ATOL,
+    )
+
 
 @pytest.mark.parametrize("num_segments", [1, 3])
 def test_active_quadrature_forward_dynamics_terms_match_public_matrices(

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -1044,6 +1044,20 @@ def test_active_quadrature_kinematics_matches_existing_batched_path(
     assert_allclose(J_quads, J_expected, rtol=RTOL, atol=ATOL)
     assert_allclose(Jd_quads, Jd_expected, rtol=RTOL, atol=ATOL)
 
+    weights_fast, g_fast, J_fast, Jd_fast = model._active_quadrature_kinematics(
+        q, qd, convective_only_jd=True
+    )
+
+    assert_allclose(weights_fast, weights_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(g_fast, g_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(J_fast, J_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(
+        jnp.einsum("ijkl,l->ijk", Jd_fast, qd),
+        jnp.einsum("ijkl,l->ijk", Jd_expected, qd),
+        rtol=RTOL,
+        atol=ATOL,
+    )
+
 
 @pytest.mark.parametrize("num_segments", [1, 3])
 @pytest.mark.parametrize(

--- a/tests/systems/test_planar_pcs.py
+++ b/tests/systems/test_planar_pcs.py
@@ -1269,6 +1269,20 @@ def test_active_quadrature_kinematics_matches_existing_batched_path_planar(
     assert_allclose(J_quads, J_expected, rtol=RTOL, atol=ATOL)
     assert_allclose(Jd_quads, Jd_expected, rtol=RTOL, atol=ATOL)
 
+    weights_fast, g_fast, J_fast, Jd_fast = model._active_quadrature_kinematics(
+        q, qd, convective_only_jd=True
+    )
+
+    assert_allclose(weights_fast, weights_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(g_fast, g_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(J_fast, J_expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(
+        jnp.einsum("ijkl,l->ijk", Jd_fast, qd),
+        jnp.einsum("ijkl,l->ijk", Jd_expected, qd),
+        rtol=RTOL,
+        atol=ATOL,
+    )
+
 
 @pytest.mark.parametrize("num_segments", [1, 3])
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR keeps the public/full Jacobian derivative paths Christoffel-compatible,
while using a cheaper convective-equivalent `Jd` only inside the optimized
forward-dynamics paths that assemble `C(q, qd) @ qd` directly.

The key observation is that for forward dynamics we never need the standalone
full Coriolis matrix. We only need the product `Jd @ qd` inside the convective
force integral. In that product, the local `Ad_inv_dot @ T` contribution
vanishes because it becomes an adjoint action of a twist on itself. Therefore
the active quadrature forward-dynamics path can use the simpler local update:

```python
Jd_segment = Ad_inv @ Td
```

instead of:

```python
Jd_segment = Ad_inv_dot @ T + Ad_inv @ Td
```

The full `Jd` remains the default for Jacobian derivative APIs and full Coriolis
matrix computations.

## Changes

- Added `convective_only_jd` mode to active quadrature kinematics for:
  - `PCS`
  - `PlanarPCS`
  - `GVS`
- Switched each `_active_quadrature_forward_dynamics_terms(...)` path to use
  `convective_only_jd=True`.
- Added regression checks that:
  - default active quadrature `Jd` still matches the existing full batched path
  - convective-only `Jd` gives the same `Jd @ qd`
  - optimized forward-dynamics terms still match public matrix computations
- Added benchmark scripts for PCS and GVS forward dynamics and `rollout_to`.

## Validation

```bash
uv run --extra test pytest tests/systems/test_pcs.py tests/systems/test_planar_pcs.py tests/systems/test_gvs.py -k "active_quadrature or forward_dynamics_matches_manual_computation"
# 37 passed
```

```bash
uv run --extra dev ruff check benchmarks/gvs_jd_mode.py benchmarks/pcs_forward_dynamics_jd_mode.py benchmarks/pcs_rollout_jd_mode.py
# All checks passed
```

```bash
git diff --check
# passed
```

## Benchmarks

All timings are median wall-clock milliseconds, compilation excluded. The
"convective Jd" column is this PR's forward-dynamics path.

### PCS `forward_dynamics`

`max_abs_error` was zero for all rows shown.

| segments | dof | full Jd ms | convective Jd ms | speedup |
|---:|---:|---:|---:|---:|
| 1 | 6 | 0.0739 | 0.0720 | 1.03x |
| 2 | 12 | 0.1035 | 0.0970 | 1.07x |
| 4 | 24 | 0.1298 | 0.1248 | 1.04x |
| 8 | 48 | 0.2423 | 0.2297 | 1.06x |
| 16 | 96 | 0.6452 | 0.6386 | 1.01x |
| 32 | 192 | 2.4498 | 2.3574 | 1.04x |
| 64 | 384 | 12.6689 | 12.8721 | 0.98x |

### PCS `rollout_to`

`max_abs_error` was zero for all rows shown. The rollout benchmark uses a stable
rest-state setup with zero gravity/input and 20 fixed solver steps.

| segments | dof | full Jd ms | convective Jd ms | speedup |
|---:|---:|---:|---:|---:|
| 1 | 6 | 2.7262 | 2.7233 | 1.00x |
| 2 | 12 | 5.6269 | 5.2520 | 1.07x |
| 4 | 24 | 8.9841 | 8.8818 | 1.01x |
| 8 | 48 | 23.2982 | 22.9055 | 1.02x |
| 16 | 96 | 69.4912 | 69.3910 | 1.00x |
| 32 | 192 | 283.2479 | 278.0974 | 1.02x |
| 64 | 384 | 1603.4356 | 1581.4007 | 1.01x |

### GVS `forward_dynamics`

`max_abs_error` was zero for all rows shown. These timings use small randomized
states/inputs to avoid large-system solve amplification dominating the ablation.

| segments | dof | full Jd ms | convective Jd ms | speedup |
|---:|---:|---:|---:|---:|
| 1 | 9 | 0.1609 | 0.1576 | 1.02x |
| 2 | 19 | 0.2723 | 0.2729 | 1.00x |
| 4 | 45 | 0.5675 | 0.5534 | 1.03x |
| 8 | 98 | 1.3932 | 1.3531 | 1.03x |
| 12 | 155 | 2.5544 | 2.5971 | 0.98x |
| 16 | 201 | 4.1355 | 4.2510 | 0.97x |
| 24 | 311 | 12.5708 | 12.6304 | 1.00x |

An additional repeat-heavy rerun for the rows that sometimes regress showed a
small but repeatable break-even/slower result, still with exact output agreement:

| segments | dof | full Jd ms | convective Jd ms | speedup |
|---:|---:|---:|---:|---:|
| 8 | 98 | 1.3134 | 1.3195 | 1.00x |
| 12 | 155 | 2.5859 | 2.6056 | 0.99x |
| 16 | 201 | 4.4793 | 4.5405 | 0.99x |

### GVS `rollout_to`

`max_abs_error` was zero for all rows shown. The rollout benchmark uses a stable
rest-state setup with zero gravity/input and 20 fixed solver steps.

| segments | dof | full Jd ms | convective Jd ms | speedup |
|---:|---:|---:|---:|---:|
| 1 | 9 | 6.6528 | 6.9993 | 0.95x |
| 2 | 19 | 16.0941 | 16.1416 | 1.00x |
| 4 | 45 | 48.5075 | 48.4933 | 1.00x |
| 8 | 98 | 133.0833 | 133.6575 | 1.00x |
| 12 | 155 | 280.9576 | 289.5635 | 0.97x |
| 16 | 201 | 525.0478 | 529.1397 | 0.99x |

## Interpretation

The simplification is correctness-preserving for the direct forward-dynamics
convective-force path. For PCS, it gives a small but measurable single-step
speedup in many cases, though the benefit is eventually dominated by inertia
assembly and the dense solve.

For GVS, the result is mostly break-even and can be slightly slower. This is not
only measurement noise: repeat-heavy runs reproduce small regressions around
1%. The reason is that the simplification removes very little actual work from
the GVS recurrence. Both the full and convective-only paths still compute the
same poses, tangents, tangent derivatives, Magnus basis derivatives, adjoint
derivatives, inertia terms, gravity terms, and dense solve. Locally, the change
mostly removes an addition into an existing small matrix multiply:

```python
Ad_dot @ (J_prev + T_active)
```

becomes:

```python
Ad_dot @ J_prev
```

The number of matrix multiplies is unchanged. The deleted work is small enough
that XLA scheduling, fusion, register pressure, cache behavior, and timing noise
can dominate. In `rollout_to`, Diffrax stepper overhead and repeated dense
dynamics calls further dilute the local savings.

The main value of this change is API consistency and correctness separation:
full Coriolis/Jacobian derivative computations remain Christoffel-compatible,
while forward dynamics avoids unnecessary local terms when only `C(q, qd) @ qd`
is required.
