### PR TITLE
[codex] Centralize soft robot length property

### DIFF
--- a/src/soromox/systems/articulated/articulated_soft_robot.py
+++ b/src/soromox/systems/articulated/articulated_soft_robot.py
@@ -173,11 +173,6 @@ class ArticulatedSoftRobot(SoftRobot):
         return False
 
     @property
-    def length(self) -> Array:
-        """Total chain length measured along the straight link centerlines."""
-        return jnp.sum(self.segment_length)
-
-    @property
     def segment_length(self) -> Array:
         """Per-link centerline lengths."""
         return jnp.linalg.norm(self.p_tip, axis=1)

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -280,11 +280,6 @@ class GVS(SoftRobot):
         return False
 
     @property
-    def length(self) -> Array:
-        """Total backbone length."""
-        return jnp.sum(self.segment_lengths)
-
-    @property
     def segment_length(self) -> Array:
         """Per-segment backbone lengths."""
         return jnp.asarray(self.segment_lengths)

--- a/src/soromox/systems/hsa/planar_hsa.py
+++ b/src/soromox/systems/hsa/planar_hsa.py
@@ -574,11 +574,6 @@ class PlanarHSA(SoftRobot):
         return True
 
     @property
-    def length(self) -> Array:
-        """Total backbone length."""
-        return self.Lmax
-
-    @property
     def segment_length(self) -> Array:
         """Per-segment backbone lengths."""
         return jnp.asarray(self.L)

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -195,11 +195,6 @@ class PCS(SoftRobot):
         return False
 
     @property
-    def length(self) -> Array:
-        """Total backbone length."""
-        return jnp.sum(self.L)
-
-    @property
     def segment_length(self) -> Array:
         """Per-segment backbone lengths."""
         return jnp.asarray(self.L)

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -192,11 +192,6 @@ class PlanarPCS(SoftRobot):
         return True
 
     @property
-    def length(self) -> Array:
-        """Total backbone length."""
-        return jnp.sum(self.L)
-
-    @property
     def segment_length(self) -> Array:
         """Per-segment backbone lengths."""
         return jnp.asarray(self.L)

--- a/src/soromox/systems/pendulum/pendulum.py
+++ b/src/soromox/systems/pendulum/pendulum.py
@@ -133,11 +133,6 @@ class Pendulum(SoftRobot):
         return True
 
     @property
-    def length(self) -> Array:
-        """Total chain length."""
-        return jnp.sum(self.L)
-
-    @property
     def segment_length(self) -> Array:
         """Per-link lengths."""
         return jnp.asarray(self.L)

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -102,10 +102,9 @@ class SoftRobot(DynamicalSystem):
         return None
 
     @property
-    @abstractmethod
     def length(self) -> Array:
         """Total backbone length of the robot (scalar)."""
-        ...
+        return jnp.sum(jnp.atleast_1d(jnp.asarray(self.segment_length)))
 
     @property
     @abstractmethod

--- a/tests/systems/test_soft_robot_defaults.py
+++ b/tests/systems/test_soft_robot_defaults.py
@@ -28,10 +28,6 @@ class _PlanarDefaultRobot(SoftRobot):
         self.integration_weights = jnp.array([0.0, 1.0, 0.0], dtype=jnp.float64)
 
     @property
-    def length(self) -> Array:
-        return jnp.sum(self.L)
-
-    @property
     def segment_length(self) -> Array:
         return self.L
 
@@ -151,6 +147,12 @@ def test_custom_jvp_global_toggle_context_manager_restores_state() -> None:
 
     assert not custom_jvp_enabled()
     set_custom_jvp_enabled(True)
+
+
+def test_default_length_sums_segment_lengths() -> None:
+    robot = _PlanarDefaultRobot()
+
+    assert_allclose(robot.length, jnp.sum(robot.segment_length), rtol=1e-12, atol=1e-12)
 
 
 def test_custom_jvp_toggle_controls_public_forward_kinematics_arc_length_jvp() -> None:

--- a/tests/systems/test_system_lengths.py
+++ b/tests/systems/test_system_lengths.py
@@ -1,0 +1,227 @@
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import pytest
+from numpy.testing import assert_allclose
+from system_param_builders import (
+    articulated_params,
+    linear_tendon_routing,
+    pcs_params,
+    pendulum_params,
+    planar_hsa_params_from_legacy,
+    planar_pcs_params,
+    tendon_actuated_pcs_params,
+    tendon_actuated_pendulum_params,
+    tendon_actuated_planar_pcs_params,
+)
+
+import soromox
+from soromox.parameters.hsa_params import PARAMS_FPU_CONTROL
+from soromox.systems import (
+    GVS,
+    PCS,
+    ArticulatedSoftRobot,
+    CrossSectionGeometry,
+    ISupport,
+    ISupportParams,
+    PCSStructure,
+    Pendulum,
+    PlanarHSA,
+    PlanarHSAStructure,
+    PlanarPCS,
+    PlanarPCSStructure,
+    PneumaticActuatedPlanarPCS,
+    PneumaticActuatedPlanarPCSParams,
+    TendonActuatedGVS,
+    TendonActuatedPCS,
+    TendonActuatedPendulum,
+    TendonActuatedPlanarPCS,
+)
+from soromox.systems.gvs import GVSSegment, JointSpec, LinkSpec, StrainBasisSpec
+
+jax.config.update("jax_enable_x64", True)
+
+
+def _pcs_params(length):
+    num_segments = len(length)
+    return pcs_params(
+        base_pose=jnp.zeros((6,)),
+        length=jnp.asarray(length, dtype=jnp.float64),
+        radius=0.02 * jnp.ones((num_segments,), dtype=jnp.float64),
+        density=1000.0 * jnp.ones((num_segments,), dtype=jnp.float64),
+        young_modulus=1e6 * jnp.ones((num_segments,), dtype=jnp.float64),
+        shear_modulus=1e5 * jnp.ones((num_segments,), dtype=jnp.float64),
+        damping_matrix=jnp.eye(6 * num_segments, dtype=jnp.float64),
+        gravity=jnp.array([0.0, 0.0, -9.81], dtype=jnp.float64),
+    )
+
+
+def _planar_pcs_params(length):
+    num_segments = len(length)
+    return planar_pcs_params(
+        base_angle=jnp.array(0.0),
+        length=jnp.asarray(length, dtype=jnp.float64),
+        radius=0.02 * jnp.ones((num_segments,), dtype=jnp.float64),
+        density=1000.0 * jnp.ones((num_segments,), dtype=jnp.float64),
+        young_modulus=1e6 * jnp.ones((num_segments,), dtype=jnp.float64),
+        shear_modulus=1e5 * jnp.ones((num_segments,), dtype=jnp.float64),
+        damping_matrix=jnp.eye(3 * num_segments, dtype=jnp.float64),
+        gravity=jnp.array([0.0, -9.81], dtype=jnp.float64),
+    )
+
+
+def _pendulum_params(length):
+    length = jnp.asarray(length, dtype=jnp.float64)
+    num_links = len(length)
+    return pendulum_params(
+        mass=jnp.arange(1, num_links + 1, dtype=jnp.float64),
+        moment_inertia=0.1 * jnp.arange(1, num_links + 1, dtype=jnp.float64),
+        length=length,
+        center_of_mass_length=0.5 * length,
+        gravity=jnp.array([0.0, -9.81], dtype=jnp.float64),
+    )
+
+
+def _articulated_robot():
+    p_tip = jnp.array(
+        [[0.3, 0.0, 0.0], [0.0, 0.4, 0.0], [0.0, 0.0, 0.5]], dtype=jnp.float64
+    )
+    num_links = p_tip.shape[0]
+    joint_screw = jnp.zeros((num_links, 6), dtype=jnp.float64).at[:, 2].set(1.0)
+    inertia = jnp.stack(
+        [jnp.eye(3, dtype=jnp.float64) * (0.01 + 0.01 * i) for i in range(num_links)]
+    )
+    return ArticulatedSoftRobot(
+        articulated_params(
+            joint_screw=joint_screw,
+            tip_position=p_tip,
+            center_of_mass_position=0.5 * p_tip,
+            mass=jnp.ones((num_links,), dtype=jnp.float64),
+            center_of_mass_inertia=inertia,
+            gravity=jnp.array([0.0, 0.0, -9.81], dtype=jnp.float64),
+        )
+    )
+
+
+def _segments():
+    lengths = [0.11, 0.13, 0.17]
+    return [
+        GVSSegment(
+            link=LinkSpec(
+                cross_section_geometry=CrossSectionGeometry.CIRCULAR,
+                E=1e6,
+                nu=0.45,
+                rho=1000.0,
+                eta=0.0,
+                L=length,
+                r_i=0.02,
+                r_f=0.02,
+            ),
+            joint=JointSpec(type="fixed"),
+            basis=StrainBasisSpec(
+                type="monomial",
+                active=[1, 1, 1, 1, 1, 1],
+                orders=[0, 0, 0, 0, 0, 0],
+                xi_ref=[0, 0, 0, 1, 0, 0],
+            ),
+            num_gauss_points=5,
+        )
+        for length in lengths
+    ]
+
+
+def _tendon_routing(num_segments):
+    return linear_tendon_routing(
+        y_intercept=jnp.array([0.005], dtype=jnp.float64),
+        z_intercept=jnp.array([0.005], dtype=jnp.float64),
+        y_slope=jnp.array([0.0], dtype=jnp.float64),
+        z_slope=jnp.array([0.0], dtype=jnp.float64),
+        attachment_segment_index=jnp.array([num_segments - 1], dtype=jnp.int32),
+    )
+
+
+def _pneumatic_planar_robot():
+    body = _planar_pcs_params([0.08, 0.12])
+    params = PneumaticActuatedPlanarPCSParams(
+        **body.__dict__,
+        chamber_inner_radius=jnp.array([0.002, 0.002], dtype=jnp.float64),
+        chamber_outer_radius=jnp.array([0.004, 0.004], dtype=jnp.float64),
+        chamber_angle=jnp.array([jnp.pi / 3.0, jnp.pi / 3.0], dtype=jnp.float64),
+        chamber_distance=jnp.array([0.01, 0.01], dtype=jnp.float64),
+    )
+    return PneumaticActuatedPlanarPCS(
+        params=params, structure=PlanarPCSStructure(num_gauss_points=1)
+    )
+
+
+def _isupport_robot():
+    body = _pcs_params([0.08, 0.12])
+    params = ISupportParams(
+        **body.__dict__,
+        chamber_inner_radius=jnp.array([0.002, 0.002], dtype=jnp.float64),
+        chamber_outer_radius=jnp.array([0.004, 0.004], dtype=jnp.float64),
+        chamber_distance=jnp.array([0.01, 0.01], dtype=jnp.float64),
+        chamber_angle_offset=jnp.array([0.0, 0.0], dtype=jnp.float64),
+    )
+    return ISupport(params=params, structure=PCSStructure(num_gauss_points=1))
+
+
+def _planar_hsa_robot():
+    params = planar_hsa_params_from_legacy(PARAMS_FPU_CONTROL)
+    path = (
+        Path(soromox.__file__).parent
+        / "symbolic_expressions"
+        / "planar_hsa_ns-1_nrs-2.dill"
+    )
+    return PlanarHSA(
+        params=params,
+        structure=PlanarHSAStructure(symbolic_expression_path=str(path)),
+    )
+
+
+@pytest.mark.parametrize(
+    "robot",
+    [
+        PCS(params=_pcs_params([0.08, 0.12, 0.2])),
+        PlanarPCS(params=_planar_pcs_params([0.08, 0.12, 0.2])),
+        Pendulum(_pendulum_params([0.7, 0.9, 1.1])),
+        TendonActuatedPendulum(
+            tendon_actuated_pendulum_params(
+                body=_pendulum_params([0.7, 0.9, 1.1]),
+                active_routing_matrix=jnp.tril(jnp.ones((3, 3), dtype=jnp.float64)),
+            )
+        ),
+        _articulated_robot(),
+        GVS.from_segments(_segments(), gravity=jnp.array([0.0, 0.0, -9.81])),
+        TendonActuatedGVS.from_segments(
+            _segments(),
+            gravity=jnp.array([0.0, 0.0, -9.81]),
+            active_tendon_routing=_tendon_routing(3),
+        ),
+        TendonActuatedPCS(
+            params=tendon_actuated_pcs_params(
+                body=_pcs_params([0.08, 0.12, 0.2]),
+                active_tendon_routing=_tendon_routing(3),
+            ),
+            structure=PCSStructure(num_gauss_points=3),
+        ),
+        TendonActuatedPlanarPCS(
+            params=tendon_actuated_planar_pcs_params(
+                body=_planar_pcs_params([0.08, 0.12, 0.2]),
+                tendon_distance=0.02
+                * jnp.ones((3, 2), dtype=jnp.float64).at[:, 1].set(-1.0),
+            )
+        ),
+        _pneumatic_planar_robot(),
+        _isupport_robot(),
+        _planar_hsa_robot(),
+    ],
+)
+def test_length_returns_total_robot_length(robot):
+    assert_allclose(
+        robot.length,
+        jnp.sum(jnp.asarray(robot.segment_length)),
+        rtol=1e-12,
+        atol=1e-12,
+    )


### PR DESCRIPTION
## Summary

Centralizes the `SoftRobot.length` property so total robot length is derived once from `segment_length`.

## Changes

- Implements the default `SoftRobot.length` as `sum(segment_length)`.
- Removes redundant downstream `length` overrides from PCS, PlanarPCS, GVS, Pendulum, ArticulatedSoftRobot, and PlanarHSA.
- Adds regression coverage that instantiates concrete robot families and verifies `length` returns total robot length.

## Validation

- `uv run pytest tests/systems/test_soft_robot_defaults.py::test_default_length_sums_segment_lengths tests/systems/test_system_lengths.py tests/systems/test_pcs.py::test_public_pcs_accessors_and_geometry_helpers tests/systems/test_planar_pcs.py::test_public_planar_pcs_accessors_geometry_and_chi tests/systems/test_gvs.py::test_public_gvs_accessors_geometry_and_actuation_matrix`
- `uv run ruff check src/soromox/systems/soft_robot.py tests/systems/test_soft_robot_defaults.py tests/systems/test_system_lengths.py`
- `uv run ruff check --select F821 src/soromox/systems/pcs/pcs.py src/soromox/systems/pcs/planar_pcs.py src/soromox/systems/gvs/core.py src/soromox/systems/pendulum/pendulum.py src/soromox/systems/articulated/articulated_soft_robot.py src/soromox/systems/hsa/planar_hsa.py`