### PR TITLE
Add potential_force helper

### DIFF
--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -840,6 +840,20 @@ class SoftRobot(DynamicalSystem):
         """
         return self._gravitational_force(q)
 
+    def potential_force(self, q: Array) -> Array:
+        """
+        Compute the total conservative generalized force.
+
+        This is the sum of gravitational and elastic forces.
+
+        Args:
+            q: Generalized coordinates of shape (num_dofs,).
+
+        Returns:
+            tau_pot: Potential force of shape (num_dofs,).
+        """
+        return self.gravitational_force(q) + self.elastic_force(q)
+
     def _gravitational_force(self, q: Array) -> Array:
         """
         Protected gravitational-force hook.
@@ -1112,7 +1126,7 @@ class SoftRobot(DynamicalSystem):
 
     def _potential_energy_gradient(self, q: Array) -> Array:
         """Gradient of total potential energy with respect to q."""
-        return self.gravitational_force(q) + self.elastic_force(q)
+        return self.potential_force(q)
 
     @eqx.filter_custom_jvp
     @staticmethod

--- a/tests/systems/test_soft_robot_defaults.py
+++ b/tests/systems/test_soft_robot_defaults.py
@@ -302,6 +302,21 @@ def test_default_gravity_force_and_forward_dynamics() -> None:
     assert_allclose(robot.forward_dynamics(0.0, y, (u, tau_ext)), jnp.r_[qd, qdd])
 
 
+def test_default_potential_force_sums_conservative_forces() -> None:
+    robot = _PlanarDefaultRobot()
+    q = jnp.array([0.2, -0.3], dtype=jnp.float64)
+
+    expected = robot.gravitational_force(q) + robot.elastic_force(q)
+
+    assert_allclose(robot.potential_force(q), expected, rtol=1e-12, atol=1e-12)
+    assert_allclose(
+        robot._potential_energy_gradient(q),
+        robot.potential_force(q),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
 def test_default_coriolis_matrix_is_energy_consistent() -> None:
     robot = _PlanarDefaultRobot()
     q = jnp.array([0.2, -0.3], dtype=jnp.float64)


### PR DESCRIPTION
## Summary
- add SoftRobot.potential_force(q) as the sum of gravitational and elastic force
- route the existing potential-energy gradient helper through the new public method
- add a focused default SoftRobot regression test

## Tests
- uv run pytest tests/systems/test_soft_robot_defaults.py