### PR TITLE
Migrate soft robot base pose API

### DIFF
--- a/docs/api/systems/gvs/gvs.md
+++ b/docs/api/systems/gvs/gvs.md
@@ -39,7 +39,7 @@ segment = GVSSegment(
 robot = GVS.from_segments(
     [segment],
     gravity=jnp.array([0.0, 0.0, -9.81]),
-    base_pose=jnp.zeros(6),
+    base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     max_dof=4,
 )
 q = jnp.zeros(robot.num_dofs)

--- a/docs/api/systems/gvs/tendon-actuated-gvs.md
+++ b/docs/api/systems/gvs/tendon-actuated-gvs.md
@@ -40,7 +40,7 @@ active_tendon_routing = LinearTendonRoutingParams(
 robot = TendonActuatedGVS.from_segments(
     [segment],
     gravity=jnp.array([0.0, 0.0, -9.81]),
-    base_pose=jnp.zeros(6),
+    base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     max_dof=4,
     active_tendon_routing=active_tendon_routing,
 )

--- a/docs/api/systems/pcs/tendon-actuated-pcs.md
+++ b/docs/api/systems/pcs/tendon-actuated-pcs.md
@@ -32,7 +32,7 @@ body_params = PCSParams(
     shear_modulus=jnp.array([1e5, 1e5]),
     damping_matrix=jnp.eye(12),
     gravity=jnp.array([0.0, 0.0, -9.81]),
-    base_pose=jnp.zeros(6),
+    base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     reference_strain=jnp.tile(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), 2),
 )
 

--- a/docs/api/utilities/parameters.md
+++ b/docs/api/utilities/parameters.md
@@ -65,7 +65,7 @@ or `(num_links,)`.
 | `shear_modulus` | Per-segment shear modulus |
 | `damping_matrix` | Generalized damping matrix |
 | `gravity` | Gravity vector |
-| `base_pose` / `base_angle` | Base configuration |
+| `base_pose` | Base configuration as scalar-first quaternion pose |
 | `reference_strain` | Reference strain vector |
 | `joint_rest_configuration` | Joint coordinates where elastic joint force is zero |
 
@@ -128,13 +128,23 @@ params = PCSParams(
     shear_modulus=jnp.array([1e5, 1e5]),
     damping_matrix=jnp.eye(12),
     gravity=jnp.array([0.0, 0.0, -9.81]),
-    base_pose=jnp.zeros(6),
+    base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     reference_strain=jnp.tile(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), 2),
 )
 
 robot = PCS(params=params, structure=PCSStructure(num_gauss_points=5))
 updated_robot = robot.update_params(length=jnp.array([0.12, 0.1]))
 ```
+
+`base_pose` convention:
+
+- Planar systems use shape `(3,)`: `[theta, x, y]`, where `theta` is a
+  right-handed angle in radians about the out-of-plane z-axis.
+- Spatial systems use shape `(7,)`: `[qw, qx, qy, qz, x, y, z]`.
+- Spatial quaternions are scalar-first Hamilton quaternions, normalized before
+  use, and must have nonzero finite norm.
+- Zero base rotation means the undeformed soft-robot backbone is aligned with
+  the positive base-frame x-axis.
 
 ## API Reference
 

--- a/docs/development/extending.md
+++ b/docs/development/extending.md
@@ -1046,7 +1046,7 @@ params = PlanarPCSParams(
     damping_matrix=jnp.eye(9),
     gravity=jnp.array([0.0, -9.81]),
     reference_strain=jnp.tile(jnp.array([0.0, 1.0, 0.0]), 3),
-    base_angle=jnp.array(jnp.pi / 2),
+    base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
 )
 robot = PlanarPCS(params=params)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,7 +122,7 @@ Get up and running in minutes:
         young_modulus=2e3 * jnp.ones((num_segments,)),
         shear_modulus=1e3 * jnp.ones((num_segments,)),
         damping_matrix=1e-3 * jnp.eye(3 * num_segments),
-        base_angle=jnp.array(jnp.pi / 2),
+        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
     )
     robot = PlanarPCS(params=params)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -181,7 +181,7 @@ Test your installation with this quick verification script:
         damping_matrix=jnp.eye(3),
         gravity=jnp.array([0.0, -9.81]),
         reference_strain=jnp.array([0.0, 1.0, 0.0]),
-        base_angle=jnp.array(jnp.pi / 2),
+        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
     )
     robot = PlanarPCS(params=params)
     robot.forward_kinematics(jnp.zeros(robot.num_dofs), s=0.1)
@@ -205,7 +205,7 @@ Test your installation with this quick verification script:
         damping_matrix=jnp.eye(6),
         gravity=jnp.array([0.0, -9.81]),
         reference_strain=jnp.tile(jnp.array([0.0, 1.0, 0.0]), 2),
-        base_angle=jnp.array(jnp.pi / 2),
+        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
     )
     robot = PlanarPCS(params=params)
 

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -184,6 +184,13 @@ Each robot system expects a typed Equinox PyTree params object. Numeric fields a
 JAX arrays, so same-shape updates can flow through `jit`, `grad`, and `vmap`
 without changing the compiled structure.
 
+`base_pose` follows the dimensionality of the robot. Planar robots expect
+`[theta, x, y]`, where `theta` is a right-handed angle in radians about the
+out-of-plane z-axis. Spatial robots expect `[qw, qx, qy, qz, x, y, z]`, using
+scalar-first Hamilton quaternions. Zero base rotation means the undeformed
+backbone is aligned with the positive base-frame x-axis. Spatial quaternions
+must have nonzero finite norm and are normalized before transform construction.
+
 ```python title="Parameter Structure"
 params = PCSParams(
     length=link_lengths,
@@ -259,7 +266,7 @@ Ready for something more advanced? Let's simulate a soft continuum robot:
         young_modulus=2e3 * jnp.ones((num_segments,)),
         shear_modulus=1e3 * jnp.ones((num_segments,)),
         damping_matrix=damping_matrix,
-        base_angle=jnp.array(jnp.pi / 2),
+        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
     )
     # Note: Damping helps stabilize simulations and represents material dissipation.
     # For static analysis, you can omit this or set to zero.

--- a/examples/control/actuation_space/setpoint_regulation_comparison.py
+++ b/examples/control/actuation_space/setpoint_regulation_comparison.py
@@ -75,7 +75,7 @@ def create_robot() -> tuple[TendonActuatedPCS, int]:
         ).flatten()
     )
     body_params = PCSParams(
-        base_pose=jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]),
+        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
         length=segment_lengths,
         radius=radius * jnp.ones((num_segments,)),
         density=rho,

--- a/examples/control/configuration_space/setpoint_regulation_comparison.py
+++ b/examples/control/configuration_space/setpoint_regulation_comparison.py
@@ -48,7 +48,7 @@ def create_robot() -> tuple[PCS, int]:
         ).flatten()
     )
     params = PCSParams(
-        base_pose=jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]),
+        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,

--- a/examples/control/configuration_space/trajectory_tracking_comparison.py
+++ b/examples/control/configuration_space/trajectory_tracking_comparison.py
@@ -64,7 +64,7 @@ def create_robot() -> tuple[PCS, int]:
         ).flatten()
     )
     params = PCSParams(
-        base_pose=jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]),
+        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,

--- a/examples/control/operational_space/control_pcs_with_cf_cbf_clf.py
+++ b/examples/control/operational_space/control_pcs_with_cf_cbf_clf.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     # The robot is modeled as a two-segment piecewise-constant-strain body.
     # Each vector entry corresponds to one segment.
     params = {
-        "p0": jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]),  # base pose
+        "p0": jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),  # base pose
         "L": 15e-2
         * 2
         / num_segments

--- a/examples/control/operational_space/control_pcs_with_impedance.py
+++ b/examples/control/operational_space/control_pcs_with_impedance.py
@@ -39,9 +39,8 @@ def main():
     num_segments = 2
     rho = 1070 * jnp.ones((num_segments,))  # Volumetric density [kg/m^3]
 
-    # Define the initial base pose (identity for simplicity - rod points along x-axis)
-    # p0 defines the base orientation in Euler angles convention
-    p0 = jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0])
+    # Define the initial scalar-first quaternion base pose.
+    p0 = jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0])
 
     segment_lengths = 1e-1 * jnp.ones((num_segments,))
 

--- a/examples/control/operational_space/control_tendon_actuated_pcs_with_synergistic.py
+++ b/examples/control/operational_space/control_tendon_actuated_pcs_with_synergistic.py
@@ -42,9 +42,8 @@ def main():
     num_segments = 2
     rho = 1070 * jnp.ones((num_segments,))  # Volumetric density [kg/m^3]
 
-    # Define the initial base pose (identity for simplicity - rod points along x-axis)
-    # p0 defines the base orientation in Euler angles convention
-    p0 = jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0])
+    # Define the initial scalar-first quaternion base pose.
+    p0 = jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0])
 
     segment_lengths = 1e-1 * jnp.ones((num_segments,))
 

--- a/examples/optimization/control_gain_optimization_with_collocated.py
+++ b/examples/optimization/control_gain_optimization_with_collocated.py
@@ -79,7 +79,7 @@ damping_matrix = 1e-3 * jnp.diag(
     ).flatten()
 )
 body_params = PCSParams(
-    base_pose=jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]),
+    base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
     length=segment_lengths,
     radius=radius * jnp.ones((num_segments,)),
     density=rho,

--- a/examples/optimization/control_gain_optimization_with_synergistic.py
+++ b/examples/optimization/control_gain_optimization_with_synergistic.py
@@ -83,7 +83,7 @@ damping_matrix = 1e-3 * jnp.diag(
     ).flatten()
 )
 body_params = PCSParams(
-    base_pose=jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]),
+    base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
     length=segment_lengths,
     radius=radius * jnp.ones((num_segments,)),
     density=rho,

--- a/examples/simulation/gvs/simulate_tendon_actuated_gvs.py
+++ b/examples/simulation/gvs/simulate_tendon_actuated_gvs.py
@@ -102,7 +102,7 @@ active_tendon_routing = LinearTendonRoutingParams(
 )
 # attention: 0DEG -> Y+, 180DEG -> Y-, 90DEG -> Z+, 270DEG -> Z-
 
-p0 = jnp.array([-jnp.pi / 2, jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0])
+p0 = jnp.array([jnp.sqrt(0.5), 0.0, jnp.sqrt(0.5), 0.0, 0.0, 0.0, 0.0])
 
 # 2 link version
 segments = [
@@ -122,7 +122,7 @@ robot = TendonActuatedGVS.from_segments(
     scale_rotational_basis_by_length=True,
 )
 # debug: check g0
-# g0_test = lie.exp_SE3(p0)
+# g0_test = lie.transform_from_quaternion_pose_SE3(p0)
 # print("g0_test:\n", g0_test[:3,:3])
 
 ### MATRICES CHECKING AND PRINTING ###

--- a/examples/simulation/pcs/simulate_batched_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_batched_tendon_actuated_pcs.py
@@ -41,7 +41,7 @@ def build_robot() -> TendonActuatedPCS:
         ).flatten()
     )
     body_params = PCSParams(
-        base_pose=jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]),
+        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         ).flatten()
     )
     params = ISupportParams(
-        base_pose=jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]),
+        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
         length=segment_lengths,
         radius=35.6 * 1e-3 * jnp.ones((num_segments,)),
         density=1104 * jnp.ones((num_segments,)),

--- a/examples/simulation/pcs/simulate_pcs.py
+++ b/examples/simulation/pcs/simulate_pcs.py
@@ -168,8 +168,8 @@ if __name__ == "__main__":
         q_demo,
         color_config=RendererColorConfig(
             backbone=BackboneColorConfig(point_palette="soromox:glacier"),
-            tendon_color=(0.2, 0.4, 0.8),
             base_plate_color=(0.15, 0.15, 0.15),
+            tendon_color=(0.2, 0.4, 0.8),
         ),
     )
 

--- a/examples/simulation/pcs/simulate_pcs.py
+++ b/examples/simulation/pcs/simulate_pcs.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     )
     params = PCSParams(
         base_pose=jnp.array(
-            [jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]
+            [0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]
         ),  # Initial position and orientation
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),

--- a/examples/simulation/pcs/simulate_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_planar_pcs.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         ).flatten()
     )
     params = PlanarPCSParams(
-        base_angle=jnp.array(jnp.pi / 2),  # initial orientation angle [rad]
+        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,

--- a/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
         ).flatten()
     )
     params = PneumaticActuatedPlanarPCSParams(
-        base_angle=jnp.array(jnp.pi / 2),
+        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,

--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     )
     body_params = PCSParams(
         base_pose=jnp.array(
-            [jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]
+            [0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]
         ),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),

--- a/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         ).flatten()
     )
     params = TendonActuatedPlanarPCSParams(
-        base_angle=jnp.array(jnp.pi / 2),
+        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,

--- a/examples/system_identification/identify_soft_tentacle_parameters.py
+++ b/examples/system_identification/identify_soft_tentacle_parameters.py
@@ -419,7 +419,7 @@ if __name__ == "__main__":
         ),
         attachment_segment_index=jnp.array([0, 0]),
     )
-    p0 = jnp.array([-jnp.pi / 2, jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0])
+    p0 = jnp.array([jnp.sqrt(0.5), 0.0, jnp.sqrt(0.5), 0.0, 0.0, 0.0, 0.0])
 
     segments = [
         GVSSegment(

--- a/examples/system_identification/identify_soft_tentacle_residual.py
+++ b/examples/system_identification/identify_soft_tentacle_residual.py
@@ -633,7 +633,7 @@ if __name__ == "__main__":
         ),
         attachment_segment_index=jnp.array([0, 0]),
     )
-    p0 = jnp.array([-jnp.pi / 2, jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0])
+    p0 = jnp.array([jnp.sqrt(0.5), 0.0, jnp.sqrt(0.5), 0.0, 0.0, 0.0, 0.0])
 
     robot = TendonActuatedGVS.from_segments(
         [
@@ -1064,4 +1064,3 @@ if __name__ == "__main__":
     # plt.savefig("violin_error_distribution_12markers.pdf", format="pdf", bbox_inches="tight")
     # plt.savefig("violin_error_distribution_12markers.jpg", format="jpg", dpi=300, bbox_inches="tight")
     plt.show()
-

--- a/src/soromox/coordinate_transformations/operational_space_dynamics.py
+++ b/src/soromox/coordinate_transformations/operational_space_dynamics.py
@@ -505,7 +505,7 @@ class OperationalSpaceDynamics(eqx.Module):
         For 3D robots (PCS), forward_kinematics returns a 4x4 SE(3) matrix.
         We extract the pose using the configured rotation representation:
         - ROTATION_VECTOR: [omega_x, omega_y, omega_z, p_x, p_y, p_z] (6D)
-        - QUATERNION: [q_x, q_y, q_z, q_w, p_x, p_y, p_z] (7D)
+        - QUATERNION: [q_w, q_x, q_y, q_z, p_x, p_y, p_z] (7D)
         - ROTATION_MATRIX_6D: [r6d_0, ..., r6d_5, p_x, p_y, p_z] (9D)
 
         For planar robots (PlanarPCS, Pendulum), forward_kinematics returns
@@ -765,7 +765,7 @@ class OperationalSpaceDynamics(eqx.Module):
 
         For 3D robots, the FULL pose at each point depends on rotation_representation:
         - ROTATION_VECTOR: [rx, ry, rz, p_x, p_y, p_z] (6D per point)
-        - QUATERNION: [q_x, q_y, q_z, q_w, p_x, p_y, p_z] (7D per point)
+        - QUATERNION: [q_w, q_x, q_y, q_z, p_x, p_y, p_z] (7D per point)
         - ROTATION_MATRIX_6D: [r6d_0, ..., r6d_5, p_x, p_y, p_z] (9D per point)
 
         For planar robots, the pose at each point is [theta, x, y] (3D per point).
@@ -800,7 +800,7 @@ class OperationalSpaceDynamics(eqx.Module):
 
         For 3D robots, the pose at each point depends on rotation_representation:
         - ROTATION_VECTOR: [rx, ry, rz, p_x, p_y, p_z] (6D per point)
-        - QUATERNION: [q_x, q_y, q_z, q_w, p_x, p_y, p_z] (7D per point)
+        - QUATERNION: [q_w, q_x, q_y, q_z, p_x, p_y, p_z] (7D per point)
         - ROTATION_MATRIX_6D: [r6d_0, ..., r6d_5, p_x, p_y, p_z] (9D per point)
 
         For planar robots, the pose at each point is [theta, x, y] (3D per point).

--- a/src/soromox/parameters/hsa_params.py
+++ b/src/soromox/parameters/hsa_params.py
@@ -28,7 +28,9 @@ def planar_hsa_params_from_values(params: dict[str, Array]) -> PlanarHSAParams:
     """Build typed planar HSA params from the generated numeric value set."""
     hysteresis = params.get("hysteresis", {})
     return PlanarHSAParams(
-        base_angle=jnp.asarray(params["th0"]),
+        base_pose=jnp.concatenate(
+            [jnp.asarray(params["th0"]).reshape(1), jnp.zeros(2)]
+        ),
         length=jnp.asarray(params["L"]),
         proximal_cap_length=jnp.asarray(params["lpc"]),
         distal_cap_length=jnp.asarray(params["ldc"]),

--- a/src/soromox/parameters/hsa_params.py
+++ b/src/soromox/parameters/hsa_params.py
@@ -28,9 +28,7 @@ def planar_hsa_params_from_values(params: dict[str, Array]) -> PlanarHSAParams:
     """Build typed planar HSA params from the generated numeric value set."""
     hysteresis = params.get("hysteresis", {})
     return PlanarHSAParams(
-        base_pose=jnp.concatenate(
-            [jnp.asarray(params["th0"]).reshape(1), jnp.zeros(2)]
-        ),
+        base_pose=jnp.array([jnp.asarray(params["th0"]), 0.0, 0.0]),
         length=jnp.asarray(params["L"]),
         proximal_cap_length=jnp.asarray(params["lpc"]),
         distal_cap_length=jnp.asarray(params["ldc"]),

--- a/src/soromox/rendering/base.py
+++ b/src/soromox/rendering/base.py
@@ -45,6 +45,11 @@ class BaseSoftRobotRenderer(ABC):
         background_color: RGB tuple for background color (0-1 range)
         color_config: Shared color configuration for renderers
         L_max: Total length of the robot backbone
+        base_pose: Robot base pose coordinates. Planar robots use
+            ``[theta, x, y]``; spatial robots use scalar-first quaternion pose
+            ``[qw, qx, qy, qz, x, y, z]``.
+        base_transform: Homogeneous base transform. Shape ``(3, 3)`` for
+            planar robots and ``(4, 4)`` for spatial robots.
     """
 
     def __init__(
@@ -73,6 +78,8 @@ class BaseSoftRobotRenderer(ABC):
         self.background_color = background_color
         self.color_config = color_config or RendererColorConfig()
         self._is_planar = bool(robot.is_planar)
+        self.base_pose = jnp.asarray(robot.base_pose)
+        self.base_transform = jnp.asarray(robot.base_transform)
 
         self._color_cache: dict[tuple[int, int, int], ResolvedBackboneColors] = {}
         self._segment_cache: dict[int, tuple[np.ndarray, np.ndarray]] = {}
@@ -86,6 +93,142 @@ class BaseSoftRobotRenderer(ABC):
             self._batched_fk_tendons = jax.vmap(
                 robot.forward_kinematics_tendons, in_axes=(None, 0), out_axes=1
             )
+
+    def _base_position(self, dim: int | None = None) -> np.ndarray:
+        """Return the configured base translation in renderer coordinates.
+
+        Args:
+            dim: Optional target dimension. ``2`` returns ``[x, y]``; ``3``
+                returns ``[x, y, z]`` with planar bases padded by ``z = 0``.
+                If omitted, the renderer dimensionality is used.
+
+        Returns:
+            Base position as a NumPy array with shape ``(dim,)``.
+        """
+        target_dim = 3 if (dim is None and self.is_3d) else 2 if dim is None else dim
+        transform = np.asarray(self.base_transform, dtype=np.float64)
+        if transform.shape == (3, 3):
+            pos = np.array([transform[0, 2], transform[1, 2]], dtype=np.float64)
+        elif transform.shape == (4, 4):
+            pos = np.asarray(transform[:3, 3], dtype=np.float64)
+        else:
+            raise ValueError(
+                "base_transform must have shape (3, 3) or (4, 4), "
+                f"got {transform.shape}."
+            )
+        return self._match_vector_dim(pos, target_dim, name="base position")
+
+    def _base_tangent_axis(self, dim: int | None = None) -> np.ndarray:
+        """Return the configured base-frame +x direction.
+
+        The soft-robot convention is that zero base rotation aligns the
+        undeformed backbone with the positive base-frame x-axis. This helper
+        returns that axis after applying ``base_transform``.
+
+        Args:
+            dim: Optional target dimension. ``2`` returns the planar xy axis;
+                ``3`` returns xyz, padding planar axes by ``z = 0``.
+
+        Returns:
+            Unit vector as a NumPy array with shape ``(dim,)``.
+        """
+        target_dim = 3 if (dim is None and self.is_3d) else 2 if dim is None else dim
+        transform = np.asarray(self.base_transform, dtype=np.float64)
+        if transform.shape == (3, 3):
+            axis = np.asarray(transform[:2, 0], dtype=np.float64)
+        elif transform.shape == (4, 4):
+            axis = np.asarray(transform[:3, 0], dtype=np.float64)
+        else:
+            raise ValueError(
+                "base_transform must have shape (3, 3) or (4, 4), "
+                f"got {transform.shape}."
+            )
+        axis = self._match_vector_dim(axis, target_dim, name="base tangent axis")
+        norm = np.linalg.norm(axis)
+        if norm <= 1e-12:
+            fallback = np.zeros(target_dim, dtype=np.float64)
+            fallback[0] = 1.0
+            return fallback
+        return axis / norm
+
+    @staticmethod
+    def _match_vector_dim(
+        value: np.ndarray,
+        target_dim: int,
+        *,
+        name: str,
+    ) -> np.ndarray:
+        """Return ``value`` with dimension ``target_dim`` by optional z-padding."""
+        vector = np.asarray(value, dtype=np.float64).reshape(-1)
+        if vector.shape[0] == target_dim:
+            return vector
+        if vector.shape[0] + 1 == target_dim:
+            return np.concatenate([vector, np.zeros(1, dtype=np.float64)])
+        if target_dim == 2 and vector.shape[0] == 3:
+            return vector[:2]
+        raise ValueError(
+            f"{name} must have dimension {target_dim}, got {vector.shape}."
+        )
+
+    def _normalize_base_offsets(
+        self,
+        base_offsets: Array | np.ndarray,
+        *,
+        num_robots: int,
+        target_dim: int,
+        allow_single: bool = False,
+        name: str = "base_offsets",
+    ) -> jax.Array:
+        """Validate and dimension-match per-robot positional base offsets.
+
+        Args:
+            base_offsets: Offset array. Expected shape is ``(N, dim)`` for
+                batched calls. If ``allow_single`` is true, ``(dim,)`` and
+                ``(1, dim)`` are accepted for a single robot.
+            num_robots: Required number of rows.
+            target_dim: Desired spatial dimension, usually the curve dimension.
+            allow_single: Whether to accept a one-dimensional single offset.
+            name: Name used in error messages.
+
+        Returns:
+            JAX array with shape ``(num_robots, target_dim)``. 2D offsets are
+            padded with ``z = 0`` when ``target_dim == 3``.
+        """
+        offsets = jnp.asarray(base_offsets)
+        if offsets.ndim == 1 and allow_single:
+            offsets = offsets.reshape(1, -1)
+        if offsets.ndim != 2:
+            raise ValueError(f"{name} must have shape (N, dim), got {offsets.shape}.")
+        if offsets.shape[0] != num_robots:
+            raise ValueError(
+                f"{name} first dimension ({offsets.shape[0]}) must match "
+                f"number of robots ({num_robots})."
+            )
+        if offsets.shape[1] == target_dim:
+            return offsets
+        if offsets.shape[1] + 1 == target_dim:
+            pad = jnp.zeros((offsets.shape[0], 1), dtype=offsets.dtype)
+            return jnp.concatenate([offsets, pad], axis=1)
+        raise ValueError(
+            f"{name} must have shape ({num_robots}, {target_dim}) or "
+            f"({num_robots}, {target_dim - 1}), got {offsets.shape}."
+        )
+
+    def _single_base_offset(
+        self,
+        base_offsets: Array | np.ndarray | None,
+        *,
+        target_dim: int,
+    ) -> jax.Array | None:
+        """Return a single normalized base offset or ``None``."""
+        if base_offsets is None:
+            return None
+        return self._normalize_base_offsets(
+            base_offsets,
+            num_robots=1,
+            target_dim=target_dim,
+            allow_single=True,
+        )[0]
 
     @property
     def is_planar(self) -> bool:
@@ -133,37 +276,18 @@ class BaseSoftRobotRenderer(ABC):
             return None
 
         q_batch = jnp.asarray(q_batch)
-        base_offsets = jnp.asarray(base_offsets)
-
         if q_batch.ndim != 2:
             raise ValueError(
                 f"q_batch must have shape (N, DOF), got {q_batch.shape} with ndim={q_batch.ndim}"
             )
-        if base_offsets.ndim != 2:
-            raise ValueError(
-                f"base_offsets must have shape (N, dim), got {base_offsets.shape}"
-            )
-        if base_offsets.shape[0] != q_batch.shape[0]:
-            raise ValueError(
-                f"base_offsets first dimension ({base_offsets.shape[0]}) must "
-                f"match batch size ({q_batch.shape[0]})"
-            )
-
         s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
         tendon_curves = jax.vmap(lambda q: self._batched_fk_tendons(q, s_ps))(q_batch)
-
-        if base_offsets.shape[1] == tendon_curves.shape[-1]:
-            offsets = base_offsets
-        elif base_offsets.shape[1] + 1 == tendon_curves.shape[-1]:
-            pad = jnp.zeros((base_offsets.shape[0], 1), dtype=tendon_curves.dtype)
-            offsets = jnp.concatenate([base_offsets, pad], axis=1)
-        else:
-            raise ValueError(
-                f"base_offsets must have shape (N, {tendon_curves.shape[-1]}) or "
-                f"(N, {tendon_curves.shape[-1] - 1}), got {base_offsets.shape}"
-            )
-
-        return tendon_curves + offsets[:, None, None, :]
+        base_offsets = self._normalize_base_offsets(
+            base_offsets,
+            num_robots=int(q_batch.shape[0]),
+            target_dim=int(tendon_curves.shape[-1]),
+        )
+        return tendon_curves + base_offsets[:, None, None, :]
 
     def _extract_positions(self, poses: Array) -> Array:
         """Extract xyz or xy positions from FK poses.
@@ -590,36 +714,18 @@ class BaseSoftRobotRenderer(ABC):
             Array of shape (N, num_points, dim) - batch-first
         """
         q_batch = jnp.asarray(q_batch)
-        base_offsets = jnp.asarray(base_offsets)
-
         if q_batch.ndim != 2:
             raise ValueError(
                 f"q_batch must have shape (N, DOF), got {q_batch.shape} with ndim={q_batch.ndim}"
             )
-        if base_offsets.ndim != 2:
-            raise ValueError(
-                f"base_offsets must have shape (N, dim), got {base_offsets.shape}"
-            )
-        if base_offsets.shape[0] != q_batch.shape[0]:
-            raise ValueError(
-                f"base_offsets first dimension ({base_offsets.shape[0]}) must "
-                f"match batch size ({q_batch.shape[0]})"
-            )
 
         # vmap over the configurations
         curves = jax.vmap(self.compute_backbone_curve)(q_batch)  # (N, num_points, dim)
-
-        # Match base offset dimensionality to curve dimensionality (2D vs 3D)
-        if base_offsets.shape[1] == curves.shape[-1]:
-            offsets = base_offsets
-        elif base_offsets.shape[1] + 1 == curves.shape[-1]:
-            pad = jnp.zeros((base_offsets.shape[0], 1), dtype=curves.dtype)
-            offsets = jnp.concatenate([base_offsets, pad], axis=1)
-        else:
-            raise ValueError(
-                f"base_offsets must have shape (N, {curves.shape[-1]}) or "
-                f"(N, {curves.shape[-1] - 1}), got {base_offsets.shape}"
-            )
+        offsets = self._normalize_base_offsets(
+            base_offsets,
+            num_robots=int(q_batch.shape[0]),
+            target_dim=int(curves.shape[-1]),
+        )
 
         # Add base offsets: (N, num_points, dim) + (N, 1, dim)
         return curves + offsets[:, None, :]

--- a/src/soromox/rendering/base.py
+++ b/src/soromox/rendering/base.py
@@ -177,6 +177,7 @@ class BaseSoftRobotRenderer(ABC):
         num_robots: int,
         target_dim: int,
         allow_single: bool = False,
+        allow_extra_rows: bool = False,
         name: str = "base_offsets",
     ) -> jax.Array:
         """Validate and dimension-match per-robot positional base offsets.
@@ -188,6 +189,10 @@ class BaseSoftRobotRenderer(ABC):
             num_robots: Required number of rows.
             target_dim: Desired spatial dimension, usually the curve dimension.
             allow_single: Whether to accept a one-dimensional single offset.
+            allow_extra_rows: Whether to accept more rows than ``num_robots``
+                and use the leading ``num_robots`` rows. Intended for
+                constructor-level layout configurations reused across smaller
+                batches.
             name: Name used in error messages.
 
         Returns:
@@ -199,6 +204,8 @@ class BaseSoftRobotRenderer(ABC):
             offsets = offsets.reshape(1, -1)
         if offsets.ndim != 2:
             raise ValueError(f"{name} must have shape (N, dim), got {offsets.shape}.")
+        if allow_extra_rows and offsets.shape[0] > num_robots:
+            offsets = offsets[:num_robots]
         if offsets.shape[0] != num_robots:
             raise ValueError(
                 f"{name} first dimension ({offsets.shape[0]}) must match "
@@ -219,6 +226,7 @@ class BaseSoftRobotRenderer(ABC):
         base_offsets: Array | np.ndarray | None,
         *,
         target_dim: int,
+        allow_extra_rows: bool = False,
     ) -> jax.Array | None:
         """Return a single normalized base offset or ``None``."""
         if base_offsets is None:
@@ -228,6 +236,7 @@ class BaseSoftRobotRenderer(ABC):
             num_robots=1,
             target_dim=target_dim,
             allow_single=True,
+            allow_extra_rows=allow_extra_rows,
         )[0]
 
     @property

--- a/src/soromox/rendering/matplotlib_renderer.py
+++ b/src/soromox/rendering/matplotlib_renderer.py
@@ -401,8 +401,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             center_origin=False,
             tendon_curves=tendon_curves,
             record_path=record_path,
-            tendon_color=cfg.tendon_color,
             base_plate_color=cfg.base_plate_color,
+            tendon_color=cfg.tendon_color,
             playback_speed=playback_speed,
             camera_config=camera_config,
         )
@@ -497,8 +497,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             center_origin=True,
             tendon_curves=tendon_curves,
             record_path=record_path,
-            tendon_color=cfg.tendon_color,
             base_plate_color=cfg.base_plate_color,
+            tendon_color=cfg.tendon_color,
             playback_speed=playback_speed,
             camera_config=camera_config,
         )
@@ -514,15 +514,15 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         center_origin: bool,
         tendon_curves: np.ndarray | None = None,
         record_path: str | None = None,
-        tendon_color: tuple[float, float, float] | None = None,
         base_plate_color: tuple[float, float, float] | None = None,
+        tendon_color: tuple[float, float, float] | None = None,
         playback_speed: float = 1.0,
         camera_config: CameraConfig | None = None,
     ):
         """Shared Matplotlib animation for one or more robots."""
         num_robots, num_steps, _, _ = all_curves.shape
-        tendon_color = tendon_color or self.color_config.tendon_color
         base_plate_color = base_plate_color or self.color_config.base_plate_color
+        tendon_color = tendon_color or self.color_config.tendon_color
 
         max_extent = float(np.max(np.abs(all_curves))) if all_curves.size else 0.0
         width_m = max(self.L_max * 3, 2.0 * max_extent * 1.1)

--- a/src/soromox/rendering/matplotlib_renderer.py
+++ b/src/soromox/rendering/matplotlib_renderer.py
@@ -132,21 +132,15 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         else:
             num_robots = 1
             curves = self.compute_backbone_curve(q_arr)[None, ...]
-            if base_offsets is not None:
-                offs = np.asarray(base_offsets, dtype=np.float64)
-                if offs.ndim == 1:
-                    offs = offs.reshape(1, -1)
-                if offs.shape[0] != 1:
-                    raise ValueError(
-                        f"base_offsets must have shape (dim,) or (1, dim) for single robot; got {offs.shape}"
-                    )
-                if offs.shape[1] + 1 == curves.shape[-1]:
-                    offs = np.concatenate([offs, np.zeros((offs.shape[0], 1))], axis=1)
-                if offs.shape[1] != curves.shape[-1]:
-                    raise ValueError(
-                        f"base_offsets second dimension ({offs.shape[1]}) must match curve dimension ({curves.shape[-1]})"
-                    )
-                curves = curves + offs[0]
+            offset_source = (
+                base_offsets if base_offsets is not None else self._base_offsets
+            )
+            single_offset = self._single_base_offset(
+                offset_source,
+                target_dim=int(curves.shape[-1]),
+            )
+            if single_offset is not None:
+                curves = curves + single_offset
             resolved_colors = self.resolve_backbone_colors(1, color_config=cfg)
             width_m = self.L_max * 3
 
@@ -161,8 +155,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
                 tendon_curves_np = np.array(self.compute_tendon_curves(q_arr))[
                     None, ...
                 ]
-                if base_offsets is not None:
-                    tendon_curves_np = tendon_curves_np + offs[0]
+                if single_offset is not None:
+                    tendon_curves_np = tendon_curves_np + np.asarray(single_offset)
 
         fig = plt.figure(figsize=(self.width / 100, self.height / 100), dpi=100)
         fig.patch.set_facecolor(self.background_color)
@@ -189,6 +183,7 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         )
 
         self._plot_backbone(ax, curves_np, resolved_colors.per_robot_point_rgba)
+        self._plot_base_markers(ax, curves_np, cfg.base_plate_color)
 
         if tendon_curves_np is not None:
             for idx in range(num_robots):
@@ -377,29 +372,21 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         curves = np.array(
             jax.vmap(self.compute_backbone_curve)(q_ts), dtype=np.float64
         )  # (T, P, dim)
-        if base_offsets is not None:
-            offs = np.asarray(base_offsets, dtype=np.float64)
-            if offs.ndim == 1:
-                offs = offs.reshape(1, -1)
-            if offs.shape[0] not in (1,):
-                raise ValueError(
-                    f"base_offsets must have shape (dim,) or (1, dim) for single robot; got {offs.shape}"
-                )
-            if offs.shape[1] + 1 == curves.shape[-1]:
-                offs = np.concatenate([offs, np.zeros((offs.shape[0], 1))], axis=1)
-            if offs.shape[1] != curves.shape[-1]:
-                raise ValueError(
-                    f"base_offsets second dimension ({offs.shape[1]}) must match curve dimension ({curves.shape[-1]})"
-                )
-            curves = curves + offs[0]
+        offset_source = base_offsets if base_offsets is not None else self._base_offsets
+        single_offset = self._single_base_offset(
+            offset_source,
+            target_dim=int(curves.shape[-1]),
+        )
+        if single_offset is not None:
+            curves = curves + single_offset
         all_curves = curves[None, ...]  # (1, T, P, dim)
         tendon_curves = None
         if render_tendons and self._has_tendons:
             tendon_curves = np.array(
                 jax.vmap(self.compute_tendon_curves)(q_ts), dtype=np.float64
             )[None, ...]  # (1, T, n_tendon, P, dim)
-            if base_offsets is not None:
-                tendon_curves = tendon_curves + offs[0]
+            if single_offset is not None:
+                tendon_curves = tendon_curves + np.asarray(single_offset)
 
         cfg = color_config or self.color_config
         resolved_colors = self.resolve_backbone_colors(1, color_config=cfg)
@@ -415,6 +402,7 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             tendon_curves=tendon_curves,
             record_path=record_path,
             tendon_color=cfg.tendon_color,
+            base_plate_color=cfg.base_plate_color,
             playback_speed=playback_speed,
             camera_config=camera_config,
         )
@@ -483,10 +471,6 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         all_curves_time_first = jax.vmap(curves_for_timestep)(q_ts_time_first)
         all_curves = np.asarray(all_curves_time_first.transpose(1, 0, 2, 3))
 
-        # Axis sizing based on geometry spread
-        max_extent = float(np.max(np.abs(all_curves))) if all_curves.size else 0.0
-        width_m = max(self.L_max * 3, 2.0 * max_extent * 1.1)
-
         cfg = color_config or self.color_config
         resolved_colors = self.resolve_backbone_colors(
             int(num_robots), color_config=cfg
@@ -514,6 +498,7 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             tendon_curves=tendon_curves,
             record_path=record_path,
             tendon_color=cfg.tendon_color,
+            base_plate_color=cfg.base_plate_color,
             playback_speed=playback_speed,
             camera_config=camera_config,
         )
@@ -530,12 +515,14 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         tendon_curves: np.ndarray | None = None,
         record_path: str | None = None,
         tendon_color: tuple[float, float, float] | None = None,
+        base_plate_color: tuple[float, float, float] | None = None,
         playback_speed: float = 1.0,
         camera_config: CameraConfig | None = None,
     ):
         """Shared Matplotlib animation for one or more robots."""
         num_robots, num_steps, _, _ = all_curves.shape
         tendon_color = tendon_color or self.color_config.tendon_color
+        base_plate_color = base_plate_color or self.color_config.base_plate_color
 
         max_extent = float(np.max(np.abs(all_curves))) if all_curves.size else 0.0
         width_m = max(self.L_max * 3, 2.0 * max_extent * 1.1)
@@ -588,9 +575,11 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
                 ax.add_collection(lc)
             lines.append(lc)
 
+        base_artists = self._plot_base_markers(ax, all_curves[:, 0], base_plate_color)
+
         tendon_lines: list[list] = []
         if tendon_curves is not None:
-            for idx in range(num_robots):
+            for _idx in range(num_robots):
                 robot_lines = []
                 n_tend = tendon_curves.shape[2]
                 for _ in range(n_tend):
@@ -617,6 +606,7 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             for idx, line in enumerate(lines):
                 segments = self._curve_to_segments(curves_frame[idx])
                 line.set_segments(segments)
+            self._update_base_markers(base_artists, curves_frame)
             if tendon_curves is not None:
                 for idx, tc in enumerate(tendon_curves):
                     tend_frame = tc[frame_idx]
@@ -640,14 +630,14 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
                         if self.is_3d:
                             tl.set_3d_properties([])
                 flat_tendon = [tl for sub in tendon_lines for tl in sub]
-                return lines + flat_tendon + [title_text]
+                return lines + flat_tendon + base_artists + [title_text]
 
             def update(frame_idx):
                 frame_idx_int = int(frame_idx)
                 _update_lines(frame_idx_int)
                 title_text.set_text(f"t = {float(ts[frame_idx_int]):.2f} s")
                 flat_tendon = [tl for sub in tendon_lines for tl in sub]
-                return lines + flat_tendon + [title_text]
+                return lines + flat_tendon + base_artists + [title_text]
 
             actual_interval = max(1, int(round(interval / playback_speed)))
             ani = FuncAnimation(
@@ -756,6 +746,94 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         if curve.shape[0] < 2:
             return np.zeros((0, 2, curve.shape[1]), dtype=curve.dtype)
         return np.stack([curve[:-1], curve[1:]], axis=1)
+
+    def _plot_base_markers(
+        self,
+        ax,
+        curves: np.ndarray,
+        base_plate_color: tuple[float, float, float],
+    ) -> list:
+        """Draw compact base markers at the configured base positions."""
+        artists = []
+        if curves.size == 0:
+            return artists
+        dim = int(curves.shape[-1])
+        axis = self._base_tangent_axis(dim=dim)
+        marker_len = max(0.04 * self.L_max, 1e-3)
+        for curve in curves:
+            base = np.asarray(curve[0], dtype=np.float64)
+            if dim == 3:
+                (artist,) = ax.plot(
+                    [
+                        base[0] - 0.5 * marker_len * axis[0],
+                        base[0] + 0.5 * marker_len * axis[0],
+                    ],
+                    [
+                        base[1] - 0.5 * marker_len * axis[1],
+                        base[1] + 0.5 * marker_len * axis[1],
+                    ],
+                    [
+                        base[2] - 0.5 * marker_len * axis[2],
+                        base[2] + 0.5 * marker_len * axis[2],
+                    ],
+                    color=base_plate_color,
+                    linewidth=max(self.line_width, 2.0),
+                )
+            else:
+                normal = np.array([-axis[1], axis[0]], dtype=np.float64)
+                (artist,) = ax.plot(
+                    [
+                        base[0] - 0.5 * marker_len * normal[0],
+                        base[0] + 0.5 * marker_len * normal[0],
+                    ],
+                    [
+                        base[1] - 0.5 * marker_len * normal[1],
+                        base[1] + 0.5 * marker_len * normal[1],
+                    ],
+                    color=base_plate_color,
+                    linewidth=max(self.line_width, 2.0),
+                )
+            artists.append(artist)
+        return artists
+
+    def _update_base_markers(self, artists: list, curves: np.ndarray) -> None:
+        """Update animated Matplotlib base markers."""
+        if not artists:
+            return
+        dim = int(curves.shape[-1])
+        axis = self._base_tangent_axis(dim=dim)
+        marker_len = max(0.04 * self.L_max, 1e-3)
+        for artist, curve in zip(artists, curves):
+            base = np.asarray(curve[0], dtype=np.float64)
+            if dim == 3:
+                artist.set_data(
+                    [
+                        base[0] - 0.5 * marker_len * axis[0],
+                        base[0] + 0.5 * marker_len * axis[0],
+                    ],
+                    [
+                        base[1] - 0.5 * marker_len * axis[1],
+                        base[1] + 0.5 * marker_len * axis[1],
+                    ],
+                )
+                artist.set_3d_properties(
+                    [
+                        base[2] - 0.5 * marker_len * axis[2],
+                        base[2] + 0.5 * marker_len * axis[2],
+                    ]
+                )
+            else:
+                normal = np.array([-axis[1], axis[0]], dtype=np.float64)
+                artist.set_data(
+                    [
+                        base[0] - 0.5 * marker_len * normal[0],
+                        base[0] + 0.5 * marker_len * normal[0],
+                    ],
+                    [
+                        base[1] - 0.5 * marker_len * normal[1],
+                        base[1] + 0.5 * marker_len * normal[1],
+                    ],
+                )
 
     @staticmethod
     def _segment_colors_from_point_pairs(point_colors: np.ndarray) -> np.ndarray:

--- a/src/soromox/rendering/matplotlib_renderer.py
+++ b/src/soromox/rendering/matplotlib_renderer.py
@@ -117,12 +117,21 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         spacing = self.grid_spacing
         if batched:
             num_robots = int(q_arr.shape[0])
-            base_offsets_arr = (
+            uses_configured_offsets = (
+                base_offsets is None and self._base_offsets is not None
+            )
+            offset_source = (
                 self._compute_grid_offsets(num_robots, spacing)
                 if (base_offsets is None and self._base_offsets is None)
-                else jnp.asarray(
-                    base_offsets if base_offsets is not None else self._base_offsets
-                )
+                else base_offsets
+                if base_offsets is not None
+                else self._base_offsets
+            )
+            base_offsets_arr = self._normalize_base_offsets(
+                offset_source,
+                num_robots=num_robots,
+                target_dim=3 if self.is_3d else 2,
+                allow_extra_rows=uses_configured_offsets,
             )
 
             curves = self.compute_backbone_curves_batched(q_arr, base_offsets_arr)
@@ -138,6 +147,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             single_offset = self._single_base_offset(
                 offset_source,
                 target_dim=int(curves.shape[-1]),
+                allow_extra_rows=base_offsets is None
+                and self._base_offsets is not None,
             )
             if single_offset is not None:
                 curves = curves + single_offset
@@ -376,6 +387,7 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         single_offset = self._single_base_offset(
             offset_source,
             target_dim=int(curves.shape[-1]),
+            allow_extra_rows=base_offsets is None and self._base_offsets is not None,
         )
         if single_offset is not None:
             curves = curves + single_offset
@@ -455,12 +467,21 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             )
 
         spacing = self.grid_spacing
-        base_offsets_arr = (
+        uses_configured_offsets = (
+            base_offsets is None and self._base_offsets is not None
+        )
+        offset_source = (
             self._compute_grid_offsets(int(num_robots), spacing)
             if (base_offsets is None and self._base_offsets is None)
-            else jnp.asarray(
-                base_offsets if base_offsets is not None else self._base_offsets
-            )
+            else base_offsets
+            if base_offsets is not None
+            else self._base_offsets
+        )
+        base_offsets_arr = self._normalize_base_offsets(
+            offset_source,
+            num_robots=int(num_robots),
+            target_dim=3 if self.is_3d else 2,
+            allow_extra_rows=uses_configured_offsets,
         )
 
         # Precompute all backbone curves with offsets applied
@@ -782,10 +803,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         u = u / np.linalg.norm(u)
         v = np.cross(axis, u)
         angles = np.linspace(0.0, 2.0 * np.pi, 65)
-        return (
-            base[None, :]
-            + radius
-            * (np.cos(angles)[:, None] * u[None, :] + np.sin(angles)[:, None] * v)
+        return base[None, :] + radius * (
+            np.cos(angles)[:, None] * u[None, :] + np.sin(angles)[:, None] * v
         )
 
     def _plot_base_markers(

--- a/src/soromox/rendering/matplotlib_renderer.py
+++ b/src/soromox/rendering/matplotlib_renderer.py
@@ -747,6 +747,47 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             return np.zeros((0, 2, curve.shape[1]), dtype=curve.dtype)
         return np.stack([curve[:-1], curve[1:]], axis=1)
 
+    @staticmethod
+    def _base_plate_marker_points(
+        base: np.ndarray,
+        axis: np.ndarray,
+        marker_diameter: float,
+        dim: int,
+    ) -> np.ndarray:
+        """Return points that represent the base plate face in Matplotlib."""
+        base = np.asarray(base, dtype=np.float64)
+        axis = np.asarray(axis, dtype=np.float64)
+        axis_norm = np.linalg.norm(axis)
+        if axis_norm <= 1e-12:
+            axis = np.zeros(dim, dtype=np.float64)
+            axis[0] = 1.0
+        else:
+            axis = axis / axis_norm
+
+        radius = 0.5 * marker_diameter
+        if dim == 2:
+            normal = np.array([-axis[1], axis[0]], dtype=np.float64)
+            return np.stack(
+                [
+                    base - radius * normal,
+                    base + radius * normal,
+                ],
+                axis=0,
+            )
+
+        reference = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+        if abs(float(np.dot(axis, reference))) > 0.95:
+            reference = np.array([0.0, 1.0, 0.0], dtype=np.float64)
+        u = np.cross(axis, reference)
+        u = u / np.linalg.norm(u)
+        v = np.cross(axis, u)
+        angles = np.linspace(0.0, 2.0 * np.pi, 65)
+        return (
+            base[None, :]
+            + radius
+            * (np.cos(angles)[:, None] * u[None, :] + np.sin(angles)[:, None] * v)
+        )
+
     def _plot_base_markers(
         self,
         ax,
@@ -762,34 +803,19 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         marker_len = max(0.04 * self.L_max, 1e-3)
         for curve in curves:
             base = np.asarray(curve[0], dtype=np.float64)
+            marker = self._base_plate_marker_points(base, axis, marker_len, dim)
             if dim == 3:
                 (artist,) = ax.plot(
-                    [
-                        base[0] - 0.5 * marker_len * axis[0],
-                        base[0] + 0.5 * marker_len * axis[0],
-                    ],
-                    [
-                        base[1] - 0.5 * marker_len * axis[1],
-                        base[1] + 0.5 * marker_len * axis[1],
-                    ],
-                    [
-                        base[2] - 0.5 * marker_len * axis[2],
-                        base[2] + 0.5 * marker_len * axis[2],
-                    ],
+                    marker[:, 0],
+                    marker[:, 1],
+                    marker[:, 2],
                     color=base_plate_color,
                     linewidth=max(self.line_width, 2.0),
                 )
             else:
-                normal = np.array([-axis[1], axis[0]], dtype=np.float64)
                 (artist,) = ax.plot(
-                    [
-                        base[0] - 0.5 * marker_len * normal[0],
-                        base[0] + 0.5 * marker_len * normal[0],
-                    ],
-                    [
-                        base[1] - 0.5 * marker_len * normal[1],
-                        base[1] + 0.5 * marker_len * normal[1],
-                    ],
+                    marker[:, 0],
+                    marker[:, 1],
                     color=base_plate_color,
                     linewidth=max(self.line_width, 2.0),
                 )
@@ -805,34 +831,17 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         marker_len = max(0.04 * self.L_max, 1e-3)
         for artist, curve in zip(artists, curves):
             base = np.asarray(curve[0], dtype=np.float64)
+            marker = self._base_plate_marker_points(base, axis, marker_len, dim)
             if dim == 3:
                 artist.set_data(
-                    [
-                        base[0] - 0.5 * marker_len * axis[0],
-                        base[0] + 0.5 * marker_len * axis[0],
-                    ],
-                    [
-                        base[1] - 0.5 * marker_len * axis[1],
-                        base[1] + 0.5 * marker_len * axis[1],
-                    ],
+                    marker[:, 0],
+                    marker[:, 1],
                 )
-                artist.set_3d_properties(
-                    [
-                        base[2] - 0.5 * marker_len * axis[2],
-                        base[2] + 0.5 * marker_len * axis[2],
-                    ]
-                )
+                artist.set_3d_properties(marker[:, 2])
             else:
-                normal = np.array([-axis[1], axis[0]], dtype=np.float64)
                 artist.set_data(
-                    [
-                        base[0] - 0.5 * marker_len * normal[0],
-                        base[0] + 0.5 * marker_len * normal[0],
-                    ],
-                    [
-                        base[1] - 0.5 * marker_len * normal[1],
-                        base[1] + 0.5 * marker_len * normal[1],
-                    ],
+                    marker[:, 0],
+                    marker[:, 1],
                 )
 
     @staticmethod

--- a/src/soromox/rendering/open3d_renderer.py
+++ b/src/soromox/rendering/open3d_renderer.py
@@ -79,11 +79,17 @@ def _make_base_plate(
     resolution: int = 48,
     apply_color: bool = True,
     apply_translation: bool = True,
+    normal_xyz: np.ndarray | None = None,
 ) -> o3d.geometry.TriangleMesh:
     """Create a base plate cylinder mesh."""
     mesh = o3d.geometry.TriangleMesh.create_cylinder(
         radius=float(radius), height=float(thickness), resolution=resolution, split=1
     )
+    if normal_xyz is not None:
+        R = _axis_alignment_rotation(normal_xyz)
+        transform = np.eye(4)
+        transform[:3, :3] = R
+        mesh.transform(transform)
     mesh.compute_vertex_normals()
     if apply_color:
         mesh.paint_uniform_color(np.array(color, dtype=np.float64))
@@ -864,11 +870,11 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         offsets = base_offsets if base_offsets is not None else self._base_offsets
         if offsets is None:
             offsets = self._compute_grid_offsets(int(N), self.grid_spacing)
-        offsets = jnp.asarray(offsets)
-        if offsets.ndim != 2 or offsets.shape[0] != N:
-            raise ValueError(
-                f"base_offsets must have shape (N, 2/3); got {offsets.shape}"
-            )
+        offsets = self._normalize_base_offsets(
+            offsets,
+            num_robots=int(N),
+            target_dim=3,
+        )
 
         # Backbone curves (T, N, P, 3) -> (N, T, P, 3)
         q_ts_time_first = q_ts_arr.transpose(1, 0, 2)
@@ -953,13 +959,15 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             q_frame = scene_data.q_ts[robot_idx, frame_idx]
             sections, max_radius = self._cross_sections_for_points(q_frame, s_ps)
             base_color_rgba = ensure_rgba(np.asarray(cfg.base_plate_color))[0]
+            base_axis = self._base_tangent_axis(dim=3)
             base_mesh = _make_base_plate(
-                curve[0],
+                curve[0] - 0.5 * self.base_plate_thickness * base_axis,
                 radius=float(self.base_plate_radius_scale * max_radius),
                 thickness=self.base_plate_thickness,
                 color=tuple(base_color_rgba[:3]),
                 apply_color=False,
                 apply_translation=True,
+                normal_xyz=base_axis,
             )
             scene.add_geometry(f"base_{robot_idx}", base_mesh, mat_for(base_color_rgba))
 
@@ -1499,11 +1507,13 @@ class Open3DRenderer(BaseSoftRobotRenderer):
     ) -> tuple[object, list[list[CachedMesh]]]:
         """Add base and backbone meshes for one robot; return handles."""
         base_color = self._blend_with_background(base_plate_color)
+        base_axis = self._base_tangent_axis(dim=3)
         base_mesh = _make_base_plate(
-            curve0[0],
+            curve0[0] - 0.5 * self.base_plate_thickness * base_axis,
             radius=float(self.base_plate_radius_scale * max_radius),
             thickness=self.base_plate_thickness,
             color=base_color,
+            normal_xyz=base_axis,
         )
         vis.add_geometry(base_mesh)
 
@@ -1570,7 +1580,9 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         layout: SegmentLayout,
     ) -> None:
         """Translate base and backbone geometry to a new curve position."""
-        delta = curve[0] - _mesh_center(base_mesh)
+        base_axis = self._base_tangent_axis(dim=3)
+        base_center = curve[0] - 0.5 * self.base_plate_thickness * base_axis
+        delta = base_center - _mesh_center(base_mesh)
         base_mesh.translate(delta, relative=True)
         vis.update_geometry(base_mesh)
 
@@ -1618,6 +1630,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                 "Open3D viewer assumes cross_section_geometry is configuration-independent; "
                 "geometry is frozen to the first frame.",
                 RuntimeWarning,
+                stacklevel=2,
             )
             self._warned_dynamic_geometry = True
 

--- a/src/soromox/rendering/open3d_renderer.py
+++ b/src/soromox/rendering/open3d_renderer.py
@@ -867,6 +867,9 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             ts_np = np.arange(T, dtype=np.float64)
 
         # Compute base offsets
+        uses_configured_offsets = (
+            base_offsets is None and self._base_offsets is not None
+        )
         offsets = base_offsets if base_offsets is not None else self._base_offsets
         if offsets is None:
             offsets = self._compute_grid_offsets(int(N), self.grid_spacing)
@@ -874,6 +877,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             offsets,
             num_robots=int(N),
             target_dim=3,
+            allow_extra_rows=uses_configured_offsets,
         )
 
         # Backbone curves (T, N, P, 3) -> (N, T, P, 3)

--- a/src/soromox/rendering/opencv_planar_renderer.py
+++ b/src/soromox/rendering/opencv_planar_renderer.py
@@ -53,7 +53,7 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
             backbone_thickness: Line thickness for backbone (None = auto)
             base_radius_scale: Multiplier applied to the cross-section span for the base marker
             length_scale: Scale factor for robot in image (robot occupies height/length_scale)
-            origin_uv: Pixel coordinates of robot base (None = center of image)
+            origin_uv: Pixel coordinates of world origin (None = center of image)
         """
         super().__init__(robot, width, height, num_points, background_color)
 
@@ -116,11 +116,31 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
             base_radius_m = 0.02 * self.L_max
         return max(2, int(base_radius_m * ppm))
 
-    def render_frame(self, q: Array) -> np.ndarray:
+    def _world_to_pixel(
+        self,
+        points: np.ndarray,
+        *,
+        origin_uv: np.ndarray,
+        ppm: float,
+    ) -> np.ndarray:
+        """Map planar world xy coordinates to OpenCV pixel coordinates."""
+        pts = np.asarray(points, dtype=float)
+        px = (pts * ppm).astype(np.int32)
+        px[..., 1] = -px[..., 1]
+        return origin_uv + px
+
+    def render_frame(
+        self,
+        q: Array,
+        *,
+        base_offsets: Array | None = None,
+    ) -> np.ndarray:
         """Render single configuration to BGR image array.
 
         Args:
             q: Robot configuration array of shape (DOF,) for a single robot.
+            base_offsets: Optional positional offset with shape ``(2,)`` or
+                ``(3,)``. The z component is ignored for this planar renderer.
 
         Returns:
             img (np.ndarray): BGR image of shape (height, width, 3), dtype uint8.
@@ -130,7 +150,7 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
         # Pixel per meter
         ppm = h / (self.length_scale * self.L_max)
 
-        # Robot origin in pixel coordinates
+        # World origin in pixel coordinates
         if self.origin_uv is None:
             origin_uv = np.array([w // 2, h // 2], dtype=np.int32)
         else:
@@ -142,18 +162,16 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
         )  # RGB to BGR
         img = np.full((h, w, 3), bg_uint8, dtype=np.uint8)
 
-        # Draw base marker
-        base_radius = self._base_radius_px(ppm, q)
-        cv2.circle(img, tuple(origin_uv), base_radius, self.base_color, -1)
-
         # Compute backbone curve in pixel coordinates (N, 2)
         curve = np.asarray(self.compute_backbone_curve(q), dtype=float)
         if curve.ndim != 2 or curve.shape[1] != 2:
             raise ValueError(
                 f"Expected planar backbone curve of shape (N, 2), got {curve.shape}"
             )
-        curve_px = (curve * ppm).astype(np.int32)
-        curve_px[:, 1] = -curve_px[:, 1]  # Invert y for image coordinates
+        offset = self._single_base_offset(base_offsets, target_dim=2)
+        if offset is not None:
+            curve = curve + np.asarray(offset)
+        curve_uv = self._world_to_pixel(curve, origin_uv=origin_uv, ppm=ppm)
 
         lengths = self.robot.segment_length
         thicknesses, uniform_thickness = self._auto_backbone_thickness(ppm, lengths, q)
@@ -170,7 +188,7 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
                     selector = (s_ps >= L_cum[segment_idx]) & (
                         s_ps < L_cum[segment_idx + 1]
                     )
-                segment_curve = origin_uv + curve_px[selector]
+                segment_curve = curve_uv[selector]
                 if segment_curve.shape[0] > 1:
                     cv2.polylines(
                         img,
@@ -180,7 +198,6 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
                         thickness=int(thicknesses[segment_idx]),
                     )
         else:
-            curve_uv = origin_uv + curve_px
             if curve_uv.shape[0] > 1:
                 cv2.polylines(
                     img,
@@ -190,15 +207,22 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
                     thickness=int(uniform_thickness),
                 )
 
+        # Draw base marker at the transformed base position after the backbone
+        # so it remains visible.
+        base_radius = self._base_radius_px(ppm, q)
+        cv2.circle(img, tuple(curve_uv[0]), base_radius, self.base_color, -1)
+
         return img
 
-    def show(self, q: Array) -> None:
+    def show(self, q: Array, *, base_offsets: Array | None = None) -> None:
         """Display single frame in OpenCV window.
 
         Args:
             q: Robot configuration array of shape (DOF,).
+            base_offsets: Optional positional offset with shape ``(2,)`` or
+                ``(3,)``.
         """
-        img = self.render_frame(q)
+        img = self.render_frame(q, base_offsets=base_offsets)
         win = "Planar Renderer"
         cv2.namedWindow(win, cv2.WINDOW_NORMAL)
         cv2.imshow(win, img)

--- a/src/soromox/rendering/planar_hsa/opencv_renderer.py
+++ b/src/soromox/rendering/planar_hsa/opencv_renderer.py
@@ -85,11 +85,18 @@ class OpenCVPlanarHSARenderer(BaseOpenCVRenderer):
         """Extract xy from SE(2) poses [theta, x, y]."""
         return poses[:, 1:3]
 
-    def render_frame(self, q: Array) -> np.ndarray:
+    def render_frame(
+        self,
+        q: Array,
+        *,
+        base_offsets: Array | None = None,
+    ) -> np.ndarray:
         """Render single configuration to BGR image array.
 
         Args:
             q: Robot configuration array
+            base_offsets: Optional positional offset with shape ``(2,)`` or
+                ``(3,)``. The z component is ignored for this planar renderer.
 
         Returns:
             BGR image as numpy array of shape (height, width, 3), dtype uint8
@@ -109,13 +116,21 @@ class OpenCVPlanarHSARenderer(BaseOpenCVRenderer):
         chiR_ps = self._batched_fk_rod(q, s_ps, 1)  # right rod
         chip_ps = self._batched_fk_platform(q, jnp.arange(0, robot.num_segments))
 
+        offset = self._single_base_offset(base_offsets, target_dim=2)
+        if offset is not None:
+            offset_jax = jnp.asarray(offset, dtype=chiv_ps.dtype)
+            chiv_ps = chiv_ps.at[1:3, :].add(offset_jax[:, None])
+            chiL_ps = chiL_ps.at[1:3, :].add(offset_jax[:, None])
+            chiR_ps = chiR_ps.at[1:3, :].add(offset_jax[:, None])
+            chip_ps = chip_ps.at[:, 1:3].add(offset_jax[None, :])
+
         # Initialize white background
         bg_uint8 = tuple(
             int(c * 255) for c in self.background_color[::-1]
         )  # RGB to BGR
         img = np.full((h, w, 3), bg_uint8, dtype=np.uint8)
 
-        # Robot origin in pixel coordinates
+        # World origin in pixel coordinates
         uv_robot_origin = np.array([w // 2, int(h * 0.9)], dtype=np.int32)
         uv_robot_origin_jax = jnp.array(uv_robot_origin)
 
@@ -128,9 +143,14 @@ class OpenCVPlanarHSARenderer(BaseOpenCVRenderer):
 
         batched_chi2u = vmap(chi2u, in_axes=-1, out_axes=0)
 
-        # Draw base
+        base_xy = self._base_position(dim=2)
+        if offset is not None:
+            base_xy = base_xy + np.asarray(offset)
+        base_uv = np.asarray(chi2u(jnp.array([0.0, base_xy[0], base_xy[1]])))
+
+        # Draw base support below the transformed base position.
         cv2.rectangle(
-            img, (0, uv_robot_origin[1]), (w, h), color=self.base_color, thickness=-1
+            img, (0, int(base_uv[1])), (w, h), color=self.base_color, thickness=-1
         )
 
         # Add proximal and distal cap points to backbone
@@ -247,13 +267,15 @@ class OpenCVPlanarHSARenderer(BaseOpenCVRenderer):
 
         return img
 
-    def show(self, q: Array) -> None:
+    def show(self, q: Array, *, base_offsets: Array | None = None) -> None:
         """Display single frame in OpenCV window.
 
         Args:
             q: Robot configuration
+            base_offsets: Optional positional offset with shape ``(2,)`` or
+                ``(3,)``.
         """
-        img = self.render_frame(q)
+        img = self.render_frame(q, base_offsets=base_offsets)
         win = "Planar HSA"
         cv2.namedWindow(win, cv2.WINDOW_NORMAL)
         cv2.imshow(win, img)

--- a/src/soromox/rendering/viser_renderer.py
+++ b/src/soromox/rendering/viser_renderer.py
@@ -18,6 +18,7 @@ import threading
 import time
 import webbrowser
 from collections.abc import Callable, Generator
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -411,10 +412,8 @@ class ViserRenderer(BaseSoftRobotRenderer):
             self._stop_live_mode_internal()
 
         # Close server - use stop() method instead of close()
-        try:
+        with suppress(Exception):
             self._server.stop()
-        except Exception:
-            pass  # Server may already be closed
         self._server = None
         self._scene_handles = None
 
@@ -539,9 +538,10 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
             self._scene_handles.backbone_points.append(robot_points)
 
-            # Create base plate (Z-aligned, no rotation needed)
-            base_pos = curve[0].copy()
-            base_pos[2] -= self._base_plate_thickness / 2
+            # Create base plate perpendicular to the configured base-frame +x axis.
+            base_axis = self._base_tangent_axis(dim=3)
+            base_pos = curve[0].copy() - 0.5 * self._base_plate_thickness * base_axis
+            base_wxyz = _direction_to_quaternion(base_axis)
             base_handle = self._server.scene.add_mesh_trimesh(
                 name=f"/robots/robot_{robot_idx}/base_plate",
                 mesh=self._make_cylinder_trimesh(
@@ -551,6 +551,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
                     direction=None,  # Already Z-aligned
                 ),
                 position=tuple(base_pos),
+                wxyz=base_wxyz,
             )
             self._scene_handles.base_plates.append(base_handle)
 
@@ -703,6 +704,14 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         for robot_idx in range(num_robots):
             curve = curves[robot_idx]  # (num_points, 3)
+            if robot_idx < len(self._scene_handles.base_plates):
+                base_axis = self._base_tangent_axis(dim=3)
+                base_handle = self._scene_handles.base_plates[robot_idx]
+                base_handle.position = tuple(
+                    curve[0] - 0.5 * self._base_plate_thickness * base_axis
+                )
+                base_handle.wxyz = _direction_to_quaternion(base_axis)
+
             robot_points = self._scene_handles.backbone_points[robot_idx]
 
             if self._backbone_style == "discrete":
@@ -948,19 +957,18 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         num_robots = q.shape[0]
 
-        # Compute base offsets
-        if base_offsets is not None:
-            base_offsets = jnp.asarray(base_offsets)
-        elif self._base_offsets is not None:
-            base_offsets = jnp.asarray(self._base_offsets)[:num_robots]
-        else:
-            base_offsets = self._compute_grid_offsets(num_robots, self._grid_spacing)
-
-        # Pad to 3D if needed
-        if base_offsets.shape[1] == 2:
-            base_offsets = jnp.concatenate(
-                [base_offsets, jnp.zeros((num_robots, 1))], axis=1
-            )
+        offset_source = (
+            base_offsets
+            if base_offsets is not None
+            else self._base_offsets
+            if self._base_offsets is not None
+            else self._compute_grid_offsets(num_robots, self._grid_spacing)
+        )
+        base_offsets = self._normalize_base_offsets(
+            offset_source,
+            num_robots=int(num_robots),
+            target_dim=3,
+        )
 
         # Compute backbone curves
         curves = np.asarray(self.compute_backbone_curves_batched(q, base_offsets))
@@ -1045,19 +1053,18 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         num_robots = q.shape[0]
 
-        # Compute base offsets
-        if base_offsets is not None:
-            base_offsets = jnp.asarray(base_offsets)
-        elif self._base_offsets is not None:
-            base_offsets = jnp.asarray(self._base_offsets)[:num_robots]
-        else:
-            base_offsets = self._compute_grid_offsets(num_robots, self._grid_spacing)
-
-        # Pad to 3D if needed
-        if base_offsets.shape[1] == 2:
-            base_offsets = jnp.concatenate(
-                [base_offsets, jnp.zeros((num_robots, 1))], axis=1
-            )
+        offset_source = (
+            base_offsets
+            if base_offsets is not None
+            else self._base_offsets
+            if self._base_offsets is not None
+            else self._compute_grid_offsets(num_robots, self._grid_spacing)
+        )
+        base_offsets = self._normalize_base_offsets(
+            offset_source,
+            num_robots=int(num_robots),
+            target_dim=3,
+        )
 
         # Compute backbone curves
         curves = np.asarray(self.compute_backbone_curves_batched(q, base_offsets))
@@ -1188,22 +1195,21 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         num_robots, num_frames, num_dofs = q_ts.shape
 
-        # Compute base offsets
         if multi_robot_layout == "overlay":
-            # All robots at same position
-            base_offsets = jnp.zeros((num_robots, 3))
-        elif base_offsets is not None:
-            base_offsets = jnp.asarray(base_offsets)
-        elif self._base_offsets is not None:
-            base_offsets = jnp.asarray(self._base_offsets)[:num_robots]
+            offset_source = jnp.zeros((num_robots, 3))
         else:
-            base_offsets = self._compute_grid_offsets(num_robots, self._grid_spacing)
-
-        # Pad to 3D if needed
-        if base_offsets.shape[1] == 2:
-            base_offsets = jnp.concatenate(
-                [base_offsets, jnp.zeros((num_robots, 1))], axis=1
+            offset_source = (
+                base_offsets
+                if base_offsets is not None
+                else self._base_offsets
+                if self._base_offsets is not None
+                else self._compute_grid_offsets(num_robots, self._grid_spacing)
             )
+        base_offsets = self._normalize_base_offsets(
+            offset_source,
+            num_robots=int(num_robots),
+            target_dim=3,
+        )
 
         cfg = color_config or self.color_config
         resolved_colors = self.resolve_backbone_colors(num_robots, color_config=cfg)
@@ -1967,14 +1973,13 @@ class LiveModeController:
 
         num_robots = q.shape[0]
 
-        # Compute base offsets
-        base_offsets = self._renderer._compute_grid_offsets(
-            num_robots, self._renderer._grid_spacing
+        base_offsets = self._renderer._normalize_base_offsets(
+            self._renderer._compute_grid_offsets(
+                num_robots, self._renderer._grid_spacing
+            ),
+            num_robots=int(num_robots),
+            target_dim=3,
         )
-        if base_offsets.shape[1] == 2:
-            base_offsets = jnp.concatenate(
-                [base_offsets, jnp.zeros((num_robots, 1))], axis=1
-            )
 
         # Compute curves
         curves = np.asarray(

--- a/src/soromox/rendering/viser_renderer.py
+++ b/src/soromox/rendering/viser_renderer.py
@@ -957,6 +957,9 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         num_robots = q.shape[0]
 
+        uses_configured_offsets = (
+            base_offsets is None and self._base_offsets is not None
+        )
         offset_source = (
             base_offsets
             if base_offsets is not None
@@ -968,6 +971,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
             offset_source,
             num_robots=int(num_robots),
             target_dim=3,
+            allow_extra_rows=uses_configured_offsets,
         )
 
         # Compute backbone curves
@@ -1053,6 +1057,9 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         num_robots = q.shape[0]
 
+        uses_configured_offsets = (
+            base_offsets is None and self._base_offsets is not None
+        )
         offset_source = (
             base_offsets
             if base_offsets is not None
@@ -1064,6 +1071,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
             offset_source,
             num_robots=int(num_robots),
             target_dim=3,
+            allow_extra_rows=uses_configured_offsets,
         )
 
         # Compute backbone curves
@@ -1197,7 +1205,11 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         if multi_robot_layout == "overlay":
             offset_source = jnp.zeros((num_robots, 3))
+            uses_configured_offsets = False
         else:
+            uses_configured_offsets = (
+                base_offsets is None and self._base_offsets is not None
+            )
             offset_source = (
                 base_offsets
                 if base_offsets is not None
@@ -1209,6 +1221,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
             offset_source,
             num_robots=int(num_robots),
             target_dim=3,
+            allow_extra_rows=uses_configured_offsets,
         )
 
         cfg = color_config or self.color_config

--- a/src/soromox/systems/articulated/articulated_soft_robot.py
+++ b/src/soromox/systems/articulated/articulated_soft_robot.py
@@ -109,10 +109,10 @@ class ArticulatedSoftRobot(SoftRobot):
 
     def __init__(self, params: ArticulatedSoftRobotParams, **kwargs: Any) -> None:
         """Initialize an articulated soft robot from typed dynamic parameters."""
-        super().__init__(**kwargs)
         if not isinstance(params, ArticulatedSoftRobotParams):
             raise TypeError("params must be an ArticulatedSoftRobotParams instance.")
         params.validate()
+        super().__init__(base_pose=params.base_pose, **kwargs)
         self.params = params
 
         joint_screw = jnp.asarray(params.joint_screw)
@@ -263,7 +263,7 @@ class ArticulatedSoftRobot(SoftRobot):
 
         _, frames = lax.scan(
             _step,
-            jnp.eye(4, dtype=q.dtype),
+            jnp.asarray(self.base_transform, dtype=q.dtype),
             (self.g_parent_joint, self.joint_screw, q, self.p_com, self.p_tip),
         )
         return frames
@@ -945,9 +945,11 @@ class ArticulatedSoftRobot(SoftRobot):
             joint_rest_configuration,
             radius,
         ) = self._validated_param_arrays(params)
+        base_pose = jnp.asarray(params.base_pose, dtype=jnp.float64)
         return eqx.tree_at(
             lambda model: (
                 model.params,
+                model.base_pose,
                 model.joint_screw,
                 model.g_parent_joint,
                 model.p_tip,
@@ -963,6 +965,7 @@ class ArticulatedSoftRobot(SoftRobot):
             self,
             (
                 params,
+                base_pose,
                 joint_screw,
                 parent_to_joint_transform,
                 tip_position,

--- a/src/soromox/systems/articulated/params.py
+++ b/src/soromox/systems/articulated/params.py
@@ -3,7 +3,10 @@ __all__ = ["ArticulatedSoftRobotParams"]
 from jax import Array
 from jax import numpy as jnp
 
-from soromox.systems.params import BaseArticulatedSoftRobotParams
+from soromox.systems.params import (
+    BaseArticulatedSoftRobotParams,
+    validate_quaternion_base_pose,
+)
 
 
 class ArticulatedSoftRobotParams(BaseArticulatedSoftRobotParams):
@@ -11,6 +14,8 @@ class ArticulatedSoftRobotParams(BaseArticulatedSoftRobotParams):
 
     Per-joint screw axes and transforms define the dynamic link geometry used by
     the articulated model. The number of joints is fixed by array shapes.
+    ``base_pose`` uses scalar-first quaternion SE(3) coordinates
+    ``[qw, qx, qy, qz, x, y, z]`` with nonzero finite quaternion norm.
     """
 
     joint_screw: Array
@@ -35,7 +40,6 @@ class ArticulatedSoftRobotParams(BaseArticulatedSoftRobotParams):
             "center_of_mass_position": (n_links, 3),
             "mass": (n_links,),
             "center_of_mass_inertia": (n_links, 3, 3),
-            "base_pose": (6,),
             "gravity": (3,),
             "joint_stiffness": (n_links, n_links),
             "joint_damping": (n_links, n_links),
@@ -48,3 +52,4 @@ class ArticulatedSoftRobotParams(BaseArticulatedSoftRobotParams):
                 raise ValueError(
                     f"{name} must have shape {expected_shape}, got {value.shape}."
                 )
+        validate_quaternion_base_pose("base_pose", self.base_pose, (7,))

--- a/src/soromox/systems/articulated/params.py
+++ b/src/soromox/systems/articulated/params.py
@@ -35,6 +35,7 @@ class ArticulatedSoftRobotParams(BaseArticulatedSoftRobotParams):
             "center_of_mass_position": (n_links, 3),
             "mass": (n_links,),
             "center_of_mass_inertia": (n_links, 3, 3),
+            "base_pose": (6,),
             "gravity": (3,),
             "joint_stiffness": (n_links, n_links),
             "joint_damping": (n_links, n_links),

--- a/src/soromox/systems/gvs/_assembly.py
+++ b/src/soromox/systems/gvs/_assembly.py
@@ -8,6 +8,7 @@ import soromox.utils.lie_algebra as lie
 from soromox.systems.gvs.params import GVSParams
 from soromox.systems.gvs.primitives import Basis, Joint
 from soromox.systems.gvs.structures import GVSSegmentStructure, GVSStructure
+from soromox.systems.params import validate_quaternion_base_pose
 from soromox.utils.basic import compute_strain_basis
 
 
@@ -282,11 +283,10 @@ def assign_gvs_runtime_arrays(
 
     if p0 is None:
         p0_arr = jnp.array(
-            [jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0], dtype=jnp.float64
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=jnp.float64
         )
     else:
         p0_arr = jnp.asarray(p0, dtype=jnp.float64)
-    if p0_arr.size != 6:
-        raise ValueError("p0 must have shape (6,) when provided")
+    validate_quaternion_base_pose("p0", p0_arr, (7,))
     _set_model_field(model, "base_pose", p0_arr)
-    _set_model_field(model, "g0", lie.exp_SE3(p0_arr))
+    _set_model_field(model, "g0", lie.transform_from_quaternion_pose_SE3(p0_arr))

--- a/src/soromox/systems/gvs/_assembly.py
+++ b/src/soromox/systems/gvs/_assembly.py
@@ -288,4 +288,5 @@ def assign_gvs_runtime_arrays(
         p0_arr = jnp.asarray(p0, dtype=jnp.float64)
     if p0_arr.size != 6:
         raise ValueError("p0 must have shape (6,) when provided")
+    _set_model_field(model, "base_pose", p0_arr)
     _set_model_field(model, "g0", lie.exp_SE3(p0_arr))

--- a/src/soromox/systems/gvs/construction.py
+++ b/src/soromox/systems/gvs/construction.py
@@ -30,7 +30,7 @@ def params_and_structure_from_segments(
     input_segments = tuple(segments)
     n_segments = len(input_segments)
     if base_pose is None:
-        base_pose = jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0])
+        base_pose = jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 
     dofs_joint = [
         Joint.DICT_JOINT_TYPE_DOF[segment.joint.type] for segment in input_segments

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -201,12 +201,12 @@ class GVS(SoftRobot):
         **kwargs: Any,
     ) -> None:
         """Initialize a GVS robot from typed params and static segment structure."""
-        super().__init__(**kwargs)
         if not isinstance(params, GVSParams):
             raise TypeError("params must be a GVSParams instance.")
         if not isinstance(structure, GVSStructure):
             raise TypeError("structure must be a GVSStructure instance.")
         params.validate_against_structure(structure)
+        super().__init__(base_pose=params.base_pose, **kwargs)
         self.params = params
         self.structure = structure
         self.scale_rotational_basis_by_length = bool(
@@ -924,6 +924,7 @@ class GVS(SoftRobot):
                 model.xi_ref_Z1,
                 model.xi_ref_Z2,
                 model.joint_stiffness,
+                model.base_pose,
                 model.g0,
                 model.g,
             ),
@@ -936,6 +937,7 @@ class GVS(SoftRobot):
                 xi_ref_Z1,
                 xi_ref_Z2,
                 joint_stiffness,
+                base_pose,
                 lie.exp_SE3(base_pose),
                 jnp.concatenate([jnp.zeros(3, dtype=gravity.dtype), gravity]),
             ),

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -902,8 +902,8 @@ class GVS(SoftRobot):
         if gravity.shape != (3,):
             raise ValueError(f"gravity must have shape (3,), got {gravity.shape}.")
         base_pose = jnp.asarray(params.base_pose, dtype=jnp.float64)
-        if base_pose.shape != (6,):
-            raise ValueError(f"base_pose must have shape (6,), got {base_pose.shape}.")
+        if base_pose.shape != (7,):
+            raise ValueError(f"base_pose must have shape (7,), got {base_pose.shape}.")
 
         updated_self = eqx.tree_at(
             lambda model: (
@@ -938,7 +938,7 @@ class GVS(SoftRobot):
                 xi_ref_Z2,
                 joint_stiffness,
                 base_pose,
-                lie.exp_SE3(base_pose),
+                lie.transform_from_quaternion_pose_SE3(base_pose),
                 jnp.concatenate([jnp.zeros(3, dtype=gravity.dtype), gravity]),
             ),
         )

--- a/src/soromox/systems/gvs/params.py
+++ b/src/soromox/systems/gvs/params.py
@@ -10,6 +10,7 @@ from soromox.systems.params import (
     BaseTendonRoutingParams,
     LinearTendonRoutingParams,
     PassiveTendonParams,
+    validate_quaternion_base_pose,
 )
 
 
@@ -79,6 +80,8 @@ class GVSParams(BaseSoftRobotParams):
     because it parameterizes the strain basis/reference configuration rather
     than link geometry or material properties. ``joint_stiffness`` has shape
     ``(num_segments, max_dof, max_dof)`` and is padded to the static GVS layout.
+    ``base_pose`` uses scalar-first quaternion SE(3) coordinates
+    ``[qw, qx, qy, qz, x, y, z]`` with nonzero finite quaternion norm.
     """
 
     link: GVSLinkParams
@@ -91,9 +94,7 @@ class GVSParams(BaseSoftRobotParams):
         gravity = jnp.asarray(self.gravity)
         if gravity.shape != (3,):
             raise ValueError(f"gravity must have shape (3,), got {gravity.shape}.")
-        base_pose = jnp.asarray(self.base_pose)
-        if base_pose.shape != (6,):
-            raise ValueError(f"base_pose must have shape (6,), got {base_pose.shape}.")
+        validate_quaternion_base_pose("base_pose", self.base_pose, (7,))
         reference_strain = jnp.asarray(self.reference_strain)
         if reference_strain.shape != (n_segments, 6):
             raise ValueError(

--- a/src/soromox/systems/gvs/params.py
+++ b/src/soromox/systems/gvs/params.py
@@ -82,7 +82,6 @@ class GVSParams(BaseSoftRobotParams):
     """
 
     link: GVSLinkParams
-    base_pose: Array
     reference_strain: Array
     joint_stiffness: Array
 

--- a/src/soromox/systems/hsa/params.py
+++ b/src/soromox/systems/hsa/params.py
@@ -3,7 +3,7 @@ __all__ = ["PlanarHSAParams"]
 from jax import Array
 from jax import numpy as jnp
 
-from soromox.systems.params import BaseSoftRobotParams
+from soromox.systems.params import BaseSoftRobotParams, validate_planar_base_pose
 
 
 class PlanarHSAParams(BaseSoftRobotParams):
@@ -12,7 +12,10 @@ class PlanarHSAParams(BaseSoftRobotParams):
     Field names denote one segment/platform quantity; leading axes store the
     batched values. Arrays store length, rod geometry, reference strain
     components, platform/cap dimensions, end-effector offset, and optional
-    hysteresis coefficients used by the symbolic HSA expressions.
+    hysteresis coefficients used by the symbolic HSA expressions. ``base_pose``
+    stores the planar pose ``[theta, x, y]`` with shape ``(3,)``. ``theta`` is
+    a right-handed angle in radians about the out-of-plane z-axis, and
+    ``x``/``y`` are direct translations in the parent frame.
     """
 
     length: Array
@@ -110,7 +113,6 @@ class PlanarHSAParams(BaseSoftRobotParams):
                 )
 
         scalar_shapes = {
-            "base_pose": (3,),
             "platform_mass": (),
             "platform_center_of_gravity": (2,),
             "gravity": (2,),
@@ -122,6 +124,7 @@ class PlanarHSAParams(BaseSoftRobotParams):
                 raise ValueError(
                     f"{name} must have shape {expected_shape}, got {value.shape}."
                 )
+        validate_planar_base_pose("base_pose", self.base_pose)
 
         hysteresis_basis = jnp.asarray(self.hysteresis_basis)
         if hysteresis_basis.size == 0:

--- a/src/soromox/systems/hsa/params.py
+++ b/src/soromox/systems/hsa/params.py
@@ -3,10 +3,10 @@ __all__ = ["PlanarHSAParams"]
 from jax import Array
 from jax import numpy as jnp
 
-from soromox.systems.params import BaseSystemParams
+from soromox.systems.params import BaseSoftRobotParams
 
 
-class PlanarHSAParams(BaseSystemParams):
+class PlanarHSAParams(BaseSoftRobotParams):
     """Dynamic parameters for planar HSA systems.
 
     Field names denote one segment/platform quantity; leading axes store the
@@ -15,7 +15,6 @@ class PlanarHSAParams(BaseSystemParams):
     hysteresis coefficients used by the symbolic HSA expressions.
     """
 
-    base_angle: Array
     length: Array
     proximal_cap_length: Array
     distal_cap_length: Array
@@ -111,7 +110,7 @@ class PlanarHSAParams(BaseSystemParams):
                 )
 
         scalar_shapes = {
-            "base_angle": (),
+            "base_pose": (3,),
             "platform_mass": (),
             "platform_center_of_gravity": (2,),
             "gravity": (2,),

--- a/src/soromox/systems/hsa/planar_hsa.py
+++ b/src/soromox/systems/hsa/planar_hsa.py
@@ -9,6 +9,7 @@ import sympy as sp
 from jax import Array, jacfwd, lax
 from jax import numpy as jnp
 
+import soromox.utils.lie_algebra as lie
 from soromox.systems.hsa.params import PlanarHSAParams
 from soromox.systems.hsa.structures import PlanarHSAStructure
 from soromox.systems.soft_robot import CrossSectionGeometry, SoftRobot
@@ -223,7 +224,7 @@ class PlanarHSA(SoftRobot):
         base_offset = jnp.concatenate(
             [
                 jnp.zeros(1, dtype=chi.dtype),
-                jnp.asarray(self.base_pose[1:], dtype=chi.dtype),
+                jnp.asarray(self.base_pose[1:3], dtype=chi.dtype),
             ]
         )
         return chi + base_offset

--- a/src/soromox/systems/hsa/planar_hsa.py
+++ b/src/soromox/systems/hsa/planar_hsa.py
@@ -158,7 +158,7 @@ class PlanarHSA(SoftRobot):
     ) -> dict[str, Array | dict[str, Array]]:
         """Map typed HSA params to the symbolic-expression parameter names."""
         mapped: dict[str, Array | dict[str, Array]] = {
-            "th0": params.base_angle,
+            "th0": params.base_pose[0],
             "L": params.length,
             "lpc": params.proximal_cap_length,
             "ldc": params.distal_cap_length,
@@ -215,8 +215,18 @@ class PlanarHSA(SoftRobot):
                             params_for_lambdify.append(param)
                 else:
                     for param in jnp.asarray(params_vals).flatten():
-                        params_for_lambdify.append(param)
+                            params_for_lambdify.append(param)
         return params_for_lambdify
+
+    def _with_base_translation(self, chi: Array) -> Array:
+        """Apply the planar base translation to a symbolic pose."""
+        base_offset = jnp.concatenate(
+            [
+                jnp.zeros(1, dtype=chi.dtype),
+                jnp.asarray(self.base_pose[1:], dtype=chi.dtype),
+            ]
+        )
+        return chi + base_offset
 
     def __init__(
         self,
@@ -239,7 +249,7 @@ class PlanarHSA(SoftRobot):
         if not isinstance(structure, PlanarHSAStructure):
             raise TypeError("structure must be a PlanarHSAStructure instance.")
         params.validate()
-        super().__init__(eps=structure.eps, **kwargs)
+        super().__init__(eps=structure.eps, base_pose=params.base_pose, **kwargs)
         self.params = params
         symbolic_expression_params = self._symbolic_expression_params(
             params, structure.consider_hysteresis
@@ -759,6 +769,7 @@ class PlanarHSA(SoftRobot):
         params.validate()
 
         arrays = (
+            jnp.asarray(params.base_pose),
             jnp.asarray(params.length),
             jnp.asarray(params.rod_offset),
             jnp.asarray(params.bending_reference),
@@ -771,6 +782,7 @@ class PlanarHSA(SoftRobot):
             jnp.asarray(params.phi_max),
         )
         current_arrays = (
+            self.base_pose,
             self.L,
             self.roff,
             self.kappa_b_ref,
@@ -783,6 +795,7 @@ class PlanarHSA(SoftRobot):
             self.phi_max,
         )
         names = (
+            "base_pose",
             "length",
             "rod_offset",
             "bending_reference",
@@ -800,7 +813,7 @@ class PlanarHSA(SoftRobot):
                     f"{name} must have shape {current.shape}, got {value.shape}."
                 )
 
-        L = arrays[0]
+        L = arrays[1]
         L_cum = jnp.cumsum(jnp.concatenate([jnp.zeros(1, dtype=L.dtype), L]))
         symbolic_expression_params = self._symbolic_expression_params(
             params, self.consider_hysteresis
@@ -855,6 +868,7 @@ class PlanarHSA(SoftRobot):
         return eqx.tree_at(
             lambda model: (
                 model.params,
+                model.base_pose,
                 model.params_for_lambdify,
                 model.L,
                 model.L_cum,
@@ -878,11 +892,11 @@ class PlanarHSA(SoftRobot):
             self,
             (
                 params,
+                arrays[0],
                 params_for_lambdify,
                 L,
                 L_cum,
                 L_cum[-1],
-                arrays[1],
                 arrays[2],
                 arrays[3],
                 arrays[4],
@@ -890,8 +904,9 @@ class PlanarHSA(SoftRobot):
                 arrays[6],
                 arrays[7],
                 arrays[8],
-                *hysteresis_arrays,
                 arrays[9],
+                *hysteresis_arrays,
+                arrays[10],
             ),
         )
 
@@ -1066,7 +1081,7 @@ class PlanarHSA(SoftRobot):
             chi, 1
         )  # shift from [p_x, p_y, theta] (symbolic derivation def) to [theta, p_x, p_y] (SE(2) convention)
 
-        return chi
+        return self._with_base_translation(chi)
 
     _forward_kinematics = forward_kinematics_virtual_backbone
 
@@ -1127,7 +1142,7 @@ class PlanarHSA(SoftRobot):
             chir, 1
         )  # shift from [p_x, p_y, theta] (symbolic derivation def) to [theta, p_x, p_y] (SE(2) convention)
 
-        return chir
+        return self._with_base_translation(chir)
 
     @eqx.filter_jit
     def forward_kinematics_platform(self, q: Array, segment_idx: Array) -> Array:
@@ -1157,7 +1172,7 @@ class PlanarHSA(SoftRobot):
             chip, 1
         )  # shift from [p_x, p_y, theta] (symbolic derivation def) to [theta, p_x, p_y] (SE(2) convention)
 
-        return chip
+        return self._with_base_translation(chip)
 
     @eqx.filter_jit
     def forward_kinematics_end_effector(self, q: Array) -> Array:
@@ -1184,7 +1199,7 @@ class PlanarHSA(SoftRobot):
             chiee, 1
         )  # shift from [p_x, p_y, theta] (symbolic derivation def) to [theta, p_x, p_y] (SE(2) convention)
 
-        return chiee
+        return self._with_base_translation(chiee)
 
     @eqx.filter_jit
     def jacobian_end_effector(self, q: Array) -> Array:

--- a/src/soromox/systems/params.py
+++ b/src/soromox/systems/params.py
@@ -68,10 +68,13 @@ class BaseSystemParams(eqx.Module):
 class BaseSoftRobotParams(BaseSystemParams):
     """Common dynamic parameters for soft robot systems.
 
-    ``gravity`` is a JAX array in the dimensional convention of the concrete
-    model, for example 2D planar gravity or 3D spatial gravity.
+    ``base_pose`` and ``gravity`` are JAX arrays in the dimensional convention of
+    the concrete model. Planar robots use ``base_pose = [theta, x, y]`` and
+    2D gravity; spatial robots use ``base_pose = [phi, theta, psi, x, y, z]`` and
+    3D gravity.
     """
 
+    base_pose: Array
     gravity: Array
 
 

--- a/src/soromox/systems/params.py
+++ b/src/soromox/systems/params.py
@@ -6,6 +6,8 @@ __all__ = [
     "BaseTendonRoutingParams",
     "LinearTendonRoutingParams",
     "PassiveTendonParams",
+    "validate_planar_base_pose",
+    "validate_quaternion_base_pose",
 ]
 
 from dataclasses import fields
@@ -14,6 +16,83 @@ from typing import Any
 import equinox as eqx
 from jax import Array
 from jax import numpy as jnp
+from jax.errors import ConcretizationTypeError, TracerBoolConversionError
+
+
+def _validate_finite_array(
+    name: str, value: Array, expected_shape: tuple[int, ...]
+) -> Array:
+    """Validate array shape and concrete finite values when available."""
+    array = jnp.asarray(value)
+    if array.shape != expected_shape:
+        raise ValueError(f"{name} must have shape {expected_shape}, got {array.shape}.")
+    try:
+        all_finite = bool(jnp.isfinite(array).all())
+    except (ConcretizationTypeError, TracerBoolConversionError):
+        return array
+    if not all_finite:
+        raise ValueError(f"{name} must contain only finite values.")
+    return array
+
+
+def validate_planar_base_pose(name: str, value: Array) -> None:
+    """Validate a planar base pose.
+
+    Args:
+        name: Parameter name used in error messages.
+        value: Planar pose array with shape ``(3,)`` in ``[theta, x, y]``
+            order. ``theta`` is a right-handed rotation angle in radians about
+            the out-of-plane z-axis. ``x`` and ``y`` are direct translation
+            coordinates in the parent frame.
+
+    Returns:
+        None.
+
+    Raises:
+        ValueError: If the shape is not ``(3,)`` or any concrete entry is
+            non-finite. During JAX tracing, only the static shape check is
+            performed.
+    """
+    _validate_finite_array(name, value, (3,))
+
+
+def validate_quaternion_base_pose(
+    name: str,
+    value: Array,
+    expected_shape: tuple[int, ...],
+    *,
+    min_norm: float = 1e-12,
+) -> None:
+    """Validate a scalar-first quaternion base pose.
+
+    Args:
+        name: Parameter name used in error messages.
+        value: Base pose array whose first four entries are a scalar-first
+            Hamilton quaternion in ``[qw, qx, qy, qz]`` order. Spatial systems
+            use shape ``(7,)`` with ``[qw, qx, qy, qz, x, y, z]``.
+        expected_shape: Required full pose shape, typically ``(7,)``.
+        min_norm: Minimum allowed Euclidean norm for the quaternion component.
+
+    Concrete parameter objects are checked for finite entries and nonzero
+    quaternion norm. During JAX tracing, only the static shape check is
+    performed; transform helpers still avoid zero-norm division to keep traced
+    code finite.
+
+    Raises:
+        ValueError: If the shape is wrong, any entry is non-finite, or the
+            quaternion component is zero or numerically too small to normalize
+            safely.
+    """
+    pose = _validate_finite_array(name, value, expected_shape)
+    try:
+        quaternion_norm = float(jnp.linalg.norm(pose[:4]))
+    except (ConcretizationTypeError, TracerBoolConversionError):
+        return
+    if quaternion_norm <= min_norm:
+        raise ValueError(
+            f"{name} quaternion must have norm greater than {min_norm}, "
+            f"got {quaternion_norm}."
+        )
 
 
 def _attachment_segment_index(value: Any) -> int | tuple[int, ...]:
@@ -68,10 +147,13 @@ class BaseSystemParams(eqx.Module):
 class BaseSoftRobotParams(BaseSystemParams):
     """Common dynamic parameters for soft robot systems.
 
-    ``base_pose`` and ``gravity`` are JAX arrays in the dimensional convention of
-    the concrete model. Planar robots use ``base_pose = [theta, x, y]`` and
-    2D gravity; spatial robots use ``base_pose = [phi, theta, psi, x, y, z]`` and
-    3D gravity.
+    ``base_pose`` and ``gravity`` are JAX arrays in the dimensional convention
+    of the concrete model. Planar robots use ``base_pose = [theta, x, y]`` with
+    2D gravity, where ``theta`` is a right-handed angle in radians about the
+    out-of-plane z-axis. Spatial robots use
+    ``base_pose = [qw, qx, qy, qz, x, y, z]`` with 3D gravity. Spatial
+    quaternions are scalar-first Hamilton quaternions, normalized before
+    transform construction, and must have nonzero finite norm.
     """
 
     base_pose: Array

--- a/src/soromox/systems/pcs/isupport.py
+++ b/src/soromox/systems/pcs/isupport.py
@@ -99,15 +99,12 @@ class ISupport(PCS):
         Args:
             params (Dict[str, Array]): Dictionary containing the parameters of the robot.
                 Dictionary containing the robot parameters:
-                - "p0": (optional) List/Array of shape (6,)
-                    Initial orientation angle and position in the inertial frame [rad, m]
-                    [ψ, θ, φ, x0, y0, z0]
-                        [ψ, θ, φ] are the Euler angles in the ZXZ convention:
-                            ψ (psi) : Rotation around Z axis (fixed axis)
-                            θ (thêta) : Rotation around X' axis (movable axis after first rotation)
-                            φ (phi) : Rotation about the Z' axis (movable axis after the first two rotations)
-                        [x0, y0, z0] : Position of the robot in the inertial frame
-                    Defaults to [pi/2, pi/2, 0.0, 0.0, 0.0, 0.0] (i.e. aligned with the z-axis and at the origin).
+                - "base_pose": (optional) List/Array of shape (7,)
+                    Scalar-first quaternion pose ``[qw, qx, qy, qz, x0, y0, z0]``
+                    in the inertial frame. The quaternion represents the base
+                    orientation and the translation is inserted directly into
+                    the homogeneous transform. Defaults to identity rotation
+                    and zero translation.
                 - "L": List/Array of num_segments floats
                     Length of each segment [m]
                 - "r": List/Array of num_segments floats

--- a/src/soromox/systems/pcs/params.py
+++ b/src/soromox/systems/pcs/params.py
@@ -16,6 +16,8 @@ from soromox.systems.params import (
     BaseTendonRoutingParams,
     LinearTendonRoutingParams,
     PassiveTendonParams,
+    validate_planar_base_pose,
+    validate_quaternion_base_pose,
 )
 
 
@@ -51,8 +53,9 @@ class PCSParams(BaseContinuumSoftRobotParams):
 
     ``length``, ``radius``, material parameters, and density use a leading
     segment axis. ``damping_matrix`` is the full flattened strain damping matrix.
-    ``base_pose`` is the SE(3) base pose vector used to initialize the base
-    transform.
+    ``base_pose`` is the scalar-first quaternion SE(3) base pose vector
+    ``[qw, qx, qy, qz, x, y, z]`` used to initialize the base transform. The
+    quaternion is normalized before use and must have nonzero finite norm.
     """
 
     radius: Array
@@ -67,14 +70,17 @@ class PCSParams(BaseContinuumSoftRobotParams):
         _require_shape(
             "damping_matrix", self.damping_matrix, (6 * n_segments, 6 * n_segments)
         )
-        _require_shape("base_pose", self.base_pose, (6,))
+        validate_quaternion_base_pose("base_pose", self.base_pose, (7,))
 
 
 class PlanarPCSParams(BaseContinuumSoftRobotParams):
     """Dynamic parameters for the planar PCS model.
 
     The leading axis of per-segment fields indexes planar constant-strain
-    segments. ``base_pose`` stores the planar base pose ``[theta, x, y]``.
+    segments. ``base_pose`` stores the planar pose ``[theta, x, y]`` with shape
+    ``(3,)``. ``theta`` is a right-handed angle in radians about the
+    out-of-plane z-axis, and ``x``/``y`` are direct translations in the parent
+    frame.
     """
 
     radius: Array
@@ -89,7 +95,7 @@ class PlanarPCSParams(BaseContinuumSoftRobotParams):
         _require_shape(
             "damping_matrix", self.damping_matrix, (3 * n_segments, 3 * n_segments)
         )
-        _require_shape("base_pose", self.base_pose, (3,))
+        validate_planar_base_pose("base_pose", self.base_pose)
 
 
 class TendonActuatedPCSParams(BaseSystemParams):

--- a/src/soromox/systems/pcs/params.py
+++ b/src/soromox/systems/pcs/params.py
@@ -59,8 +59,6 @@ class PCSParams(BaseContinuumSoftRobotParams):
     young_modulus: Array
     shear_modulus: Array
     damping_matrix: Array
-    base_pose: Array
-
     def validate(self) -> None:
         n_segments = _validate_continuum_base(self, strain_dim=6, gravity_dim=3)
         _require_shape("radius", self.radius, (n_segments,))
@@ -76,15 +74,13 @@ class PlanarPCSParams(BaseContinuumSoftRobotParams):
     """Dynamic parameters for the planar PCS model.
 
     The leading axis of per-segment fields indexes planar constant-strain
-    segments. ``base_angle`` stores the planar base orientation.
+    segments. ``base_pose`` stores the planar base pose ``[theta, x, y]``.
     """
 
     radius: Array
     young_modulus: Array
     shear_modulus: Array
     damping_matrix: Array
-    base_angle: Array
-
     def validate(self) -> None:
         n_segments = _validate_continuum_base(self, strain_dim=3, gravity_dim=2)
         _require_shape("radius", self.radius, (n_segments,))
@@ -93,7 +89,7 @@ class PlanarPCSParams(BaseContinuumSoftRobotParams):
         _require_shape(
             "damping_matrix", self.damping_matrix, (3 * n_segments, 3 * n_segments)
         )
-        _require_shape("base_angle", self.base_angle, ())
+        _require_shape("base_pose", self.base_pose, (3,))
 
 
 class TendonActuatedPCSParams(BaseSystemParams):

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -107,10 +107,10 @@ class PCS(SoftRobot):
         **kwargs: Any,
     ):
         """Initialize the PCS class from typed dynamic parameters."""
-        super().__init__(**kwargs)
         if not isinstance(params, PCSParams):
             raise TypeError("params must be a PCSParams instance.")
         params.validate()
+        super().__init__(base_pose=params.base_pose, **kwargs)
         if structure is None:
             structure = PCSStructure()
         self.params = params
@@ -229,7 +229,8 @@ class PCS(SoftRobot):
     def _set_params(self, params: PCSParams) -> None:
         """Set cached runtime arrays from typed parameters."""
         # Initial position and orientation angle
-        p0 = params.base_pose
+        self.base_pose = jnp.asarray(params.base_pose, dtype=jnp.float64)
+        p0 = self.base_pose
         p0 = jnp.asarray(p0, dtype=jnp.float64)
         if p0.size != 6:
             raise ValueError(f"base_pose must have shape (6,), got {p0.size}")
@@ -347,6 +348,7 @@ class PCS(SoftRobot):
         updated_self = eqx.tree_at(
             lambda m: (
                 m.params,
+                m.base_pose,
                 m.g0,
                 m.g,
                 m.L,
@@ -361,6 +363,7 @@ class PCS(SoftRobot):
             self,
             (
                 params if stored_params is None else stored_params,
+                base_pose,
                 lie.exp_SE3(base_pose),
                 jnp.concatenate([jnp.zeros(3, dtype=gravity.dtype), gravity]),
                 segment_lengths,

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -232,9 +232,9 @@ class PCS(SoftRobot):
         self.base_pose = jnp.asarray(params.base_pose, dtype=jnp.float64)
         p0 = self.base_pose
         p0 = jnp.asarray(p0, dtype=jnp.float64)
-        if p0.size != 6:
-            raise ValueError(f"base_pose must have shape (6,), got {p0.size}")
-        self.g0 = lie.exp_SE3(p0)
+        if p0.size != 7:
+            raise ValueError(f"base_pose must have shape (7,), got {p0.size}")
+        self.g0 = lie.transform_from_quaternion_pose_SE3(p0)
 
         # Gravitational acceleration vector
         g = params.gravity
@@ -364,7 +364,7 @@ class PCS(SoftRobot):
             (
                 params if stored_params is None else stored_params,
                 base_pose,
-                lie.exp_SE3(base_pose),
+                lie.transform_from_quaternion_pose_SE3(base_pose),
                 jnp.concatenate([jnp.zeros(3, dtype=gravity.dtype), gravity]),
                 segment_lengths,
                 jnp.cumsum(

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -33,7 +33,7 @@ class PlanarPCS(SoftRobot):
     Attributes:
         num_segments: Number of segments (constant strain sections) along the robot.
         num_actuators: Number of actuators (control inputs) for the robot.
-        th0: Initial orientation angle of the robot in radians.
+        base_pose: Initial planar base pose ``[theta, x, y]``.
         g: Gravitational acceleration vector (embedded in a 3D vector).
             [0, g_x, g_y]
         L, r, E, G, rho, D: Physical properties of each segment (length, radius, elastic/shear modulus, etc.).
@@ -67,7 +67,6 @@ class PlanarPCS(SoftRobot):
     params: PlanarPCSParams
 
     # Robot parameters
-    th0: Array  # Initial orientation angle [rad]
     g: Array  # Gravitational acceleration vector
 
     L: Array  # Length of the segments
@@ -104,10 +103,10 @@ class PlanarPCS(SoftRobot):
         **kwargs: Any,
     ):
         """Initialize the PlanarPCS class from typed dynamic parameters."""
-        super().__init__(**kwargs)
         if not isinstance(params, PlanarPCSParams):
             raise TypeError("params must be a PlanarPCSParams instance.")
         params.validate()
+        super().__init__(base_pose=params.base_pose, **kwargs)
         if structure is None:
             structure = PlanarPCSStructure()
         self.params = params
@@ -217,10 +216,7 @@ class PlanarPCS(SoftRobot):
 
     def _set_params(self, params: PlanarPCSParams) -> None:
         """Set cached runtime arrays from typed parameters."""
-        # Initial orientation angle
-        th0 = params.base_angle
-        th0 = jnp.asarray(th0, dtype=jnp.float64)
-        self.th0 = th0
+        self.base_pose = jnp.asarray(params.base_pose, dtype=jnp.float64)
 
         # Gravitational acceleration vector
         g = params.gravity
@@ -315,7 +311,7 @@ class PlanarPCS(SoftRobot):
                 "reference_strain shape changes the model structure; construct a new PlanarPCS."
             )
 
-        base_angle = jnp.asarray(params.base_angle, dtype=jnp.float64)
+        base_pose = jnp.asarray(params.base_pose, dtype=jnp.float64)
         gravity = jnp.asarray(params.gravity, dtype=jnp.float64)
         segment_lengths = jnp.asarray(params.length, dtype=jnp.float64)
         radius = jnp.asarray(params.radius, dtype=jnp.float64)
@@ -334,7 +330,7 @@ class PlanarPCS(SoftRobot):
         updated_self = eqx.tree_at(
             lambda m: (
                 m.params,
-                m.th0,
+                m.base_pose,
                 m.g,
                 m.L,
                 m.L_cum,
@@ -348,7 +344,7 @@ class PlanarPCS(SoftRobot):
             self,
             (
                 params if stored_params is None else stored_params,
-                base_angle,
+                base_pose,
                 jnp.concatenate([jnp.zeros(1, dtype=gravity.dtype), gravity]),
                 segment_lengths,
                 jnp.cumsum(
@@ -480,9 +476,7 @@ class PlanarPCS(SoftRobot):
 
         segment_idx, s_local = self.classify_segment(s)
 
-        chi_0 = jnp.concatenate(
-            [self.th0[None], jnp.zeros(2)]
-        )  # Initial configuration [theta, x, y]
+        chi_0 = jnp.asarray(self.base_pose, dtype=xi.dtype)
 
         # Iteration function
         def chi_i(chi_prev: Array, i: Array) -> tuple[Array, Array]:
@@ -597,13 +591,7 @@ class PlanarPCS(SoftRobot):
         """
         xi = self.strain(q).reshape(self.num_segments, 3)
 
-        # base configuration [theta, x, y]
-        chi_base = jnp.concatenate(
-            [
-                jnp.asarray(self.th0, dtype=xi.dtype)[None],
-                jnp.zeros(2, dtype=xi.dtype),
-            ]
-        )
+        chi_base = jnp.asarray(self.base_pose, dtype=xi.dtype)
 
         def integrate_segment(chi_prev: Array, i: Array) -> tuple[Array, Array]:
             xi_i = lax.dynamic_index_in_dim(xi, i, axis=0, keepdims=False)
@@ -668,12 +656,7 @@ class PlanarPCS(SoftRobot):
         xi = self.strain(q).reshape(self.num_segments, 3)
 
         chi_tips = self.forward_kinematics_tips(q)
-        chi_base = jnp.concatenate(
-            [
-                jnp.asarray(self.th0, dtype=xi.dtype)[None],
-                jnp.zeros(2, dtype=xi.dtype),
-            ]
-        )
+        chi_base = jnp.asarray(self.base_pose, dtype=xi.dtype)
         chi_bases = jnp.concatenate([chi_base[None, :], chi_tips[:-1]], axis=0)
 
         segment_indices, s_local_ps = vmap(self.classify_segment)(s_ps)
@@ -735,16 +718,13 @@ class PlanarPCS(SoftRobot):
         Returns:
             chi_rel (Array): relative poses of shape (num_segments, 3) where each row is [delta_theta, delta_x, delta_y]
                             representing the relative pose change from the previous segment tip.
-                            The first segment's relative pose is computed w.r.t. the base at (0, 0, 0).
+                            The first segment's relative pose is computed w.r.t. ``base_pose``.
         """
         # Ensure chi_tips has the correct shape
         chi_tips = chi_tips.reshape(self.num_segments, 3)
 
-        # Base pose at the origin: [theta=self.th0, x=0, y=0]
-        base_pose = jnp.array([self.th0, 0.0, 0.0])
-
         # Create array of previous poses: base + all segment tips except the last
-        prev_poses = jnp.concatenate([base_pose[None, :], chi_tips[:-1]], axis=0)
+        prev_poses = jnp.concatenate([self.base_pose[None, :], chi_tips[:-1]], axis=0)
 
         # Compute relative poses vectorized
         # For SE(2), the relative transformation between poses chi_prev and chi_curr is:
@@ -1126,14 +1106,9 @@ class PlanarPCS(SoftRobot):
             dtype: Desired floating-point dtype of the returned array.
 
         Returns:
-            Planar base pose ``[theta0, 0, 0]`` with shape ``(3,)``.
+            Planar base pose ``[theta0, x0, y0]`` with shape ``(3,)``.
         """
-        return jnp.concatenate(
-            [
-                jnp.asarray(self.th0, dtype=dtype)[None],
-                jnp.zeros(2, dtype=dtype),
-            ]
-        )
+        return jnp.asarray(self.base_pose, dtype=dtype)
 
     def _update_body_jacobian_step(
         self, J_prev: Array, i: Array, Ad_inv: Array, T: Array
@@ -1287,12 +1262,7 @@ class PlanarPCS(SoftRobot):
         segment_idx, s_local = self.classify_segment(s)
 
         zeros = jnp.zeros((self.num_segments, 3, 3), dtype=xi.dtype)
-        chi0 = jnp.concatenate(
-            [
-                jnp.asarray(self.th0, dtype=xi.dtype)[None],
-                jnp.zeros(2, dtype=xi.dtype),
-            ]
-        )
+        chi0 = jnp.asarray(self.base_pose, dtype=xi.dtype)
 
         def scan_body(
             carry: tuple[Array, Array, Array, Array, Array, Array],
@@ -1362,12 +1332,7 @@ class PlanarPCS(SoftRobot):
         segment_idx, s_local = self.classify_segment(s)
 
         zeros = jnp.zeros((self.num_segments, 3, 3), dtype=xi.dtype)
-        chi0 = jnp.concatenate(
-            [
-                jnp.asarray(self.th0, dtype=xi.dtype)[None],
-                jnp.zeros(2, dtype=xi.dtype),
-            ]
-        )
+        chi0 = jnp.asarray(self.base_pose, dtype=xi.dtype)
 
         def scan_body(
             carry: tuple[Array, Array, Array, Array, Array, Array, Array],
@@ -2573,16 +2538,7 @@ class PlanarPCS(SoftRobot):
         )
         s_local = Xs_scaled - self.L_cum[:-1, None]
 
-        th0 = jnp.asarray(self.th0, dtype=xi.dtype)
-        g0 = lie.exp_SE2(
-            jnp.stack(
-                [
-                    th0,
-                    jnp.zeros((), dtype=xi.dtype),
-                    jnp.zeros((), dtype=xi.dtype),
-                ]
-            )
-        )
+        g0 = lie.exp_SE2(jnp.asarray(self.base_pose, dtype=xi.dtype))
 
         def scan_fk(g_base: Array, i: Array) -> tuple[Array, Array]:
             xi_i = lax.dynamic_index_in_dim(xi, i, axis=0, keepdims=False)

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -33,7 +33,7 @@ class PlanarPCS(SoftRobot):
     Attributes:
         num_segments: Number of segments (constant strain sections) along the robot.
         num_actuators: Number of actuators (control inputs) for the robot.
-        base_pose: Initial planar base pose ``[theta, x, y]``.
+        base_pose: Initial planar pose ``[theta, x, y]`` with ``theta`` in radians.
         g: Gravitational acceleration vector (embedded in a 3D vector).
             [0, g_x, g_y]
         L, r, E, G, rho, D: Physical properties of each segment (length, radius, elastic/shear modulus, etc.).
@@ -476,7 +476,7 @@ class PlanarPCS(SoftRobot):
 
         segment_idx, s_local = self.classify_segment(s)
 
-        chi_0 = jnp.asarray(self.base_pose, dtype=xi.dtype)
+        chi_0 = self._base_planar_pose(xi.dtype)
 
         # Iteration function
         def chi_i(chi_prev: Array, i: Array) -> tuple[Array, Array]:
@@ -591,7 +591,7 @@ class PlanarPCS(SoftRobot):
         """
         xi = self.strain(q).reshape(self.num_segments, 3)
 
-        chi_base = jnp.asarray(self.base_pose, dtype=xi.dtype)
+        chi_base = self._base_planar_pose(xi.dtype)
 
         def integrate_segment(chi_prev: Array, i: Array) -> tuple[Array, Array]:
             xi_i = lax.dynamic_index_in_dim(xi, i, axis=0, keepdims=False)
@@ -656,7 +656,7 @@ class PlanarPCS(SoftRobot):
         xi = self.strain(q).reshape(self.num_segments, 3)
 
         chi_tips = self.forward_kinematics_tips(q)
-        chi_base = jnp.asarray(self.base_pose, dtype=xi.dtype)
+        chi_base = self._base_planar_pose(xi.dtype)
         chi_bases = jnp.concatenate([chi_base[None, :], chi_tips[:-1]], axis=0)
 
         segment_indices, s_local_ps = vmap(self.classify_segment)(s_ps)
@@ -724,7 +724,8 @@ class PlanarPCS(SoftRobot):
         chi_tips = chi_tips.reshape(self.num_segments, 3)
 
         # Create array of previous poses: base + all segment tips except the last
-        prev_poses = jnp.concatenate([self.base_pose[None, :], chi_tips[:-1]], axis=0)
+        chi_base = self._base_planar_pose(chi_tips.dtype)
+        prev_poses = jnp.concatenate([chi_base[None, :], chi_tips[:-1]], axis=0)
 
         # Compute relative poses vectorized
         # For SE(2), the relative transformation between poses chi_prev and chi_curr is:
@@ -1262,7 +1263,7 @@ class PlanarPCS(SoftRobot):
         segment_idx, s_local = self.classify_segment(s)
 
         zeros = jnp.zeros((self.num_segments, 3, 3), dtype=xi.dtype)
-        chi0 = jnp.asarray(self.base_pose, dtype=xi.dtype)
+        chi0 = self._base_planar_pose(xi.dtype)
 
         def scan_body(
             carry: tuple[Array, Array, Array, Array, Array, Array],
@@ -1332,7 +1333,7 @@ class PlanarPCS(SoftRobot):
         segment_idx, s_local = self.classify_segment(s)
 
         zeros = jnp.zeros((self.num_segments, 3, 3), dtype=xi.dtype)
-        chi0 = jnp.asarray(self.base_pose, dtype=xi.dtype)
+        chi0 = self._base_planar_pose(xi.dtype)
 
         def scan_body(
             carry: tuple[Array, Array, Array, Array, Array, Array, Array],
@@ -1515,7 +1516,7 @@ class PlanarPCS(SoftRobot):
         """Adjoint of the planar pose rotation, with zero translation."""
         theta = chi[0]
         zero = jnp.zeros((), dtype=theta.dtype)
-        g = lie.exp_SE2(jnp.stack([theta, zero, zero]))
+        g = lie.transform_from_planar_pose_SE2(jnp.stack([theta, zero, zero]))
         return lie.Adjoint_g_SE2(g)
 
     def _body_jacobian_to_inertial(self, chi: Array, J_local: Array) -> Array:
@@ -1596,7 +1597,7 @@ class PlanarPCS(SoftRobot):
 
         def lift_theta(th: Array) -> Array:
             zeros = jnp.zeros((), dtype=th.dtype)
-            return lie.exp_SE2(jnp.stack([th, zeros, zeros]))
+            return lie.transform_from_planar_pose_SE2(jnp.stack([th, zeros, zeros]))
 
         g_rot_ps = vmap(lift_theta)(thetas)
         Ad_g_ps = vmap(lie.Adjoint_g_SE2)(g_rot_ps)
@@ -1623,7 +1624,9 @@ class PlanarPCS(SoftRobot):
         def rotate_pair(chi_i: Array, J_i: Array) -> Array:
             theta = chi_i[0]
             zeros = jnp.zeros((), dtype=theta.dtype)
-            g_rot = lie.exp_SE2(jnp.stack([theta, zeros, zeros]))
+            g_rot = lie.transform_from_planar_pose_SE2(
+                jnp.stack([theta, zeros, zeros])
+            )
             return lie.Adjoint_g_SE2(g_rot) @ J_i
 
         return vmap(rotate_pair)(chi_tips, J_local_tips)
@@ -1936,7 +1939,7 @@ class PlanarPCS(SoftRobot):
 
         def lift_theta(th: Array) -> Array:
             zeros = jnp.zeros((), dtype=th.dtype)
-            return lie.exp_SE2(jnp.stack([th, zeros, zeros]))
+            return lie.transform_from_planar_pose_SE2(jnp.stack([th, zeros, zeros]))
 
         g_rot_ps = vmap(lift_theta)(thetas)
         Ad_g_ps = vmap(lie.Adjoint_g_SE2)(g_rot_ps)
@@ -2214,7 +2217,7 @@ class PlanarPCS(SoftRobot):
         )
 
         chi_ps = self.forward_kinematics_batched(q, Xs_scaled.flatten())
-        g_ps = vmap(lie.exp_SE2)(chi_ps.reshape(-1, 3))
+        g_ps = vmap(lie.transform_from_planar_pose_SE2)(chi_ps.reshape(-1, 3))
         g_ps = g_ps.reshape(self.num_segments, self.num_integration_points, 3, 3)
 
         J_ps = self._J_local_batched(q, Xs_scaled.flatten())
@@ -2538,7 +2541,9 @@ class PlanarPCS(SoftRobot):
         )
         s_local = Xs_scaled - self.L_cum[:-1, None]
 
-        g0 = lie.exp_SE2(jnp.asarray(self.base_pose, dtype=xi.dtype))
+        g0 = lie.transform_from_planar_pose_SE2(
+            jnp.asarray(self.base_pose, dtype=xi.dtype)
+        )
 
         def scan_fk(g_base: Array, i: Array) -> tuple[Array, Array]:
             xi_i = lax.dynamic_index_in_dim(xi, i, axis=0, keepdims=False)

--- a/src/soromox/systems/pendulum/params.py
+++ b/src/soromox/systems/pendulum/params.py
@@ -7,6 +7,7 @@ from soromox.systems.params import (
     BaseArticulatedSoftRobotParams,
     BaseSystemParams,
     PassiveTendonParams,
+    validate_planar_base_pose,
 )
 
 
@@ -16,6 +17,9 @@ class PendulumParams(BaseArticulatedSoftRobotParams):
     The leading axis indexes links/joints. ``moment_inertia`` and
     ``center_of_mass_length`` are per link, while stiffness and damping are
     generalized-coordinate matrices inherited from the articulated base class.
+    ``base_pose`` stores the planar pose ``[theta, x, y]`` with shape ``(3,)``.
+    ``theta`` is a right-handed angle in radians about the out-of-plane z-axis,
+    and ``x``/``y`` are direct translations in the parent frame.
     """
 
     moment_inertia: Array
@@ -51,9 +55,7 @@ class PendulumParams(BaseArticulatedSoftRobotParams):
         gravity = jnp.asarray(self.gravity)
         if gravity.shape != (2,):
             raise ValueError(f"gravity must have shape (2,), got {gravity.shape}.")
-        base_pose = jnp.asarray(self.base_pose)
-        if base_pose.shape != (3,):
-            raise ValueError(f"base_pose must have shape (3,), got {base_pose.shape}.")
+        validate_planar_base_pose("base_pose", self.base_pose)
 
 
 class TendonActuatedPendulumParams(BaseSystemParams):

--- a/src/soromox/systems/pendulum/params.py
+++ b/src/soromox/systems/pendulum/params.py
@@ -51,6 +51,9 @@ class PendulumParams(BaseArticulatedSoftRobotParams):
         gravity = jnp.asarray(self.gravity)
         if gravity.shape != (2,):
             raise ValueError(f"gravity must have shape (2,), got {gravity.shape}.")
+        base_pose = jnp.asarray(self.base_pose)
+        if base_pose.shape != (3,):
+            raise ValueError(f"base_pose must have shape (3,), got {base_pose.shape}.")
 
 
 class TendonActuatedPendulumParams(BaseSystemParams):

--- a/src/soromox/systems/pendulum/pendulum.py
+++ b/src/soromox/systems/pendulum/pendulum.py
@@ -7,6 +7,7 @@ import equinox as eqx
 from jax import Array, vmap
 from jax import numpy as jnp
 
+import soromox.utils.lie_algebra as lie
 from soromox.systems.pendulum.params import PendulumParams
 from soromox.systems.soft_robot import CrossSectionGeometry, SoftRobot
 
@@ -237,7 +238,12 @@ class Pendulum(SoftRobot):
         Returns:
             Array: Cumulative angles θ_i = Σ_{k=0..i} q[k], shape (N,) [rad]
         """
-        return self.base_pose[0] + jnp.cumsum(q)  # (n,)
+        base_theta = jnp.asarray(self.base_pose[0], dtype=q.dtype)
+        return base_theta + jnp.cumsum(q)  # (n,)
+
+    def _base_xy(self, dtype: jnp.dtype) -> Array:
+        """Return the planar base translation stored in ``base_pose``."""
+        return jnp.asarray(self.base_pose[1:3], dtype=dtype)
 
     def _directions(self, q: Array) -> Array:
         """
@@ -272,7 +278,7 @@ class Pendulum(SoftRobot):
         seg_vecs = self.L[:, None] * dirs  # (n,2)
         tips = jnp.cumsum(seg_vecs, axis=0)  # tip positions of each link
         # Proximal positions p_joint[i] = tip[i-1] with base at 0
-        base_xy = jnp.asarray(self.base_pose[1:], dtype=q.dtype)
+        base_xy = self._base_xy(q.dtype)
         p_joints = jnp.concatenate([base_xy[None, :], base_xy + tips[:-1]], axis=0)
         return p_joints
 
@@ -305,7 +311,7 @@ class Pendulum(SoftRobot):
         """
         dirs = self._directions(q)
         seg_vecs = self.L[:, None] * dirs
-        base_xy = jnp.asarray(self.base_pose[1:], dtype=q.dtype)
+        base_xy = self._base_xy(q.dtype)
         p_tips = base_xy + jnp.cumsum(seg_vecs, axis=0)  # (n,2)
         return p_tips
 

--- a/src/soromox/systems/pendulum/pendulum.py
+++ b/src/soromox/systems/pendulum/pendulum.py
@@ -91,10 +91,10 @@ class Pendulum(SoftRobot):
         **kwargs: Any,
     ) -> None:
         """Initialize the pendulum system with typed parameters."""
-        super().__init__(**kwargs)
         if not isinstance(params, PendulumParams):
             raise TypeError("params must be a PendulumParams instance.")
         params.validate()
+        super().__init__(base_pose=params.base_pose, **kwargs)
         self.params = params
 
         # Basic parameter extraction
@@ -169,6 +169,7 @@ class Pendulum(SoftRobot):
         return eqx.tree_at(
             lambda x: (
                 x.params,
+                x.base_pose,
                 x.m,
                 x.I,
                 x.L,
@@ -182,6 +183,7 @@ class Pendulum(SoftRobot):
             self,
             (
                 params if stored_params is None else stored_params,
+                jnp.asarray(params.base_pose),
                 jnp.asarray(params.mass),
                 jnp.asarray(params.moment_inertia),
                 jnp.asarray(params.length),
@@ -209,6 +211,7 @@ class Pendulum(SoftRobot):
             "joint_damping",
             "joint_rest_configuration",
             "radius",
+            "base_pose",
             "gravity",
         )
         for name in shape_locked_fields:
@@ -234,7 +237,7 @@ class Pendulum(SoftRobot):
         Returns:
             Array: Cumulative angles θ_i = Σ_{k=0..i} q[k], shape (N,) [rad]
         """
-        return jnp.cumsum(q)  # (n,)
+        return self.base_pose[0] + jnp.cumsum(q)  # (n,)
 
     def _directions(self, q: Array) -> Array:
         """
@@ -269,8 +272,8 @@ class Pendulum(SoftRobot):
         seg_vecs = self.L[:, None] * dirs  # (n,2)
         tips = jnp.cumsum(seg_vecs, axis=0)  # tip positions of each link
         # Proximal positions p_joint[i] = tip[i-1] with base at 0
-        zeros = jnp.zeros((1, 2), dtype=q.dtype)
-        p_joints = jnp.concatenate([zeros, tips[:-1]], axis=0)  # (n,2)
+        base_xy = jnp.asarray(self.base_pose[1:], dtype=q.dtype)
+        p_joints = jnp.concatenate([base_xy[None, :], base_xy + tips[:-1]], axis=0)
         return p_joints
 
     def _com_positions(self, q: Array) -> Array:
@@ -302,7 +305,8 @@ class Pendulum(SoftRobot):
         """
         dirs = self._directions(q)
         seg_vecs = self.L[:, None] * dirs
-        p_tips = jnp.cumsum(seg_vecs, axis=0)  # (n,2)
+        base_xy = jnp.asarray(self.base_pose[1:], dtype=q.dtype)
+        p_tips = base_xy + jnp.cumsum(seg_vecs, axis=0)  # (n,2)
         return p_tips
 
     @eqx.filter_jit

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -14,6 +14,10 @@ from jax import numpy as jnp
 import soromox.utils.lie_algebra as lie
 from soromox.autodiff import custom_jvp_enabled
 from soromox.systems.dynamical_system import DynamicalSystem
+from soromox.systems.params import (
+    validate_planar_base_pose,
+    validate_quaternion_base_pose,
+)
 
 
 class CrossSectionGeometry(IntEnum):
@@ -44,15 +48,15 @@ class SoftRobot(DynamicalSystem):
         num_actuators (int): Number of actuators.
         global_eps (float): Global epsilon for numerical computations.
         base_pose (Array): Base frame pose coordinates for the robot. Planar
-            robots use shape ``(3,)`` with SE(2) coordinates
-            ``[theta, x, y]``, where ``theta`` is the base-frame angle in
-            radians and ``x, y`` are the base-frame translation. Spatial robots
-            use shape ``(6,)`` with SE(3) coordinates
-            ``[phi, theta, psi, x, y, z]``; the rotational entries follow the
-            ZYX Euler convention used by :func:`soromox.utils.lie_algebra.se3.exp_SE3`,
-            and ``x, y, z`` are inserted directly as the base translation. In the
-            standard zero-rotation base pose, the soft robot backbone is aligned
-            with the positive base-frame x-axis.
+            robots use shape ``(3,)`` with coordinates ``[theta, x, y]``,
+            where ``theta`` is a right-handed angle in radians about the
+            out-of-plane z-axis. Spatial robots use shape ``(7,)`` with
+            coordinates ``[qw, qx, qy, qz, x, y, z]``. Spatial quaternions are
+            scalar-first Hamilton quaternions, normalized before use, and
+            represent the base-frame orientation; translations are inserted
+            directly. Configured spatial quaternions must have nonzero finite
+            norm. In the standard zero-rotation base pose, the soft robot
+            backbone is aligned with the positive base-frame x-axis.
         num_gauss_points (int | Array | None): Requested nonzero
             Gauss-Legendre quadrature point count. May be scalar for systems
             with a uniform grid or an array for systems with per-segment grids.
@@ -93,21 +97,30 @@ class SoftRobot(DynamicalSystem):
         Args:
             eps (float): Optional global epsilon value for numerical computations.
                 If not provided, defaults to 10x machine epsilon for float64.
-            base_pose: Optional base frame pose coordinates. Planar robots expect
-                shape ``(3,)`` with ``[theta, x, y]``. Spatial robots expect
-                shape ``(6,)`` with ``[phi, theta, psi, x, y, z]`` using the
-                same ZYX Euler-angle and direct-translation convention as
-                :func:`soromox.utils.lie_algebra.se3.exp_SE3`. If omitted, the
-                identity base pose is used in the appropriate dimension. With
-                zero base rotation, the soft robot backbone is aligned with the
-                positive base-frame x-axis.
+            base_pose: Optional base frame pose coordinates. Planar robots
+                expect shape ``(3,)`` with ``[theta, x, y]``. Spatial robots
+                expect shape ``(7,)`` with ``[qw, qx, qy, qz, x, y, z]``.
+                Spatial quaternions are scalar-first Hamilton quaternions,
+                normalized before use, and must have nonzero finite norm. If
+                omitted, the zero-rotation base pose is used in the appropriate
+                dimension. With zero base rotation, the soft robot backbone is
+                aligned with the positive base-frame x-axis.
             **kwargs: Additional keyword arguments (unused, kept for API compatibility).
         """
         # Note: We don't call super().__init__() here because Equinox modules
         # work like dataclasses - fields are set directly rather than through
         # parent __init__ calls. Child classes must set num_dofs and num_actuators.
         if base_pose is None:
-            base_pose = jnp.zeros(3 if self.is_planar else 6, dtype=jnp.float64)
+            if self.is_planar:
+                base_pose = jnp.zeros(3, dtype=jnp.float64)
+            else:
+                base_pose = jnp.array(
+                    [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=jnp.float64
+                )
+        if self.is_planar:
+            validate_planar_base_pose("base_pose", base_pose)
+        else:
+            validate_quaternion_base_pose("base_pose", base_pose, (7,))
         self.base_pose = jnp.asarray(base_pose, dtype=jnp.float64)
         self.num_gauss_points = None
         self.num_integration_points = None
@@ -149,12 +162,14 @@ class SoftRobot(DynamicalSystem):
     def base_transform(self) -> Array:
         """Return the homogeneous transform represented by ``base_pose``.
 
-        Planar robots return an SE(2) matrix with shape ``(3, 3)``. Spatial
-        robots return an SE(3) matrix with shape ``(4, 4)``.
+        Planar robots consume ``[theta, x, y]`` and return an SE(2) matrix with
+        shape ``(3, 3)``. Spatial robots consume
+        ``[qw, qx, qy, qz, x, y, z]`` and return an SE(3) matrix with shape
+        ``(4, 4)``. Spatial quaternions are scalar-first Hamilton quaternions.
         """
         if self.is_planar:
-            return lie.exp_SE2(jnp.asarray(self.base_pose))
-        return lie.exp_SE3(jnp.asarray(self.base_pose))
+            return lie.transform_from_planar_pose_SE2(jnp.asarray(self.base_pose))
+        return lie.transform_from_quaternion_pose_SE3(jnp.asarray(self.base_pose))
 
     @abstractmethod
     def cross_section_geometry(self, q: Array, s: Array) -> tuple[Array, Array]:
@@ -635,7 +650,7 @@ class SoftRobot(DynamicalSystem):
         """Convert the public pose representation to a homogeneous matrix."""
         if self.is_planar:
             if pose.ndim == 1 and pose.shape[0] == 3:
-                return lie.exp_SE2(pose)
+                return lie.transform_from_planar_pose_SE2(pose)
             if pose.shape == (3, 3):
                 return pose
             raise ValueError(

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -43,6 +43,16 @@ class SoftRobot(DynamicalSystem):
         num_dofs (int): Number of degrees of freedom (configuration variables).
         num_actuators (int): Number of actuators.
         global_eps (float): Global epsilon for numerical computations.
+        base_pose (Array): Base frame pose coordinates for the robot. Planar
+            robots use shape ``(3,)`` with SE(2) coordinates
+            ``[theta, x, y]``, where ``theta`` is the base-frame angle in
+            radians and ``x, y`` are the base-frame translation. Spatial robots
+            use shape ``(6,)`` with SE(3) coordinates
+            ``[phi, theta, psi, x, y, z]``; the rotational entries follow the
+            ZYX Euler convention used by :func:`soromox.utils.lie_algebra.se3.exp_SE3`,
+            and ``x, y, z`` are inserted directly as the base translation. In the
+            standard zero-rotation base pose, the soft robot backbone is aligned
+            with the positive base-frame x-axis.
         num_gauss_points (int | Array | None): Requested nonzero
             Gauss-Legendre quadrature point count. May be scalar for systems
             with a uniform grid or an array for systems with per-segment grids.
@@ -57,6 +67,7 @@ class SoftRobot(DynamicalSystem):
 
     # global epsilon for numerical computations
     global_eps: float  # Global epsilon for numerical computations
+    base_pose: Array
     num_gauss_points: int | Array | None
     num_integration_points: int | Array | None
     integration_points: Array | None
@@ -71,17 +82,33 @@ class SoftRobot(DynamicalSystem):
         """
         return jnp.sqrt(self.global_eps)
 
-    def __init__(self, eps: float | None = None, **kwargs: Any):
+    def __init__(
+        self,
+        eps: float | None = None,
+        base_pose: Array | None = None,
+        **kwargs: Any,
+    ):
         """Initialize the SoftRobot.
 
         Args:
             eps (float): Optional global epsilon value for numerical computations.
                 If not provided, defaults to 10x machine epsilon for float64.
+            base_pose: Optional base frame pose coordinates. Planar robots expect
+                shape ``(3,)`` with ``[theta, x, y]``. Spatial robots expect
+                shape ``(6,)`` with ``[phi, theta, psi, x, y, z]`` using the
+                same ZYX Euler-angle and direct-translation convention as
+                :func:`soromox.utils.lie_algebra.se3.exp_SE3`. If omitted, the
+                identity base pose is used in the appropriate dimension. With
+                zero base rotation, the soft robot backbone is aligned with the
+                positive base-frame x-axis.
             **kwargs: Additional keyword arguments (unused, kept for API compatibility).
         """
         # Note: We don't call super().__init__() here because Equinox modules
         # work like dataclasses - fields are set directly rather than through
         # parent __init__ calls. Child classes must set num_dofs and num_actuators.
+        if base_pose is None:
+            base_pose = jnp.zeros(3 if self.is_planar else 6, dtype=jnp.float64)
+        self.base_pose = jnp.asarray(base_pose, dtype=jnp.float64)
         self.num_gauss_points = None
         self.num_integration_points = None
         self.integration_points = None
@@ -117,6 +144,17 @@ class SoftRobot(DynamicalSystem):
     def is_planar(self) -> bool:
         """Return True for planar (SE(2)) robots, False for spatial (SE(3))."""
         ...
+
+    @property
+    def base_transform(self) -> Array:
+        """Return the homogeneous transform represented by ``base_pose``.
+
+        Planar robots return an SE(2) matrix with shape ``(3, 3)``. Spatial
+        robots return an SE(3) matrix with shape ``(4, 4)``.
+        """
+        if self.is_planar:
+            return lie.exp_SE2(jnp.asarray(self.base_pose))
+        return lie.exp_SE3(jnp.asarray(self.base_pose))
 
     @abstractmethod
     def cross_section_geometry(self, q: Array, s: Array) -> tuple[Array, Array]:

--- a/src/soromox/utils/lie_algebra/se2.py
+++ b/src/soromox/utils/lie_algebra/se2.py
@@ -1,7 +1,7 @@
 __all__ = [
     "tilde_SE2",
     "hat_SE2",
-    "exp_SE2",
+    "transform_from_planar_pose_SE2",
     "log_SE2",
     "exp_gn_SE2",
     "adjoint_se2",
@@ -61,32 +61,30 @@ def hat_SE2(vec3: Array) -> Array:
     return hat
 
 
-def exp_SE2(vec3: Array) -> Array:
-    """
-    Construct an SE(2) homogeneous transform from raw pose coordinates.
+def transform_from_planar_pose_SE2(pose: Array) -> Array:
+    """Construct an SE(2) homogeneous transform from planar pose coordinates.
 
-    This helper keeps the historical ``exp_SE2`` name, but it is not the
-    matrix exponential of ``hat_SE2(vec3)`` for a general twist. The
-    translational entries are inserted directly into the homogeneous transform:
-    ``vec3 = [theta, x, y]`` maps to ``[[R(theta), [x, y]], [0, 0, 1]]``.
-
-    Use :func:`exp_gn_SE2` when ``vec3`` represents a Lie-algebra twist whose
-    translational component must be integrated by the SE(2) exponential.
+    This helper is not the matrix exponential of ``hat_SE2(pose)``. It treats
+    the input as direct pose coordinates, so the translational entries are
+    inserted directly into the homogeneous transform:
+    ``pose = [theta, x, y]`` maps to
+    ``[[R(theta), [x, y]], [0, 0, 1]]``. Use :func:`exp_gn_SE2` when the input
+    represents a Lie-algebra twist whose translational component must be
+    integrated by the SE(2) exponential.
 
     Args:
-        vec3 (Array): shape (3,) or (3, 1)
-            Pose coordinates ``[theta, x, y]`` where ``theta`` is the planar
-            rotation angle and ``(x, y)`` is the raw translation vector.
+        pose: Planar pose with shape ``(3,)`` in ``[theta, x, y]`` order.
+            ``theta`` is a right-handed rotation angle in radians about the
+            out-of-plane z-axis. ``x`` and ``y`` are direct translation
+            coordinates in the parent frame.
 
     Returns:
-        g: shape (3, 3)
-            Homogeneous pose with rotation ``R(theta)`` and translation
-            ``[x, y]``.
+        Array: Homogeneous SE(2) transform with shape ``(3, 3)``.
     """
-    vec3 = vec3.reshape(-1)  # Ensure vec3 is a 1D array
+    pose = jnp.asarray(pose).reshape(-1)
 
-    theta = vec3[0]
-    p = vec3[1:].reshape((2, 1))
+    theta = pose[0]
+    p = pose[1:3].reshape((2, 1))
 
     cos = jnp.cos(theta)
     sin = jnp.sin(theta)

--- a/src/soromox/utils/lie_algebra/se3.py
+++ b/src/soromox/utils/lie_algebra/se3.py
@@ -1,7 +1,7 @@
 __all__ = [
     "tilde_SE3",
     "hat_SE3",
-    "exp_SE3",
+    "transform_from_quaternion_pose_SE3",
     "log_SE3",
     "exp_gn_SE3",
     "adjoint_se3",
@@ -16,6 +16,8 @@ __all__ = [
 
 import jax.numpy as jnp
 from jax import Array, lax
+
+from soromox.utils.rotations import quaternion_to_rotation_matrix
 
 
 def _rotational_strain_magnitude(xi: Array, eps: float | Array) -> Array:
@@ -96,46 +98,30 @@ def hat_SE3(vec6: Array) -> Array:
     return hat
 
 
-def exp_SE3(vec6: Array) -> Array:
+def transform_from_quaternion_pose_SE3(pose: Array) -> Array:
     """
-    Construct an SE(3) homogeneous transform from raw pose coordinates.
+    Construct an SE(3) homogeneous transform from quaternion pose coordinates.
 
-    This helper keeps the historical ``exp_SE3`` name, but it is not the
-    matrix exponential of ``hat_SE3(vec6)`` for a general twist. The rotational
-    coordinates are interpreted as ZYX Euler angles and the translational
-    entries are inserted directly into the homogeneous transform:
-    ``vec6 = [phi, theta, psi, x, y, z]`` maps to
-    ``[[R_zyx(phi, theta, psi), [x, y, z]], [0, 0, 0, 1]]``.
-
-    Use :func:`exp_gn_SE3` when ``vec6`` represents a Lie-algebra twist whose
+    This helper is not the matrix exponential of ``hat_SE3(pose)``. The
+    translational entries are inserted directly into the homogeneous transform:
+    ``pose = [qw, qx, qy, qz, x, y, z]`` maps to
+    ``[[R(q), [x, y, z]], [0, 0, 0, 1]]``. Use :func:`exp_gn_SE3` when the input
+    represents a Lie-algebra twist whose
     translational component must be integrated by the SE(3) exponential.
 
     Args:
-        vec6 (Array): shape (6,) or (6, 1)
-            Pose coordinates ``[phi, theta, psi, x, y, z]`` with ZYX Euler
-            convention for the rotation part and raw translation ``(x, y, z)``.
+        pose: Pose coordinates with shape ``(7,)`` in
+            ``[qw, qx, qy, qz, x, y, z]`` order. The quaternion is scalar-first
+            and normalized before constructing the rotation matrix. The
+            translation ``(x, y, z)`` is inserted directly.
 
     Returns:
         g: shape (4, 4)
-            Homogeneous pose with ZYX Euler rotation and translation
-            ``[x, y, z]``.
+            Homogeneous pose with quaternion rotation and translation ``[x, y, z]``.
     """
-    vec6 = vec6.reshape(-1)  # Ensure vec6 is a 1D array
-
-    phi = vec6[0]
-    theta = vec6[1]
-    psi = vec6[2]
-    cosphi, sinphi = jnp.cos(phi), jnp.sin(phi)
-    costheta, sintheta = jnp.cos(theta), jnp.sin(theta)
-    cospsi, sinpsi = jnp.cos(psi), jnp.sin(psi)
-
-    p = vec6[3:].reshape((3, 1))
-
-    Rphi = jnp.array([[cosphi, -sinphi, 0], [sinphi, cosphi, 0], [0, 0, 1]])
-    Rtheta = jnp.array([[1, 0, 0], [0, costheta, -sintheta], [0, sintheta, costheta]])
-    Rpsi = jnp.array([[cospsi, -sinpsi, 0], [sinpsi, cospsi, 0], [0, 0, 1]])
-    # Combine the rotations
-    R = Rpsi @ Rtheta @ Rphi  # Rotation matrix
+    pose = jnp.asarray(pose).reshape(-1)
+    R = quaternion_to_rotation_matrix(pose[:4])
+    p = pose[4:].reshape((3, 1))
 
     g = jnp.block([[R, p], [jnp.zeros((1, 3)), jnp.ones((1, 1))]])
 

--- a/src/soromox/utils/rotations.py
+++ b/src/soromox/utils/rotations.py
@@ -93,27 +93,37 @@ class RotationRepresentation(Enum):
 DEFAULT_ROTATION_EPS = 1e-10
 
 
-def normalize_quaternion(quaternion: Array) -> Array:
+def normalize_quaternion(
+    quaternion: Array,
+    eps: float | Array | None = None,
+) -> Array:
     """Normalize a scalar-first Hamilton quaternion.
 
     Args:
         quaternion: Quaternion with shape ``(4,)`` in ``[qw, qx, qy, qz]``
             order. ``qw`` is the scalar component and ``[qx, qy, qz]`` is the
             vector component.
+        eps: Optional nonnegative norm threshold. If the quaternion norm is
+            less than or equal to ``eps``, the identity quaternion is returned.
+            Defaults to machine epsilon for the quaternion dtype.
 
     Returns:
         Array: Unit quaternion with shape ``(4,)`` in ``[qw, qx, qy, qz]``
-        order. If the input norm is numerically zero, the identity quaternion
-        ``[1, 0, 0, 0]`` is returned to avoid division-by-zero NaNs in traced
-        computations. Parameter validators reject zero-norm configured poses.
+        order. If the input norm is numerically smaller than ``eps``, the
+        identity quaternion ``[1, 0, 0, 0]`` is returned to avoid
+        division-by-zero NaNs in traced computations. Parameter validators
+        reject zero-norm configured poses.
     """
     dtype = jnp.result_type(quaternion, 1.0)
     q = jnp.asarray(quaternion, dtype=dtype).reshape(-1)
     norm = jnp.linalg.norm(q)
-    eps = jnp.asarray(jnp.finfo(q.dtype).eps, dtype=q.dtype)
+    if eps is None:
+        eps_arr = jnp.asarray(jnp.finfo(q.dtype).eps, dtype=q.dtype)
+    else:
+        eps_arr = jnp.asarray(eps, dtype=q.dtype)
     identity = jnp.array([1.0, 0.0, 0.0, 0.0], dtype=q.dtype)
-    safe_norm = jnp.where(norm > eps, norm, jnp.ones((), dtype=q.dtype))
-    return jnp.where(norm > eps, q / safe_norm, identity)
+    safe_norm = jnp.where(norm > eps_arr, norm, jnp.ones((), dtype=q.dtype))
+    return jnp.where(norm > eps_arr, q / safe_norm, identity)
 
 
 def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -> Array:
@@ -191,7 +201,7 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
     # Ensure canonical form with positive scalar part (qw >= 0)
     quat = jnp.where(quat[0] < 0, -quat, quat)
 
-    quat = normalize_quaternion(quat)
+    quat = normalize_quaternion(quat, eps=eps)
 
     return quat
 
@@ -273,7 +283,7 @@ def quaternion_to_rotation_vector(
         >>> omega = quaternion_to_rotation_vector(q)
         >>> # omega ≈ [0, 0, π/2]
     """
-    quat = normalize_quaternion(quat)
+    quat = normalize_quaternion(quat, eps=eps)
     q_w = quat[0]
     q_vec = quat[1:4]
 
@@ -341,7 +351,7 @@ def rotation_vector_to_quaternion(
 
     quat = jnp.array([q_w, q_vec[0], q_vec[1], q_vec[2]])
 
-    return normalize_quaternion(quat)
+    return normalize_quaternion(quat, eps=eps)
 
 
 def rotation_matrix_to_rotation_vector(

--- a/src/soromox/utils/rotations.py
+++ b/src/soromox/utils/rotations.py
@@ -9,10 +9,10 @@ rotations (θ ≈ π) correctly.
 All functions are JAX-compatible and can be used with jit, vmap, and grad.
 
 Quaternion Convention:
-    This module uses the [x, y, z, w] convention for quaternions, where w is
-    the scalar part and [x, y, z] is the vector part. The quaternion represents
-    a rotation by angle θ around unit axis n as:
-        q = [sin(θ/2) * n_x, sin(θ/2) * n_y, sin(θ/2) * n_z, cos(θ/2)]
+    This module uses scalar-first Hamilton quaternions in ``[qw, qx, qy, qz]``
+    order, where ``qw`` is the scalar part and ``[qx, qy, qz]`` is the vector
+    part. A rotation by angle θ around unit axis n is represented as:
+        q = [cos(θ/2), sin(θ/2) * n_x, sin(θ/2) * n_y, sin(θ/2) * n_z]
 
 Rotation Representations:
     This module supports multiple rotation representations via the RotationRepresentation
@@ -39,6 +39,7 @@ __all__ = [
     # Enum
     "RotationRepresentation",
     # Conversion functions
+    "normalize_quaternion",
     "rotation_matrix_to_quaternion",
     "quaternion_to_rotation_matrix",
     "quaternion_to_rotation_vector",
@@ -92,6 +93,29 @@ class RotationRepresentation(Enum):
 DEFAULT_ROTATION_EPS = 1e-10
 
 
+def normalize_quaternion(quaternion: Array) -> Array:
+    """Normalize a scalar-first Hamilton quaternion.
+
+    Args:
+        quaternion: Quaternion with shape ``(4,)`` in ``[qw, qx, qy, qz]``
+            order. ``qw`` is the scalar component and ``[qx, qy, qz]`` is the
+            vector component.
+
+    Returns:
+        Array: Unit quaternion with shape ``(4,)`` in ``[qw, qx, qy, qz]``
+        order. If the input norm is numerically zero, the identity quaternion
+        ``[1, 0, 0, 0]`` is returned to avoid division-by-zero NaNs in traced
+        computations. Parameter validators reject zero-norm configured poses.
+    """
+    dtype = jnp.result_type(quaternion, 1.0)
+    q = jnp.asarray(quaternion, dtype=dtype).reshape(-1)
+    norm = jnp.linalg.norm(q)
+    eps = jnp.asarray(jnp.finfo(q.dtype).eps, dtype=q.dtype)
+    identity = jnp.array([1.0, 0.0, 0.0, 0.0], dtype=q.dtype)
+    safe_norm = jnp.where(norm > eps, norm, jnp.ones((), dtype=q.dtype))
+    return jnp.where(norm > eps, q / safe_norm, identity)
+
+
 def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -> Array:
     """
     Convert a rotation matrix to a unit quaternion.
@@ -104,14 +128,15 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
         eps: Small value to avoid division by zero. Default is 1e-10.
 
     Returns:
-        q: Unit quaternion [x, y, z, w] of shape (4,).
+        q: Unit quaternion with shape ``(4,)`` in scalar-first
+            ``[qw, qx, qy, qz]`` order.
 
     Example:
         >>> import jax.numpy as jnp
         >>> from soromox.utils.rotations import rotation_matrix_to_quaternion
         >>> R = jnp.eye(3)  # Identity rotation
         >>> q = rotation_matrix_to_quaternion(R)
-        >>> # q ≈ [0, 0, 0, 1] (identity quaternion)
+        >>> # q ≈ [1, 0, 0, 0] (identity quaternion)
 
     References:
         Shepperd, S. W. (1978). Quaternion from rotation matrix.
@@ -126,7 +151,7 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
     q_x1 = (R[2, 1] - R[1, 2]) / jnp.maximum(s1, eps)
     q_y1 = (R[0, 2] - R[2, 0]) / jnp.maximum(s1, eps)
     q_z1 = (R[1, 0] - R[0, 1]) / jnp.maximum(s1, eps)
-    quat1 = jnp.array([q_x1, q_y1, q_z1, q_w1])
+    quat1 = jnp.array([q_w1, q_x1, q_y1, q_z1])
 
     # Case 2: R[0,0] is largest diagonal (best for rotations around x-axis)
     s2 = jnp.sqrt(jnp.maximum(1.0 + R[0, 0] - R[1, 1] - R[2, 2], 0.0)) * 2
@@ -134,7 +159,7 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
     q_x2 = 0.25 * s2
     q_y2 = (R[0, 1] + R[1, 0]) / jnp.maximum(s2, eps)
     q_z2 = (R[0, 2] + R[2, 0]) / jnp.maximum(s2, eps)
-    quat2 = jnp.array([q_x2, q_y2, q_z2, q_w2])
+    quat2 = jnp.array([q_w2, q_x2, q_y2, q_z2])
 
     # Case 3: R[1,1] is largest diagonal (best for rotations around y-axis)
     s3 = jnp.sqrt(jnp.maximum(1.0 + R[1, 1] - R[0, 0] - R[2, 2], 0.0)) * 2
@@ -142,7 +167,7 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
     q_x3 = (R[0, 1] + R[1, 0]) / jnp.maximum(s3, eps)
     q_y3 = 0.25 * s3
     q_z3 = (R[1, 2] + R[2, 1]) / jnp.maximum(s3, eps)
-    quat3 = jnp.array([q_x3, q_y3, q_z3, q_w3])
+    quat3 = jnp.array([q_w3, q_x3, q_y3, q_z3])
 
     # Case 4: R[2,2] is largest diagonal (best for rotations around z-axis)
     s4 = jnp.sqrt(jnp.maximum(1.0 + R[2, 2] - R[0, 0] - R[1, 1], 0.0)) * 2
@@ -150,7 +175,7 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
     q_x4 = (R[0, 2] + R[2, 0]) / jnp.maximum(s4, eps)
     q_y4 = (R[1, 2] + R[2, 1]) / jnp.maximum(s4, eps)
     q_z4 = 0.25 * s4
-    quat4 = jnp.array([q_x4, q_y4, q_z4, q_w4])
+    quat4 = jnp.array([q_w4, q_x4, q_y4, q_z4])
 
     # Select the most numerically stable case based on largest component
     quat = jnp.where(
@@ -163,11 +188,10 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
         ),
     )
 
-    # Ensure canonical form with positive scalar part (w >= 0)
-    quat = jnp.where(quat[3] < 0, -quat, quat)
+    # Ensure canonical form with positive scalar part (qw >= 0)
+    quat = jnp.where(quat[0] < 0, -quat, quat)
 
-    # Normalize to unit quaternion
-    quat = quat / jnp.linalg.norm(quat)
+    quat = normalize_quaternion(quat)
 
     return quat
 
@@ -177,7 +201,9 @@ def quaternion_to_rotation_matrix(quat: Array) -> Array:
     Convert a unit quaternion to a rotation matrix.
 
     Args:
-        quat: Unit quaternion [x, y, z, w] of shape (4,).
+        quat: Quaternion with shape ``(4,)`` in scalar-first Hamilton
+            ``[qw, qx, qy, qz]`` order. The quaternion is normalized before
+            constructing the matrix.
 
     Returns:
         R: Rotation matrix of shape (3, 3).
@@ -185,15 +211,17 @@ def quaternion_to_rotation_matrix(quat: Array) -> Array:
     Example:
         >>> import jax.numpy as jnp
         >>> from soromox.utils.rotations import quaternion_to_rotation_matrix
-        >>> q = jnp.array([0.0, 0.0, 0.0, 1.0])  # Identity quaternion
+        >>> q = jnp.array([1.0, 0.0, 0.0, 0.0])  # Identity quaternion
         >>> R = quaternion_to_rotation_matrix(q)
         >>> # R ≈ eye(3) (identity rotation matrix)
 
     Note:
-        The quaternion should be normalized. If not, the output rotation
-        matrix may not be orthonormal.
+        If the quaternion norm is numerically zero, identity rotation is used
+        to keep traced computations finite. Configured robot base poses are
+        validated separately and reject zero-norm quaternions.
     """
-    x, y, z, w = quat[0], quat[1], quat[2], quat[3]
+    quat = normalize_quaternion(quat)
+    w, x, y, z = quat[0], quat[1], quat[2], quat[3]
 
     # Pre-compute squared terms
     x2, y2, z2, w2 = x * x, y * y, z * z, w * w
@@ -230,7 +258,8 @@ def quaternion_to_rotation_vector(
     unit axis n, the rotation vector is ω = θ * n.
 
     Args:
-        quat: Unit quaternion [x, y, z, w] of shape (4,).
+        quat: Unit quaternion with shape ``(4,)`` in scalar-first Hamilton
+            ``[qw, qx, qy, qz]`` order.
         eps: Small value to avoid division by zero. Default is 1e-10.
 
     Returns:
@@ -240,13 +269,13 @@ def quaternion_to_rotation_vector(
         >>> import jax.numpy as jnp
         >>> from soromox.utils.rotations import quaternion_to_rotation_vector
         >>> # 90-degree rotation around z-axis
-        >>> q = jnp.array([0, 0, jnp.sin(jnp.pi/4), jnp.cos(jnp.pi/4)])
+        >>> q = jnp.array([jnp.cos(jnp.pi/4), 0, 0, jnp.sin(jnp.pi/4)])
         >>> omega = quaternion_to_rotation_vector(q)
         >>> # omega ≈ [0, 0, π/2]
     """
-    # Extract quaternion components: q = [x, y, z, w]
-    q_vec = quat[:3]  # [x, y, z]
-    q_w = quat[3]  # w
+    quat = normalize_quaternion(quat)
+    q_w = quat[0]
+    q_vec = quat[1:4]
 
     # Compute the rotation angle using atan2 for numerical stability
     q_vec_norm = jnp.linalg.norm(q_vec)
@@ -281,7 +310,8 @@ def rotation_vector_to_quaternion(
         eps: Small value for numerical stability at small angles. Default is 1e-10.
 
     Returns:
-        q: Unit quaternion [x, y, z, w] of shape (4,).
+        q: Unit quaternion with shape ``(4,)`` in scalar-first Hamilton
+            ``[qw, qx, qy, qz]`` order.
 
     Example:
         >>> import jax.numpy as jnp
@@ -289,7 +319,7 @@ def rotation_vector_to_quaternion(
         >>> # 90-degree rotation around z-axis
         >>> omega = jnp.array([0.0, 0.0, jnp.pi / 2])
         >>> q = rotation_vector_to_quaternion(omega)
-        >>> # q ≈ [0, 0, sin(π/4), cos(π/4)]
+        >>> # q ≈ [cos(π/4), 0, 0, sin(π/4)]
     """
     angle = jnp.linalg.norm(omega)
     half_angle = angle / 2.0
@@ -309,12 +339,9 @@ def rotation_vector_to_quaternion(
         1.0,  # Small angle approximation: cos(θ/2) ≈ 1
     )
 
-    quat = jnp.array([q_vec[0], q_vec[1], q_vec[2], q_w])
+    quat = jnp.array([q_w, q_vec[0], q_vec[1], q_vec[2]])
 
-    # Normalize to ensure unit quaternion (handles numerical errors)
-    quat = quat / jnp.linalg.norm(quat)
-
-    return quat
+    return normalize_quaternion(quat)
 
 
 def rotation_matrix_to_rotation_vector(
@@ -484,29 +511,32 @@ def quaternion_multiply(q1: Array, q2: Array) -> Array:
     That is, q1 * q2 represents rotating by q2 first, then by q1.
 
     Args:
-        q1: First quaternion [x, y, z, w] of shape (4,).
-        q2: Second quaternion [x, y, z, w] of shape (4,).
+        q1: First quaternion with shape ``(4,)`` in scalar-first Hamilton
+            ``[qw, qx, qy, qz]`` order.
+        q2: Second quaternion with shape ``(4,)`` in scalar-first Hamilton
+            ``[qw, qx, qy, qz]`` order.
 
     Returns:
-        q: Product quaternion [x, y, z, w] of shape (4,).
+        q: Product quaternion with shape ``(4,)`` in ``[qw, qx, qy, qz]``
+            order.
 
     Example:
         >>> import jax.numpy as jnp
         >>> from soromox.utils.rotations import quaternion_multiply
-        >>> q1 = jnp.array([0, 0, 0, 1])  # Identity
-        >>> q2 = jnp.array([0, 0, jnp.sin(jnp.pi/4), jnp.cos(jnp.pi/4)])  # 90° around z
+        >>> q1 = jnp.array([1, 0, 0, 0])  # Identity
+        >>> q2 = jnp.array([jnp.cos(jnp.pi/4), 0, 0, jnp.sin(jnp.pi/4)])  # 90° around z
         >>> q = quaternion_multiply(q1, q2)
         >>> # q ≈ q2
     """
-    x1, y1, z1, w1 = q1[0], q1[1], q1[2], q1[3]
-    x2, y2, z2, w2 = q2[0], q2[1], q2[2], q2[3]
+    w1, x1, y1, z1 = q1[0], q1[1], q1[2], q1[3]
+    w2, x2, y2, z2 = q2[0], q2[1], q2[2], q2[3]
 
     return jnp.array(
         [
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
             w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
             w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
             w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
-            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
         ]
     )
 
@@ -519,19 +549,21 @@ def quaternion_conjugate(q: Array) -> Array:
     the opposite rotation.
 
     Args:
-        q: Quaternion [x, y, z, w] of shape (4,).
+        q: Quaternion with shape ``(4,)`` in scalar-first Hamilton
+            ``[qw, qx, qy, qz]`` order.
 
     Returns:
-        q_conj: Conjugate quaternion [-x, -y, -z, w] of shape (4,).
+        q_conj: Conjugate quaternion with shape ``(4,)`` and coordinates
+            ``[qw, -qx, -qy, -qz]``.
 
     Example:
         >>> import jax.numpy as jnp
         >>> from soromox.utils.rotations import quaternion_conjugate
-        >>> q = jnp.array([0, 0, jnp.sin(jnp.pi/4), jnp.cos(jnp.pi/4)])  # 90° around z
+        >>> q = jnp.array([jnp.cos(jnp.pi/4), 0, 0, jnp.sin(jnp.pi/4)])  # 90° around z
         >>> q_conj = quaternion_conjugate(q)
         >>> # q_conj represents -90° around z
     """
-    return jnp.array([-q[0], -q[1], -q[2], q[3]])
+    return jnp.array([q[0], -q[1], -q[2], -q[3]])
 
 
 # =============================================================================
@@ -657,8 +689,10 @@ def rotation_quat_error(
     to ensure the shortest path is taken.
 
     Args:
-        q_current: Current quaternion [x, y, z, w] of shape (4,).
-        q_desired: Desired quaternion [x, y, z, w] of shape (4,).
+        q_current: Current quaternion with shape ``(4,)`` in scalar-first
+            Hamilton ``[qw, qx, qy, qz]`` order.
+        q_desired: Desired quaternion with shape ``(4,)`` in scalar-first
+            Hamilton ``[qw, qx, qy, qz]`` order.
         eps: Small value for numerical stability. Default is 1e-10.
 
     Returns:
@@ -677,7 +711,7 @@ def rotation_quat_error(
     q_error = quaternion_multiply(q_desired, q_current_inv)
 
     # Ensure shortest path by flipping if scalar part is negative
-    q_error = jnp.where(q_error[3] < 0, -q_error, q_error)
+    q_error = jnp.where(q_error[0] < 0, -q_error, q_error)
 
     # Convert to rotation vector
     return quaternion_to_rotation_vector(q_error, eps=eps)

--- a/src/soromox/utils/twist.py
+++ b/src/soromox/utils/twist.py
@@ -122,14 +122,14 @@ def twist_callable_from_pose_callable_factory(
                     angular_vel = orient_dot
 
                 elif rotation_representation == RotationRepresentation.QUATERNION:
-                    # For quaternion q = [x, y, z, w]:
+                    # For scalar-first quaternion q = [qw, qx, qy, qz]:
                     # ω = 2 * Im(q^{-1} ⊗ dq/dt)
                     # where q^{-1} = q* (conjugate) for unit quaternions
                     q_conj = quaternion_conjugate(orient)
                     # Note: orient_dot is dq/dt, not a unit quaternion
                     omega_quat = 2.0 * quaternion_multiply(q_conj, orient_dot)
                     # Angular velocity is the imaginary (vector) part
-                    angular_vel = omega_quat[:3]
+                    angular_vel = omega_quat[1:4]
 
                 elif (
                     rotation_representation == RotationRepresentation.ROTATION_MATRIX_6D

--- a/tests/lie_algebra/test_lie_algebra_se2.py
+++ b/tests/lie_algebra/test_lie_algebra_se2.py
@@ -13,11 +13,11 @@ from soromox.utils.lie_algebra.se2 import (
     Tangent_gi_se2,
     adjoint_se2,
     coadjoint_se2,
-    exp_SE2,
     hat_SE2,
     exp_gn_SE2,
     log_SE2,
     tilde_SE2,
+    transform_from_planar_pose_SE2,
 )
 from soromox.utils.tolerance import Tolerance
 
@@ -40,19 +40,19 @@ def test_tilde_se2_returns_skew_matrix():
     assert_allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-def test_log_se2_inverts_exp_se2():
+def test_log_se2_inverts_planar_pose_transform_se2():
     vec = jnp.array([0.4, -0.7, 1.2])
 
-    g = exp_SE2(vec)
+    g = transform_from_planar_pose_SE2(vec)
     recovered = log_SE2(g, eps=EPS)
 
     assert_allclose(recovered, vec, rtol=RTOL, atol=ATOL)
 
 
-def test_log_se2_inverts_exp_se2_zero_angle():
+def test_log_se2_inverts_planar_pose_transform_se2_zero_angle():
     vec = jnp.array([0.0, 0.3, -0.2])
 
-    g = exp_SE2(vec)
+    g = transform_from_planar_pose_SE2(vec)
     recovered = log_SE2(g, eps=EPS)
 
     assert_allclose(recovered, vec, rtol=RTOL, atol=ATOL)
@@ -94,7 +94,7 @@ def test_log_se2_pure_rotation():
 
 def test_log_se2_handles_near_identity_transform():
     vec = jnp.array([1e-10, 2e-4, -3e-4])
-    g = exp_SE2(vec)
+    g = transform_from_planar_pose_SE2(vec)
 
     recovered = log_SE2(g, eps=EPS)
 
@@ -108,7 +108,7 @@ def test_log_se2_round_trip_random_vectors():
     for _ in range(5):
         key, subkey = jax.random.split(key)
         vec = jax.random.uniform(subkey, shape=(3,), minval=-0.9, maxval=0.9)
-        g = exp_SE2(vec)
+        g = transform_from_planar_pose_SE2(vec)
         recovered = log_SE2(g, eps=EPS)
 
         assert_allclose(recovered, vec, rtol=RTOL, atol=ATOL)
@@ -143,7 +143,7 @@ def test_hat_se2_returns_expected_matrix():
     assert_allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-def test_exp_se2_produces_rotation_and_translation():
+def test_transform_from_planar_pose_se2_produces_rotation_and_translation():
     vec = jnp.array([jnp.pi / 2.0, 1.0, -2.0])
     expected = jnp.array(
         [
@@ -153,7 +153,7 @@ def test_exp_se2_produces_rotation_and_translation():
         ]
     )
 
-    result = exp_SE2(vec)
+    result = transform_from_planar_pose_SE2(vec)
 
     assert_allclose(result, expected, rtol=RTOL, atol=ATOL)
 
@@ -194,7 +194,7 @@ def test_coadjoint_se2_matches_closed_form():
 
 def test_adjoint_g_se2_matches_manual_construction():
     vec = jnp.array([jnp.pi / 3.0, 0.5, -0.2])
-    g = exp_SE2(vec)
+    g = transform_from_planar_pose_SE2(vec)
     R = g[:2, :2]
     t = g[:2, 2].reshape((2, 1))
     expected = jnp.concatenate(
@@ -212,7 +212,7 @@ def test_adjoint_g_se2_matches_manual_construction():
 
 def test_adjoint_g_inv_se2_is_matrix_inverse():
     vec = jnp.array([jnp.pi / 4.0, 0.2, -0.7])
-    g = exp_SE2(vec)
+    g = transform_from_planar_pose_SE2(vec)
 
     adj = Adjoint_g_SE2(g)
     adj_inv = Adjoint_g_inv_SE2(g)

--- a/tests/lie_algebra/test_lie_algebra_se3.py
+++ b/tests/lie_algebra/test_lie_algebra_se3.py
@@ -4,7 +4,12 @@ from jax.scipy.linalg import expm
 from numpy.testing import assert_allclose
 import pytest
 
-from soromox.utils.lie_algebra.se2 import adjoint_se2, exp_SE2, tilde_SE2
+from soromox.utils.lie_algebra.se2 import (
+    adjoint_se2,
+    exp_gn_SE2,
+    tilde_SE2,
+    transform_from_planar_pose_SE2,
+)
 from soromox.utils.lie_algebra.se3 import (
     Adjoint_g_SE3,
     Adjoint_g_inv_SE3,
@@ -14,11 +19,11 @@ from soromox.utils.lie_algebra.se3 import (
     Tangent_gi_se3,
     adjoint_se3,
     coadjoint_se3,
-    exp_SE3,
     exp_gn_SE3,
     hat_SE3,
     log_SE3,
     tilde_SE3,
+    transform_from_quaternion_pose_SE3,
 )
 from soromox.utils.tolerance import Tolerance
 
@@ -41,6 +46,15 @@ def _embed_se2_transform(mat3):
     g = g.at[:2, :2].set(mat3[:2, :2])
     g = g.at[:2, 3].set(mat3[:2, 2])
     return g
+
+
+def _quaternion_z(theta):
+    half = 0.5 * theta
+    return jnp.array([jnp.cos(half), 0.0, 0.0, jnp.sin(half)])
+
+
+def _transform_from_planar_pose(vec2):
+    return transform_from_planar_pose_SE2(vec2)
 
 
 def test_tilde_se3_matches_z_axis_rotation():
@@ -70,21 +84,44 @@ def test_hat_se3_embeds_planar_hat():
     assert_allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-def test_exp_se3_matches_planar_embedding():
+def test_exp_gn_se3_matches_planar_embedding():
     vec2 = jnp.array([jnp.pi / 4.0, 0.3, -0.5])
     vec6 = _embed_se2_twist(vec2)
 
-    g_se3 = exp_SE3(vec6)
-    g_expected = _embed_se2_transform(exp_SE2(vec2))
+    g_se3 = exp_gn_SE3(vec6, EPS)
+    g_expected = _embed_se2_transform(exp_gn_SE2(vec2, EPS))
 
     assert_allclose(g_se3, g_expected, rtol=RTOL, atol=ATOL)
+
+
+def test_transform_from_quaternion_pose_se3_matches_planar_embedding():
+    theta = jnp.pi / 4.0
+    translation = jnp.array([0.3, -0.5, 0.2])
+    pose = jnp.concatenate([_quaternion_z(theta), translation])
+
+    result = transform_from_quaternion_pose_SE3(pose)
+    expected = _embed_se2_transform(
+        _transform_from_planar_pose(jnp.array([theta, translation[0], translation[1]]))
+    ).at[2, 3].set(translation[2])
+
+    assert_allclose(result, expected, rtol=RTOL, atol=ATOL)
+
+
+def test_transform_from_quaternion_pose_se3_zero_quaternion_is_finite_identity():
+    pose = jnp.array([0.0, 0.0, 0.0, 0.0, 1.0, -2.0, 3.0])
+
+    result = transform_from_quaternion_pose_SE3(pose)
+
+    expected = jnp.eye(4).at[:3, 3].set(jnp.array([1.0, -2.0, 3.0]))
+    assert jnp.isfinite(result).all()
+    assert_allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
 def test_log_se3_recovers_planar_rotation_without_translation():
     vec2 = jnp.array([0.6, 0.0, 0.0])
     vec6 = _embed_se2_twist(vec2)
 
-    g = exp_SE3(vec6)
+    g = exp_gn_SE3(vec6, EPS)
     recovered = log_SE3(g, eps=EPS)
 
     assert_allclose(recovered, vec6, rtol=RTOL, atol=ATOL)
@@ -121,7 +158,7 @@ def test_log_se3_pure_rotation_about_x_axis():
 
 def test_log_se3_handles_near_identity_transform():
     vec = jnp.array([1e-9, -2e-9, 3e-9, 5e-4, -4e-4, 3e-4])
-    g = exp_SE3(vec)
+    g = exp_gn_SE3(vec, EPS)
 
     recovered = log_SE3(g, eps=EPS)
 
@@ -131,7 +168,7 @@ def test_log_se3_handles_near_identity_transform():
 
 def test_log_se3_handles_identity_transform():
     vec = jnp.array([0.0, 0.0, 0.0, 0.2, 0.0, 0.0])
-    g = exp_SE3(vec)
+    g = exp_gn_SE3(vec, EPS)
 
     recovered = log_SE3(g, eps=EPS)
 
@@ -196,7 +233,7 @@ def test_coadjoint_se3_matches_block_structure():
 
 def test_adjoint_g_se3_matches_planar_embedding():
     vec2 = jnp.array([jnp.pi / 6.0, 0.4, -0.7])
-    g2 = exp_SE2(vec2)
+    g2 = _transform_from_planar_pose(vec2)
     g3 = _embed_se2_transform(g2)
 
     result = Adjoint_g_SE3(g3)
@@ -210,7 +247,7 @@ def test_adjoint_g_se3_matches_planar_embedding():
 
 def test_adjoint_g_inv_se3_is_inverse():
     vec2 = jnp.array([jnp.pi / 5.0, -0.2, 0.6])
-    g3 = _embed_se2_transform(exp_SE2(vec2))
+    g3 = _embed_se2_transform(_transform_from_planar_pose(vec2))
 
     adj = Adjoint_g_SE3(g3)
     adj_inv = Adjoint_g_inv_SE3(g3)

--- a/tests/rendering/test_base_renderer.py
+++ b/tests/rendering/test_base_renderer.py
@@ -1,5 +1,6 @@
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
 from soromox.rendering.base import BaseSoftRobotRenderer
@@ -67,6 +68,33 @@ def test_renderer_normalizes_base_offsets_to_curve_dimension():
 
     assert offsets.shape == (2, 3)
     assert_allclose(offsets, jnp.array([[0.1, -0.2, 0.0], [0.3, 0.4, 0.0]]))
+
+
+def test_renderer_can_slice_configured_base_offsets_to_batch_size():
+    robot = DummyPlanarRobot(jnp.array([0.0, 0.0, 0.0]))
+    renderer = DummyRenderer(robot)
+
+    offsets = renderer._normalize_base_offsets(
+        jnp.array([[0.1, -0.2], [0.3, 0.4], [0.5, 0.6]]),
+        num_robots=2,
+        target_dim=2,
+        allow_extra_rows=True,
+    )
+
+    assert offsets.shape == (2, 2)
+    assert_allclose(offsets, jnp.array([[0.1, -0.2], [0.3, 0.4]]))
+
+
+def test_renderer_rejects_extra_explicit_base_offsets_by_default():
+    robot = DummyPlanarRobot(jnp.array([0.0, 0.0, 0.0]))
+    renderer = DummyRenderer(robot)
+
+    with pytest.raises(ValueError, match="number of robots"):
+        renderer._normalize_base_offsets(
+            jnp.array([[0.1, -0.2], [0.3, 0.4]]),
+            num_robots=1,
+            target_dim=2,
+        )
 
 
 def test_matplotlib_2d_base_marker_is_perpendicular_to_base_tangent():

--- a/tests/rendering/test_base_renderer.py
+++ b/tests/rendering/test_base_renderer.py
@@ -3,6 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from soromox.rendering.base import BaseSoftRobotRenderer
+from soromox.rendering.matplotlib_renderer import MatplotlibRenderer
 from soromox.rendering.opencv_planar_renderer import OpenCVPlanarRenderer
 from soromox.systems.soft_robot import CrossSectionGeometry
 from soromox.utils import lie_algebra as lie
@@ -50,7 +51,7 @@ def test_renderer_exposes_base_pose_transform_and_axis():
     assert_allclose(renderer.base_transform, robot.base_transform)
     assert_allclose(renderer._base_position(dim=3), np.array([1.0, 2.0, 0.0]))
     assert_allclose(
-        renderer._base_tangent_axis(dim=3), np.array([0.0, 1.0, 0.0]), atol=1e-12
+        renderer._base_tangent_axis(dim=3), np.array([0.0, 1.0, 0.0]), atol=1e-7
     )
 
 
@@ -66,6 +67,34 @@ def test_renderer_normalizes_base_offsets_to_curve_dimension():
 
     assert offsets.shape == (2, 3)
     assert_allclose(offsets, jnp.array([[0.1, -0.2, 0.0], [0.3, 0.4, 0.0]]))
+
+
+def test_matplotlib_2d_base_marker_is_perpendicular_to_base_tangent():
+    base = np.array([1.0, 2.0])
+    tangent = np.array([0.0, 1.0])
+
+    marker = MatplotlibRenderer._base_plate_marker_points(
+        base, tangent, marker_diameter=0.4, dim=2
+    )
+
+    assert marker.shape == (2, 2)
+    assert_allclose(marker.mean(axis=0), base)
+    assert_allclose(marker[1] - marker[0], np.array([-0.4, 0.0]))
+    assert_allclose(np.dot(marker[1] - marker[0], tangent), 0.0, atol=1e-12)
+
+
+def test_matplotlib_3d_base_marker_lies_in_plate_face_plane():
+    base = np.array([1.0, 2.0, 3.0])
+    normal = np.array([1.0, 0.0, 0.0])
+
+    marker = MatplotlibRenderer._base_plate_marker_points(
+        base, normal, marker_diameter=0.4, dim=3
+    )
+
+    assert marker.shape == (65, 3)
+    assert_allclose(marker[0], marker[-1], atol=1e-12)
+    assert_allclose((marker - base) @ normal, np.zeros(marker.shape[0]), atol=1e-12)
+    assert_allclose(np.linalg.norm(marker - base, axis=1), 0.2, atol=1e-12)
 
 
 def test_opencv_planar_base_marker_uses_base_pose_and_offset():

--- a/tests/rendering/test_base_renderer.py
+++ b/tests/rendering/test_base_renderer.py
@@ -1,0 +1,88 @@
+import jax.numpy as jnp
+import numpy as np
+from numpy.testing import assert_allclose
+
+from soromox.rendering.base import BaseSoftRobotRenderer
+from soromox.rendering.opencv_planar_renderer import OpenCVPlanarRenderer
+from soromox.systems.soft_robot import CrossSectionGeometry
+from soromox.utils import lie_algebra as lie
+
+
+class DummyPlanarRobot:
+    is_planar = True
+    length = jnp.array(1.0)
+    segment_length = jnp.array([1.0])
+
+    def __init__(self, base_pose: jnp.ndarray):
+        self.base_pose = jnp.asarray(base_pose)
+        self.base_transform = lie.transform_from_planar_pose_SE2(self.base_pose)
+
+    def forward_kinematics_batched(self, q, s_ps):
+        theta = self.base_pose[0]
+        direction = jnp.array([jnp.cos(theta), jnp.sin(theta)])
+        xy = self.base_pose[1:3] + s_ps[:, None] * direction
+        theta_ps = jnp.full((s_ps.shape[0], 1), theta, dtype=s_ps.dtype)
+        return jnp.concatenate([theta_ps, xy], axis=1)
+
+    def forward_kinematics(self, q, s):
+        return self.forward_kinematics_batched(q, jnp.asarray([s]))[0]
+
+    def cross_section_geometry(self, q, s):
+        return CrossSectionGeometry.CIRCULAR, jnp.array([0.02])
+
+
+class DummyRenderer(BaseSoftRobotRenderer):
+    def render_frame(self, q):
+        return np.zeros((self.height, self.width, 3), dtype=np.uint8)
+
+    def render_sequence(self, ts, q_ts, playback_speed=1.0, record_path=None, **kwargs):
+        return None
+
+    def show(self, q, **kwargs):
+        return None
+
+
+def test_renderer_exposes_base_pose_transform_and_axis():
+    robot = DummyPlanarRobot(jnp.array([jnp.pi / 2, 1.0, 2.0]))
+    renderer = DummyRenderer(robot)
+
+    assert_allclose(renderer.base_pose, jnp.array([jnp.pi / 2, 1.0, 2.0]))
+    assert_allclose(renderer.base_transform, robot.base_transform)
+    assert_allclose(renderer._base_position(dim=3), np.array([1.0, 2.0, 0.0]))
+    assert_allclose(
+        renderer._base_tangent_axis(dim=3), np.array([0.0, 1.0, 0.0]), atol=1e-12
+    )
+
+
+def test_renderer_normalizes_base_offsets_to_curve_dimension():
+    robot = DummyPlanarRobot(jnp.array([0.0, 0.0, 0.0]))
+    renderer = DummyRenderer(robot)
+
+    offsets = renderer._normalize_base_offsets(
+        jnp.array([[0.1, -0.2], [0.3, 0.4]]),
+        num_robots=2,
+        target_dim=3,
+    )
+
+    assert offsets.shape == (2, 3)
+    assert_allclose(offsets, jnp.array([[0.1, -0.2, 0.0], [0.3, 0.4, 0.0]]))
+
+
+def test_opencv_planar_base_marker_uses_base_pose_and_offset():
+    robot = DummyPlanarRobot(jnp.array([0.0, 0.2, 0.1]))
+    renderer = OpenCVPlanarRenderer(
+        robot,
+        width=100,
+        height=100,
+        num_points=5,
+        base_color=(0, 255, 0),
+        backbone_color=(0, 0, 0),
+        length_scale=2.0,
+        origin_uv=(50, 50),
+    )
+
+    img = renderer.render_frame(jnp.array([]), base_offsets=jnp.array([0.1, -0.1]))
+
+    # ppm = height / (length_scale * L_max) = 50. Base xy + offset = [0.3, 0.0].
+    expected_uv = (65, 50)
+    assert tuple(img[expected_uv[1], expected_uv[0]]) == (0, 255, 0)

--- a/tests/system_param_builders.py
+++ b/tests/system_param_builders.py
@@ -20,6 +20,18 @@ from soromox.systems import (
 )
 
 
+def spatial_base_pose(
+    x: float | Array = 0.0, y: float | Array = 0.0, z: float | Array = 0.0
+) -> Array:
+    return jnp.array([1.0, 0.0, 0.0, 0.0, x, y, z])
+
+
+def planar_base_pose(
+    theta: float | Array = 0.0, x: float | Array = 0.0, y: float | Array = 0.0
+) -> Array:
+    return jnp.array([theta, x, y])
+
+
 def pcs_params(
     *,
     length: Array,
@@ -35,7 +47,7 @@ def pcs_params(
     length = jnp.asarray(length)
     num_segments = length.shape[0]
     if base_pose is None:
-        base_pose = jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0])
+        base_pose = spatial_base_pose()
     if reference_strain is None:
         reference_strain = jnp.tile(
             jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), num_segments
@@ -70,7 +82,7 @@ def planar_pcs_params(
     if reference_strain is None:
         reference_strain = jnp.tile(jnp.array([0.0, 1.0, 0.0]), num_segments)
     if base_pose is None:
-        base_pose = jnp.array([jnp.pi / 2, 0.0, 0.0])
+        base_pose = planar_base_pose(jnp.pi / 2)
     return PlanarPCSParams(
         length=length,
         radius=jnp.asarray(radius),
@@ -108,7 +120,7 @@ def pendulum_params(
     if radius is None:
         radius = 0.05 * jnp.asarray(length)
     if base_pose is None:
-        base_pose = jnp.zeros(3)
+        base_pose = planar_base_pose()
     return PendulumParams(
         base_pose=jnp.asarray(base_pose),
         mass=mass,
@@ -151,7 +163,7 @@ def articulated_params(
     if radius is None:
         radius = 0.05 * jnp.linalg.norm(jnp.asarray(tip_position), axis=1)
     if base_pose is None:
-        base_pose = jnp.zeros(6)
+        base_pose = spatial_base_pose()
     return ArticulatedSoftRobotParams(
         base_pose=jnp.asarray(base_pose),
         joint_screw=joint_screw,
@@ -304,9 +316,7 @@ def tendon_actuated_gvs_params(
 def planar_hsa_params_from_legacy(params: dict) -> PlanarHSAParams:
     hysteresis = params.get("hysteresis", {})
     return PlanarHSAParams(
-        base_pose=jnp.concatenate(
-            [jnp.asarray(params["th0"]).reshape(1), jnp.zeros(2)]
-        ),
+        base_pose=jnp.array([jnp.asarray(params["th0"]), 0.0, 0.0]),
         length=jnp.asarray(params["L"]),
         proximal_cap_length=jnp.asarray(params["lpc"]),
         distal_cap_length=jnp.asarray(params["ldc"]),

--- a/tests/system_param_builders.py
+++ b/tests/system_param_builders.py
@@ -62,13 +62,15 @@ def planar_pcs_params(
     shear_modulus: Array,
     damping_matrix: Array,
     gravity: Array,
-    base_angle: Array | float = jnp.pi / 2,
+    base_pose: Array | None = None,
     reference_strain: Array | None = None,
 ) -> PlanarPCSParams:
     length = jnp.asarray(length)
     num_segments = length.shape[0]
     if reference_strain is None:
         reference_strain = jnp.tile(jnp.array([0.0, 1.0, 0.0]), num_segments)
+    if base_pose is None:
+        base_pose = jnp.array([jnp.pi / 2, 0.0, 0.0])
     return PlanarPCSParams(
         length=length,
         radius=jnp.asarray(radius),
@@ -77,7 +79,7 @@ def planar_pcs_params(
         shear_modulus=jnp.asarray(shear_modulus),
         damping_matrix=jnp.asarray(damping_matrix),
         gravity=jnp.asarray(gravity),
-        base_angle=jnp.asarray(base_angle),
+        base_pose=jnp.asarray(base_pose),
         reference_strain=jnp.asarray(reference_strain),
     )
 
@@ -93,6 +95,7 @@ def pendulum_params(
     joint_damping: Array | None = None,
     joint_rest_configuration: Array | None = None,
     radius: Array | None = None,
+    base_pose: Array | None = None,
 ) -> PendulumParams:
     mass = jnp.asarray(mass)
     n = mass.shape[0]
@@ -104,7 +107,10 @@ def pendulum_params(
         joint_rest_configuration = jnp.zeros((n,))
     if radius is None:
         radius = 0.05 * jnp.asarray(length)
+    if base_pose is None:
+        base_pose = jnp.zeros(3)
     return PendulumParams(
+        base_pose=jnp.asarray(base_pose),
         mass=mass,
         moment_inertia=jnp.asarray(moment_inertia),
         length=jnp.asarray(length),
@@ -130,6 +136,7 @@ def articulated_params(
     joint_damping: Array | None = None,
     joint_rest_configuration: Array | None = None,
     radius: Array | None = None,
+    base_pose: Array | None = None,
 ) -> ArticulatedSoftRobotParams:
     joint_screw = jnp.asarray(joint_screw)
     n = joint_screw.shape[0]
@@ -143,7 +150,10 @@ def articulated_params(
         joint_rest_configuration = jnp.zeros((n,))
     if radius is None:
         radius = 0.05 * jnp.linalg.norm(jnp.asarray(tip_position), axis=1)
+    if base_pose is None:
+        base_pose = jnp.zeros(6)
     return ArticulatedSoftRobotParams(
+        base_pose=jnp.asarray(base_pose),
         joint_screw=joint_screw,
         parent_to_joint_transform=jnp.asarray(parent_to_joint_transform),
         tip_position=jnp.asarray(tip_position),
@@ -215,7 +225,7 @@ def tendon_actuated_planar_pcs_params(
         shear_modulus=body.shear_modulus,
         damping_matrix=body.damping_matrix,
         gravity=body.gravity,
-        base_angle=body.base_angle,
+        base_pose=body.base_pose,
         reference_strain=body.reference_strain,
         tendon_distance=jnp.asarray(tendon_distance),
     )
@@ -294,7 +304,9 @@ def tendon_actuated_gvs_params(
 def planar_hsa_params_from_legacy(params: dict) -> PlanarHSAParams:
     hysteresis = params.get("hysteresis", {})
     return PlanarHSAParams(
-        base_angle=jnp.asarray(params["th0"]),
+        base_pose=jnp.concatenate(
+            [jnp.asarray(params["th0"]).reshape(1), jnp.zeros(2)]
+        ),
         length=jnp.asarray(params["L"]),
         proximal_cap_length=jnp.asarray(params["lpc"]),
         distal_cap_length=jnp.asarray(params["ldc"]),

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -4,7 +4,7 @@ import numpy as onp
 import pytest
 from jax import Array, jacfwd, jacrev, jvp
 from numpy.testing import assert_allclose
-from system_param_builders import gvs_params_from_segments, pcs_params
+from system_param_builders import gvs_params_from_segments, pcs_params, spatial_base_pose
 
 import soromox.utils.lie_algebra as lie
 from soromox.systems import GVS, PCS, CrossSectionGeometry, PCSStructure
@@ -70,13 +70,13 @@ def build_matched_gvs_pcs(num_segments: int = 1, n_gauss: int = 5) -> tuple[GVS,
 
     # initialize the GVS model
     gvs_params, gvs_structure = gvs_params_from_segments(
-        segments, gravity=g, base_pose=jnp.zeros(6)
+        segments, gravity=g, base_pose=spatial_base_pose()
     )
     robot_gvs = GVS(params=gvs_params, structure=gvs_structure)
 
     # PCS definition with identical geometry and material params
     params = pcs_params(
-        base_pose=jnp.zeros(6),
+        base_pose=spatial_base_pose(),
         length=Ls,
         radius=rs,
         density=rhos,
@@ -339,7 +339,7 @@ def build_constant_strain_gvs(
     params, structure = gvs_params_from_segments(
         segments,
         gravity=jnp.array([0.0, 0.0, -9.81]),
-        base_pose=jnp.zeros(6),
+        base_pose=spatial_base_pose(),
         max_dof=max_dof,
         scale_rotational_basis_by_length=scale_rotational_basis_by_length,
     )
@@ -389,14 +389,14 @@ def test_gvs_segment_factories_match_explicit_constructor() -> None:
     params, structure = GVS.params_from_segments(
         segments,
         gravity=gravity,
-        base_pose=jnp.zeros(6),
+        base_pose=spatial_base_pose(),
         max_dof=6,
     )
     explicit = GVS(params=params, structure=structure)
     factory = GVS.from_segments(
         segments,
         gravity=gravity,
-        base_pose=jnp.zeros(6),
+        base_pose=spatial_base_pose(),
         max_dof=6,
     )
 

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -9,7 +9,7 @@ from soromox.systems import PCS, CrossSectionGeometry, PCSStructure
 from soromox.utils.integration import scale_interior_gaussian_quadrature
 from soromox.utils.lie_algebra.se3 import Adjoint_g_SE3, log_SE3
 from soromox.utils.tolerance import Tolerance
-from system_param_builders import pcs_params
+from system_param_builders import pcs_params, spatial_base_pose
 
 jax.config.update("jax_enable_x64", True)  # double precision
 
@@ -39,7 +39,7 @@ def make_pcs(
     if xi_ref is None:
         xi_ref = jnp.tile(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), num_segments)
     params = pcs_params(
-        base_pose=jnp.zeros((6,)),
+        base_pose=spatial_base_pose(),
         length=L,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=1070 * jnp.ones((num_segments,)),
@@ -141,7 +141,7 @@ def test_constant_strain_call():
 
     num_segments = 1
     params = pcs_params(
-        base_pose=jnp.zeros(6),
+        base_pose=spatial_base_pose(),
         length=L,
         radius=jnp.array([2e-2]),
         density=1000 * jnp.ones((1,)),
@@ -247,7 +247,7 @@ def test_constant_strain_call():
     # test energies
     print("\nTesting energies... ------------------------")
     robot = robot.update_params(
-        base_pose=jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0])
+        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
     )
     q = jnp.zeros((6,))
     qd = jnp.zeros((6,))

--- a/tests/systems/test_pcs_2d_vs_3d_coherence.py
+++ b/tests/systems/test_pcs_2d_vs_3d_coherence.py
@@ -6,7 +6,12 @@ from typing import List, Tuple
 
 from soromox.systems import PCS, PCSStructure, PlanarPCS, PlanarPCSStructure
 from soromox.utils.tolerance import Tolerance
-from system_param_builders import pcs_params, planar_pcs_params
+from system_param_builders import (
+    pcs_params,
+    planar_base_pose,
+    planar_pcs_params,
+    spatial_base_pose,
+)
 
 
 jax.config.update("jax_enable_x64", True)
@@ -29,7 +34,7 @@ def make_planar_model(
         * L[:, None]
     ).flatten()
     params = planar_pcs_params(
-        base_pose=jnp.array([0.0, 0.0, 0.0]),
+        base_pose=planar_base_pose(),
         length=L,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=1070 * jnp.ones((num_segments,)),
@@ -50,7 +55,7 @@ def make_spatial_model(num_segments: int, total_length: float = TOTAL_LENGTH) ->
         * L[:, None]
     ).flatten()
     params = pcs_params(
-        base_pose=jnp.zeros((6,)),
+        base_pose=spatial_base_pose(),
         length=L,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=1070 * jnp.ones((num_segments,)),

--- a/tests/systems/test_pcs_2d_vs_3d_coherence.py
+++ b/tests/systems/test_pcs_2d_vs_3d_coherence.py
@@ -29,7 +29,7 @@ def make_planar_model(
         * L[:, None]
     ).flatten()
     params = planar_pcs_params(
-        base_angle=jnp.array(0.0),
+        base_pose=jnp.array([0.0, 0.0, 0.0]),
         length=L,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=1070 * jnp.ones((num_segments,)),

--- a/tests/systems/test_planar_pcs.py
+++ b/tests/systems/test_planar_pcs.py
@@ -46,7 +46,7 @@ def make_planar_pcs(
         ).flatten()
     )
     params = planar_pcs_params(
-        base_angle=jnp.array(th0),  # initial orientation angle [rad]
+        base_pose=jnp.array([th0, 0.0, 0.0]),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,
@@ -113,7 +113,7 @@ def segment_tip_poses(model: PlanarPCS, q: Array) -> Array:
 def constant_strain_inverse_kinematics_fn(params, xi_ref, chi, s) -> Array:
     # split the chi vector into x, y, and th0
     th, px, py = chi
-    th0 = params.base_angle.item()
+    th0 = params.base_pose[0].item()
     print("th0 = ", th0)
     xi = (
         (th - th0)
@@ -489,7 +489,7 @@ def test_inverse_kinematics_relative_pose_computation():
     )
 
     # Manually compute the first relative pose (segment 1 w.r.t. base)
-    base_pose = jnp.array([model.th0, 0.0, 0.0])
+    base_pose = model.base_pose
     expected_rel_0 = chi_tips[0] - base_pose
     expected_rel_0 = expected_rel_0.at[1:].set(
         jnp.array(

--- a/tests/systems/test_planar_pcs.py
+++ b/tests/systems/test_planar_pcs.py
@@ -7,9 +7,10 @@ from numpy.testing import assert_allclose
 
 from soromox.systems import CrossSectionGeometry, PlanarPCS, PlanarPCSStructure
 from soromox.utils.integration import scale_interior_gaussian_quadrature
-from soromox.utils.lie_algebra.se2 import Adjoint_g_SE2, exp_SE2
+from soromox.utils import lie_algebra as lie
+from soromox.utils.lie_algebra.se2 import Adjoint_g_SE2
 from soromox.utils.tolerance import Tolerance
-from system_param_builders import planar_pcs_params
+from system_param_builders import planar_base_pose, planar_pcs_params
 
 jax.config.update("jax_enable_x64", True)  # double precision
 
@@ -46,7 +47,7 @@ def make_planar_pcs(
         ).flatten()
     )
     params = planar_pcs_params(
-        base_pose=jnp.array([th0, 0.0, 0.0]),
+        base_pose=planar_base_pose(th0),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,
@@ -489,7 +490,7 @@ def test_inverse_kinematics_relative_pose_computation():
     )
 
     # Manually compute the first relative pose (segment 1 w.r.t. base)
-    base_pose = model.base_pose
+    base_pose = model._base_planar_pose(chi_tips.dtype)
     expected_rel_0 = chi_tips[0] - base_pose
     expected_rel_0 = expected_rel_0.at[1:].set(
         jnp.array(
@@ -733,7 +734,7 @@ def test_jacobian_bodyframe_inertialframe_coherence(num_segments: int):
         J_body = model.jacobian_bodyframe(q, s)
         chi = model.forward_kinematics(q, s)
         # only rotation
-        g = exp_SE2(jnp.array([chi[0], 0.0, 0.0]))
+        g = lie.transform_from_planar_pose_SE2(jnp.array([chi[0], 0.0, 0.0]))
         J_expected = Adjoint_g_SE2(g) @ J_body
 
         assert jnp.allclose(J_impl, J_expected, rtol=1e-6, atol=1e-7), (
@@ -1342,7 +1343,9 @@ def test_integration_kinematics_matches_existing_batched_path_planar(
     num_inner = model.num_gauss_points
 
     chi_expected = model.forward_kinematics_batched(q, s_points)
-    g_expected = jax.vmap(exp_SE2)(chi_expected).reshape(num_segments, num_inner, 3, 3)
+    g_expected = jax.vmap(lie.transform_from_planar_pose_SE2)(chi_expected).reshape(
+        num_segments, num_inner, 3, 3
+    )
     J_full, Jd_full = model._J_Jd_local_batched(q, qd, s_points)
     J_expected = (J_full @ model.B_xi).reshape(num_segments, num_inner, 3, dof)
     Jd_expected = (Jd_full @ model.B_xi).reshape(num_segments, num_inner, 3, dof)

--- a/tests/systems/test_pneumatic_pcs_models.py
+++ b/tests/systems/test_pneumatic_pcs_models.py
@@ -20,7 +20,7 @@ from soromox.systems import (
 
 def make_pneumatic_planar_params():
     return PneumaticActuatedPlanarPCSParams(
-        base_angle=jnp.array(0.0),
+        base_pose=jnp.array([0.0, 0.0, 0.0]),
         length=jnp.array([0.1]),
         radius=jnp.array([0.02]),
         density=jnp.array([1000.0]),

--- a/tests/systems/test_pneumatic_pcs_models.py
+++ b/tests/systems/test_pneumatic_pcs_models.py
@@ -7,6 +7,7 @@ jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp
 import pytest
+from system_param_builders import planar_base_pose, spatial_base_pose
 
 from soromox.systems import (
     ISupport,
@@ -20,7 +21,7 @@ from soromox.systems import (
 
 def make_pneumatic_planar_params():
     return PneumaticActuatedPlanarPCSParams(
-        base_pose=jnp.array([0.0, 0.0, 0.0]),
+        base_pose=planar_base_pose(),
         length=jnp.array([0.1]),
         radius=jnp.array([0.02]),
         density=jnp.array([1000.0]),
@@ -38,7 +39,7 @@ def make_pneumatic_planar_params():
 
 def make_isupport_params(num_segments=1):
     return ISupportParams(
-        base_pose=jnp.zeros((6,)),
+        base_pose=spatial_base_pose(),
         length=jnp.full((num_segments,), 0.1),
         radius=jnp.full((num_segments,), 0.02),
         density=jnp.full((num_segments,), 1000.0),

--- a/tests/systems/test_soft_robot_defaults.py
+++ b/tests/systems/test_soft_robot_defaults.py
@@ -248,9 +248,9 @@ def test_default_integration_kinematics_uses_bodyframe_samples() -> None:
 
     s_ps = jnp.array([[0.5], [2.0]], dtype=jnp.float64)
     s_flat = s_ps.reshape(-1)
-    g_expected = jax.vmap(lambda s: lie.exp_SE2(robot.forward_kinematics(q, s)))(
-        s_flat
-    ).reshape(2, 1, 3, 3)
+    g_expected = jax.vmap(
+        lambda s: lie.transform_from_planar_pose_SE2(robot.forward_kinematics(q, s))
+    )(s_flat).reshape(2, 1, 3, 3)
     J_expected, Jd_expected = robot.jacobian_and_time_derivative_bodyframe_batched(
         q, qd, s_flat
     )

--- a/tests/systems/test_system_lengths.py
+++ b/tests/systems/test_system_lengths.py
@@ -60,7 +60,7 @@ def _pcs_params(length):
 def _planar_pcs_params(length):
     num_segments = len(length)
     return planar_pcs_params(
-        base_angle=jnp.array(0.0),
+        base_pose=jnp.array([0.0, 0.0, 0.0]),
         length=jnp.asarray(length, dtype=jnp.float64),
         radius=0.02 * jnp.ones((num_segments,), dtype=jnp.float64),
         density=1000.0 * jnp.ones((num_segments,), dtype=jnp.float64),

--- a/tests/systems/test_system_lengths.py
+++ b/tests/systems/test_system_lengths.py
@@ -9,8 +9,10 @@ from system_param_builders import (
     linear_tendon_routing,
     pcs_params,
     pendulum_params,
+    planar_base_pose,
     planar_hsa_params_from_legacy,
     planar_pcs_params,
+    spatial_base_pose,
     tendon_actuated_pcs_params,
     tendon_actuated_pendulum_params,
     tendon_actuated_planar_pcs_params,
@@ -46,7 +48,7 @@ jax.config.update("jax_enable_x64", True)
 def _pcs_params(length):
     num_segments = len(length)
     return pcs_params(
-        base_pose=jnp.zeros((6,)),
+        base_pose=spatial_base_pose(),
         length=jnp.asarray(length, dtype=jnp.float64),
         radius=0.02 * jnp.ones((num_segments,), dtype=jnp.float64),
         density=1000.0 * jnp.ones((num_segments,), dtype=jnp.float64),
@@ -60,7 +62,7 @@ def _pcs_params(length):
 def _planar_pcs_params(length):
     num_segments = len(length)
     return planar_pcs_params(
-        base_pose=jnp.array([0.0, 0.0, 0.0]),
+        base_pose=planar_base_pose(),
         length=jnp.asarray(length, dtype=jnp.float64),
         radius=0.02 * jnp.ones((num_segments,), dtype=jnp.float64),
         density=1000.0 * jnp.ones((num_segments,), dtype=jnp.float64),

--- a/tests/systems/test_tendon_actuated_gvs.py
+++ b/tests/systems/test_tendon_actuated_gvs.py
@@ -18,6 +18,7 @@ from system_param_builders import (
     linear_tendon_routing,
     passive_tendon_params,
     pcs_params,
+    spatial_base_pose,
     tendon_actuated_pcs_params,
 )
 
@@ -94,7 +95,7 @@ def _make_tendon_pcs(
         ).flatten()
     )
     body = pcs_params(
-        base_pose=jnp.zeros((6,)) if base_pose is None else base_pose,
+        base_pose=spatial_base_pose() if base_pose is None else base_pose,
         length=segment_lengths,
         radius=jnp.full((num_segments,), 0.015),
         density=1300.0 * jnp.ones((num_segments,)),
@@ -722,7 +723,7 @@ def test_tendon_actatuated_gvs_vs_pcs():
         segments=_segments([link1], [joint1], [basis1], num_gauss_points),
         gravity=g,
         tendon_params=tendon_params,
-        base_pose=jnp.zeros((6,)),
+        base_pose=spatial_base_pose(),
         scale_rotational_basis_by_length=False,
     )
 
@@ -736,7 +737,7 @@ def test_tendon_actatuated_gvs_vs_pcs():
         gravity=jnp.array([0.0, 0.0, 9.81]),
         tendon_params=tendon_params,
         strain_selector=strain_selector,
-        base_pose=jnp.zeros((6,)),
+        base_pose=spatial_base_pose(),
     )
 
     dof = sum(robotGVS.dofs_per_segment.reshape(-1))

--- a/tests/systems/test_tendon_actuated_pcs.py
+++ b/tests/systems/test_tendon_actuated_pcs.py
@@ -13,6 +13,7 @@ from system_param_builders import (
     linear_tendon_routing,
     passive_tendon_params,
     pcs_params,
+    spatial_base_pose,
     tendon_actuated_pcs_params,
 )
 
@@ -42,7 +43,7 @@ def _create_robot(
         ).flatten()
     )
     body = pcs_params(
-        base_pose=jnp.zeros(6),  # Initial position and orientation
+        base_pose=spatial_base_pose(),  # Initial position and orientation
         length=segment_lengths,
         radius=1.0 * jnp.ones((num_segments,)),  # default: 2e-2
         density=rho,

--- a/tests/systems/test_tendon_actuated_planar_pcs.py
+++ b/tests/systems/test_tendon_actuated_planar_pcs.py
@@ -7,7 +7,11 @@ from numpy.testing import assert_allclose
 
 from soromox.systems import TendonActuatedPlanarPCS
 from soromox.utils.tolerance import Tolerance
-from system_param_builders import planar_pcs_params, tendon_actuated_planar_pcs_params
+from system_param_builders import (
+    planar_base_pose,
+    planar_pcs_params,
+    tendon_actuated_planar_pcs_params,
+)
 
 
 def _build_planar_robot(num_segments: int = 3) -> TendonActuatedPlanarPCS:
@@ -20,7 +24,7 @@ def _build_planar_robot(num_segments: int = 3) -> TendonActuatedPlanarPCS:
         ).flatten()
     )
     body = planar_pcs_params(
-        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
+        base_pose=planar_base_pose(jnp.pi / 2),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,

--- a/tests/systems/test_tendon_actuated_planar_pcs.py
+++ b/tests/systems/test_tendon_actuated_planar_pcs.py
@@ -20,7 +20,7 @@ def _build_planar_robot(num_segments: int = 3) -> TendonActuatedPlanarPCS:
         ).flatten()
     )
     body = planar_pcs_params(
-        base_angle=jnp.array(jnp.pi / 2),
+        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,

--- a/tests/systems/test_typed_params_api.py
+++ b/tests/systems/test_typed_params_api.py
@@ -8,7 +8,9 @@ from system_param_builders import (
     passive_tendon_params,
     pcs_params,
     pendulum_params,
+    planar_base_pose,
     planar_pcs_params,
+    spatial_base_pose,
     tendon_actuated_pcs_params,
 )
 
@@ -137,6 +139,30 @@ def test_planar_pcs_params_validate_base_pose_shape():
 
     with pytest.raises(ValueError, match="base_pose"):
         params.validate()
+
+
+def test_spatial_params_validate_base_pose_quaternion_norm():
+    with pytest.raises(ValueError, match="quaternion"):
+        _pcs_params().replace(
+            base_pose=jnp.array(
+                [0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0], dtype=jnp.float64
+            )
+        )
+
+
+def test_planar_params_validate_base_pose_finite_values():
+    planar = planar_pcs_params(
+        length=jnp.array([0.1], dtype=jnp.float64),
+        radius=jnp.array([0.02], dtype=jnp.float64),
+        density=jnp.array([1000.0], dtype=jnp.float64),
+        young_modulus=jnp.array([1e6], dtype=jnp.float64),
+        shear_modulus=jnp.array([1e5], dtype=jnp.float64),
+        damping_matrix=jnp.eye(3, dtype=jnp.float64),
+        gravity=jnp.array([0.0, -9.81], dtype=jnp.float64),
+        base_pose=jnp.array([jnp.nan, 1.0, 2.0], dtype=jnp.float64),
+    )
+    with pytest.raises(ValueError, match="finite"):
+        planar.validate()
 
 
 def test_tendon_attachment_indices_are_static_topology():
@@ -280,7 +306,7 @@ def test_removed_plural_typed_param_names_fail():
         "shear_modulus": jnp.array([1e5], dtype=jnp.float64),
         "damping_matrix": jnp.eye(6, dtype=jnp.float64),
         "gravity": jnp.array([0.0, 0.0, -9.81], dtype=jnp.float64),
-        "base_pose": jnp.zeros(6, dtype=jnp.float64),
+        "base_pose": spatial_base_pose(),
         "reference_strain": jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
     }
     with pytest.raises(TypeError, match="segment_lengths"):
@@ -290,7 +316,7 @@ def test_removed_plural_typed_param_names_fail():
         )
 
     pendulum_kwargs = {
-        "base_pose": jnp.zeros(3, dtype=jnp.float64),
+        "base_pose": planar_base_pose(),
         "mass": jnp.array([1.0], dtype=jnp.float64),
         "moment_inertia": jnp.array([0.1], dtype=jnp.float64),
         "gravity": jnp.array([0.0, -9.81], dtype=jnp.float64),
@@ -321,7 +347,7 @@ def test_removed_plural_typed_param_names_fail():
         )
 
     articulated_kwargs = {
-        "base_pose": jnp.zeros(6, dtype=jnp.float64),
+        "base_pose": spatial_base_pose(),
         "parent_to_joint_transform": jnp.eye(4, dtype=jnp.float64)[None, :, :],
         "tip_position": jnp.array([[0.5, 0.0, 0.0]], dtype=jnp.float64),
         "center_of_mass_position": jnp.array([[0.25, 0.0, 0.0]], dtype=jnp.float64),

--- a/tests/systems/test_typed_params_api.py
+++ b/tests/systems/test_typed_params_api.py
@@ -123,7 +123,7 @@ def test_system_update_rejects_static_shape_changes():
         robot.update_params(unknown=jnp.array([0.0]))
 
 
-def test_planar_pcs_params_validate_scalar_base_angle():
+def test_planar_pcs_params_validate_base_pose_shape():
     params = planar_pcs_params(
         length=jnp.array([0.1], dtype=jnp.float64),
         radius=jnp.array([0.02], dtype=jnp.float64),
@@ -132,10 +132,10 @@ def test_planar_pcs_params_validate_scalar_base_angle():
         shear_modulus=jnp.array([1e5], dtype=jnp.float64),
         damping_matrix=jnp.eye(3, dtype=jnp.float64),
         gravity=jnp.array([0.0, -9.81], dtype=jnp.float64),
-        base_angle=jnp.array([0.0], dtype=jnp.float64),
+        base_pose=jnp.array([0.0], dtype=jnp.float64),
     )
 
-    with pytest.raises(ValueError, match="base_angle"):
+    with pytest.raises(ValueError, match="base_pose"):
         params.validate()
 
 
@@ -290,6 +290,7 @@ def test_removed_plural_typed_param_names_fail():
         )
 
     pendulum_kwargs = {
+        "base_pose": jnp.zeros(3, dtype=jnp.float64),
         "mass": jnp.array([1.0], dtype=jnp.float64),
         "moment_inertia": jnp.array([0.1], dtype=jnp.float64),
         "gravity": jnp.array([0.0, -9.81], dtype=jnp.float64),
@@ -320,6 +321,7 @@ def test_removed_plural_typed_param_names_fail():
         )
 
     articulated_kwargs = {
+        "base_pose": jnp.zeros(6, dtype=jnp.float64),
         "parent_to_joint_transform": jnp.eye(4, dtype=jnp.float64)[None, :, :],
         "tip_position": jnp.array([[0.5, 0.0, 0.0]], dtype=jnp.float64),
         "center_of_mass_position": jnp.array([[0.25, 0.0, 0.0]], dtype=jnp.float64),

--- a/tests/test_rotations.py
+++ b/tests/test_rotations.py
@@ -64,8 +64,8 @@ class TestRotationMatrixToQuaternion:
         R = jnp.eye(3)
         q = rotation_matrix_to_quaternion(R)
 
-        # Identity quaternion is [0, 0, 0, 1]
-        expected = jnp.array([0.0, 0.0, 0.0, 1.0])
+        # Identity quaternion is [1, 0, 0, 0]
+        expected = jnp.array([1.0, 0.0, 0.0, 0.0])
         assert_allclose(q, expected, atol=1e-10)
 
     @pytest.mark.parametrize(
@@ -85,11 +85,11 @@ class TestRotationMatrixToQuaternion:
         # Unit quaternion should have norm 1
         assert_allclose(jnp.linalg.norm(q), 1.0, atol=1e-10)
 
-        # w component should be cos(45°) = sqrt(2)/2
-        assert_allclose(q[3], np.cos(angle / 2), atol=1e-10)
+        # scalar component should be cos(45°) = sqrt(2)/2
+        assert_allclose(q[0], np.cos(angle / 2), atol=1e-10)
 
         # Vector part norm should be sin(45°) = sqrt(2)/2
-        assert_allclose(jnp.linalg.norm(q[:3]), np.sin(angle / 2), atol=1e-10)
+        assert_allclose(jnp.linalg.norm(q[1:4]), np.sin(angle / 2), atol=1e-10)
 
     def test_quaternion_is_normalized(self):
         """Test that output quaternion is always normalized."""
@@ -100,12 +100,14 @@ class TestRotationMatrixToQuaternion:
         assert_allclose(jnp.linalg.norm(q), 1.0, atol=1e-10)
 
     def test_positive_w_convention(self):
-        """Test that w component is non-negative (canonical form)."""
+        """Test that scalar component is non-negative (canonical form)."""
         for angle in [0.5, 1.5, 2.5, 3.0]:
             for axis in [[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 1]]:
                 R = rotation_matrix_from_axis_angle(axis, angle)
                 q = rotation_matrix_to_quaternion(R)
-                assert q[3] >= 0, f"w should be non-negative, got {q[3]}"
+                assert q[0] >= 0, (
+                    f"scalar component should be non-negative, got {q[0]}"
+                )
 
     def test_custom_eps(self):
         """Test that custom eps parameter works."""
@@ -121,7 +123,7 @@ class TestQuaternionToRotationMatrix:
 
     def test_identity_quaternion(self):
         """Test that identity quaternion gives identity rotation matrix."""
-        q = jnp.array([0.0, 0.0, 0.0, 1.0])
+        q = jnp.array([1.0, 0.0, 0.0, 0.0])
         R = quaternion_to_rotation_matrix(q)
 
         assert_allclose(R, jnp.eye(3), atol=1e-10)
@@ -142,10 +144,10 @@ class TestQuaternionToRotationMatrix:
         # Create quaternion for 90-degree rotation
         q = jnp.array(
             [
+                np.cos(angle / 2),
                 axis_normalized[0] * np.sin(angle / 2),
                 axis_normalized[1] * np.sin(angle / 2),
                 axis_normalized[2] * np.sin(angle / 2),
-                np.cos(angle / 2),
             ]
         )
 
@@ -156,7 +158,7 @@ class TestQuaternionToRotationMatrix:
 
     def test_rotation_matrix_is_orthonormal(self):
         """Test that output rotation matrix is orthonormal."""
-        q = jnp.array([0.1, 0.2, 0.3, 0.9])
+        q = jnp.array([0.9, 0.1, 0.2, 0.3])
         q = q / jnp.linalg.norm(q)  # Normalize
 
         R = quaternion_to_rotation_matrix(q)
@@ -185,7 +187,7 @@ class TestQuaternionToRotationVector:
 
     def test_identity_quaternion(self):
         """Test that identity quaternion gives zero rotation vector."""
-        q = jnp.array([0.0, 0.0, 0.0, 1.0])
+        q = jnp.array([1.0, 0.0, 0.0, 0.0])
         omega = quaternion_to_rotation_vector(q)
 
         assert_allclose(omega, jnp.zeros(3), atol=1e-10)
@@ -204,10 +206,10 @@ class TestQuaternionToRotationVector:
         axis = np.array(axis) / np.linalg.norm(axis)
         q = jnp.array(
             [
+                np.cos(angle / 2),
                 axis[0] * np.sin(angle / 2),
                 axis[1] * np.sin(angle / 2),
                 axis[2] * np.sin(angle / 2),
-                np.cos(angle / 2),
             ]
         )
         omega = quaternion_to_rotation_vector(q)
@@ -231,7 +233,7 @@ class TestRotationVectorToQuaternion:
         omega = jnp.zeros(3)
         q = rotation_vector_to_quaternion(omega)
 
-        expected = jnp.array([0.0, 0.0, 0.0, 1.0])
+        expected = jnp.array([1.0, 0.0, 0.0, 0.0])
         assert_allclose(q, expected, atol=1e-10)
 
     @pytest.mark.parametrize(
@@ -253,16 +255,16 @@ class TestRotationVectorToQuaternion:
         # Expected quaternion
         q_expected = jnp.array(
             [
+                np.cos(angle / 2),
                 axis[0] * np.sin(angle / 2),
                 axis[1] * np.sin(angle / 2),
                 axis[2] * np.sin(angle / 2),
-                np.cos(angle / 2),
             ]
         )
 
         # Quaternions may differ by sign (q and -q represent same rotation)
-        # Compare with canonical form (positive w)
-        if q_expected[3] < 0:
+        # Compare with canonical form (positive scalar component)
+        if q_expected[0] < 0:
             q_expected = -q_expected
 
         assert_allclose(q, q_expected, atol=1e-6)
@@ -294,8 +296,8 @@ class TestRotationVectorToQuaternion:
             q = rotation_vector_to_quaternion(omega)
 
             # Should be close to identity with small z component
-            assert_allclose(q[3], 1.0, atol=1e-4)
-            assert_allclose(jnp.linalg.norm(q[:3]), angle / 2, atol=angle)
+            assert_allclose(q[0], 1.0, atol=1e-4)
+            assert_allclose(jnp.linalg.norm(q[1:4]), angle / 2, atol=angle)
 
     def test_custom_eps(self):
         """Test that custom eps parameter works."""
@@ -539,7 +541,7 @@ class TestJAXCompatibility:
         def loss_fn(q_vec_angle):
             # Create a quaternion from angle (rotation around z-axis)
             half_angle = q_vec_angle / 2
-            quat = jnp.array([0.0, 0.0, jnp.sin(half_angle), jnp.cos(half_angle)])
+            quat = jnp.array([jnp.cos(half_angle), 0.0, 0.0, jnp.sin(half_angle)])
             omega = quaternion_to_rotation_vector(quat)
             return jnp.sum(omega**2)
 
@@ -574,7 +576,7 @@ class TestJAXCompatibility:
             R = quaternion_to_rotation_matrix(q)
             return jnp.sum(R**2)
 
-        q = jnp.array([0.1, 0.2, 0.3, 0.9])
+        q = jnp.array([0.9, 0.1, 0.2, 0.3])
         grad_fn = jax.grad(loss_fn)
 
         grad_q = grad_fn(q)
@@ -678,8 +680,8 @@ class TestQuaternionOperations:
 
     def test_quaternion_identity_multiply(self):
         """Test that multiplying by identity gives the same quaternion."""
-        q_identity = jnp.array([0.0, 0.0, 0.0, 1.0])
-        q = jnp.array([0.1, 0.2, 0.3, 0.9])
+        q_identity = jnp.array([1.0, 0.0, 0.0, 0.0])
+        q = jnp.array([0.9, 0.1, 0.2, 0.3])
         q = q / jnp.linalg.norm(q)
 
         result = quaternion_multiply(q_identity, q)
@@ -690,35 +692,35 @@ class TestQuaternionOperations:
 
     def test_quaternion_multiply_inverse(self):
         """Test that q * q^{-1} = identity."""
-        q = jnp.array([0.1, 0.2, 0.3, 0.9])
+        q = jnp.array([0.9, 0.1, 0.2, 0.3])
         q = q / jnp.linalg.norm(q)
 
         q_inv = quaternion_conjugate(q)
         result = quaternion_multiply(q, q_inv)
 
         # Should be identity quaternion
-        identity = jnp.array([0.0, 0.0, 0.0, 1.0])
+        identity = jnp.array([1.0, 0.0, 0.0, 0.0])
         assert_allclose(result, identity, atol=1e-10)
 
     def test_quaternion_conjugate(self):
         """Test quaternion conjugate."""
-        q = jnp.array([0.1, 0.2, 0.3, 0.9])
+        q = jnp.array([0.9, 0.1, 0.2, 0.3])
         q_conj = quaternion_conjugate(q)
 
-        expected = jnp.array([-0.1, -0.2, -0.3, 0.9])
+        expected = jnp.array([0.9, -0.1, -0.2, -0.3])
         assert_allclose(q_conj, expected, atol=1e-10)
 
     def test_quaternion_multiply_composition(self):
         """Test that quaternion multiplication correctly composes rotations."""
         # Two 90-degree rotations around z-axis should give 180-degree rotation
         angle = np.pi / 2
-        q_90z = jnp.array([0, 0, np.sin(angle / 2), np.cos(angle / 2)])
+        q_90z = jnp.array([np.cos(angle / 2), 0, 0, np.sin(angle / 2)])
 
         q_180z = quaternion_multiply(q_90z, q_90z)
 
         # Should represent 180-degree rotation around z
-        # q = [0, 0, sin(90°), cos(90°)] = [0, 0, 1, 0]
-        expected = jnp.array([0.0, 0.0, 1.0, 0.0])
+        # q = [cos(90°), 0, 0, sin(90°)] = [0, 0, 0, 1]
+        expected = jnp.array([0.0, 0.0, 0.0, 1.0])
         assert_allclose(jnp.abs(q_180z), jnp.abs(expected), atol=1e-10)
 
 
@@ -911,7 +913,7 @@ class TestRotationQuatError:
 
     def test_small_rotation_error(self):
         """Test small rotation error."""
-        q_current = jnp.array([0.0, 0.0, 0.0, 1.0])  # Identity
+        q_current = jnp.array([1.0, 0.0, 0.0, 0.0])  # Identity
         omega_error = jnp.array([0.0, 0.0, 0.1])
         q_desired = rotation_vector_to_quaternion(omega_error)
 
@@ -943,7 +945,7 @@ class TestRotationQuatError:
 
     def test_antipodal_handling(self):
         """Test that antipodal quaternions give zero error."""
-        q = jnp.array([0.1, 0.2, 0.3, 0.9])
+        q = jnp.array([0.9, 0.1, 0.2, 0.3])
         q = q / jnp.linalg.norm(q)
 
         # Antipodal quaternion represents the same rotation

--- a/tests/test_rotations.py
+++ b/tests/test_rotations.py
@@ -21,6 +21,7 @@ from numpy.testing import assert_allclose
 from soromox.utils.rotations import (
     RotationRepresentation,
     angle_error,
+    normalize_quaternion,
     quaternion_conjugate,
     quaternion_multiply,
     quaternion_to_rotation_matrix,
@@ -54,6 +55,21 @@ def rotation_matrix_from_axis_angle(axis, angle):
     )
     R = np.eye(3) + np.sin(angle) * K + (1 - np.cos(angle)) * K @ K
     return jnp.array(R)
+
+
+def test_normalize_quaternion_uses_configurable_eps():
+    q = jnp.array([1e-8, 1e-8, 0.0, 0.0])
+
+    assert_allclose(
+        normalize_quaternion(q, eps=1e-6),
+        jnp.array([1.0, 0.0, 0.0, 0.0]),
+        atol=1e-12,
+    )
+    assert_allclose(
+        normalize_quaternion(q, eps=1e-10),
+        jnp.array([jnp.sqrt(0.5), jnp.sqrt(0.5), 0.0, 0.0]),
+        atol=1e-12,
+    )
 
 
 class TestRotationMatrixToQuaternion:
@@ -105,9 +121,7 @@ class TestRotationMatrixToQuaternion:
             for axis in [[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 1]]:
                 R = rotation_matrix_from_axis_angle(axis, angle)
                 q = rotation_matrix_to_quaternion(R)
-                assert q[0] >= 0, (
-                    f"scalar component should be non-negative, got {q[0]}"
-                )
+                assert q[0] >= 0, f"scalar component should be non-negative, got {q[0]}"
 
     def test_custom_eps(self):
         """Test that custom eps parameter works."""

--- a/tests/utils/test_twist_from_pose.py
+++ b/tests/utils/test_twist_from_pose.py
@@ -193,9 +193,9 @@ class TestCreateTwistFromPoseFnQuaternion:
     def test_quaternion_constant_pose(self):
         """Constant quaternion pose should give zero angular velocity."""
 
-        # Unit quaternion for identity rotation: [0, 0, 0, 1]
+        # Unit quaternion for identity rotation: [1, 0, 0, 0]
         def pose_fn(t):
-            return jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])  # [quat, pos]
+            return jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])  # [quat, pos]
 
         twist_fn = twist_callable_from_pose_callable_factory(
             pose_fn=pose_fn,
@@ -216,7 +216,7 @@ class TestCreateTwistFromPoseFnQuaternion:
 
         def pose_fn(t):
             # Identity quaternion (constant), position moving
-            return jnp.array([0.0, 0.0, 0.0, 1.0, t * 0.1, 0.0, 0.0])
+            return jnp.array([1.0, 0.0, 0.0, 0.0, t * 0.1, 0.0, 0.0])
 
         twist_fn = twist_callable_from_pose_callable_factory(
             pose_fn=pose_fn,


### PR DESCRIPTION
## Summary

- Introduces a shared `SoftRobot.base_pose` API and a derived `base_transform` property.
- Uses explicit base pose conventions across the library:
  - planar robots: `[theta, x, y]`
  - spatial robots: scalar-first Hamilton quaternion pose `[qw, qx, qy, qz, x, y, z]`
- Migrates existing systems, typed parameter objects, constructors, update paths, tests, docs, and examples to the new `base_pose` semantics without compatibility aliases.
- Replaces the old direct-pose `exp_SE2` / `exp_SE3` helpers with semantically named pose-to-transform helpers:
  - `transform_from_planar_pose_SE2`
  - `transform_from_quaternion_pose_SE3`
- Migrates rotation utilities to scalar-first quaternions and adds an `eps` argument to `normalize_quaternion`.
- Updates renderers so configured base transforms and positional offsets are honored:
  - Matplotlib, Viser, and Open3D orient/render the base plate from the configured base-frame `+x` axis.
  - Matplotlib 3D now draws the base plate face plane, matching the Viser/Open3D convention.
  - OpenCV planar and planar-HSA renderers account for transformed base positions and positional offsets.
  - Constructor-level renderer `base_offsets` may be reused for smaller batches by slicing leading rows; explicit per-call offsets still have to match the rendered batch size.

## Conventions

- Zero base rotation means the undeformed soft robot backbone is aligned with the positive base-frame x-axis.
- Planar `base_pose` has shape `(3,)` and stores `[theta, x, y]`, with `theta` a right-handed angle about the out-of-plane z-axis.
- Spatial `base_pose` has shape `(7,)` and stores `[qw, qx, qy, qz, x, y, z]`.
- Spatial quaternions are scalar-first Hamilton quaternions. They are normalized before transform construction and validated to reject zero-norm/non-finite configured base poses.
- `base_transform` returns shape `(3, 3)` for planar robots and `(4, 4)` for spatial robots.

## Validation

- `uv run pytest tests/rendering/test_base_renderer.py tests/test_rotations.py tests/utils/test_twist_from_pose.py` - 119 passed
- `uv run ruff check src/soromox/utils/rotations.py src/soromox/rendering/base.py src/soromox/rendering/matplotlib_renderer.py src/soromox/rendering/opencv_planar_renderer.py src/soromox/rendering/planar_hsa/opencv_renderer.py src/soromox/rendering/viser_renderer.py src/soromox/rendering/open3d_renderer.py tests/rendering/test_base_renderer.py` - passed
- `uv run ruff check` - fails on existing repository-wide lint debt outside the migration surface, including pre-existing example/test issues on `main`
- `uv run pytest` - 940 passed
