### PR TITLE
Fix multi-segment I-SUPPORT simulation

### DIFF
--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -17,7 +17,7 @@ from soromox.rendering import MatplotlibRenderer
 from soromox.systems import ISupport, ISupportParams, SystemState
 
 if __name__ == "__main__":
-    num_segments = 1
+    num_segments = 2
 
     # Elastic modulus and poisson ratio
     E = 1.6464 * 1e6  # Elastic modulus [Pa]
@@ -33,7 +33,11 @@ if __name__ == "__main__":
     # gamma_t = 806  # translational damping constant [1/s]
     # gamma_r = 1.9416 * 10**(-4)  # rotational damping constant [m^2/s]
     gamma_t = 806 * 1e-3  # translational damping constant [1/s]
-    gamma_r = 1.0 * 1e-4  # rotational damping constant [m^2/s]
+    gamma_r = 1.0 * 1e-3  # rotational damping constant [m^2/s]
+    # Damping is specified per unit backbone length and must be integrated over
+    # each segment, matching the strain-space stiffness assembly. Without this
+    # length scaling the velocity term makes the two-segment fixed-step rollout
+    # unnecessarily stiff and can drive the explicit solver to NaNs.
     damping_matrix = jnp.diag(
         (
             jnp.repeat(
@@ -41,6 +45,7 @@ if __name__ == "__main__":
                 num_segments,
                 axis=0,
             )
+            * segment_lengths[:, None]
         ).flatten()
     )
     params = ISupportParams(
@@ -83,7 +88,10 @@ if __name__ == "__main__":
     # print("A:\n", A)
 
     # Actuation pressures
-    u = jnp.array([2e-1, 0.0, 0.0]) * 1e5
+    u = (
+        jnp.repeat(jnp.array([2e-1, 0.0, 0.0])[None, :], num_segments, axis=0).flatten()
+        * 1e5
+    )
 
     # Simulation time parameters
     t0 = 0.0

--- a/src/soromox/systems/pcs/isupport.py
+++ b/src/soromox/systems/pcs/isupport.py
@@ -88,7 +88,7 @@ class ISupport(PCS):
         self.num_chambers_per_segment = num_chambers_per_segment
         self.num_actuators = (
             self.num_segments * self.num_chambers_per_segment
-        )  # each segment has three control inputs (u1, u2, u3)
+        )  # each segment has one pressure input per chamber
 
         self._set_params(params)
 
@@ -412,9 +412,10 @@ class ISupport(PCS):
             jnp.arange(self.num_segments),
         )
 
-        # we need to sum the contributions of the actuation of each segment
-        A = blk_diag(
+        # assemble the contributions of the actuation of each segment
+        A_full = blk_diag(
             A_blocks_tot
         )  # shape (6 * num_segments, num_segments * num_chambers_per_segment)
+        A = self.B_xi.T @ A_full  # shape (num_active_strains, num_actuators)
 
         return A

--- a/src/soromox/systems/pcs/isupport.py
+++ b/src/soromox/systems/pcs/isupport.py
@@ -6,6 +6,7 @@ from jax import Array, vmap
 
 from soromox.systems.pcs.params import ISupportParams
 from soromox.systems.pcs.structures import PCSStructure
+from soromox.utils.array_math import blk_diag
 
 from .pcs import PCS
 
@@ -50,7 +51,6 @@ class ISupport(PCS):
     """
 
     params: ISupportParams
-    actuation_basis: Array  # actuation basis, shape (num_segments * 2, num_actuators)
 
     r_chamber_in: Array  # inner radius of each segment's chamber, shape (num_segments,)
     r_chamber_out: (
@@ -67,7 +67,6 @@ class ISupport(PCS):
         self,
         params: ISupportParams,
         structure: PCSStructure | None = None,
-        segment_actuation_selector: Array | None = None,
         num_chambers_per_segment: int = 3,
         **kwargs: Any,
     ):
@@ -78,9 +77,6 @@ class ISupport(PCS):
             params: Dynamic I-SUPPORT parameters.
             structure: Static PCS layout. If omitted, the default PCS structure
                 is used.
-            segment_actuation_selector: Boolean array of shape ``(num_segments,)``
-                specifying which segments are actively controlled. Defaults to all
-                segments active.
             num_chambers_per_segment:
                 Number of pneumatic chambers per segment. Defaults to 3.
             **kwargs: Additional keyword arguments.
@@ -89,24 +85,10 @@ class ISupport(PCS):
             raise TypeError("params must be an ISupportParams instance.")
         super().__init__(params, structure=structure, **kwargs)
 
-        if segment_actuation_selector is None:
-            segment_actuation_selector = jnp.ones(self.num_segments, dtype=bool)
         self.num_chambers_per_segment = num_chambers_per_segment
-
         self.num_actuators = (
-            int(jnp.sum(segment_actuation_selector)) * self.num_chambers_per_segment
+            self.num_segments * self.num_chambers_per_segment
         )  # each segment has three control inputs (u1, u2, u3)
-
-        actuation_basis = jnp.zeros(
-            (self.num_chambers_per_segment * self.num_segments, self.num_actuators)
-        )
-        actuation_basis_cumsum = jnp.cumsum(segment_actuation_selector)
-        for i in range(self.num_segments):
-            j = int(actuation_basis_cumsum[i].item()) - 1
-            if segment_actuation_selector[i].item() is True:
-                actuation_basis = actuation_basis.at[2 * i, j].set(1.0)
-                actuation_basis = actuation_basis.at[2 * i + 1, j + 1].set(1.0)
-        self.actuation_basis = actuation_basis
 
         self._set_params(params)
 
@@ -430,16 +412,9 @@ class ISupport(PCS):
             jnp.arange(self.num_segments),
         )
 
-        # # For debugging purposes, we can use a for loop instead of vmap
-        # A_blocks_tot = jnp.stack(
-        #     [A_segment_i(i) for i in range(self.num_segments)],
-        #     axis=0
-        # )
-
         # we need to sum the contributions of the actuation of each segment
-        A = jnp.concatenate(A_blocks_tot, axis=-1)
-
-        # apply the actuation_basis
-        A = A @ self.actuation_basis
+        A = blk_diag(
+            A_blocks_tot
+        )  # shape (6 * num_segments, num_segments * num_chambers_per_segment)
 
         return A

--- a/tests/systems/test_pneumatic_pcs_models.py
+++ b/tests/systems/test_pneumatic_pcs_models.py
@@ -235,6 +235,52 @@ def test_isupport_actuation_matrix_assembles_segments_block_diagonal():
     assert jnp.all(jnp.linalg.norm(actuation_matrix, axis=0) > 0.0)
 
 
+def test_isupport_actuation_matrix_projects_to_active_strains():
+    params = make_isupport_params(num_segments=2)
+    strain_selector = jnp.array(
+        [
+            False,
+            True,
+            True,
+            True,
+            False,
+            False,
+            False,
+            True,
+            True,
+            True,
+            False,
+            False,
+        ],
+        dtype=bool,
+    )
+    full_robot = ISupport(params=params, structure=PCSStructure(num_gauss_points=1))
+    reduced_robot = ISupport(
+        params=params,
+        structure=PCSStructure(
+            num_gauss_points=1,
+            strain_selector=strain_selector,
+        ),
+    )
+
+    full_actuation_matrix = full_robot.actuation_matrix(
+        jnp.zeros((full_robot.num_dofs,))
+    )
+    reduced_actuation_matrix = reduced_robot.actuation_matrix(
+        jnp.zeros((reduced_robot.num_dofs,))
+    )
+
+    assert reduced_robot.num_actuators == full_robot.num_actuators
+    assert reduced_actuation_matrix.shape == (
+        reduced_robot.num_dofs,
+        reduced_robot.num_actuators,
+    )
+    assert jnp.allclose(
+        reduced_actuation_matrix,
+        reduced_robot.B_xi.T @ full_actuation_matrix,
+    )
+
+
 def test_isupport_update_params_and_validation():
     params = make_isupport_params()
     robot = ISupport(params=params, structure=PCSStructure(num_gauss_points=1))

--- a/tests/systems/test_pneumatic_pcs_models.py
+++ b/tests/systems/test_pneumatic_pcs_models.py
@@ -36,22 +36,47 @@ def make_pneumatic_planar_params():
     )
 
 
-def make_isupport_params():
+def make_isupport_params(num_segments=1):
     return ISupportParams(
         base_pose=jnp.zeros((6,)),
-        length=jnp.array([0.1]),
-        radius=jnp.array([0.02]),
-        density=jnp.array([1000.0]),
+        length=jnp.full((num_segments,), 0.1),
+        radius=jnp.full((num_segments,), 0.02),
+        density=jnp.full((num_segments,), 1000.0),
         gravity=jnp.array([0.0, 0.0, -9.81]),
-        young_modulus=jnp.array([2e3]),
-        shear_modulus=jnp.array([1e3]),
-        damping_matrix=1e-3 * jnp.eye(6),
-        reference_strain=jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
-        chamber_inner_radius=jnp.array([0.002]),
-        chamber_outer_radius=jnp.array([0.004]),
-        chamber_distance=jnp.array([0.01]),
-        chamber_angle_offset=jnp.array([0.0]),
+        young_modulus=jnp.full((num_segments,), 2e3),
+        shear_modulus=jnp.full((num_segments,), 1e3),
+        damping_matrix=1e-3 * jnp.eye(6 * num_segments),
+        reference_strain=jnp.tile(
+            jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), num_segments
+        ),
+        chamber_inner_radius=jnp.full((num_segments,), 0.002),
+        chamber_outer_radius=jnp.full((num_segments,), 0.004),
+        chamber_distance=jnp.full((num_segments,), 0.01),
+        chamber_angle_offset=jnp.zeros((num_segments,)),
     )
+
+
+def expected_isupport_segment_actuation(params, segment_idx, num_chambers=3):
+    chamber_area = jnp.pi * params.chamber_inner_radius[segment_idx] ** 2
+    chamber_distance = params.chamber_distance[segment_idx]
+    chamber_angles = params.chamber_angle_offset[segment_idx] + jnp.linspace(
+        0.0, 2.0 * jnp.pi, num_chambers, endpoint=False
+    )
+    expected_columns = []
+    for angle in chamber_angles:
+        expected_columns.append(
+            jnp.array(
+                [
+                    0.0,
+                    -chamber_distance * jnp.cos(angle) * chamber_area,
+                    chamber_distance * jnp.sin(angle) * chamber_area,
+                    chamber_area,
+                    0.0,
+                    0.0,
+                ]
+            )
+        )
+    return jnp.stack(expected_columns, axis=-1)
 
 
 def test_pneumatic_planar_pcs_circular_geometry_and_actuation_matrix():
@@ -172,6 +197,42 @@ def test_isupport_geometry_helpers_and_actuation_matrix_shape():
     actuation_matrix = robot.actuation_matrix(jnp.zeros((6,)))
     assert actuation_matrix.shape == (6, 3)
     assert not jnp.isnan(actuation_matrix).any()
+
+
+def test_isupport_actuation_matrix_matches_per_segment_chamber_model():
+    params = make_isupport_params()
+    robot = ISupport(params=params, structure=PCSStructure(num_gauss_points=1))
+
+    actuation_matrix = robot.actuation_matrix(jnp.zeros((robot.num_dofs,)))
+
+    assert actuation_matrix.shape == (6, robot.num_chambers_per_segment)
+    assert jnp.allclose(
+        actuation_matrix,
+        expected_isupport_segment_actuation(params, 0, robot.num_chambers_per_segment),
+    )
+    assert jnp.all(jnp.linalg.norm(actuation_matrix, axis=0) > 0.0)
+
+
+def test_isupport_actuation_matrix_assembles_segments_block_diagonal():
+    params = make_isupport_params(num_segments=2).replace(
+        chamber_inner_radius=jnp.array([0.002, 0.003]),
+        chamber_distance=jnp.array([0.01, 0.015]),
+        chamber_angle_offset=jnp.array([0.0, 0.2]),
+    )
+    robot = ISupport(params=params, structure=PCSStructure(num_gauss_points=1))
+
+    actuation_matrix = robot.actuation_matrix(jnp.zeros((robot.num_dofs,)))
+    num_chambers = robot.num_chambers_per_segment
+    expected_segment_0 = expected_isupport_segment_actuation(params, 0, num_chambers)
+    expected_segment_1 = expected_isupport_segment_actuation(params, 1, num_chambers)
+
+    assert robot.num_actuators == 2 * num_chambers
+    assert actuation_matrix.shape == (12, robot.num_actuators)
+    assert jnp.allclose(actuation_matrix[:6, :num_chambers], expected_segment_0)
+    assert jnp.allclose(actuation_matrix[6:, num_chambers:], expected_segment_1)
+    assert jnp.allclose(actuation_matrix[:6, num_chambers:], 0.0)
+    assert jnp.allclose(actuation_matrix[6:, :num_chambers], 0.0)
+    assert jnp.all(jnp.linalg.norm(actuation_matrix, axis=0) > 0.0)
 
 
 def test_isupport_update_params_and_validation():


### PR DESCRIPTION
## Summary

- Fix multi-segment I-SUPPORT actuation by assembling per-segment chamber actuation blocks with `blk_diag`.
- Remove the stale I-SUPPORT segment actuation selector so `num_actuators` always matches the assembled chamber columns.
- Update the I-SUPPORT simulation example to run two segments with per-segment pressure inputs.
- Scale example damping by segment length so the fixed-step explicit rollout does not become unnecessarily stiff.
- Add regression coverage for both the per-segment chamber actuation model and multi-segment block-diagonal assembly.

## Root cause

The I-SUPPORT actuation matrix previously concatenated segment actuation blocks and projected them through a selector that did not represent three independent chambers per segment correctly. For multi-segment robots this collapsed or dropped actuator columns instead of preserving one independent set of chamber inputs per segment.

In the simulation example, damping coefficients were also used directly as generalized damping entries instead of being integrated over segment length, which made the two-segment rollout much stiffer than the one-segment case.

## Validation

- `uv run pytest tests/systems/test_pneumatic_pcs_models.py tests/systems/test_system_lengths.py -q`
- Headless two-segment zero-pressure rollout to `2.0s` at `solver_dt=5e-5` stayed finite during local debugging.