### PR TITLE
Fix Ruff formatting and lint issues

### DIFF
--- a/bump_version.py
+++ b/bump_version.py
@@ -25,12 +25,11 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Tuple
 
 
-def parse_version(version_string: str) -> Tuple[int, int, int]:
+def parse_version(version_string: str) -> tuple[int, int, int]:
     """Parse a semantic version string into major, minor, patch components."""
-    match = re.match(r'^(\d+)\.(\d+)\.(\d+)(?:-.*)?$', version_string)
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:-.*)?$", version_string)
     if not match:
         raise ValueError(f"Invalid version format: {version_string}")
     return int(match.group(1)), int(match.group(2)), int(match.group(3))
@@ -54,10 +53,7 @@ def update_pyproject_toml(file_path: Path, new_version: str) -> None:
     """Update version in pyproject.toml."""
     content = file_path.read_text()
     updated_content = re.sub(
-        r'^version = "[^"]+"',
-        f'version = "{new_version}"',
-        content,
-        flags=re.MULTILINE
+        r'^version = "[^"]+"', f'version = "{new_version}"', content, flags=re.MULTILINE
     )
     file_path.write_text(updated_content)
     print(f"✓ Updated {file_path}")
@@ -68,13 +64,10 @@ def update_citation_cff(file_path: Path, new_version: str) -> None:
     if not file_path.exists():
         print(f"⚠ {file_path} does not exist, skipping")
         return
-    
+
     content = file_path.read_text()
     updated_content = re.sub(
-        r'^version: "[^"]+"',
-        f'version: "{new_version}"',
-        content,
-        flags=re.MULTILINE
+        r'^version: "[^"]+"', f'version: "{new_version}"', content, flags=re.MULTILINE
     )
     file_path.write_text(updated_content)
     print(f"✓ Updated {file_path}")
@@ -85,19 +78,15 @@ def update_changelog(file_path: Path, new_version: str, old_version: str) -> Non
     if not file_path.exists():
         print(f"⚠ {file_path} does not exist, skipping")
         return
-    
+
     content = file_path.read_text()
     today = datetime.now().strftime("%Y-%m-%d")
-    
+
     # Replace the unreleased version with the new version and date
     if f"## [{old_version}]" in content:
         updated_content = content.replace(
-            f"## [{old_version}] - TBD",
-            f"## [{new_version}] - {today}"
-        ).replace(
-            f"## [{old_version}] - 2025-XX-XX",
-            f"## [{new_version}] - {today}"
-        )
+            f"## [{old_version}] - TBD", f"## [{new_version}] - {today}"
+        ).replace(f"## [{old_version}] - 2025-XX-XX", f"## [{new_version}] - {today}")
     else:
         # Add new version entry at the top of the changelog
         changelog_entry = f"""
@@ -108,19 +97,19 @@ def update_changelog(file_path: Path, new_version: str, old_version: str) -> Non
 
 """
         # Find the position after the header to insert new entry
-        lines = content.split('\n')
+        lines = content.split("\n")
         insert_pos = 0
         for i, line in enumerate(lines):
-            if line.strip().startswith('## [') and 'Unreleased' not in line:
+            if line.strip().startswith("## [") and "Unreleased" not in line:
                 insert_pos = i
                 break
-        
+
         if insert_pos > 0:
             lines.insert(insert_pos, changelog_entry.strip())
-            updated_content = '\n'.join(lines)
+            updated_content = "\n".join(lines)
         else:
             updated_content = content + changelog_entry
-    
+
     file_path.write_text(updated_content)
     print(f"✓ Updated {file_path}")
 
@@ -130,13 +119,10 @@ def update_pkg_info(file_path: Path, new_version: str) -> None:
     if not file_path.exists():
         print(f"⚠ {file_path} does not exist, skipping")
         return
-    
+
     content = file_path.read_text()
     updated_content = re.sub(
-        r'^Version: [^\n]+',
-        f'Version: {new_version}',
-        content,
-        flags=re.MULTILINE
+        r"^Version: [^\n]+", f"Version: {new_version}", content, flags=re.MULTILINE
     )
     file_path.write_text(updated_content)
     print(f"✓ Updated {file_path}")
@@ -145,7 +131,7 @@ def update_pkg_info(file_path: Path, new_version: str) -> None:
 def increment_version(current_version: str, bump_type: str) -> str:
     """Increment version based on bump type."""
     major, minor, patch = parse_version(current_version)
-    
+
     if bump_type == "major":
         return format_version(major + 1, 0, 0)
     elif bump_type == "minor":
@@ -160,29 +146,51 @@ def main():
     parser = argparse.ArgumentParser(
         description="Bump version across all SoRoMoX project files",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__.split("Usage:")[1] if "Usage:" in __doc__ else ""
+        epilog=__doc__.split("Usage:")[1] if "Usage:" in __doc__ else "",
     )
-    
+
     version_group = parser.add_mutually_exclusive_group(required=True)
-    version_group.add_argument("version", nargs="?", help="New version number (e.g., 0.2.0)")
-    version_group.add_argument("--major", action="store_true", help="Increment major version")
-    version_group.add_argument("--minor", action="store_true", help="Increment minor version")
-    version_group.add_argument("--patch", action="store_true", help="Increment patch version")
-    
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be changed without making changes")
-    parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
-    parser.add_argument("--create-tag", action="store_true", help="Create and push git tag after version bump")
-    parser.add_argument("--push", action="store_true", help="Push changes and tags to origin after version bump")
-    
+    version_group.add_argument(
+        "version", nargs="?", help="New version number (e.g., 0.2.0)"
+    )
+    version_group.add_argument(
+        "--major", action="store_true", help="Increment major version"
+    )
+    version_group.add_argument(
+        "--minor", action="store_true", help="Increment minor version"
+    )
+    version_group.add_argument(
+        "--patch", action="store_true", help="Increment patch version"
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be changed without making changes",
+    )
+    parser.add_argument(
+        "--yes", "-y", action="store_true", help="Skip confirmation prompt"
+    )
+    parser.add_argument(
+        "--create-tag",
+        action="store_true",
+        help="Create and push git tag after version bump",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        help="Push changes and tags to origin after version bump",
+    )
+
     args = parser.parse_args()
-    
+
     # Define file paths
     root_dir = Path(__file__).parent
     pyproject_path = root_dir / "pyproject.toml"
     citation_path = root_dir / "CITATION.cff"
     changelog_path = root_dir / "docs" / "development" / "changelog.md"
     pkg_info_path = root_dir / "src" / "soromox.egg-info" / "PKG-INFO"
-    
+
     # Get current version
     try:
         current_version = get_current_version(pyproject_path)
@@ -190,7 +198,7 @@ def main():
     except Exception as e:
         print(f"Error reading current version: {e}")
         sys.exit(1)
-    
+
     # Determine new version
     if args.version:
         new_version = args.version
@@ -206,9 +214,9 @@ def main():
         except ValueError as e:
             print(f"Error: {e}")
             sys.exit(1)
-    
+
     print(f"New version: {new_version}")
-    
+
     if args.dry_run:
         print("\n🔍 DRY RUN - No files will be modified")
         print(f"Would update version from {current_version} to {new_version} in:")
@@ -217,73 +225,83 @@ def main():
         print(f"  - {changelog_path}")
         print(f"  - {pkg_info_path}")
         return
-    
+
     # Confirm before making changes
     if current_version == new_version:
         print("⚠ New version is the same as current version. Proceeding anyway...")
-    
+
     if not args.yes:
-        response = input(f"\nUpdate version from {current_version} to {new_version}? [y/N]: ")
-        if response.lower() not in ('y', 'yes'):
+        response = input(
+            f"\nUpdate version from {current_version} to {new_version}? [y/N]: "
+        )
+        if response.lower() not in ("y", "yes"):
             print("Aborted.")
             sys.exit(0)
     else:
-        print(f"\n✓ Auto-confirmed version update from {current_version} to {new_version}")
-    
+        print(
+            f"\n✓ Auto-confirmed version update from {current_version} to {new_version}"
+        )
+
     # Update files
     print(f"\n🚀 Updating version to {new_version}...")
-    
+
     try:
         update_pyproject_toml(pyproject_path, new_version)
         update_citation_cff(citation_path, new_version)
         update_changelog(changelog_path, new_version, current_version)
         update_pkg_info(pkg_info_path, new_version)
-        
+
         print(f"\n✅ Successfully updated version to {new_version}")
-        
+
         # Git operations
         if args.create_tag or args.push:
-            print(f"\n� Performing git operations...")
+            print("\n� Performing git operations...")
             try:
                 # Stage and commit changes
                 subprocess.run(["git", "add", "."], check=True, cwd=root_dir)
                 subprocess.run(
-                    ["git", "commit", "-m", f"Bump version to {new_version}"], 
-                    check=True, cwd=root_dir
+                    ["git", "commit", "-m", f"Bump version to {new_version}"],
+                    check=True,
+                    cwd=root_dir,
                 )
-                print(f"✓ Committed version bump")
-                
+                print("✓ Committed version bump")
+
                 if args.create_tag:
                     # Create git tag
                     subprocess.run(
-                        ["git", "tag", f"v{new_version}"], 
-                        check=True, cwd=root_dir
+                        ["git", "tag", f"v{new_version}"], check=True, cwd=root_dir
                     )
                     print(f"✓ Created git tag v{new_version}")
-                
+
                 if args.push:
                     # Push changes and tags
                     subprocess.run(["git", "push"], check=True, cwd=root_dir)
                     if args.create_tag:
-                        subprocess.run(["git", "push", "--tags"], check=True, cwd=root_dir)
-                    print(f"✓ Pushed changes and tags to origin")
-                    
+                        subprocess.run(
+                            ["git", "push", "--tags"], check=True, cwd=root_dir
+                        )
+                    print("✓ Pushed changes and tags to origin")
+
             except subprocess.CalledProcessError as e:
                 print(f"❌ Git operation failed: {e}")
                 print("You may need to perform git operations manually.")
                 sys.exit(1)
-        
-        print(f"\n�📝 Next steps:")
+
+        print("\n�📝 Next steps:")
         if not (args.create_tag and args.push):
             print("1. Review the changes with: git diff")
             if not args.create_tag:
-                print("2. Commit the changes: git add . && git commit -m 'Bump version to {}'".format(new_version))
-                print("3. Create a git tag: git tag v{}".format(new_version))
+                print(
+                    f"2. Commit the changes: git add . && git commit -m 'Bump version to {new_version}'"
+                )
+                print(f"3. Create a git tag: git tag v{new_version}")
             if not args.push:
                 print("4. Push changes: git push && git push --tags")
-        print("5. GitHub Actions will automatically create a release when the tag is pushed")
+        print(
+            "5. GitHub Actions will automatically create a release when the tag is pushed"
+        )
         print("6. The release will include changelog content extracted automatically")
-        
+
     except Exception as e:
         print(f"❌ Error updating files: {e}")
         sys.exit(1)

--- a/examples/control/actuation_space/setpoint_regulation_comparison.py
+++ b/examples/control/actuation_space/setpoint_regulation_comparison.py
@@ -393,7 +393,7 @@ def main():
     print(header)
     print("-" * 70)
 
-    for name, results in all_results.items():
+    for name, _results in all_results.items():
         metrics = compute_metrics(results, q_des, strain_indices)
         all_results[name]["metrics"] = metrics
         rmse = metrics["rmse"]
@@ -411,7 +411,7 @@ def main():
     print(header)
     print("-" * 70)
 
-    for name, results in all_results.items():
+    for name in all_results:
         ss_error = all_results[name]["metrics"]["ss_error"]
         row = f"{name:<25}"
         for val in ss_error:
@@ -446,7 +446,7 @@ def main():
         ax = axes[idx]
 
         # Plot desired setpoint
-        t = all_results["PID (model-free)"]["t"]
+        all_results["PID (model-free)"]["t"]
         ax.axhline(
             y=q_des[strain_idx],
             color="k",
@@ -566,7 +566,7 @@ def main():
             all_results[name]["metrics"]["rmse"][strain_idx]
             for name in controller_names
         ]
-        bars = ax.bar(x + i * width, rmse_values, width, label=strain_name)
+        ax.bar(x + i * width, rmse_values, width, label=strain_name)
 
     ax.set_xlabel("Controller")
     ax.set_ylabel("RMSE")

--- a/examples/control/configuration_space/setpoint_regulation_comparison.py
+++ b/examples/control/configuration_space/setpoint_regulation_comparison.py
@@ -389,11 +389,11 @@ def main():
     x = jnp.arange(len(controller_names))
     width = 0.25
 
-    for i, (strain_idx, strain_name) in enumerate(zip(strain_indices, strain_names)):
+    for i, (_strain_idx, strain_name) in enumerate(zip(strain_indices, strain_names)):
         rmse_values = [
             all_results[name]["metrics"]["rmse"][i] for name in controller_names
         ]
-        bars = ax.bar(x + i * width, rmse_values, width, label=strain_name)
+        ax.bar(x + i * width, rmse_values, width, label=strain_name)
 
     ax.set_xlabel("Controller")
     ax.set_ylabel("RMSE")

--- a/examples/control/configuration_space/trajectory_tracking_comparison.py
+++ b/examples/control/configuration_space/trajectory_tracking_comparison.py
@@ -383,8 +383,6 @@ def main():
         "Gravity Cancellation": "#8EBA42",  # Green
     }
 
-    all_colors = {**tracker_colors, **regulator_colors}
-
     # =========================================================================
     # PART 1: Slow Trajectory - Compare Trackers and Regulators
     # =========================================================================
@@ -526,7 +524,7 @@ def main():
         rmse_values = [
             slow_results[name]["metrics"]["rmse"][i] for name in controller_names
         ]
-        bars = ax1.bar(x + i * width, rmse_values, width, label=strain_name)
+        ax1.bar(x + i * width, rmse_values, width, label=strain_name)
 
     ax1.set_xlabel("Controller")
     ax1.set_ylabel("RMSE")
@@ -545,7 +543,7 @@ def main():
         rmse_values = [
             fast_results[name]["metrics"]["rmse"][i] for name in tracker_names
         ]
-        bars = ax2.bar(x + i * width, rmse_values, width, label=strain_name)
+        ax2.bar(x + i * width, rmse_values, width, label=strain_name)
 
     ax2.set_xlabel("Controller")
     ax2.set_ylabel("RMSE")

--- a/examples/control/operational_space/control_pcs_with_cf_cbf_clf.py
+++ b/examples/control/operational_space/control_pcs_with_cf_cbf_clf.py
@@ -351,7 +351,7 @@ if __name__ == "__main__":
             )
 
             # smooth minimum
-            h_all = (-1.0 / kappa) * jnp.log(jnp.sum(jnp.exp(-kappa * H)))
+            (-1.0 / kappa) * jnp.log(jnp.sum(jnp.exp(-kappa * H)))
             # return h_all.reshape(-1)/10
             force_min = 5 + 1000 * jnp.min(H).reshape(-1)
             # return jnp.min(H).reshape(-1) *1000

--- a/examples/control/operational_space/control_tendon_actuated_pcs_with_synergistic.py
+++ b/examples/control/operational_space/control_tendon_actuated_pcs_with_synergistic.py
@@ -354,7 +354,7 @@ def main():
     if Open3DRenderer is None:
         print("\nOpen3DRenderer unavailable. Install open3d to view the animation.")
     else:
-        target_radius = float(jnp.mean(params["r"])) * 0.5
+        target_radius = float(jnp.mean(robot.params.r)) * 0.5
         target_positions = jnp.asarray(x_des_traj_pos)[None, :, :]
         renderer = Open3DRenderer(robot, num_points=50)
         renderer.render_sequence(

--- a/examples/optimization/control_gain_optimization_with_collocated.py
+++ b/examples/optimization/control_gain_optimization_with_collocated.py
@@ -87,9 +87,7 @@ body_params = PCSParams(
     young_modulus=2e3 * jnp.ones((num_segments,)),
     shear_modulus=1e3 * jnp.ones((num_segments,)),
     damping_matrix=damping_matrix,
-    reference_strain=jnp.tile(
-        jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), num_segments
-    ),
+    reference_strain=jnp.tile(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), num_segments),
 )
 
 # Tendon routing: 3 tendons at 120 degrees apart, parallel to backbone

--- a/examples/optimization/control_gain_optimization_with_synergistic.py
+++ b/examples/optimization/control_gain_optimization_with_synergistic.py
@@ -91,9 +91,7 @@ body_params = PCSParams(
     young_modulus=2e3 * jnp.ones((num_segments,)),
     shear_modulus=1e3 * jnp.ones((num_segments,)),
     damping_matrix=damping_matrix,
-    reference_strain=jnp.tile(
-        jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), num_segments
-    ),
+    reference_strain=jnp.tile(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), num_segments),
 )
 
 # Tendon routing: 3 tendons at 120 degrees apart, parallel to backbone

--- a/examples/simulation/hsa/demo_planar_hsa_motor2ee_jacobian.py
+++ b/examples/simulation/hsa/demo_planar_hsa_motor2ee_jacobian.py
@@ -88,11 +88,11 @@ def factory_fn(
         # configuration that minimizes the residual
         q = jnp.array(sol.x)
 
-        aux = dict(
-            phi=phi,
-            q=q,
-            residual=sol.fun,
-        )
+        aux = {
+            "phi": phi,
+            "q": q,
+            "residual": sol.fun,
+        }
 
         return q, aux
 

--- a/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_pneumatic_actuated_planar_pcs.py
@@ -36,9 +36,7 @@ def sweep_actuation_mapping(
     # mark the points that are not controllable as the u1 and u2 terms share the same sign
     non_controllable_selector = A_pts[..., 0, 0] * A_pts[..., 0, 1] >= 0.0
     non_controllable_indices = jnp.where(non_controllable_selector)[0]
-    non_controllable_boundary_indices = jnp.where(
-        non_controllable_selector[:-1] != non_controllable_selector[1:]
-    )[0]
+    jnp.where(non_controllable_selector[:-1] != non_controllable_selector[1:])[0]
     # plot the mapping on the bending strain for various bending strains
     fig, ax = plt.subplots(
         num="pneumatic_planar_pcs_actuation_mapping_bending_torque_vs_bending_strain"

--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -15,8 +15,8 @@ from soromox.rendering import (
 )
 from soromox.systems import (
     LinearTendonRoutingParams,
-    PCSParams,
     PassiveTendonParams,
+    PCSParams,
     SystemState,
     TendonActuatedPCS,
     TendonActuatedPCSParams,
@@ -41,9 +41,7 @@ if __name__ == "__main__":
         ).flatten()
     )
     body_params = PCSParams(
-        base_pose=jnp.array(
-            [0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]
-        ),
+        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
         density=rho,

--- a/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
+++ b/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
@@ -113,7 +113,7 @@ def draw_robot(
     try:
         A_pt = onp.asarray(robot.A_pt)
         Np = A_pt.shape[1]
-    except:
+    except AttributeError:
         A_pt = onp.zeros((N, N))
 
     # Transform robot poses to pixel coordinates. Should be of shape (N, 2)
@@ -273,7 +273,7 @@ if __name__ == "__main__":
         (video_width, video_height),
     )
 
-    for time_idx, t in enumerate(video_ts):
+    for time_idx, _t in enumerate(video_ts):
         img = draw_robot(
             robot,
             qs[time_idx],

--- a/examples/system_identification/identify_soft_tentacle_parameters.py
+++ b/examples/system_identification/identify_soft_tentacle_parameters.py
@@ -1,4 +1,3 @@
-from functools import partial
 import os
 
 import equinox as eqx
@@ -6,8 +5,8 @@ import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import numpy as onp
-import optimistix as optx
 import optax
+import optimistix as optx
 import pandas as pd
 
 from soromox.systems import (
@@ -68,7 +67,9 @@ def _transform_points(
 
 def _load_marker_data():
     ### EXCEL DATA READING ###
-    Rot = jnp.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=jnp.float64)
+    Rot = jnp.array(
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=jnp.float64
+    )
     R_alg1 = jnp.array(
         [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, -1.0, 0.0]], dtype=jnp.float64
     )
@@ -76,7 +77,6 @@ def _load_marker_data():
         [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=jnp.float64
     )
     offset = jnp.array([-0.03, -0.013, 0.0], dtype=jnp.float64)
-
 
     df = pd.read_csv("data/m1_u01.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -200,6 +200,7 @@ def _load_marker_data():
 
     return locals()
 
+
 def compute_marker_errors(robot, u_batch, q0, measured_markers_batch, E, nu, rho):
     """
     Restituisce gli errori (M, 12) = differenze per ogni marker e ogni esperimento
@@ -218,6 +219,7 @@ def compute_marker_errors(robot, u_batch, q0, measured_markers_batch, E, nu, rho
 
 
 ### SOFT ROBOT UTILITIES FUNCTIONS ###
+
 
 def draw_robot_curve(
     robot: TendonActuatedGVS,
@@ -273,6 +275,7 @@ def solve_equilibrium(robot: TendonActuatedGVS, u: jnp.ndarray, q0: jnp.ndarray)
     solver = optx.Newton(rtol=1e-6, atol=1e-6)
     statics_eq_jit = jax.jit(statics_eq)
     return optx.root_find(statics_eq_jit, solver, q0, (u), max_steps=200)
+
 
 # STATIC EQUILIBRIUM EQUATION SOLVER with UPDATED E,rho AND NU
 def solve_equilibrium_Enurho(
@@ -363,6 +366,7 @@ def make_loss_fn(
 
     return loss_fn
 
+
 if __name__ == "__main__":
     globals().update(_load_marker_data())
 
@@ -409,13 +413,19 @@ if __name__ == "__main__":
             [0.0114 * jnp.cos(jnp.pi / 180 * 30), 0.0114 * jnp.cos(jnp.pi / 180 * 150)]
         ),
         y_slope=jnp.array(
-            [-0.0295 * jnp.cos(jnp.pi / 180 * 30), -0.0295 * jnp.cos(jnp.pi / 180 * 150)]
+            [
+                -0.0295 * jnp.cos(jnp.pi / 180 * 30),
+                -0.0295 * jnp.cos(jnp.pi / 180 * 150),
+            ]
         ),
         z_intercept=jnp.array(
             [0.0114 * jnp.sin(jnp.pi / 180 * 30), 0.0114 * jnp.sin(jnp.pi / 180 * 150)]
         ),
         z_slope=jnp.array(
-            [-0.0295 * jnp.sin(jnp.pi / 180 * 30), -0.0295 * jnp.sin(jnp.pi / 180 * 150)]
+            [
+                -0.0295 * jnp.sin(jnp.pi / 180 * 30),
+                -0.0295 * jnp.sin(jnp.pi / 180 * 150),
+            ]
         ),
         attachment_segment_index=jnp.array([0, 0]),
     )
@@ -448,7 +458,6 @@ if __name__ == "__main__":
     nu_init = jnp.asarray(nu0, dtype=jnp.float64)  # shape: ()
     rho_init = jnp.asarray(rho0, dtype=jnp.float64)  # shape: ()
 
-
     # E_log_min = jnp.log(1e4)
     # E_log_max = jnp.log(1e6)
     E_min = 1e4
@@ -457,11 +466,9 @@ if __name__ == "__main__":
     nu_min, nu_max = 0.4, 0.5
     rho_min, rho_max = 1000.0, 2000.0
 
-
     # helper to avoid going outside (-1,1)
     def _atanh_clipped(x, eps=1e-6):
         return jnp.arctanh(jnp.clip(x, -1 + eps, 1 - eps))
-
 
     # inverse E mapping
     # mu_E = 0.5 * (E_log_max + E_log_min)
@@ -486,21 +493,30 @@ if __name__ == "__main__":
 
     params = (raw_E0, raw_nu0, raw_rho0)
 
-
     # Prepare batch data (measured coordinates and inputs)
+    marker_data = _load_marker_data()
+
     def _pack_markers(p1, p2, p3, p4):
         return jnp.concatenate([p1, p2, p3, p4], axis=0)  # (12,)
 
-
+    marker_samples = (
+        "m1u01",
+        "m1u015",
+        "m1u02",
+        "m1u025",
+        "m2u01",
+        "m2u015",
+        "m2u02",
+        "m2u025",
+    )
     measured_list = [
-        _pack_markers(p1_m1u01, p2_m1u01, p3_m1u01, p4_m1u01),
-        _pack_markers(p1_m1u015, p2_m1u015, p3_m1u015, p4_m1u015),
-        _pack_markers(p1_m1u02, p2_m1u02, p3_m1u02, p4_m1u02),
-        _pack_markers(p1_m1u025, p2_m1u025, p3_m1u025, p4_m1u025),
-        _pack_markers(p1_m2u01, p2_m2u01, p3_m2u01, p4_m2u01),
-        _pack_markers(p1_m2u015, p2_m2u015, p3_m2u015, p4_m2u015),
-        _pack_markers(p1_m2u02, p2_m2u02, p3_m2u02, p4_m2u02),
-        _pack_markers(p1_m2u025, p2_m2u025, p3_m2u025, p4_m2u025),
+        _pack_markers(
+            marker_data[f"p1_{sample}"],
+            marker_data[f"p2_{sample}"],
+            marker_data[f"p3_{sample}"],
+            marker_data[f"p4_{sample}"],
+        )
+        for sample in marker_samples
     ]
     measured_markers_batch = jnp.stack(measured_list, axis=1)
     radius = 0.0325
@@ -520,7 +536,6 @@ if __name__ == "__main__":
     dof = sum(robot.dofs_per_segment.reshape(-1))
     q0 = jnp.zeros((dof,), dtype=jnp.float64)
 
-
     ### GRADIENT-BASED OPTIMIZATION LOOP ###
     loss_fn = make_loss_fn(
         u_batch=u_batch, q0=q0, measured_markers_batch=measured_markers_batch
@@ -530,13 +545,11 @@ if __name__ == "__main__":
     opt = optax.chain(optax.clip_by_global_norm(1.0), optax.adam(1e-2))
     opt_state = opt.init(params)
 
-
     # best checkpoint
     best_loss = jnp.inf
     best_params = params
     best_step = -1
     loss_history = []
-
 
     num_optimization_steps = int(os.environ.get("SOROMOX_SYSID_STEPS", "100"))
     for step in range(num_optimization_steps):
@@ -563,7 +576,6 @@ if __name__ == "__main__":
 
         params = optax.apply_updates(params, updates)
 
-
     # Final parameter values
     params = best_params
     loss_val, grads = loss_and_grad(params)
@@ -585,7 +597,7 @@ if __name__ == "__main__":
     # onp.save("data/rho_hat.npy", onp.asarray(rho_hat))
     # onp.save("data/loss_history.npy", onp.asarray(loss_history))
 
-    #load results
+    # load results
     # E_hat = jnp.array(onp.load("data/E_hat.npy"))
     # nu_hat = jnp.array(onp.load("data/nu_hat.npy"))
     # rho_hat = jnp.array(onp.load("data/rho_hat.npy"))
@@ -606,7 +618,6 @@ if __name__ == "__main__":
         rms_per_marker = jnp.sqrt(jnp.mean(jnp.sum(errors_reshaped**2, axis=2), axis=0))
         return rms_per_marker  # (4,)
 
-
     rmse_before = marker_rmse(errors_before)
     rmse_after = marker_rmse(errors_after)
     # onp.save("data/rmse_before.npy", onp.asarray(rmse_before))
@@ -625,7 +636,7 @@ if __name__ == "__main__":
     # plt.title("Loss evolution during optimization")
     plt.grid(True, linestyle="--", alpha=0.5)
     plt.legend(fontsize=16)
-    plt.tick_params(axis='both', labelsize=16)
+    plt.tick_params(axis="both", labelsize=16)
     plt.tight_layout()
     # plt.savefig("loss_over_time.svg", format="svg", bbox_inches="tight")
     # plt.savefig("loss_over_time.pdf", format="pdf", bbox_inches="tight")
@@ -639,14 +650,13 @@ if __name__ == "__main__":
     plt.ylabel("RMS Position Error [m]", fontsize=16)
     # plt.title("Marker position errors before vs after optimization")
     plt.legend(fontsize=16)
-    plt.tick_params(axis='both', labelsize=16)
+    plt.tick_params(axis="both", labelsize=16)
     plt.grid(True, linestyle="--", alpha=0.5)
     plt.tight_layout()
     # plt.savefig("rmse_per_marker.svg", format="svg", bbox_inches="tight")
     # plt.savefig("rmse_per_marker.pdf", format="pdf", bbox_inches="tight")
     # plt.savefig("rmse_per_marker.jpg", format="jpg", dpi=300, bbox_inches="tight")
     plt.show()
-
 
     plt.figure(figsize=(12, 9))
     plt.plot(jnp.sqrt(jnp.sum(errors_before**2, axis=1)), "o-", label="Before")
@@ -703,8 +713,6 @@ if __name__ == "__main__":
         scale_rotational_basis_by_length=True,
     )
 
-
-
     # For each input in u_batch, solve statics and plot original vs optimized shapes
     M = int(u_batch.shape[1])
 
@@ -742,7 +750,9 @@ if __name__ == "__main__":
 
     # compute plot bounds from all points
     all_pts = []
-    for c0, ch, m0, mh, mm in zip(curves_orig, curves_hat, markers_orig, markers_hat, measured_pts):
+    for c0, ch, m0, mh, mm in zip(
+        curves_orig, curves_hat, markers_orig, markers_hat, measured_pts
+    ):
         all_pts.append(c0)
         all_pts.append(ch)
         all_pts.append(m0)
@@ -763,7 +773,7 @@ if __name__ == "__main__":
     colors = [tab10(allowed_indices[i % len(allowed_indices)]) for i in range(M)]
 
     alpha_orig = 0.25  # transparency for original (less prominent)
-    alpha_hat = 1.0    # optimized more opaque
+    alpha_hat = 1.0  # optimized more opaque
 
     for m in range(M):
         c = colors[m]
@@ -773,8 +783,22 @@ if __name__ == "__main__":
         curve_hat = curves_hat[m]
 
         # plot backbones with same color but different alpha
-        ax.plot(curve0[:, 0], curve0[:, 1], curve0[:, 2], lw=3, color=c_rgb, alpha=alpha_orig)
-        ax.plot(curve_hat[:, 0], curve_hat[:, 1], curve_hat[:, 2], lw=3, color=c_rgb, alpha=alpha_hat)
+        ax.plot(
+            curve0[:, 0],
+            curve0[:, 1],
+            curve0[:, 2],
+            lw=3,
+            color=c_rgb,
+            alpha=alpha_orig,
+        )
+        ax.plot(
+            curve_hat[:, 0],
+            curve_hat[:, 1],
+            curve_hat[:, 2],
+            lw=3,
+            color=c_rgb,
+            alpha=alpha_hat,
+        )
 
         # predicted markers: use orange for original, red for optimized
         m0 = markers_orig[m]
@@ -792,13 +816,28 @@ if __name__ == "__main__":
             a = float(grad_alphas[i])
             # original predicted marker (orange), scaled by original alpha factor
             ax.scatter(
-                m0[i, 0], m0[i, 1], m0[i, 2], marker="x", color=orange_col, s=50, alpha= a
+                m0[i, 0],
+                m0[i, 1],
+                m0[i, 2],
+                marker="x",
+                color=orange_col,
+                s=50,
+                alpha=a,
             )
             # optimized predicted marker (red)
-            ax.scatter(mh[i, 0], mh[i, 1], mh[i, 2], marker="x", color=red_col, s=90, alpha=a)
+            ax.scatter(
+                mh[i, 0], mh[i, 1], mh[i, 2], marker="x", color=red_col, s=90, alpha=a
+            )
             # measured marker (blue circle) with gradient alpha
             ax.scatter(
-                mm[i, 0], mm[i, 1], mm[i, 2], marker="o", facecolors="none", edgecolors=blue_col, s=90, alpha=a
+                mm[i, 0],
+                mm[i, 1],
+                mm[i, 2],
+                marker="o",
+                facecolors="none",
+                edgecolors=blue_col,
+                s=90,
+                alpha=a,
             )
 
     # Set axis labels and title (larger font)
@@ -806,7 +845,7 @@ if __name__ == "__main__":
     ax.set_ylabel("Y [m]", fontsize=14)
     ax.set_zlabel("Z [m]", fontsize=14)
     ax.view_init(elev=20, azim=15)
-    #ax.set_title("Shape comparison across inputs", fontsize=14)
+    # ax.set_title("Shape comparison across inputs", fontsize=14)
 
     # enforce equal aspect ratio for 3D plot
     ax.set_xlim(center[0] - max_range / 2, center[0] + max_range / 2)
@@ -816,17 +855,61 @@ if __name__ == "__main__":
 
     # create a custom legend: show division Original vs Optimized plus markers
     from matplotlib.lines import Line2D
+
     legend_elems = [
-        Line2D([0], [0], color='k', lw=2.5, linestyle='-', alpha=alpha_orig, label='Original Backbone'),
-        Line2D([0], [0], color='k', lw=3.0, linestyle='-', alpha=alpha_hat, label='Optimized Backbone'),
-        Line2D([0], [0], marker='x', color='w', markerfacecolor='orange', markeredgecolor='orange', markersize=8, label='Predicted markers (Original)'),
-        Line2D([0], [0], marker='x', color='w', markerfacecolor='red', markeredgecolor='red', markersize=8, label='Predicted markers (Optimized)'),
-        Line2D([0], [0], marker='o', color='w', markeredgecolor='blue', markerfacecolor='none', markersize=8, label='Measured markers'),
+        Line2D(
+            [0],
+            [0],
+            color="k",
+            lw=2.5,
+            linestyle="-",
+            alpha=alpha_orig,
+            label="Original Backbone",
+        ),
+        Line2D(
+            [0],
+            [0],
+            color="k",
+            lw=3.0,
+            linestyle="-",
+            alpha=alpha_hat,
+            label="Optimized Backbone",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="x",
+            color="w",
+            markerfacecolor="orange",
+            markeredgecolor="orange",
+            markersize=8,
+            label="Predicted markers (Original)",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="x",
+            color="w",
+            markerfacecolor="red",
+            markeredgecolor="red",
+            markersize=8,
+            label="Predicted markers (Optimized)",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markeredgecolor="blue",
+            markerfacecolor="none",
+            markersize=8,
+            label="Measured markers",
+        ),
     ]
-    ax.legend(handles=legend_elems, loc='upper left', fontsize=14)
+    ax.legend(handles=legend_elems, loc="upper left", fontsize=14)
 
     plt.tight_layout()
-    plt.tick_params(axis='both', labelsize=12)
+    plt.tick_params(axis="both", labelsize=12)
 
     # plt.savefig("MARKERS_CONFIG_ss.pdf", format="pdf", bbox_inches="tight")
     # plt.savefig("MARKERS_CONFIG_ss.jpg", format="jpg", dpi=300, bbox_inches="tight")

--- a/examples/system_identification/identify_soft_tentacle_residual.py
+++ b/examples/system_identification/identify_soft_tentacle_residual.py
@@ -1,20 +1,20 @@
+import equinox as eqx
 import jax
-import pandas as pd
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
-import optimistix as optx
-import equinox as eqx
-import optax
-from jax import Array
 import numpy as onp
+import optax
+import optimistix as optx
+import pandas as pd
 import seaborn as sns
+from jax import Array
 
 from soromox.systems import (
     CrossSectionGeometry,
     GVSSegment,
     JointSpec,
-    LinkSpec,
     LinearTendonRoutingParams,
+    LinkSpec,
     StrainBasisSpec,
     TendonActuatedGVS,
 )
@@ -25,8 +25,19 @@ jax.config.update("jax_enable_x64", True)
 
 ### MOCAP DATA TRANSFORMATION FUNCTIONS ###
 
-def _transform_points(pb: jnp.ndarray, p1: jnp.ndarray, p2: jnp.ndarray, p3: jnp.ndarray, p4: jnp.ndarray,
-                      Rot: jnp.ndarray, R_alg1: jnp.ndarray, R_alg2: jnp.ndarray, offset: jnp.ndarray, dyn_sel: bool):
+
+def _transform_points(
+    pb: jnp.ndarray,
+    p1: jnp.ndarray,
+    p2: jnp.ndarray,
+    p3: jnp.ndarray,
+    p4: jnp.ndarray,
+    Rot: jnp.ndarray,
+    R_alg1: jnp.ndarray,
+    R_alg2: jnp.ndarray,
+    offset: jnp.ndarray,
+    dyn_sel: bool,
+):
     if dyn_sel:
         offset_col = offset.reshape(3, 1)
         offset_col = jnp.broadcast_to(offset_col, pb.shape)
@@ -52,7 +63,13 @@ def _transform_points(pb: jnp.ndarray, p1: jnp.ndarray, p2: jnp.ndarray, p3: jnp
     p3_tr = R_total @ p3_lcl
     p4_tr = R_total @ p4_lcl
 
-    return {"pb_tr": pb_tr, "p1_tr": p1_tr, "p2_tr": p2_tr, "p3_tr": p3_tr, "p4_tr": p4_tr}
+    return {
+        "pb_tr": pb_tr,
+        "p1_tr": p1_tr,
+        "p2_tr": p2_tr,
+        "p3_tr": p3_tr,
+        "p4_tr": p4_tr,
+    }
 
 
 def compute_marker_errors(robot, u_batch, q0, measured_markers_batch, tau_batch):
@@ -64,13 +81,15 @@ def compute_marker_errors(robot, u_batch, q0, measured_markers_batch, tau_batch)
     meas_T = measured_markers_batch.T
     M = u_T.shape[0]
     if tau_batch.ndim == 1:
-        tau_mat = jnp.tile(tau_batch.reshape(dof, 1), (1, M))      # (dof, M)
+        tau_mat = jnp.tile(tau_batch.reshape(dof, 1), (1, M))  # (dof, M)
     elif tau_batch.shape == (dof, M):
-        tau_mat = tau_batch                                        # (dof, M)
+        tau_mat = tau_batch  # (dof, M)
     elif tau_batch.shape == (M, dof):
-        tau_mat = tau_batch.T                                      # (dof, M)
+        tau_mat = tau_batch.T  # (dof, M)
     else:
-        raise ValueError(f"Unexpected tau_batch shape {tau_batch.shape}; expected (dof,M), (M,dof) o (dof,) with dof={dof}, M={M}")
+        raise ValueError(
+            f"Unexpected tau_batch shape {tau_batch.shape}; expected (dof,M), (M,dof) o (dof,) with dof={dof}, M={M}"
+        )
 
     diffs = []
     for m in range(M):
@@ -100,6 +119,7 @@ def draw_robot_curve(
 
 ### SOFT ROBOT UTILITIES FUNCTIONS ###
 
+
 # ---- Marker prediction for a fixed q  ----
 def markers_from_q(robot: TendonActuatedGVS, q: jnp.ndarray) -> jnp.ndarray:
     """
@@ -109,73 +129,80 @@ def markers_from_q(robot: TendonActuatedGVS, q: jnp.ndarray) -> jnp.ndarray:
       p3 @ s=0.2800 with offset [0,0, 0.020]
       p4 @ s=sum(L) with offset [0.008,0,0]
     """
+
     def tip_at_s(s_val, offset):
-        G = robot.forward_kinematics(q, s_val)     # 4x4
-        p = G[:3, 3]; R = G[:3, :3]
+        G = robot.forward_kinematics(q, s_val)  # 4x4
+        p = G[:3, 3]
+        R = G[:3, :3]
         return p + R @ offset
 
-    p1 = tip_at_s(0.1291, jnp.array([0.0, 0.0,  0.025]))
+    p1 = tip_at_s(0.1291, jnp.array([0.0, 0.0, 0.025]))
     p2 = tip_at_s(0.2195, jnp.array([0.0, 0.0, -0.021]))
-    p3 = tip_at_s(0.2800, jnp.array([0.0, 0.0,  0.020]))
+    p3 = tip_at_s(0.2800, jnp.array([0.0, 0.0, 0.020]))
     p4 = tip_at_s(robot.length, jnp.array([0.008, 0.0, 0.0]))
     return jnp.concatenate([p1, p2, p3, p4], axis=0)  # (12,)
 
-def solve_equilibrium_with_tau(robot: TendonActuatedGVS,
-                               u: jnp.ndarray,          # (na,)
-                               tau_ext: jnp.ndarray,    # (dof,)
-                               q0: jnp.ndarray):        # (dof,)
+
+def solve_equilibrium_with_tau(
+    robot: TendonActuatedGVS,
+    u: jnp.ndarray,  # (na,)
+    tau_ext: jnp.ndarray,  # (dof,)
+    q0: jnp.ndarray,
+):  # (dof,)
     """
     Solve static equilibrium with an additive generalized external force tau_ext:
       K(q) q + G(q) - B(q) u - tau_ext = 0
     Returns: res (optimistix result with .value = q*)
     """
+
     def statics_eq(q, args):
         u_m, tau_ext = args
-        K = robot.stiffness_matrix()       # (dof,dof)
-        B = robot.actuation_matrix(q)      # (dof, na)
-        G = robot.gravitational_force(q)   # (dof,)
+        K = robot.stiffness_matrix()  # (dof,dof)
+        B = robot.actuation_matrix(q)  # (dof, na)
+        G = robot.gravitational_force(q)  # (dof,)
         return K @ q + G - B @ u_m - tau_ext
 
     solver = optx.Newton(rtol=1e-6, atol=1e-6)
-    statics_eq_jit = jax.jit(statics_eq)   # robot in closure (statico)
+    statics_eq_jit = jax.jit(statics_eq)  # robot in closure (statico)
     return optx.root_find(statics_eq_jit, solver, q0, (u, tau_ext), max_steps=200)
 
 
-def make_tau_loss_for_sample(robot: TendonActuatedGVS,
-                             u_i: jnp.ndarray,           # (na,)
-                             p_meas_i: jnp.ndarray,      # (12,)
-                             q0: jnp.ndarray,
-                             lambda_reg: float):
+def make_tau_loss_for_sample(
+    robot: TendonActuatedGVS,
+    u_i: jnp.ndarray,  # (na,)
+    p_meas_i: jnp.ndarray,  # (12,)
+    q0: jnp.ndarray,
+    lambda_reg: float,
+):
 
     def loss_tau(tau):
 
-        tau_min = jnp.array([-1,-1,-1,-1,-1,-1,-1,-0.01,-0.01])
+        tau_min = jnp.array([-1, -1, -1, -1, -1, -1, -1, -0.01, -0.01])
         tau_max = jnp.array([1, 1, 1, 1, 1, 1, 1, 0.01, 0.01])
 
         res = solve_equilibrium_with_tau(robot, u_i, tau, q0)
         q_star = res.value
-        pred = markers_from_q(robot, q_star)           # (12,)
+        pred = markers_from_q(robot, q_star)  # (12,)
         err = pred - p_meas_i
 
-        penalty = jnp.sum(jnp.square(jnp.maximum(0.0, tau - tau_max))) \
-                + jnp.sum(jnp.square(jnp.maximum(0.0, tau_min - tau)))
+        penalty = jnp.sum(jnp.square(jnp.maximum(0.0, tau - tau_max))) + jnp.sum(
+            jnp.square(jnp.maximum(0.0, tau_min - tau))
+        )
 
-
-        return 0.5 * (err @ err) \
-               + 0.5 * lambda_reg * (tau @ tau) \
-               + 1e1 * penalty
-
+        return 0.5 * (err @ err) + 0.5 * lambda_reg * (tau @ tau) + 1e1 * penalty
 
     return loss_tau
 
 
-def solve_tau_star_for_batch(robot: TendonActuatedGVS,
-                             u_batch: jnp.ndarray,                 # (na, M)
-                             measured_markers_batch: jnp.ndarray,  # (12, M)
-                             q0: jnp.ndarray,
-                             lambda_reg: float = 1e-6,
-                             steps: int = 50,
-                             lr: float = 1e-2):
+def solve_tau_star_for_batch(
+    robot: TendonActuatedGVS,
+    u_batch: jnp.ndarray,  # (na, M)
+    measured_markers_batch: jnp.ndarray,  # (12, M)
+    q0: jnp.ndarray,
+    lambda_reg: float = 1e-6,
+    steps: int = 50,
+    lr: float = 1e-2,
+):
 
     M = u_batch.shape[1]
     dof = q0.shape[0]
@@ -220,64 +247,67 @@ def solve_tau_star_for_batch(robot: TendonActuatedGVS,
 
 # ========================= NN to fit tau*(u) =========================
 
+
 class TauNN(eqx.Module):
     mlp: eqx.nn.MLP
 
-    def __init__(self, in_dim: int, out_dim: int, width: int = 64, depth: int = 2, *, key: Array):
+    def __init__(
+        self, in_dim: int, out_dim: int, width: int = 64, depth: int = 2, *, key: Array
+    ):
         self.mlp = eqx.nn.MLP(in_dim, out_dim, width, depth, key=key)
 
     def __call__(self, x):
         return self.mlp(x)
 
-def train_tau_nn(u_batch: jnp.ndarray,                 # (na, M)
-                 tau_star_batch: jnp.ndarray,          # (dof, M)
-                 gamma_wd: float = 1e-4,
-                 steps: int = 2000,
-                 lr: float = 1e-3,
-                 width: int = 64,
-                 depth: int = 2,
-                 key: Array | None = None):
+
+def train_tau_nn(
+    u_batch: jnp.ndarray,  # (na, M)
+    tau_star_batch: jnp.ndarray,  # (dof, M)
+    gamma_wd: float = 1e-4,
+    steps: int = 2000,
+    lr: float = 1e-3,
+    width: int = 64,
+    depth: int = 2,
+    key: Array | None = None,
+):
 
     if key is None:
         key = jax.random.PRNGKey(0)
-    M = u_batch.shape[1]
+    u_batch.shape[1]
     na = u_batch.shape[0]
     dof = tau_star_batch.shape[0]
 
     # Build features X: (M, na)
-    X = u_batch.T                             # (M, na)
-    Y = tau_star_batch.T                      # (M, dof)
+    X = u_batch.T  # (M, na)
+    Y = tau_star_batch.T  # (M, dof)
 
     model = TauNN(in_dim=na, out_dim=dof, width=width, depth=depth, key=key)
 
-    #base version
+    # base version
     # opt = optax.adam(lr)
 
-    #cosine decay version
+    # cosine decay version
     lr_schedule = optax.cosine_decay_schedule(
-        init_value=1e-3,
-        decay_steps=15000,
-        alpha=0.05
+        init_value=1e-3, decay_steps=15000, alpha=0.05
     )
-    opt = optax.chain(
-        optax.clip_by_global_norm(1.0),
-        optax.adam(lr_schedule)
-    )
+    opt = optax.chain(optax.clip_by_global_norm(1.0), optax.adam(lr_schedule))
 
     opt_state = opt.init(eqx.filter(model, eqx.is_inexact_array))
 
     def loss_model(m: TauNN):
-        pred = jax.vmap(lambda x: m(x))(X)               # (M, dof)
+        pred = jax.vmap(lambda x: m(x))(X)  # (M, dof)
         diff = pred - Y
         data_term = 0.5 * jnp.mean(jnp.sum(diff * diff, axis=1))
 
-        l2 = sum(jnp.sum(p**2) for p in jax.tree.leaves(eqx.filter(m, eqx.is_inexact_array)))
+        l2 = sum(
+            jnp.sum(p**2) for p in jax.tree.leaves(eqx.filter(m, eqx.is_inexact_array))
+        )
         return data_term + 0.5 * gamma_wd * l2
 
     loss_and_grad = eqx.filter_value_and_grad(loss_model)
 
     losses = []
-    for step in range(steps):
+    for _step in range(steps):
         loss_val, grads = loss_and_grad(model)
         updates, opt_state = opt.update(grads, opt_state, model)
         model = eqx.apply_updates(model, updates)
@@ -290,20 +320,17 @@ def train_tau_nn(u_batch: jnp.ndarray,                 # (na, M)
     return model, losses
 
 
-
-
-
 if __name__ == "__main__":
     ### DATA LOADING AND PROCESSING ###
-    Rot = jnp.array([[1.0, 0.0, 0.0],
-                     [0.0, 1.0, 0.0],
-                     [0.0, 0.0, 1.0]], dtype=jnp.float64)
-    R_alg1 = jnp.array([[1.0, 0.0, 0.0],
-                        [0.0, 0.0, 1.0],
-                        [0.0, -1.0, 0.0]], dtype=jnp.float64)
-    R_alg2 = jnp.array([[1.0, 0.0, 0.0],
-                        [0.0, 1.0, 0.0],
-                        [0.0, 0.0, 1.0]], dtype=jnp.float64)
+    Rot = jnp.array(
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=jnp.float64
+    )
+    R_alg1 = jnp.array(
+        [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, -1.0, 0.0]], dtype=jnp.float64
+    )
+    R_alg2 = jnp.array(
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=jnp.float64
+    )
     offset = jnp.array([-0.03, -0.013, 0.0], dtype=jnp.float64)
 
     df = pd.read_csv("data/m1_u01.csv", header=None)
@@ -314,7 +341,9 @@ if __name__ == "__main__":
     p2 = filtered[9:12]
     p3 = filtered[3:6]
     p4 = filtered[6:9]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
     pb_m1u01 = res["pb_tr"]
     p1_m1u01 = res["p1_tr"]
     p2_m1u01 = res["p2_tr"]
@@ -329,7 +358,9 @@ if __name__ == "__main__":
     p2 = filtered[12:15]
     p3 = filtered[3:6]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
     pb_m1u015 = res["pb_tr"]
     p1_m1u015 = res["p1_tr"]
     p2_m1u015 = res["p2_tr"]
@@ -344,7 +375,9 @@ if __name__ == "__main__":
     p2 = filtered[12:15]
     p3 = filtered[3:6]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
     pb_m1u02 = res["pb_tr"]
     p1_m1u02 = res["p1_tr"]
     p2_m1u02 = res["p2_tr"]
@@ -359,7 +392,9 @@ if __name__ == "__main__":
     p2 = filtered[0:3]
     p3 = filtered[6:9]
     p4 = filtered[3:6]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
     pb_m1u025 = res["pb_tr"]
     p1_m1u025 = res["p1_tr"]
     p2_m1u025 = res["p2_tr"]
@@ -374,7 +409,9 @@ if __name__ == "__main__":
     p2 = filtered[12:15]
     p3 = filtered[9:12]
     p4 = filtered[3:6]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
     pb_m2u01 = res["pb_tr"]
     p1_m2u01 = res["p1_tr"]
     p2_m2u01 = res["p2_tr"]
@@ -389,7 +426,9 @@ if __name__ == "__main__":
     p2 = filtered[12:15]
     p3 = filtered[3:6]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
     pb_m2u015 = res["pb_tr"]
     p1_m2u015 = res["p1_tr"]
     p2_m2u015 = res["p2_tr"]
@@ -404,7 +443,9 @@ if __name__ == "__main__":
     p2 = filtered[12:15]
     p3 = filtered[3:6]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
     pb_m2u02 = res["pb_tr"]
     p1_m2u02 = res["p1_tr"]
     p2_m2u02 = res["p2_tr"]
@@ -419,7 +460,9 @@ if __name__ == "__main__":
     p2 = filtered[9:12]
     p3 = filtered[0:3]
     p4 = filtered[12:15]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
     pb_m2u025 = res["pb_tr"]
     p1_m2u025 = res["p1_tr"]
     p2_m2u025 = res["p2_tr"]
@@ -434,8 +477,16 @@ if __name__ == "__main__":
     p2 = filtered[6:9]
     p3 = filtered[12:15]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m1_005, p1_m1_005, p2_m1_005, p3_m1_005, p4_m1_005 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m1_005, p1_m1_005, p2_m1_005, p3_m1_005, p4_m1_005 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m1_u012.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -445,8 +496,16 @@ if __name__ == "__main__":
     p2 = filtered[12:15]
     p3 = filtered[3:6]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m1_012, p1_m1_012, p2_m1_012, p3_m1_012, p4_m1_012 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m1_012, p1_m1_012, p2_m1_012, p3_m1_012, p4_m1_012 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m1_u018.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -456,8 +515,16 @@ if __name__ == "__main__":
     p2 = filtered[9:12]
     p3 = filtered[0:3]
     p4 = filtered[12:15]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m1_018, p1_m1_018, p2_m1_018, p3_m1_018, p4_m1_018 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m1_018, p1_m1_018, p2_m1_018, p3_m1_018, p4_m1_018 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m2_u005.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -467,8 +534,16 @@ if __name__ == "__main__":
     p2 = filtered[9:12]
     p3 = filtered[0:3]
     p4 = filtered[12:15]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m2_005, p1_m2_005, p2_m2_005, p3_m2_005, p4_m2_005 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m2_005, p1_m2_005, p2_m2_005, p3_m2_005, p4_m2_005 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m2_u012.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -478,8 +553,16 @@ if __name__ == "__main__":
     p2 = filtered[9:12]
     p3 = filtered[12:15]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m2_012, p1_m2_012, p2_m2_012, p3_m2_012, p4_m2_012 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m2_012, p1_m2_012, p2_m2_012, p3_m2_012, p4_m2_012 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m2_u018.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -489,8 +572,16 @@ if __name__ == "__main__":
     p2 = filtered[6:9]
     p3 = filtered[9:12]
     p4 = filtered[12:15]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m2_018, p1_m2_018, p2_m2_018, p3_m2_018, p4_m2_018 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m2_018, p1_m2_018, p2_m2_018, p3_m2_018, p4_m2_018 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m12_u001.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -500,8 +591,16 @@ if __name__ == "__main__":
     p2 = filtered[9:12]
     p3 = filtered[0:3]
     p4 = filtered[3:6]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m12_01, p1_m12_01, p2_m12_01, p3_m12_01, p4_m12_01 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m12_01, p1_m12_01, p2_m12_01, p3_m12_01, p4_m12_01 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m12_u002.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -511,8 +610,16 @@ if __name__ == "__main__":
     p2 = filtered[12:15]
     p3 = filtered[3:6]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m12_02, p1_m12_02, p2_m12_02, p3_m12_02, p4_m12_02 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m12_02, p1_m12_02, p2_m12_02, p3_m12_02, p4_m12_02 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m12_u001002.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -522,8 +629,16 @@ if __name__ == "__main__":
     p2 = filtered[3:6]
     p3 = filtered[0:3]
     p4 = filtered[12:15]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m12_0102, p1_m12_0102, p2_m12_0102, p3_m12_0102, p4_m12_0102 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m12_0102, p1_m12_0102, p2_m12_0102, p3_m12_0102, p4_m12_0102 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m12_u0015002.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -533,8 +648,16 @@ if __name__ == "__main__":
     p2 = filtered[9:12]
     p3 = filtered[6:9]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m12_01502, p1_m12_01502, p2_m12_01502, p3_m12_01502, p4_m12_01502 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m12_01502, p1_m12_01502, p2_m12_01502, p3_m12_01502, p4_m12_01502 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m12_u002001.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -544,8 +667,16 @@ if __name__ == "__main__":
     p2 = filtered[9:12]
     p3 = filtered[3:6]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m12_0201, p1_m12_0201, p2_m12_0201, p3_m12_0201, p4_m12_0201 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m12_0201, p1_m12_0201, p2_m12_0201, p3_m12_0201, p4_m12_0201 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m12_u0020015.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -555,8 +686,16 @@ if __name__ == "__main__":
     p2 = filtered[6:9]
     p3 = filtered[0:3]
     p4 = filtered[12:15]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m12_02015, p1_m12_02015, p2_m12_02015, p3_m12_02015, p4_m12_02015 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m12_02015, p1_m12_02015, p2_m12_02015, p3_m12_02015, p4_m12_02015 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m12_u00100005.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -566,8 +705,16 @@ if __name__ == "__main__":
     p2 = filtered[12:15]
     p3 = filtered[3:6]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m12_01005, p1_m12_01005, p2_m12_01005, p3_m12_01005, p4_m12_01005 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m12_01005, p1_m12_01005, p2_m12_01005, p3_m12_01005, p4_m12_01005 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     df = pd.read_csv("data/m12_u00050010.csv", header=None)
     vals = df.iloc[:, 2:].to_numpy(dtype=float)
@@ -577,8 +724,16 @@ if __name__ == "__main__":
     p2 = filtered[12:15]
     p3 = filtered[3:6]
     p4 = filtered[0:3]
-    res = _transform_points(pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False)
-    pb_m12_00501, p1_m12_00501, p2_m12_00501, p3_m12_00501, p4_m12_00501 = res["pb_tr"], res["p1_tr"], res["p2_tr"], res["p3_tr"], res["p4_tr"]
+    res = _transform_points(
+        pb, p1, p2, p3, p4, Rot, R_alg1, R_alg2, offset, dyn_sel=False
+    )
+    pb_m12_00501, p1_m12_00501, p2_m12_00501, p3_m12_00501, p4_m12_00501 = (
+        res["pb_tr"],
+        res["p1_tr"],
+        res["p2_tr"],
+        res["p3_tr"],
+        res["p4_tr"],
+    )
 
     ### END DATA LOADING AND PROCESSING ###
 
@@ -623,13 +778,19 @@ if __name__ == "__main__":
             [0.0114 * jnp.cos(jnp.pi / 180 * 30), 0.0114 * jnp.cos(jnp.pi / 180 * 150)]
         ),
         y_slope=jnp.array(
-            [-0.0295 * jnp.cos(jnp.pi / 180 * 30), -0.0295 * jnp.cos(jnp.pi / 180 * 150)]
+            [
+                -0.0295 * jnp.cos(jnp.pi / 180 * 30),
+                -0.0295 * jnp.cos(jnp.pi / 180 * 150),
+            ]
         ),
         z_intercept=jnp.array(
             [0.0114 * jnp.sin(jnp.pi / 180 * 30), 0.0114 * jnp.sin(jnp.pi / 180 * 150)]
         ),
         z_slope=jnp.array(
-            [-0.0295 * jnp.sin(jnp.pi / 180 * 30), -0.0295 * jnp.sin(jnp.pi / 180 * 150)]
+            [
+                -0.0295 * jnp.sin(jnp.pi / 180 * 30),
+                -0.0295 * jnp.sin(jnp.pi / 180 * 150),
+            ]
         ),
         attachment_segment_index=jnp.array([0, 0]),
     )
@@ -638,10 +799,16 @@ if __name__ == "__main__":
     robot = TendonActuatedGVS.from_segments(
         [
             GVSSegment(
-                link=link1, joint=joint1, basis=basis1, num_gauss_points=num_gauss_points[0]
+                link=link1,
+                joint=joint1,
+                basis=basis1,
+                num_gauss_points=num_gauss_points[0],
             ),
             GVSSegment(
-                link=link2, joint=joint2, basis=basis2, num_gauss_points=num_gauss_points[1]
+                link=link2,
+                joint=joint2,
+                basis=basis2,
+                num_gauss_points=num_gauss_points[1],
             ),
         ],
         gravity=jnp.asarray(g),
@@ -653,36 +820,33 @@ if __name__ == "__main__":
     # Initialize parameters
     n_links = int(robot.num_segments)
 
-
     # Prepare batch data (measured coordinates and inputs)
     def _pack_markers(p1, p2, p3, p4):
         return jnp.concatenate([p1, p2, p3, p4], axis=0)  # (12,)
 
     measured_list = [
-        _pack_markers(p1_m1u01,  p2_m1u01,  p3_m1u01,  p4_m1u01),
+        _pack_markers(p1_m1u01, p2_m1u01, p3_m1u01, p4_m1u01),
         _pack_markers(p1_m1u015, p2_m1u015, p3_m1u015, p4_m1u015),
-        _pack_markers(p1_m1u02,  p2_m1u02,  p3_m1u02,  p4_m1u02),
+        _pack_markers(p1_m1u02, p2_m1u02, p3_m1u02, p4_m1u02),
         _pack_markers(p1_m1u025, p2_m1u025, p3_m1u025, p4_m1u025),
-        _pack_markers(p1_m2u01,  p2_m2u01,  p3_m2u01,  p4_m2u01),
+        _pack_markers(p1_m2u01, p2_m2u01, p3_m2u01, p4_m2u01),
         _pack_markers(p1_m2u015, p2_m2u015, p3_m2u015, p4_m2u015),
-        _pack_markers(p1_m2u02,  p2_m2u02,  p3_m2u02,  p4_m2u02),
+        _pack_markers(p1_m2u02, p2_m2u02, p3_m2u02, p4_m2u02),
         _pack_markers(p1_m2u025, p2_m2u025, p3_m2u025, p4_m2u025),
-
         _pack_markers(p1_m1_005, p2_m1_005, p3_m1_005, p4_m1_005),
         _pack_markers(p1_m1_012, p2_m1_012, p3_m1_012, p4_m1_012),
         _pack_markers(p1_m1_018, p2_m1_018, p3_m1_018, p4_m1_018),
         _pack_markers(p1_m2_005, p2_m2_005, p3_m2_005, p4_m2_005),
         _pack_markers(p1_m2_012, p2_m2_012, p3_m2_012, p4_m2_012),
         _pack_markers(p1_m2_018, p2_m2_018, p3_m2_018, p4_m2_018),
-
-        _pack_markers(p1_m12_01,    p2_m12_01,    p3_m12_01,    p4_m12_01),
-        _pack_markers(p1_m12_02,    p2_m12_02,    p3_m12_02,    p4_m12_02),
-        _pack_markers(p1_m12_0102,  p2_m12_0102,  p3_m12_0102,  p4_m12_0102),
+        _pack_markers(p1_m12_01, p2_m12_01, p3_m12_01, p4_m12_01),
+        _pack_markers(p1_m12_02, p2_m12_02, p3_m12_02, p4_m12_02),
+        _pack_markers(p1_m12_0102, p2_m12_0102, p3_m12_0102, p4_m12_0102),
         _pack_markers(p1_m12_01502, p2_m12_01502, p3_m12_01502, p4_m12_01502),
-        _pack_markers(p1_m12_0201,  p2_m12_0201,  p3_m12_0201,  p4_m12_0201),
+        _pack_markers(p1_m12_0201, p2_m12_0201, p3_m12_0201, p4_m12_0201),
         _pack_markers(p1_m12_02015, p2_m12_02015, p3_m12_02015, p4_m12_02015),
-        _pack_markers(p1_m12_01005,  p2_m12_01005,  p3_m12_01005,  p4_m12_01005),
-        _pack_markers(p1_m12_00501,  p2_m12_00501,  p3_m12_00501,  p4_m12_00501),
+        _pack_markers(p1_m12_01005, p2_m12_01005, p3_m12_01005, p4_m12_01005),
+        _pack_markers(p1_m12_00501, p2_m12_00501, p3_m12_00501, p4_m12_00501),
     ]
     measured_markers_batch = jnp.stack(measured_list, axis=1)
     radius = 0.0325
@@ -692,30 +856,28 @@ if __name__ == "__main__":
 
     # Define mapping from sample name to u
     sample_to_u = {
-        "m1u01":      jnp.array([_neg(0.1), 0.0]),
-        "m1u015":     jnp.array([_neg(0.15), 0.0]),
-        "m1u02":      jnp.array([_neg(0.2), 0.0]),
-        "m1u025":     jnp.array([_neg(0.25), 0.0]),
-        "m2u01":      jnp.array([0.0, _neg(0.1)]),
-        "m2u015":     jnp.array([0.0, _neg(0.15)]),
-        "m2u02":      jnp.array([0.0, _neg(0.2)]),
-        "m2u025":     jnp.array([0.0, _neg(0.25)]),
-
-        "m1_005":      jnp.array([_neg(0.05), 0.0]),
-        "m1_012":      jnp.array([_neg(0.12), 0.0]),
-        "m1_018":      jnp.array([_neg(0.18), 0.0]),
-        "m2_005":      jnp.array([0.0, _neg(0.05)]),
-        "m2_012":      jnp.array([0.0, _neg(0.12)]),
-        "m2_018":      jnp.array([0.0, _neg(0.18)]),
-
-        "m12_001":         jnp.array([_neg(0.1), _neg(0.1)]),
-        "m12_002":         jnp.array([_neg(0.2), _neg(0.2)]),
-        "m12_001002":      jnp.array([_neg(0.1), _neg(0.2)]),
-        "m12_0015002":     jnp.array([_neg(0.15), _neg(0.2)]),
-        "m12_002001":      jnp.array([_neg(0.2), _neg(0.1)]),
-        "m12_0020015":     jnp.array([_neg(0.2), _neg(0.15)]),
-        "m12_00100005":    jnp.array([_neg(0.1), _neg(0.05)]),
-        "m12_00050010":    jnp.array([_neg(0.05), _neg(0.1)]),
+        "m1u01": jnp.array([_neg(0.1), 0.0]),
+        "m1u015": jnp.array([_neg(0.15), 0.0]),
+        "m1u02": jnp.array([_neg(0.2), 0.0]),
+        "m1u025": jnp.array([_neg(0.25), 0.0]),
+        "m2u01": jnp.array([0.0, _neg(0.1)]),
+        "m2u015": jnp.array([0.0, _neg(0.15)]),
+        "m2u02": jnp.array([0.0, _neg(0.2)]),
+        "m2u025": jnp.array([0.0, _neg(0.25)]),
+        "m1_005": jnp.array([_neg(0.05), 0.0]),
+        "m1_012": jnp.array([_neg(0.12), 0.0]),
+        "m1_018": jnp.array([_neg(0.18), 0.0]),
+        "m2_005": jnp.array([0.0, _neg(0.05)]),
+        "m2_012": jnp.array([0.0, _neg(0.12)]),
+        "m2_018": jnp.array([0.0, _neg(0.18)]),
+        "m12_001": jnp.array([_neg(0.1), _neg(0.1)]),
+        "m12_002": jnp.array([_neg(0.2), _neg(0.2)]),
+        "m12_001002": jnp.array([_neg(0.1), _neg(0.2)]),
+        "m12_0015002": jnp.array([_neg(0.15), _neg(0.2)]),
+        "m12_002001": jnp.array([_neg(0.2), _neg(0.1)]),
+        "m12_0020015": jnp.array([_neg(0.2), _neg(0.15)]),
+        "m12_00100005": jnp.array([_neg(0.1), _neg(0.05)]),
+        "m12_00050010": jnp.array([_neg(0.05), _neg(0.1)]),
     }
 
     u_list = [
@@ -727,14 +889,12 @@ if __name__ == "__main__":
         sample_to_u["m2u015"],
         sample_to_u["m2u02"],
         sample_to_u["m2u025"],
-
         sample_to_u["m1_005"],
         sample_to_u["m1_012"],
         sample_to_u["m1_018"],
         sample_to_u["m2_005"],
         sample_to_u["m2_012"],
         sample_to_u["m2_018"],
-
         sample_to_u["m12_001"],
         sample_to_u["m12_002"],
         sample_to_u["m12_001002"],
@@ -756,7 +916,6 @@ if __name__ == "__main__":
 
     q0 = jnp.zeros((dof,), dtype=jnp.float64)
 
-
     # 1) Identify tau*_i for each sample
     # lambda_reg = 1e-8   # regularization on tau
     # print("Starting identification of tau* for each sample ===")
@@ -774,14 +933,18 @@ if __name__ == "__main__":
     tau_star_batch_1act1 = jnp.array(onp.load("data/tau_star_batch_1actpt1.npy"))
     tau_star_batch_1act2 = jnp.array(onp.load("data/tau_star_batch_1actpt2.npy"))
     tau_star_batch_2act = jnp.array(onp.load("data/tau_star_batch_2act.npy"))
-    tau_star_batch = jnp.concatenate([tau_star_batch_1act1,tau_star_batch_1act2, tau_star_batch_2act], axis=1)
+    tau_star_batch = jnp.concatenate(
+        [tau_star_batch_1act1, tau_star_batch_1act2, tau_star_batch_2act], axis=1
+    )
 
     print("Identified tau* shape:", tau_star_batch.shape)
     # print("Identified tau* samples:", tau_star_batch)
 
     # Evaluate errors before and after tau* identification
     tau_zero_batch = jnp.zeros((dof, M), dtype=jnp.float64)
-    errors_before = compute_marker_errors(robot, u_batch, q0, measured_markers_batch, tau_zero_batch)
+    errors_before = compute_marker_errors(
+        robot, u_batch, q0, measured_markers_batch, tau_zero_batch
+    )
 
     def marker_rmse(errors):
         # errors shape: (M, 12)
@@ -793,10 +956,11 @@ if __name__ == "__main__":
     print("RMSE per marker before residual tau* identification:", rmse_before)
 
     # Evaluate errors after tau* identification
-    errors_tau_star = compute_marker_errors(robot, u_batch, q0, measured_markers_batch, tau_star_batch)
+    errors_tau_star = compute_marker_errors(
+        robot, u_batch, q0, measured_markers_batch, tau_star_batch
+    )
     rmse_tau_star = marker_rmse(errors_tau_star)
     print("RMSE per marker with residual tau* identification:", rmse_tau_star)
-
 
     # ===== Plot: robot shape for each tau* =====
     q_star_list = []
@@ -814,8 +978,11 @@ if __name__ == "__main__":
     xmin, ymin, zmin = all_pts.min(axis=0)
     xmax, ymax, zmax = all_pts.max(axis=0)
     pad = 0.05 * max(xmax - xmin, ymax - ymin, zmax - zmin)
-    lims = ( (xmin - pad, xmax + pad), (ymin - pad, ymax + pad), (zmin - pad, zmax + pad) )
-
+    lims = (
+        (xmin - pad, xmax + pad),
+        (ymin - pad, ymax + pad),
+        (zmin - pad, zmax + pad),
+    )
 
     # Compute predicted marker positions from q_star
     predicted_markers_batch = []
@@ -842,7 +1009,7 @@ if __name__ == "__main__":
 
     fig, ax = plt.subplots(figsize=(12, 9), subplot_kw={"projection": "3d"})
 
-    alpha_hat = 1.0    # full opacity
+    alpha_hat = 1.0  # full opacity
 
     for m in range(M):
         curve = curves_list[m]
@@ -861,8 +1028,25 @@ if __name__ == "__main__":
         blue_col = (0.0, 0.2, 0.8)
 
         for i in range(4):
-            ax.scatter(pred[i, 0], pred[i, 1], pred[i, 2], c=[red_col], s=90, marker='x', alpha=grad_alphas[i])
-            ax.scatter(meas[i, 0], meas[i, 1], meas[i, 2], facecolors="none", edgecolors=blue_col, s=90, marker='o', alpha=grad_alphas[i])
+            ax.scatter(
+                pred[i, 0],
+                pred[i, 1],
+                pred[i, 2],
+                c=[red_col],
+                s=90,
+                marker="x",
+                alpha=grad_alphas[i],
+            )
+            ax.scatter(
+                meas[i, 0],
+                meas[i, 1],
+                meas[i, 2],
+                facecolors="none",
+                edgecolors=blue_col,
+                s=90,
+                marker="o",
+                alpha=grad_alphas[i],
+            )
 
     # Set axis labels and title (larger font)
     ax.set_xlabel("X [m]", fontsize=14)
@@ -878,23 +1062,51 @@ if __name__ == "__main__":
 
     # create a custom legend
     from matplotlib.lines import Line2D
+
     legend_elems = [
-        Line2D([0], [0], color='k', lw=3.0, linestyle='-', alpha=alpha_hat, label='Backbone'),
-        Line2D([0], [0], marker='x', color='w', markerfacecolor='red', markeredgecolor='red', markersize=8, label='Predicted markers'),
-        Line2D([0], [0], marker='o', color='w', markeredgecolor='blue', markerfacecolor='none', markersize=8, label='Measured markers'),
+        Line2D(
+            [0],
+            [0],
+            color="k",
+            lw=3.0,
+            linestyle="-",
+            alpha=alpha_hat,
+            label="Backbone",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="x",
+            color="w",
+            markerfacecolor="red",
+            markeredgecolor="red",
+            markersize=8,
+            label="Predicted markers",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markeredgecolor="blue",
+            markerfacecolor="none",
+            markersize=8,
+            label="Measured markers",
+        ),
     ]
-    ax.legend(handles=legend_elems, loc='upper left', fontsize=14)
+    ax.legend(handles=legend_elems, loc="upper left", fontsize=14)
 
     plt.tight_layout()
-    plt.tick_params(axis='both', labelsize=12)
+    plt.tick_params(axis="both", labelsize=12)
     # plt.savefig("MARKERS_CONFIG_residual.pdf", format="pdf", bbox_inches="tight")
     # plt.savefig("MARKERS_CONFIG_residual.jpg", format="jpg", dpi=300, bbox_inches="tight")
     plt.show()
 
-
     # # # 2) Train NN: x=[u] -> tau*
-    train_idx = jnp.array([0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21])
-    test_idx = jnp.setdiff1d(jnp.arange(M), train_idx) # 1,16 test
+    train_idx = jnp.array(
+        [0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21]
+    )
+    test_idx = jnp.setdiff1d(jnp.arange(M), train_idx)  # 1,16 test
 
     # split data
     u_train = u_batch[:, train_idx]
@@ -938,27 +1150,26 @@ if __name__ == "__main__":
         tau_pred.append(tau_pred_i)
 
     tau_pred_batch = jnp.stack(tau_pred, axis=1)  # (dof, M)
-    errors_tau_pred = compute_marker_errors(robot, u_batch, q0, measured_markers_batch, tau_pred_batch)
+    errors_tau_pred = compute_marker_errors(
+        robot, u_batch, q0, measured_markers_batch, tau_pred_batch
+    )
     rmse_tau_pred = marker_rmse(errors_tau_pred)
     print("RMSE per marker with tau* NN prediction:", rmse_tau_pred)
-
 
     # # # # === Plots: Random_id vs Opt_id vs Residual vs Residual_NN ===
 
     # Per-marker error per configuration (4 subplot)
-    errs_zero = onp.asarray(errors_before).reshape(-1, 4, 3)      # (M, 4, 3)
-    errs_star = onp.asarray(errors_tau_star).reshape(-1, 4, 3)    # (M, 4, 3)
-    errs_pred = onp.asarray(errors_tau_pred).reshape(-1, 4, 3)    # (M, 4, 3)
-    errnorms_zero = onp.linalg.norm(errs_zero, axis=2)            # (M, 4)
-    errnorms_star = onp.linalg.norm(errs_star, axis=2)            # (M, 4)
-    errnorms_pred = onp.linalg.norm(errs_pred, axis=2)            # (M, 4)
-
+    errs_zero = onp.asarray(errors_before).reshape(-1, 4, 3)  # (M, 4, 3)
+    errs_star = onp.asarray(errors_tau_star).reshape(-1, 4, 3)  # (M, 4, 3)
+    errs_pred = onp.asarray(errors_tau_pred).reshape(-1, 4, 3)  # (M, 4, 3)
+    errnorms_zero = onp.linalg.norm(errs_zero, axis=2)  # (M, 4)
+    errnorms_star = onp.linalg.norm(errs_star, axis=2)  # (M, 4)
+    errnorms_pred = onp.linalg.norm(errs_pred, axis=2)  # (M, 4)
 
     # Spider plots: Error per marker across all configurations
     # Calculate RMS error for each marker across all configurations
     errnorm_zero_per_marker = onp.mean(errnorms_zero, axis=0)  # RMS for each marker
     errnorm_star_per_marker = onp.mean(errnorms_star, axis=0)  # RMS for each marker
-
 
     # Prepare data for plotting
     errnorm_zero_plot = errnorm_zero_per_marker.tolist()
@@ -973,42 +1184,73 @@ if __name__ == "__main__":
     errnorm_pred_plot = errnorm_pred_per_marker.tolist()
     errnorm_pred_plot += errnorm_pred_plot[:1]
 
-
     # Calculate RMS error per marker for initial parameters
     errors_before_id = onp.asarray(onp.load("data/errors_before.npy"))
     errs_before_id = onp.asarray(errors_before_id).reshape(-1, 4, 3)  # (M, 4, 3)
-    errnorms_before_id = onp.linalg.norm(errs_before_id, axis=2)      # (M, 4)
-    errnorm_before_id_per_marker = onp.mean(errnorms_before_id, axis=0)  # RMS for each marker
+    errnorms_before_id = onp.linalg.norm(errs_before_id, axis=2)  # (M, 4)
+    errnorm_before_id_per_marker = onp.mean(
+        errnorms_before_id, axis=0
+    )  # RMS for each marker
 
     # Prepare data for plotting
     errnorm_before_id_plot = errnorm_before_id_per_marker.tolist()
     errnorm_before_id_plot += errnorm_before_id_plot[:1]
 
-
     # Setup for 4-axis radar plot (one for each marker)
     angles_markers = onp.linspace(0, 2 * onp.pi, 4, endpoint=False).tolist()
     angles_markers += angles_markers[:1]  # Complete the circle
-    marker_labels = [f'$M_{{{i+1}}}$' for i in range(4)]
-
+    marker_labels = [f"$M_{{{i + 1}}}$" for i in range(4)]
 
     # Additional per-marker radar plot: include initial param + all cases
-    fig, ax = plt.subplots(figsize=(12, 9), subplot_kw=dict(projection='polar'))
+    fig, ax = plt.subplots(figsize=(12, 9), subplot_kw={"projection": "polar"})
 
     # Plot
-    ax.plot(angles_markers, errnorm_before_id_plot, 'o-', linewidth=2.5, label=r'Initial parameters', color='lightgray', markersize=8)
-    ax.fill(angles_markers, errnorm_before_id_plot, alpha=0.25, color='lightgray')
-    ax.plot(angles_markers, errnorm_zero_plot, 'o-', linewidth=2.5, label=r'Optimal parameters', color='gray', markersize=8)
-    ax.fill(angles_markers, errnorm_zero_plot, alpha=0.25, color='gray')
-    ax.plot(angles_markers, errnorm_star_plot, 's-', linewidth=2.5, label=r'Optimal residual', color='tab:blue', markersize=8)
-    ax.fill(angles_markers, errnorm_star_plot, alpha=0.25, color='tab:blue')
-    ax.plot(angles_markers, errnorm_pred_plot, '^--', linewidth=2.5, label=r'NN-predicted residual', color='skyblue', markersize=8)
-    ax.fill(angles_markers, errnorm_pred_plot, alpha=0.25, color='skyblue')
+    ax.plot(
+        angles_markers,
+        errnorm_before_id_plot,
+        "o-",
+        linewidth=2.5,
+        label=r"Initial parameters",
+        color="lightgray",
+        markersize=8,
+    )
+    ax.fill(angles_markers, errnorm_before_id_plot, alpha=0.25, color="lightgray")
+    ax.plot(
+        angles_markers,
+        errnorm_zero_plot,
+        "o-",
+        linewidth=2.5,
+        label=r"Optimal parameters",
+        color="gray",
+        markersize=8,
+    )
+    ax.fill(angles_markers, errnorm_zero_plot, alpha=0.25, color="gray")
+    ax.plot(
+        angles_markers,
+        errnorm_star_plot,
+        "s-",
+        linewidth=2.5,
+        label=r"Optimal residual",
+        color="tab:blue",
+        markersize=8,
+    )
+    ax.fill(angles_markers, errnorm_star_plot, alpha=0.25, color="tab:blue")
+    ax.plot(
+        angles_markers,
+        errnorm_pred_plot,
+        "^--",
+        linewidth=2.5,
+        label=r"NN-predicted residual",
+        color="skyblue",
+        markersize=8,
+    )
+    ax.fill(angles_markers, errnorm_pred_plot, alpha=0.25, color="skyblue")
 
     ax.set_xticks(angles_markers[:-1])
     ax.set_xticklabels(marker_labels, fontsize=16)
-    ax.set_ylabel('Position RMSE [m]', labelpad=30, fontsize=16)
-    ax.legend(loc='upper center', fontsize=18)
-    ax.tick_params(axis='both', labelsize=16)
+    ax.set_ylabel("Position RMSE [m]", labelpad=30, fontsize=16)
+    ax.legend(loc="upper center", fontsize=18)
+    ax.tick_params(axis="both", labelsize=16)
     ax.grid(True)
 
     plt.tight_layout()
@@ -1016,49 +1258,66 @@ if __name__ == "__main__":
     # plt.savefig("radar_error_per_marker_all_with_initial_center.jpg", format="jpg", dpi=300, bbox_inches="tight")
     plt.show()
 
-
     # Violin plot: 12 violins (4 markers × 3 tau conditions)
     # Distribution of error for each marker across all 22 configurations for each tau value
     data_list = []
-    tau_labels = [r'$\tau_{ext} = 0$', r'$\tau_{ext} = \tau_{ext}^*$', r'$\tau_{ext} = \tau_{ext,NN}$']
-    tau_names = ['Zero', 'Star', 'NN']
+    tau_labels = [
+        r"$\tau_{ext} = 0$",
+        r"$\tau_{ext} = \tau_{ext}^*$",
+        r"$\tau_{ext} = \tau_{ext,NN}$",
+    ]
+    tau_names = ["Zero", "Star", "NN"]
 
     # Collect errors for each marker-tau combination across all configurations
     for marker_idx in range(4):
         # tau = 0
         for config_idx in range(M):
-            data_list.append({
-                'Marker': f'M{marker_idx + 1}',
-                'Tau Condition': tau_labels[0],
-                'Error': errnorms_zero[config_idx, marker_idx],
-            })
+            data_list.append(
+                {
+                    "Marker": f"M{marker_idx + 1}",
+                    "Tau Condition": tau_labels[0],
+                    "Error": errnorms_zero[config_idx, marker_idx],
+                }
+            )
         # tau = tau*
         for config_idx in range(M):
-            data_list.append({
-                'Marker': f'M{marker_idx + 1}',
-                'Tau Condition': tau_labels[1],
-                'Error': errnorms_star[config_idx, marker_idx],
-            })
+            data_list.append(
+                {
+                    "Marker": f"M{marker_idx + 1}",
+                    "Tau Condition": tau_labels[1],
+                    "Error": errnorms_star[config_idx, marker_idx],
+                }
+            )
         # tau = tau_NN
         for config_idx in range(M):
-            data_list.append({
-                'Marker': f'M{marker_idx + 1}',
-                'Tau Condition': tau_labels[2],
-                'Error': errnorms_pred[config_idx, marker_idx],
-            })
+            data_list.append(
+                {
+                    "Marker": f"M{marker_idx + 1}",
+                    "Tau Condition": tau_labels[2],
+                    "Error": errnorms_pred[config_idx, marker_idx],
+                }
+            )
 
     df_violin = pd.DataFrame(data_list)
     # print("violin plot data:", df_violin.to_string())
 
     # Create violin plot with 12 violins
     fig, ax = plt.subplots(figsize=(12, 9))
-    sns.violinplot(data=df_violin, x='Marker', y='Error', hue='Tau Condition', cut=0, ax=ax,
-                   palette=['tab:orange', 'tab:blue', 'tab:green'], split=False)
-    ax.set_ylabel('Position Error Norm Distribution [m]', fontsize=18)
-    ax.set_xlabel('Markers', fontsize=18)
-    ax.grid(True, linestyle='--', alpha=0.3, axis='y')
-    ax.legend(loc='upper left', fontsize=18)
-    ax.tick_params(axis='both', labelsize=18)
+    sns.violinplot(
+        data=df_violin,
+        x="Marker",
+        y="Error",
+        hue="Tau Condition",
+        cut=0,
+        ax=ax,
+        palette=["tab:orange", "tab:blue", "tab:green"],
+        split=False,
+    )
+    ax.set_ylabel("Position Error Norm Distribution [m]", fontsize=18)
+    ax.set_xlabel("Markers", fontsize=18)
+    ax.grid(True, linestyle="--", alpha=0.3, axis="y")
+    ax.legend(loc="upper left", fontsize=18)
+    ax.tick_params(axis="both", labelsize=18)
     plt.tight_layout()
     # plt.savefig("violin_error_distribution_12markers.svg", format="svg", bbox_inches="tight")
     # plt.savefig("violin_error_distribution_12markers.pdf", format="pdf", bbox_inches="tight")

--- a/extract_changelog.py
+++ b/extract_changelog.py
@@ -10,24 +10,23 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import Optional
 
 
-def extract_version_changelog(changelog_path: Path, version: str) -> Optional[str]:
+def extract_version_changelog(changelog_path: Path, version: str) -> str | None:
     """Extract changelog content for a specific version."""
     if not changelog_path.exists():
         return None
-    
+
     content = changelog_path.read_text()
-    
+
     # Pattern to match version headers like ## [0.1.0] - 2025-XX-XX
     version_pattern = rf"^## \[{re.escape(version)}\].*$"
     next_version_pattern = r"^## \[.*\].*$"
-    
-    lines = content.split('\n')
+
+    lines = content.split("\n")
     in_version_section = False
     changelog_lines = []
-    
+
     for line in lines:
         if re.match(version_pattern, line):
             in_version_section = True
@@ -37,19 +36,19 @@ def extract_version_changelog(changelog_path: Path, version: str) -> Optional[st
             break
         elif in_version_section:
             changelog_lines.append(line)
-    
+
     if not changelog_lines:
         return None
-    
+
     # Clean up the changelog content
-    changelog_content = '\n'.join(changelog_lines).strip()
-    
+    changelog_content = "\n".join(changelog_lines).strip()
+
     # Remove empty lines at the beginning and end
-    while changelog_content.startswith('\n'):
+    while changelog_content.startswith("\n"):
         changelog_content = changelog_content[1:]
-    while changelog_content.endswith('\n\n'):
+    while changelog_content.endswith("\n\n"):
         changelog_content = changelog_content[:-1]
-    
+
     return changelog_content if changelog_content else None
 
 
@@ -57,26 +56,29 @@ def main():
     parser = argparse.ArgumentParser(
         description="Extract changelog content for a specific version"
     )
-    parser.add_argument("version", help="Version to extract changelog for (e.g., 0.1.0)")
     parser.add_argument(
-        "--changelog", 
+        "version", help="Version to extract changelog for (e.g., 0.1.0)"
+    )
+    parser.add_argument(
+        "--changelog",
         default="docs/development/changelog.md",
-        help="Path to changelog file (default: docs/development/changelog.md)"
+        help="Path to changelog file (default: docs/development/changelog.md)",
     )
     parser.add_argument(
-        "--output",
-        help="Output file for changelog content (default: stdout)"
+        "--output", help="Output file for changelog content (default: stdout)"
     )
-    
+
     args = parser.parse_args()
-    
+
     changelog_path = Path(args.changelog)
     changelog_content = extract_version_changelog(changelog_path, args.version)
-    
+
     if changelog_content is None:
-        print(f"❌ Could not find changelog for version {args.version}", file=sys.stderr)
+        print(
+            f"❌ Could not find changelog for version {args.version}", file=sys.stderr
+        )
         sys.exit(1)
-    
+
     if args.output:
         Path(args.output).write_text(changelog_content)
         print(f"✓ Changelog for v{args.version} written to {args.output}")

--- a/src/soromox/actuation/__init__.py
+++ b/src/soromox/actuation/__init__.py
@@ -1,1 +1,3 @@
-from .tendon_actuation import *
+from .tendon_actuation import linear_routing, linear_routing_arc_length_derivative
+
+__all__ = ["linear_routing", "linear_routing_arc_length_derivative"]

--- a/src/soromox/control/actuation_matrix_utils.py
+++ b/src/soromox/control/actuation_matrix_utils.py
@@ -69,7 +69,11 @@ def analyze_actuation_matrix(
         return scenario, A.shape, rank
     except Exception:
         # If we can't analyze, assume full actuation
-        return ActuationScenario.FULL_ACTUATION, (num_dofs, num_actuators), num_actuators
+        return (
+            ActuationScenario.FULL_ACTUATION,
+            (num_dofs, num_actuators),
+            num_actuators,
+        )
 
 
 def emit_actuation_warnings(
@@ -210,4 +214,3 @@ def _emit_underactuation_warnings(
         )
 
     warnings.warn(warning_msg, UserWarning, stacklevel=stacklevel)
-

--- a/src/soromox/control/closed_form_model_based_controller.py
+++ b/src/soromox/control/closed_form_model_based_controller.py
@@ -1,6 +1,6 @@
 __all__ = ["ClosedFormModelBasedController"]
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -22,9 +22,7 @@ class ClosedFormModelBasedController(BaseController):
         u_control = model_based_term + error_based_feedback_term
     """
 
-    def model_based_term(
-        self, system_state: SystemState
-    ) -> Tuple[Array, Optional[Any]]:
+    def model_based_term(self, system_state: SystemState) -> tuple[Array, Any | None]:
         """
         Compute the model-based feedforward control term.
 
@@ -47,7 +45,7 @@ class ClosedFormModelBasedController(BaseController):
 
     def error_based_feedback_term(
         self, system_state: SystemState
-    ) -> Tuple[Array, Optional[Any]]:
+    ) -> tuple[Array, Any | None]:
         """
         Compute the error-based feedback control term.
 
@@ -67,9 +65,7 @@ class ClosedFormModelBasedController(BaseController):
         """
         return jnp.zeros((self.robot.num_actuators,)), None
 
-    def __call__(
-        self, system_state: SystemState
-    ) -> Tuple[Array, Optional[Any]]:
+    def __call__(self, system_state: SystemState) -> tuple[Array, Any | None]:
         """
         Compute the combined control action.
 

--- a/src/soromox/control/configuration_space/computed_torque_tracker.py
+++ b/src/soromox/control/configuration_space/computed_torque_tracker.py
@@ -1,7 +1,7 @@
 __all__ = ["ComputedTorqueTracker"]
 
 import warnings
-from typing import Any, Optional, Tuple
+from typing import Any
 
 import jax.numpy as jnp
 from jax import Array
@@ -145,14 +145,13 @@ class ComputedTorqueTracker(ClosedFormModelBasedController):
                 f"Pustina (2022), Della Santina (2023), and Pustina (2025)."
             )
 
-        if scenario == ActuationScenario.FULL_ACTUATION:
-            if rank < n_dof:
-                raise ValueError(
-                    f"ComputedTorqueTracker requires an invertible actuation matrix, but "
-                    f"the actuation matrix is singular (rank {rank} < {n_dof}). "
-                    f"The actuation matrix must be full rank (positive-definite) for "
-                    f"computed torque control."
-                )
+        if scenario == ActuationScenario.FULL_ACTUATION and rank < n_dof:
+            raise ValueError(
+                f"ComputedTorqueTracker requires an invertible actuation matrix, but "
+                f"the actuation matrix is singular (rank {rank} < {n_dof}). "
+                f"The actuation matrix must be full rank (positive-definite) for "
+                f"computed torque control."
+            )
 
         if scenario == ActuationScenario.OVERACTUATION:
             if rank < n_dof:
@@ -175,9 +174,7 @@ class ComputedTorqueTracker(ClosedFormModelBasedController):
 
         return scenario
 
-    def model_based_term(
-        self, system_state: SystemState
-    ) -> Tuple[Array, Optional[Any]]:
+    def model_based_term(self, system_state: SystemState) -> tuple[Array, Any | None]:
         """
         Compute the model-based feedforward control term for computed torque control.
 
@@ -228,7 +225,7 @@ class ComputedTorqueTracker(ClosedFormModelBasedController):
 
     def error_based_feedback_term(
         self, system_state: SystemState
-    ) -> Tuple[Array, Optional[PIDControllerState]]:
+    ) -> tuple[Array, PIDControllerState | None]:
         """
         Compute the PID-based feedback control term for computed torque control.
 
@@ -271,7 +268,7 @@ class ComputedTorqueTracker(ClosedFormModelBasedController):
         ed = qd_des - qd  # Velocity error
 
         # Get integral error from control state (or zeros if not tracking)
-        control_state: Optional[PIDControllerState] = system_state.control_state
+        control_state: PIDControllerState | None = system_state.control_state
         if control_state is None:
             integral_error = jnp.zeros_like(q)
         else:
@@ -300,4 +297,3 @@ class ComputedTorqueTracker(ClosedFormModelBasedController):
             control_state_dot = None
 
         return u_feedback, control_state_dot
-

--- a/src/soromox/control/configuration_space/feedforward_compensation_tracker.py
+++ b/src/soromox/control/configuration_space/feedforward_compensation_tracker.py
@@ -1,6 +1,6 @@
 __all__ = ["FeedforwardCompensationTracker"]
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 import jax.numpy as jnp
 from jax import Array
@@ -107,9 +107,7 @@ class FeedforwardCompensationTracker(PIDController):
             stacklevel=4,
         )
 
-    def model_based_term(
-        self, system_state: SystemState
-    ) -> Tuple[Array, Optional[Any]]:
+    def model_based_term(self, system_state: SystemState) -> tuple[Array, Any | None]:
         """
         Compute the model-based feedforward control term for trajectory tracking.
 
@@ -152,11 +150,7 @@ class FeedforwardCompensationTracker(PIDController):
         # Compute inverse dynamics at desired trajectory
         # tau = B @ qdd + C @ qd + G + tau_el + D @ qd
         tau_model = (
-            B_des @ qdd_des
-            + C_des @ qd_des
-            + G_des
-            + tau_el_des
-            + D_des @ qd_des
+            B_des @ qdd_des + C_des @ qd_des + G_des + tau_el_des + D_des @ qd_des
         )
 
         # Get the actuation matrix at current configuration
@@ -169,4 +163,3 @@ class FeedforwardCompensationTracker(PIDController):
             u_model = jnp.linalg.pinv(A) @ tau_model
 
         return u_model, None
-

--- a/src/soromox/control/configuration_space/gravity_cancellation_regulator.py
+++ b/src/soromox/control/configuration_space/gravity_cancellation_regulator.py
@@ -1,6 +1,6 @@
 __all__ = ["GravityCancellationRegulator"]
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 import jax.numpy as jnp
 from jax import Array
@@ -104,9 +104,7 @@ class GravityCancellationRegulator(PIDController):
             stacklevel=4,
         )
 
-    def model_based_term(
-        self, system_state: SystemState
-    ) -> Tuple[Array, Optional[Any]]:
+    def model_based_term(self, system_state: SystemState) -> tuple[Array, Any | None]:
         """
         Compute the model-based feedforward control term for gravity cancellation.
 
@@ -155,4 +153,3 @@ class GravityCancellationRegulator(PIDController):
             u_model = jnp.linalg.pinv(A) @ tau_model
 
         return u_model, None
-

--- a/src/soromox/control/configuration_space/mixed_state_feedback_tracker.py
+++ b/src/soromox/control/configuration_space/mixed_state_feedback_tracker.py
@@ -1,7 +1,7 @@
 __all__ = ["MixedStateFeedbackTracker"]
 
 import warnings
-from typing import Any, Optional, Tuple
+from typing import Any
 
 import jax.numpy as jnp
 from jax import Array
@@ -138,9 +138,7 @@ class MixedStateFeedbackTracker(PIDController):
             stacklevel=3,
         )
 
-    def model_based_term(
-        self, system_state: SystemState
-    ) -> Tuple[Array, Optional[Any]]:
+    def model_based_term(self, system_state: SystemState) -> tuple[Array, Any | None]:
         """
         Compute the model-based feedforward control term for trajectory tracking.
 
@@ -187,13 +185,7 @@ class MixedStateFeedbackTracker(PIDController):
         # Compute the model-based torque
         # Inertial, Coriolis, and damping use current matrices with desired velocity/acceleration
         # Elastic force is evaluated at desired configuration
-        tau_model = (
-            B @ qdd_des
-            + C @ qd_des
-            + G
-            + tau_el_des
-            + D @ qd_des
-        )
+        tau_model = B @ qdd_des + C @ qd_des + G + tau_el_des + D @ qd_des
 
         # Get the actuation matrix at current configuration
         A = self.robot.actuation_matrix(q)
@@ -205,4 +197,3 @@ class MixedStateFeedbackTracker(PIDController):
             u_model = jnp.linalg.pinv(A) @ tau_model
 
         return u_model, None
-

--- a/src/soromox/control/configuration_space/potential_cancellation_regulator.py
+++ b/src/soromox/control/configuration_space/potential_cancellation_regulator.py
@@ -1,6 +1,6 @@
 __all__ = ["PotentialCancellationRegulator"]
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 import jax.numpy as jnp
 from jax import Array
@@ -121,9 +121,7 @@ class PotentialCancellationRegulator(PIDController):
             stacklevel=4,
         )
 
-    def model_based_term(
-        self, system_state: SystemState
-    ) -> Tuple[Array, Optional[Any]]:
+    def model_based_term(self, system_state: SystemState) -> tuple[Array, Any | None]:
         """
         Compute the model-based feedforward control term for potential cancellation.
 
@@ -166,4 +164,3 @@ class PotentialCancellationRegulator(PIDController):
             u_model = jnp.linalg.pinv(A) @ tau_model
 
         return u_model, None
-

--- a/src/soromox/control/configuration_space/potential_compensation_regulator.py
+++ b/src/soromox/control/configuration_space/potential_compensation_regulator.py
@@ -1,6 +1,6 @@
 __all__ = ["PotentialCompensationRegulator"]
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 import jax.numpy as jnp
 from jax import Array
@@ -108,9 +108,7 @@ class PotentialCompensationRegulator(PIDController):
             stacklevel=4,
         )
 
-    def model_based_term(
-        self, system_state: SystemState
-    ) -> Tuple[Array, Optional[Any]]:
+    def model_based_term(self, system_state: SystemState) -> tuple[Array, Any | None]:
         """
         Compute the model-based feedforward control term for potential compensation.
 
@@ -158,4 +156,3 @@ class PotentialCompensationRegulator(PIDController):
             u_model = jnp.linalg.pinv(A) @ tau_model
 
         return u_model, None
-

--- a/src/soromox/rendering/color_config.py
+++ b/src/soromox/rendering/color_config.py
@@ -290,9 +290,7 @@ def normalize_color_array(
     if colors.ndim == 1:
         colors = colors[None, :]
     if colors.shape[-1] not in (3, 4):
-        raise ValueError(
-            f"{name} must have 3 or 4 channels; got shape {colors.shape}"
-        )
+        raise ValueError(f"{name} must have 3 or 4 channels; got shape {colors.shape}")
     has_alpha = colors.shape[-1] == 4
     colors = ensure_rgba(colors)
     try:

--- a/src/soromox/symbolic_derivation/planar_hsa.py
+++ b/src/soromox/symbolic_derivation/planar_hsa.py
@@ -19,7 +19,7 @@ def symbolically_derive_planar_hsa_model(
         num_segments: number of constant strain segments
         filepath: path to save the derived model
         num_rods_per_segment: number of HSA rods per segment
-    
+
     Returns:
         sym_exps: dictionary with entries
             params_syms: dictionary of robot parameters
@@ -142,7 +142,7 @@ def symbolically_derive_planar_hsa_model(
     )  # twist angles
 
     # construct the symbolic matrices
-    l = sp.Matrix(l_syms)  # length of each segment
+    l = sp.Matrix(l_syms)  # noqa: E741  # length of each segment
     lpc = sp.Matrix(
         [lpc_syms]
     )  # length of the rigid proximal caps of the rods connecting to the base
@@ -204,7 +204,7 @@ def symbolically_derive_planar_hsa_model(
     # configuration variables and their derivatives
     xi = sp.Matrix(xi_syms)  # strains
     xid = sp.Matrix(xid_syms)  # strain time derivatives
-    xidd = sp.Matrix(xidd_syms)  # strain accelerations
+    sp.Matrix(xidd_syms)  # strain accelerations
     # twist angle of rods
     phi = sp.Matrix(phi_syms)
 
@@ -462,7 +462,7 @@ def symbolically_derive_planar_hsa_model(
         chiCoGp[:2, 0] = pCoGp  # the x and y position
         chiCoGp[2, 0] = th.subs(s, l[i])  # the orientation angle theta
         # Jacobians of the CoG of the platform
-        JCoGp = chiCoGp.jacobian(xi)
+        chiCoGp.jacobian(xi)
         JpCoGp = pCoGp.jacobian(xi)  # positional Jacobian of the platform
         JpCoGo = sp.simplify(sp.Matrix([[chiCoGp[2, 0]]]).jacobian(xi))
         # mass matrix of the platform
@@ -622,7 +622,7 @@ def _sym_beta_fn(vxi: sp.Matrix, roff: sp.Expr) -> sp.Matrix:
     Symbolically map the generalized coordinates to the strains in the physical rods
     Args:
         vxi: strains of the virtual backbone of shape (3, )
-    
+
     Returns:
         pxi: strains in the physical rods of shape (3, )
     """

--- a/src/soromox/symbolic_derivation/symbolic_utils.py
+++ b/src/soromox/symbolic_derivation/symbolic_utils.py
@@ -11,7 +11,7 @@ def compute_coriolis_matrix(
         q: vector of generalized coordinates of shape (num_dof,)
         qd: vector of generalized velocities of shape (num_dof,)
         simplify: whether to simplify the result
-    
+
     Returns:
         C: matrix of shape (num_dof, num_dof) containing the coriolis and centrifugal terms
     """

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -40,7 +40,9 @@ class _RolloutState:
     @classmethod
     def tree_unflatten(cls, aux, children):
         y, control_state, environment_state = children
-        return cls(y=y, control_state=control_state, environment_state=environment_state)
+        return cls(
+            y=y, control_state=control_state, environment_state=environment_state
+        )
 
 
 class DynamicalSystem(eqx.Module):
@@ -147,9 +149,7 @@ class DynamicalSystem(eqx.Module):
                 else zero_environment_state_dot
             )
 
-        tau_ext_total = self._combine_external_torques(
-            base_tau_ext, tau_environment
-        )
+        tau_ext_total = self._combine_external_torques(base_tau_ext, tau_environment)
         yd = self.forward_dynamics(t, ode_state.y, (base_u_val, tau_ext_total))
         return _RolloutState(
             y=yd,
@@ -235,9 +235,7 @@ class DynamicalSystem(eqx.Module):
                 else zero_environment_state_dot
             )
 
-        tau_ext_total = self._combine_external_torques(
-            base_tau_ext, tau_environment
-        )
+        tau_ext_total = self._combine_external_torques(base_tau_ext, tau_environment)
         yd = self.forward_dynamics(t, ode_state.y, (u_total, tau_ext_total))
         if track_control_state:
             control_state_dot = (
@@ -739,7 +737,8 @@ class DynamicalSystem(eqx.Module):
                     lambda c, c_next: jnp.concatenate(
                         [
                             jnp.broadcast_to(
-                                c, (sol.ts.shape[0] - 1,) + c.shape  # type: ignore[misc]
+                                c,
+                                (sol.ts.shape[0] - 1,) + c.shape,  # type: ignore[misc]
                             ),
                             c_next[None, ...],
                         ],

--- a/src/soromox/systems/gvs/__init__.py
+++ b/src/soromox/systems/gvs/__init__.py
@@ -12,9 +12,9 @@ from soromox.systems.gvs.structures import (
 )
 from soromox.systems.params import LinearTendonRoutingParams
 
-from .core import *
-from .specs import *
-from .tendon_actuated_gvs import *
+from .core import GVS
+from .specs import GVSSegment, JointSpec, LinkSpec, StrainBasisSpec
+from .tendon_actuated_gvs import TendonActuatedGVS
 
 __all__ = [
     "GVS",

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -1,4 +1,3 @@
-__all__ = ["GVS"]
 import math
 from typing import Any
 
@@ -48,6 +47,8 @@ from soromox.systems.soft_robot import CrossSectionGeometry, SoftRobot
 from soromox.utils.geometry import poses
 from soromox.utils.integration import gauss_quadrature
 from soromox.utils.lie_algebra import constant_strain, se3
+
+__all__ = ["GVS"]
 
 
 class GVS(SoftRobot):

--- a/src/soromox/systems/gvs/params.py
+++ b/src/soromox/systems/gvs/params.py
@@ -138,8 +138,7 @@ class GVSParams(BaseSoftRobotParams):
         max_num_gauss_points = structure.max_num_gauss_points
         if max_num_gauss_points is not None and max_num_gauss_points < 5:
             raise ValueError(
-                "max_num_gauss_points must be at least 5, "
-                f"got {max_num_gauss_points}."
+                f"max_num_gauss_points must be at least 5, got {max_num_gauss_points}."
             )
 
         dofs_joint = [

--- a/src/soromox/systems/gvs/primitives.py
+++ b/src/soromox/systems/gvs/primitives.py
@@ -190,7 +190,7 @@ class Link:
     G: Array  # Shear modulus [N/m²]
     rho: Array  # Density [kg/m³]
     eta: Array  # Material Damping [N·s/m]
-    l: Array  # Length of each divisions of the link (soft link) [m]
+    l: Array  # noqa: E741  # Length of each divisions of the link (soft link) [m]
 
     r: tuple[float, float]  # Initial and final value of the geometrical parameter
     h: tuple[float, float]  # Initial and final value of the geometrical parameter

--- a/src/soromox/systems/gvs/specs.py
+++ b/src/soromox/systems/gvs/specs.py
@@ -1,11 +1,11 @@
-__all__ = ["GVSSegment", "LinkSpec", "JointSpec", "StrainBasisSpec"]
-
 from dataclasses import dataclass, field
 from typing import Literal
 
 from jax import Array
 
 from soromox.systems.soft_robot import CrossSectionGeometry
+
+__all__ = ["GVSSegment", "LinkSpec", "JointSpec", "StrainBasisSpec"]
 
 StrainComponent = Literal[
     "kappa_x",

--- a/src/soromox/systems/gvs/strain_bases.py
+++ b/src/soromox/systems/gvs/strain_bases.py
@@ -66,12 +66,9 @@ def _polynomial_slots(X: Array, max_dof: int, family: str) -> tuple[Array, Array
         m_float = m.astype(jnp.float64)
 
         if family == "legendre":
-            p_rec = ((2 * m_float + 1) * z * p_nm1 - m_float * p_nm2) / (
-                m_float + 1
-            )
+            p_rec = ((2 * m_float + 1) * z * p_nm1 - m_float * p_nm2) / (m_float + 1)
             dp_rec = (
-                (2 * m_float + 1) * (2 * p_nm1 + z * dp_nm1)
-                - m_float * dp_nm2
+                (2 * m_float + 1) * (2 * p_nm1 + z * dp_nm1) - m_float * dp_nm2
             ) / (m_float + 1)
         elif family == "chebychev":
             p_rec = 2 * z * p_nm1 - p_nm2
@@ -266,7 +263,9 @@ def _basis_pair(
 
 
 def _monomial_pair(X: Array, Bdof: Array, Bodr: Array, max_dof: int):
-    return _basis_pair(X, Bdof, Bodr, max_dof, lambda x, _order, n: _monomial_slots(x, n))
+    return _basis_pair(
+        X, Bdof, Bodr, max_dof, lambda x, _order, n: _monomial_slots(x, n)
+    )
 
 
 def _monomial_basis(X: Array, Bdof: Array, Bodr: Array, max_dof: int):
@@ -482,9 +481,7 @@ def dB_Monomial(X: Array, Bdof: Array, Bodr: Array, max_dof: int) -> Array:
     return _monomial_pair(X, Bdof, Bodr, max_dof)[1]
 
 
-def dB_LegendrePolynomial(
-    X: Array, Bdof: Array, Bodr: Array, max_dof: int
-) -> Array:
+def dB_LegendrePolynomial(X: Array, Bdof: Array, Bodr: Array, max_dof: int) -> Array:
     """Derivative of ``B_LegendrePolynomial`` with respect to ``X``."""
     return _legendre_pair(X, Bdof, Bodr, max_dof)[1]
 

--- a/src/soromox/systems/gvs/tendon_actuated_gvs.py
+++ b/src/soromox/systems/gvs/tendon_actuated_gvs.py
@@ -1,4 +1,3 @@
-__all__ = ["TendonActuatedGVS"]
 from collections.abc import Callable
 from typing import Any
 
@@ -18,6 +17,8 @@ from soromox.utils.lie_algebra import se3, so3
 
 from .core import GVS
 from .specs import GVSSegment
+
+__all__ = ["TendonActuatedGVS"]
 
 
 class TendonActuatedGVS(GVS):

--- a/src/soromox/systems/hsa/planar_hsa.py
+++ b/src/soromox/systems/hsa/planar_hsa.py
@@ -1,4 +1,4 @@
-__all__ = ["PlanarHSA"]
+# ruff: noqa: B904
 from collections.abc import Callable
 from typing import Any
 
@@ -15,6 +15,8 @@ from soromox.utils.basic import (
     compute_strain_basis,
     concatenate_params_syms,
 )
+
+__all__ = ["PlanarHSA"]
 
 
 class PlanarHSA(SoftRobot):
@@ -256,7 +258,8 @@ class PlanarHSA(SoftRobot):
 
         # Load saved symbolic data
         try:
-            sym_exps = dill.load(open(str(structure.symbolic_expression_path), "rb"))
+            with open(str(structure.symbolic_expression_path), "rb") as sym_exp_file:
+                sym_exps = dill.load(sym_exp_file)
         except FileNotFoundError:
             raise FileNotFoundError(
                 "Symbolic expressions file not found. Please generate the symbolic expressions first."

--- a/src/soromox/systems/pcs/params.py
+++ b/src/soromox/systems/pcs/params.py
@@ -62,6 +62,7 @@ class PCSParams(BaseContinuumSoftRobotParams):
     young_modulus: Array
     shear_modulus: Array
     damping_matrix: Array
+
     def validate(self) -> None:
         n_segments = _validate_continuum_base(self, strain_dim=6, gravity_dim=3)
         _require_shape("radius", self.radius, (n_segments,))
@@ -87,6 +88,7 @@ class PlanarPCSParams(BaseContinuumSoftRobotParams):
     young_modulus: Array
     shear_modulus: Array
     damping_matrix: Array
+
     def validate(self) -> None:
         n_segments = _validate_continuum_base(self, strain_dim=3, gravity_dim=2)
         _require_shape("radius", self.radius, (n_segments,))

--- a/src/soromox/systems/pendulum/pendulum.py
+++ b/src/soromox/systems/pendulum/pendulum.py
@@ -73,7 +73,7 @@ class Pendulum(SoftRobot):
 
     # Stored physical parameters
     m: Array
-    I: Array
+    I: Array  # noqa: E741
     L: Array
     Lc: Array
     r: Array
@@ -99,14 +99,14 @@ class Pendulum(SoftRobot):
 
         # Basic parameter extraction
         m = jnp.asarray(params.mass)  # (n,)
-        I = jnp.asarray(params.moment_inertia)  # (n,)
+        inertia = jnp.asarray(params.moment_inertia)  # (n,)
         L = jnp.asarray(params.length)  # (n,)
         Lc = jnp.asarray(params.center_of_mass_length)  # (n,)
         g = jnp.asarray(params.gravity)  # (2,)
 
         n_q = m.shape[0]
         # Consistency checks (lightweight; JIT friendly if shapes static)
-        assert I.shape[0] == n_q and L.shape[0] == n_q and Lc.shape[0] == n_q, (
+        assert inertia.shape[0] == n_q and L.shape[0] == n_q and Lc.shape[0] == n_q, (
             "Parameter length mismatch"
         )
         assert g.shape[0] == 2, "Gravity vector must be length 2"
@@ -117,7 +117,7 @@ class Pendulum(SoftRobot):
 
         # set parameters
         self.m = m
-        self.I = I
+        self.I = inertia
         self.L = L
         self.Lc = Lc
         self.g = g

--- a/src/soromox/utils/__init__.py
+++ b/src/soromox/utils/__init__.py
@@ -1,7 +1,7 @@
-from .array_math import *
-from .basic import *
-from .geometry import *
-from .integration import *
-from .lie_algebra import *
-from .numerical_jacobian import *
-from .tolerance import *
+from .array_math import *  # noqa: F403
+from .basic import *  # noqa: F403
+from .geometry import *  # noqa: F403
+from .integration import *  # noqa: F403
+from .lie_algebra import *  # noqa: F403
+from .numerical_jacobian import *  # noqa: F403
+from .tolerance import *  # noqa: F403

--- a/src/soromox/utils/array_math.py
+++ b/src/soromox/utils/array_math.py
@@ -1,6 +1,7 @@
 __all__ = ["blk_diag", "blk_concat"]
-from jax import numpy as jnp
 from jax import Array, lax
+from jax import numpy as jnp
+
 
 def blk_diag(a: Array) -> Array:
     """

--- a/src/soromox/utils/basic.py
+++ b/src/soromox/utils/basic.py
@@ -13,7 +13,7 @@ def concatenate_params_syms(
 ) -> list[sp.Symbol]:
     # concatenate the robot params symbols
     params_syms_cat: list[sp.Symbol] = []
-    for params_key, params_sym in sorted(params_syms.items()):
+    for _params_key, params_sym in sorted(params_syms.items()):
         if type(params_sym) in [list, tuple]:
             params_syms_cat += params_sym
         else:
@@ -29,7 +29,7 @@ def compute_strain_basis(
     Args:
         strain_selector (Array):
             boolean array of shape (n_xi, ) specifying which strain components are active
-    
+
     Returns:
         strain_basis (Array):
             strain basis matrix of shape (n_xi, n_q) where n_q is the number of configuration variables

--- a/src/soromox/utils/numerical_jacobian.py
+++ b/src/soromox/utils/numerical_jacobian.py
@@ -221,7 +221,7 @@ def approx_derivative(
     f0=None,
     bounds=(-jnp.inf, jnp.inf),
     args=(),
-    kwargs={},
+    kwargs=None,
 ):
     """Compute finite difference approximation of the derivatives of a
     vector-valued function.
@@ -341,8 +341,10 @@ def approx_derivative(
     >>> approx_derivative(g, x0, bounds=(1.0, jnp.inf))
     array([ 2.])
     """
+    if kwargs is None:
+        kwargs = {}
     if method not in ["2-point", "3-point"]:
-        raise ValueError("Unknown method '%s'. " % method)
+        raise ValueError(f"Unknown method '{method}'. ")
 
     if x0.ndim > 1:
         raise ValueError("`x0` must have at most 1 dimension.")
@@ -409,13 +411,6 @@ def _dense_difference(fun, x0, f0, h, use_one_sided, method):
             dx = h[i]
             df = fun(x1) - f0
         elif method == "3-point" and use_one_sided[i]:
-            x1[i] += h[i]
-            x2[i] += 2 * h[i]
-            dx = x2[i] - x0[i]
-            f1 = fun(x1)
-            f2 = fun(x2)
-            df = -3.0 * f0 + 4 * f1 - f2
-
             dx01 = jnp.concatenate(
                 [
                     jnp.zeros((i,)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
-from pathlib import Path
 import sys
-
+from pathlib import Path
 
 TESTS_DIR = Path(__file__).resolve().parent
 if str(TESTS_DIR) not in sys.path:

--- a/tests/control/test_pid_control.py
+++ b/tests/control/test_pid_control.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import jax
 
 jax.config.update("jax_enable_x64", True)  # double precision
@@ -375,4 +376,3 @@ class TestPIDControlEquinoxModule:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-

--- a/tests/control/test_reference_trajectory.py
+++ b/tests/control/test_reference_trajectory.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import jax
 
 jax.config.update("jax_enable_x64", True)  # double precision

--- a/tests/coordinate_transformations/test_actuation_space_dynamics.py
+++ b/tests/coordinate_transformations/test_actuation_space_dynamics.py
@@ -11,12 +11,21 @@ References:
     PhD Thesis, Sapienza University of Rome.
 """
 
+# ruff: noqa: E402
+
 import jax
 
 jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 import pytest
 from numpy.testing import assert_allclose
+from system_param_builders import (
+    linear_tendon_routing,
+    pcs_params,
+    pendulum_params,
+    tendon_actuated_pcs_params,
+    tendon_actuated_pendulum_params,
+)
 
 from soromox.control.reference_trajectory import ReferenceTrajectory
 from soromox.coordinate_transformations import ActuationSpaceDynamics
@@ -24,13 +33,6 @@ from soromox.systems import (
     PCSStructure,
     TendonActuatedPCS,
     TendonActuatedPendulum,
-)
-from system_param_builders import (
-    linear_tendon_routing,
-    pcs_params,
-    pendulum_params,
-    tendon_actuated_pcs_params,
-    tendon_actuated_pendulum_params,
 )
 
 # -----------------------
@@ -94,7 +96,6 @@ def fully_actuated_pcs():
     For a truly fully-actuated system, we use a single segment with 2 bending DOFs
     (kappa_y, kappa_z) and 2 tendons placed at different offsets.
     """
-    num_segments = 1
     # Note: D must be provided in full strain space (num_strains x num_strains = 6x6 for 1 segment)
     # The PCS.damping_matrix() method projects it to active strain space using B_xi
     body = pcs_params(
@@ -141,7 +142,6 @@ def fully_actuated_pcs():
 @pytest.fixture
 def underactuated_pcs():
     """Create a 2-segment underactuated TendonActuatedPCS (2 tendons on 4 DOFs)."""
-    num_segments = 2
     # Note: D must be provided in full strain space (num_strains x num_strains = 12x12)
     # The PCS.damping_matrix() method projects it to active strain space using B_xi
     body = pcs_params(
@@ -173,9 +173,13 @@ def underactuated_pcs():
     # 2 tendons for 4 DOFs (underactuated)
     # Use tendons at different offsets to ensure non-singular actuation matrix
     tendon_routing_params = linear_tendon_routing(
-        y_intercept=jnp.array([0.005, 0.0]),  # first tendon at +y, second at origin in y
+        y_intercept=jnp.array(
+            [0.005, 0.0]
+        ),  # first tendon at +y, second at origin in y
         y_slope=jnp.array([0.0, 0.0]),  # slope in y
-        z_intercept=jnp.array([0.0, 0.005]),  # first tendon at origin in z, second at +z
+        z_intercept=jnp.array(
+            [0.0, 0.005]
+        ),  # first tendon at origin in z, second at +z
         z_slope=jnp.array([0.0, 0.0]),  # slope in z
         attachment_segment_index=jnp.array([1, 1]),  # both tendons attach at distal end
     )
@@ -1162,8 +1166,8 @@ class TestActuationSpaceDynamicsSystemIndependent:
             J_qdd = J @ qdd
 
             # Compute Jd @ qd using JVP (same method as the implementation)
-            def J_times_qd(q_inner):
-                return asd.jacobian(q_inner) @ qd
+            def J_times_qd(q_inner, qd_current=qd):
+                return asd.jacobian(q_inner) @ qd_current
 
             Jd_qd = jax.jvp(J_times_qd, (q,), (qd,))[1]
 

--- a/tests/coordinate_transformations/test_operational_space_dynamics.py
+++ b/tests/coordinate_transformations/test_operational_space_dynamics.py
@@ -1,17 +1,19 @@
 """Tests for OperationalSpaceDynamics class."""
 
+# ruff: noqa: E402
+
 import jax
 
 jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 import pytest
 from numpy.testing import assert_allclose
+from system_param_builders import pcs_params, pendulum_params, planar_pcs_params
 
 from soromox.coordinate_transformations import OperationalSpaceDynamics
 from soromox.systems import PCS, Pendulum, PlanarPCS
 from soromox.utils.geometry.rotations import RotationRepresentation
 from soromox.utils.tolerance import Tolerance
-from system_param_builders import pcs_params, pendulum_params, planar_pcs_params
 
 # -----------------------
 # Fixtures
@@ -210,9 +212,9 @@ class TestDynamicallyConsistentPseudoinverse:
         J, J_bar = op_space.jacobian_and_dynamically_consistent_pseudoinverse(q)
 
         J_Jbar = J @ J_bar
-        I = jnp.eye(op_space.n_operational_space)
+        identity = jnp.eye(op_space.n_operational_space)
 
-        assert_allclose(J_Jbar, I, rtol=1e-4, atol=1e-4)
+        assert_allclose(J_Jbar, identity, rtol=1e-4, atol=1e-4)
 
     def test_j_jbar_identity_pendulum(self, pendulum_robot):
         """Test J @ J_bar = I for Pendulum robot."""
@@ -223,9 +225,9 @@ class TestDynamicallyConsistentPseudoinverse:
         J, J_bar = op_space.jacobian_and_dynamically_consistent_pseudoinverse(q)
 
         J_Jbar = J @ J_bar
-        I = jnp.eye(op_space.n_operational_space)
+        identity = jnp.eye(op_space.n_operational_space)
 
-        assert_allclose(J_Jbar, I, rtol=Tolerance.rtol(), atol=Tolerance.atol())
+        assert_allclose(J_Jbar, identity, rtol=Tolerance.rtol(), atol=Tolerance.atol())
 
     def test_pseudoinverse_shape(self, pcs_robot):
         """Test shape of dynamically-consistent pseudo-inverse."""

--- a/tests/geometry/test_rotations.py
+++ b/tests/geometry/test_rotations.py
@@ -9,6 +9,8 @@ The near-180-degree case is particularly important because sin(θ) ≈ 0 for bot
 θ ≈ 0 and θ ≈ π, but the correct behavior is different in each case.
 """
 
+# ruff: noqa: E402
+
 import jax
 
 jax.config.update("jax_enable_x64", True)
@@ -612,9 +614,7 @@ class TestJAXCompatibility:
             jnp.array([0.0, 0.0, jnp.pi - 1e-7]),
         ],
     )
-    def test_rotation_matrix_to_quaternion_forward_and_reverse_mode_finite(
-        self, omega
-    ):
+    def test_rotation_matrix_to_quaternion_forward_and_reverse_mode_finite(self, omega):
         """Test finite autodiff through trace, regular, and near-pi branches."""
         R = rotation_vector_to_rotation_matrix(omega)
 

--- a/tests/lie_algebra/test_lie_algebra_se2.py
+++ b/tests/lie_algebra/test_lie_algebra_se2.py
@@ -221,8 +221,8 @@ def test_tangent_derivative_matches_autodiff(N: int = 10):
         xid = jax.random.uniform(subkey2, shape=(3,), minval=-1.0, maxval=1.0)
         s = jax.random.uniform(subkey3, shape=(), minval=0.1, maxval=1.0)
 
-        def tangent_map(xi_):
-            return constant_strain.tangent_se2(xi_, s, eps=EPS)
+        def tangent_map(xi_, s_current=s):
+            return constant_strain.tangent_se2(xi_, s_current, eps=EPS)
 
         _, autodiff = jax.jvp(tangent_map, (xi,), (xid,))
         closed_form = constant_strain.tangent_derivative_se2(xi, xid, s, eps=EPS)

--- a/tests/lie_algebra/test_lie_algebra_se3.py
+++ b/tests/lie_algebra/test_lie_algebra_se3.py
@@ -310,8 +310,8 @@ def test_tangent_derivative_matches_autodiff_random(N: int = 10):
         if jnp.linalg.norm(xi[:3]) < 1e-3:
             continue
 
-        def tangent_map(xi_):
-            return constant_strain.tangent_se3(xi_, s, eps=EPS)
+        def tangent_map(xi_, s_current=s):
+            return constant_strain.tangent_se3(xi_, s_current, eps=EPS)
 
         _, autodiff = jax.jvp(tangent_map, (xi,), (xid,))
         closed_form = constant_strain.tangent_derivative_se3(xi, xid, s, eps=EPS)

--- a/tests/systems/test_articulated_soft_robot.py
+++ b/tests/systems/test_articulated_soft_robot.py
@@ -61,9 +61,7 @@ def make_spatial_robot() -> ArticulatedSoftRobot:
     )
     params = articulated_params(
         joint_screw=joint_screws,
-        tip_position=jnp.array(
-            [[0.8, 0.0, 0.1], [0.6, 0.0, 0.2], [0.4, 0.1, 0.0]]
-        ),
+        tip_position=jnp.array([[0.8, 0.0, 0.1], [0.6, 0.0, 0.2], [0.4, 0.1, 0.0]]),
         center_of_mass_position=jnp.array(
             [[0.4, 0.0, 0.05], [0.3, 0.0, 0.1], [0.2, 0.05, 0.0]]
         ),

--- a/tests/systems/test_dynamical_system_rollout.py
+++ b/tests/systems/test_dynamical_system_rollout.py
@@ -1,9 +1,9 @@
 import equinox as eqx
 import jax
 from jax import numpy as jnp
+from system_param_builders import pendulum_params
 
 from soromox.systems import Pendulum, SystemState
-from system_param_builders import pendulum_params
 
 
 def _pendulum_params():

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -4,11 +4,15 @@ import numpy as onp
 import pytest
 from jax import Array, jacfwd, jacrev, jvp
 from numpy.testing import assert_allclose
-from system_param_builders import gvs_params_from_segments, pcs_params, spatial_base_pose
+from system_param_builders import (
+    gvs_params_from_segments,
+    pcs_params,
+    spatial_base_pose,
+)
 
-from soromox.utils.lie_algebra import se3
 from soromox.systems import GVS, PCS, CrossSectionGeometry, PCSStructure
 from soromox.systems.gvs import GVSSegment, JointSpec, LinkSpec, StrainBasisSpec
+from soromox.utils.lie_algebra import se3
 from soromox.utils.tolerance import Tolerance
 
 jax.config.update("jax_enable_x64", True)

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -4,12 +4,12 @@ import pytest
 from jax import Array, jacfwd, jacrev, jvp
 from jax import numpy as jnp
 from numpy.testing import assert_allclose
+from system_param_builders import pcs_params, spatial_base_pose
 
 from soromox.systems import PCS, CrossSectionGeometry, PCSStructure
 from soromox.utils.integration import scale_interior_gaussian_quadrature
 from soromox.utils.lie_algebra import se3
 from soromox.utils.tolerance import Tolerance
-from system_param_builders import pcs_params, spatial_base_pose
 
 jax.config.update("jax_enable_x64", True)  # double precision
 
@@ -139,7 +139,6 @@ def test_constant_strain_call():
 
     xi_ref = jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
 
-    num_segments = 1
     params = pcs_params(
         base_pose=spatial_base_pose(),
         length=L,
@@ -217,9 +216,7 @@ def test_constant_strain_call():
     )
     print("[Valid test]\n")
 
-    q = jnp.array(
-        [jnp.pi / (2 * params.length[0]), 0.0, 0.0, 0.0, 0.0, 0.0]
-    )
+    q = jnp.array([jnp.pi / (2 * params.length[0]), 0.0, 0.0, 0.0, 0.0, 0.0])
     qd = jnp.zeros((6,))
     u = jnp.ones((6,))  # identity torque for testing
     print("q = ", q, "qd = ", qd, "u = ", u)

--- a/tests/systems/test_pcs_2d_vs_3d_coherence.py
+++ b/tests/systems/test_pcs_2d_vs_3d_coherence.py
@@ -1,11 +1,8 @@
 import jax
-from jax import Array, numpy as jnp, random
-from numpy.testing import assert_allclose
 import pytest
-from typing import List, Tuple
-
-from soromox.systems import PCS, PCSStructure, PlanarPCS, PlanarPCSStructure
-from soromox.utils.tolerance import Tolerance
+from jax import Array, random
+from jax import numpy as jnp
+from numpy.testing import assert_allclose
 from system_param_builders import (
     pcs_params,
     planar_base_pose,
@@ -13,6 +10,8 @@ from system_param_builders import (
     spatial_base_pose,
 )
 
+from soromox.systems import PCS, PCSStructure, PlanarPCS, PlanarPCSStructure
+from soromox.utils.tolerance import Tolerance
 
 jax.config.update("jax_enable_x64", True)
 
@@ -30,8 +29,7 @@ def make_planar_model(
     segment_length = total_length / num_segments
     L = segment_length * jnp.ones((num_segments,))
     diag_entries = (
-        jnp.repeat(jnp.array([[1e0, 1e3, 1e3]]), num_segments, axis=0)
-        * L[:, None]
+        jnp.repeat(jnp.array([[1e0, 1e3, 1e3]]), num_segments, axis=0) * L[:, None]
     ).flatten()
     params = planar_pcs_params(
         base_pose=planar_base_pose(),
@@ -68,7 +66,7 @@ def make_spatial_model(num_segments: int, total_length: float = TOTAL_LENGTH) ->
     return PCS(params=params, structure=PCSStructure(num_gauss_points=3))
 
 
-def planar_arc_lengths(model: PlanarPCS) -> List[float]:
+def planar_arc_lengths(model: PlanarPCS) -> list[float]:
     lengths = jnp.asarray(model.L)
     cumulative = jnp.cumsum(lengths)
     total = float(cumulative[-1])
@@ -81,8 +79,8 @@ def planar_arc_lengths(model: PlanarPCS) -> List[float]:
     return sorted({float(v) for v in values if 0.0 < float(v) <= total})
 
 
-def planar_to_spatial_index_pairs(num_segments: int) -> List[Tuple[int, int]]:
-    pairs: List[Tuple[int, int]] = []
+def planar_to_spatial_index_pairs(num_segments: int) -> list[tuple[int, int]]:
+    pairs: list[tuple[int, int]] = []
     for seg in range(num_segments):
         planar_offset = 3 * seg
         spatial_offset = 6 * seg
@@ -259,12 +257,16 @@ def test_jacobian_time_derivatives_coherence(num_segments):
             Jb_planar, Jbd_planar = planar_model.jacobian_and_time_derivative_bodyframe(
                 q_planar, qd_planar, s
             )
-            Ji_planar, Jid_planar = planar_model.jacobian_and_time_derivative_inertialframe(
-                q_planar, qd_planar, s
+            Ji_planar, Jid_planar = (
+                planar_model.jacobian_and_time_derivative_inertialframe(
+                    q_planar, qd_planar, s
+                )
             )
 
-            Jb_spatial, Jbd_spatial = spatial_model.jacobian_and_time_derivative_bodyframe(
-                q_spatial, qd_spatial, s
+            Jb_spatial, Jbd_spatial = (
+                spatial_model.jacobian_and_time_derivative_bodyframe(
+                    q_spatial, qd_spatial, s
+                )
             )
             Ji_spatial, Jid_spatial = (
                 spatial_model.jacobian_and_time_derivative_inertialframe(

--- a/tests/systems/test_pendulum.py
+++ b/tests/systems/test_pendulum.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import jax
 
 jax.config.update("jax_enable_x64", True)  # double precision
@@ -5,10 +6,10 @@ import jax.numpy as jnp
 import numpy as onp
 import pytest
 from numpy.testing import assert_allclose
+from system_param_builders import pendulum_params, tendon_actuated_pendulum_params
 
 from soromox.systems import Pendulum, TendonActuatedPendulum
 from soromox.utils.tolerance import Tolerance
-from system_param_builders import pendulum_params, tendon_actuated_pendulum_params
 
 
 def make_pendulum(N: int = 2):
@@ -16,18 +17,18 @@ def make_pendulum(N: int = 2):
     assert N in (2, 3)
     if N == 2:
         m = jnp.array([1.0, 2.0])
-        I = jnp.array([0.1, 0.2])
+        inertia = jnp.array([0.1, 0.2])
         L = jnp.array([1.0, 1.5])
         Lc = jnp.array([0.5, 0.75])
     else:  # N == 3
         m = jnp.array([1.0, 2.0, 0.8])
-        I = jnp.array([0.1, 0.2, 0.05])
+        inertia = jnp.array([0.1, 0.2, 0.05])
         L = jnp.array([1.0, 1.5, 0.8])
         Lc = jnp.array([0.5, 0.75, 0.4])
 
     params = pendulum_params(
         mass=m,
-        moment_inertia=I,
+        moment_inertia=inertia,
         length=L,
         center_of_mass_length=Lc,
         gravity=jnp.array([0.0, -9.81]),
@@ -129,7 +130,10 @@ def test_jacobian_match_autodiff(N):
     J_tips_impl = robot.jacobian_tips(q)  # (N,3,N)
     # Autodiff jacobian for each link's [theta, px, py]
     for i in range(robot.num_links):
-        f_tip_i = lambda q_: robot.forward_kinematics_tips(q_)[i]
+
+        def f_tip_i(q_, link_index=i):
+            return robot.forward_kinematics_tips(q_)[link_index]
+
         J_ad_i = jax.jacfwd(f_tip_i)(q)
         assert_allclose(
             J_tips_impl[i],
@@ -141,7 +145,10 @@ def test_jacobian_match_autodiff(N):
     # COMs
     J_coms_impl = robot.jacobian_coms(q)
     for i in range(robot.num_links):
-        f_com_i = lambda q_: robot.forward_kinematics_coms(q_)[i]
+
+        def f_com_i(q_, link_index=i):
+            return robot.forward_kinematics_coms(q_)[link_index]
+
         J_ad_i = jax.jacfwd(f_com_i)(q)
         assert_allclose(
             J_coms_impl[i],
@@ -153,7 +160,10 @@ def test_jacobian_match_autodiff(N):
     # Joints
     J_joints_impl = robot.jacobian_joints(q)
     for i in range(robot.num_links):
-        f_joint_i = lambda q_: robot.forward_kinematics_joints(q_)[i]
+
+        def f_joint_i(q_, link_index=i):
+            return robot.forward_kinematics_joints(q_)[link_index]
+
         J_ad_i = jax.jacfwd(f_joint_i)(q)
         assert_allclose(
             J_joints_impl[i],
@@ -227,7 +237,7 @@ def test_inertia_matrix_at_zero_config_matches_closed_form(N):
     L = onp.array(robot.L, dtype=float)
     Lc = onp.array(robot.Lc, dtype=float)
     m = onp.array(robot.m, dtype=float)
-    I = onp.array(robot.I, dtype=float)
+    inertia = onp.array(robot.I, dtype=float)
 
     # x-positions of joints and COMs
     p_joint_x = onp.concatenate([[0.0], onp.cumsum(L)[:-1]])  # (N,)
@@ -244,7 +254,7 @@ def test_inertia_matrix_at_zero_config_matches_closed_form(N):
     # Angular part via planar Jw (lower-triangular ones per row)
     idx = onp.arange(N)
     Jw = (idx[None, :] <= idx[:, None]).astype(float)  # (N,N)
-    W_ang = onp.einsum("i,ia,ib->ab", I, Jw, Jw)
+    W_ang = onp.einsum("i,ia,ib->ab", inertia, Jw, Jw)
 
     B_expected = M_lin + W_ang
     assert_allclose(B, B_expected, rtol=Tolerance.rtol(), atol=Tolerance.atol())
@@ -433,8 +443,8 @@ def test_jacobian_matches_autodiff(N):
         J_analytical = robot.jacobian(q, jnp.array(s))
 
         # Autodiff Jacobian
-        def fk_at_s(q_):
-            return robot.forward_kinematics(q_, jnp.array(s))
+        def fk_at_s(q_, s_current=s):
+            return robot.forward_kinematics(q_, jnp.array(s_current))
 
         J_autodiff = jax.jacfwd(fk_at_s)(q)
 
@@ -484,8 +494,8 @@ def test_arc_length_jacobian_time_derivative_matches_jvp(N):
         J_closed, Jd_closed = robot.jacobian_and_time_derivative(q, qd, s_arr)
 
         # JVP
-        def J_of_q(q_):
-            return robot.jacobian(q_, s_arr)
+        def J_of_q(q_, s_current=s_arr):
+            return robot.jacobian(q_, s_current)
 
         _, Jd_jvp = jax.jvp(J_of_q, (q,), (qd,))
 

--- a/tests/systems/test_planar_hsa.py
+++ b/tests/systems/test_planar_hsa.py
@@ -1,16 +1,16 @@
+# ruff: noqa: E402
 import jax
 
 jax.config.update("jax_enable_x64", True)  # double precision
 from pathlib import Path
 
-from jax import jacfwd, grad
+from jax import grad, jacfwd, random
 from jax import numpy as jnp
-from jax import random
+from system_param_builders import planar_hsa_params_from_legacy
 
 import soromox
 from soromox.parameters.hsa_params import PARAMS_FPU_CONTROL as params
 from soromox.systems import PlanarHSA, PlanarHSAStructure
-from system_param_builders import planar_hsa_params_from_legacy
 
 typed_params = planar_hsa_params_from_legacy(params)
 num_segments = 1
@@ -122,7 +122,9 @@ def test_jacobian_wrapper_matches_virtual_backbone(seed: int = 0):
     J1 = robot.jacobian(q, s)
     J2 = robot.jacobian_virtual_backbone(q, s)
 
-    assert jnp.allclose(J1, J2, atol=1e-12), "jacobian should match jacobian_virtual_backbone"
+    assert jnp.allclose(J1, J2, atol=1e-12), (
+        "jacobian should match jacobian_virtual_backbone"
+    )
 
 
 def test_jacobian_tips(seed: int = 0):
@@ -164,7 +166,9 @@ def test_jacobian_and_time_derivative_virtual_backbone(seed: int = 0):
 
         # Verify J matches the Jacobian method
         J_direct = robot.jacobian_virtual_backbone(q, s)
-        assert jnp.allclose(J, J_direct, atol=1e-10), "J from jacobian_and_time_derivative should match jacobian"
+        assert jnp.allclose(J, J_direct, atol=1e-10), (
+            "J from jacobian_and_time_derivative should match jacobian"
+        )
 
         # Verify Jd by numerical differentiation
         eps_t = 1e-6
@@ -196,8 +200,12 @@ def test_jacobian_and_time_derivative_wrapper_matches_virtual_backbone(seed: int
     J1, Jd1 = robot.jacobian_and_time_derivative(q, qd, s)
     J2, Jd2 = robot.jacobian_and_time_derivative_virtual_backbone(q, qd, s)
 
-    assert jnp.allclose(J1, J2, atol=1e-12), "jacobian_and_time_derivative J should match"
-    assert jnp.allclose(Jd1, Jd2, atol=1e-12), "jacobian_and_time_derivative Jd should match"
+    assert jnp.allclose(J1, J2, atol=1e-12), (
+        "jacobian_and_time_derivative J should match"
+    )
+    assert jnp.allclose(Jd1, Jd2, atol=1e-12), (
+        "jacobian_and_time_derivative Jd should match"
+    )
 
 
 def test_gravitational_energy(seed: int = 0):
@@ -223,7 +231,9 @@ def test_gravitational_energy(seed: int = 0):
             print(f"G = {G}")
             print(f"G_from_energy = {G_from_energy}")
             print(f"diff = {jnp.abs(G - G_from_energy)}")
-            raise ValueError("Gravitational force should be gradient of gravitational energy")
+            raise ValueError(
+                "Gravitational force should be gradient of gravitational energy"
+            )
 
 
 def test_kinetic_energy(seed: int = 0):
@@ -253,7 +263,9 @@ def test_kinetic_energy(seed: int = 0):
 
         # Zero velocity should give zero kinetic energy
         T_zero = robot.kinetic_energy(q, jnp.zeros_like(qd))
-        assert jnp.abs(T_zero) < 1e-15, "Kinetic energy with zero velocity should be zero"
+        assert jnp.abs(T_zero) < 1e-15, (
+            "Kinetic energy with zero velocity should be zero"
+        )
 
 
 def test_elastic_energy(seed: int = 0):
@@ -321,7 +333,9 @@ def test_stiffness_matrix(seed: int = 0):
 
     # Stiffness matrix should be positive semi-definite
     eigenvalues = jnp.linalg.eigvalsh(K)
-    assert jnp.all(eigenvalues >= -1e-10), "Stiffness matrix should be positive semi-definite"
+    assert jnp.all(eigenvalues >= -1e-10), (
+        "Stiffness matrix should be positive semi-definite"
+    )
 
 
 def test_potential_energy(seed: int = 0):
@@ -339,7 +353,9 @@ def test_potential_energy(seed: int = 0):
         U_K = robot.elastic_energy(q)
         U_G = robot.gravitational_energy(q)
 
-        assert jnp.allclose(U, U_K + U_G, atol=1e-10), "Potential energy should be U_K + U_G"
+        assert jnp.allclose(U, U_K + U_G, atol=1e-10), (
+            "Potential energy should be U_K + U_G"
+        )
 
 
 def test_total_energy(seed: int = 0):

--- a/tests/systems/test_tendon_actuated_gvs.py
+++ b/tests/systems/test_tendon_actuated_gvs.py
@@ -1,10 +1,19 @@
+# ruff: noqa: E402
 import jax
 import pytest
 
 jax.config.update("jax_enable_x64", True)  # double precision
 import numpy as onp
+import optimistix as optx
 from jax import numpy as jnp
 from numpy.testing import assert_allclose
+from system_param_builders import (
+    linear_tendon_routing,
+    passive_tendon_params,
+    pcs_params,
+    spatial_base_pose,
+    tendon_actuated_pcs_params,
+)
 
 from soromox.systems import (
     CrossSectionGeometry,
@@ -14,15 +23,6 @@ from soromox.systems import (
 )
 from soromox.systems.gvs import GVSSegment, JointSpec, LinkSpec, StrainBasisSpec
 from soromox.utils.tolerance import Tolerance
-from system_param_builders import (
-    linear_tendon_routing,
-    passive_tendon_params,
-    pcs_params,
-    spatial_base_pose,
-    tendon_actuated_pcs_params,
-)
-
-import optimistix as optx
 
 
 def _segments(
@@ -680,6 +680,7 @@ def test_tendon_actatuated_ActMatrix_gvs_vs_pcs():
             atol=Tolerance.atol(),
         )
         print("[Valid test]\n")
+
 
 def test_tendon_actatuated_gvs_vs_pcs():
     """

--- a/tests/systems/test_tendon_actuated_pcs.py
+++ b/tests/systems/test_tendon_actuated_pcs.py
@@ -1,14 +1,12 @@
+# ruff: noqa: E402
 import jax
 import pytest
 
 jax.config.update("jax_enable_x64", True)  # double precision
+
 from jax import Array
 from jax import numpy as jnp
 from numpy.testing import assert_allclose
-from typing import Optional
-
-from soromox.systems import LinearTendonRoutingParams, PassiveTendonParams, PCSStructure, TendonActuatedPCS
-from soromox.utils.tolerance import Tolerance
 from system_param_builders import (
     linear_tendon_routing,
     passive_tendon_params,
@@ -17,6 +15,14 @@ from system_param_builders import (
     tendon_actuated_pcs_params,
 )
 
+from soromox.systems import (
+    LinearTendonRoutingParams,
+    PassiveTendonParams,
+    PCSStructure,
+    TendonActuatedPCS,
+)
+from soromox.utils.tolerance import Tolerance
+
 XI_REF = jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0], dtype=jnp.float64)
 
 
@@ -24,8 +30,8 @@ def _create_robot(
     segment_lengths: Array,
     tendon_params: LinearTendonRoutingParams,
     strain_selector=None,
-    passive_tendon_routing: Optional[LinearTendonRoutingParams] = None,
-    passive_tendon: Optional[PassiveTendonParams] = None,
+    passive_tendon_routing: LinearTendonRoutingParams | None = None,
+    passive_tendon: PassiveTendonParams | None = None,
 ) -> TendonActuatedPCS:
     """
     Helper that builds a TendonActuatedPCS instance with consistent material parameters.
@@ -627,9 +633,7 @@ def test_update_tendon_params():
         active_tendon_routing=active_params.replace(y_intercept=new_ry)
     )
 
-    assert_allclose(
-        updated_robot_active.active_tendon_routing.y_intercept, new_ry
-    )
+    assert_allclose(updated_robot_active.active_tendon_routing.y_intercept, new_ry)
     assert_allclose(
         updated_robot_active.active_tendon_routing.z_intercept,
         active_params.z_intercept,

--- a/tests/systems/test_tendon_actuated_planar_pcs.py
+++ b/tests/systems/test_tendon_actuated_planar_pcs.py
@@ -1,17 +1,18 @@
+# ruff: noqa: E402
 import jax
 
 jax.config.update("jax_enable_x64", True)
 
 from jax import numpy as jnp
 from numpy.testing import assert_allclose
-
-from soromox.systems import TendonActuatedPlanarPCS
-from soromox.utils.tolerance import Tolerance
 from system_param_builders import (
     planar_base_pose,
     planar_pcs_params,
     tendon_actuated_planar_pcs_params,
 )
+
+from soromox.systems import TendonActuatedPlanarPCS
+from soromox.utils.tolerance import Tolerance
 
 
 def _build_planar_robot(num_segments: int = 3) -> TendonActuatedPlanarPCS:

--- a/tests/systems/test_typed_params_api.py
+++ b/tests/systems/test_typed_params_api.py
@@ -144,9 +144,7 @@ def test_planar_pcs_params_validate_base_pose_shape():
 def test_spatial_params_validate_base_pose_quaternion_norm():
     with pytest.raises(ValueError, match="quaternion"):
         _pcs_params().replace(
-            base_pose=jnp.array(
-                [0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0], dtype=jnp.float64
-            )
+            base_pose=jnp.array([0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0], dtype=jnp.float64)
         )
 
 

--- a/tests/test_numerical_jacobian.py
+++ b/tests/test_numerical_jacobian.py
@@ -1,9 +1,12 @@
+# ruff: noqa: E402
 from functools import partial
+
 import jax
 
 jax.config.update("jax_enable_x64", True)  # double precision
 from jax import Array, random
 from jax import numpy as jnp
+
 from soromox.utils.numerical_jacobian import approx_derivative
 
 
@@ -15,7 +18,7 @@ def test_finite_differences(method="2-point"):
     jac_numdiff_fn = partial(approx_derivative, fun, method=method)
 
     rng = random.PRNGKey(0)
-    for i in range(100):
+    for _i in range(100):
         rng, subrng = random.split(rng)
         x = random.uniform(subrng, (2,), minval=-1.0, maxval=1.0)
 

--- a/tests/utils/test_twist_from_pose.py
+++ b/tests/utils/test_twist_from_pose.py
@@ -1,5 +1,7 @@
 """Tests for twist_callable_from_pose_callable_factory utility function."""
 
+# ruff: noqa: E402
+
 import jax
 
 jax.config.update("jax_enable_x64", True)  # double precision

--- a/tools/benchmarks/benchmark_derivative_paths.py
+++ b/tools/benchmarks/benchmark_derivative_paths.py
@@ -88,13 +88,11 @@ def _kinetic_energy_gradient_from_tangent(
     q_basis = _basis_like(q)
     qd_basis = _basis_like(qd)
     dT_dq = jax.vmap(
-        lambda q_tangent: system._kinetic_energy_jvp_tangent(
-            q, qd, q_tangent, None
-        )
+        lambda q_tangent: system._kinetic_energy_jvp_tangent(q, qd, q_tangent, None)
     )(q_basis)
-    dT_dqd = jax.vmap(
-        lambda qdd: system._kinetic_energy_jvp_tangent(q, qd, None, qdd)
-    )(qd_basis)
+    dT_dqd = jax.vmap(lambda qdd: system._kinetic_energy_jvp_tangent(q, qd, None, qdd))(
+        qd_basis
+    )
     return dT_dq, dT_dqd
 
 
@@ -106,9 +104,9 @@ def _total_energy_gradient_from_tangent(
     dE_dq = jax.vmap(
         lambda q_tangent: system._total_energy_jvp_tangent(q, qd, q_tangent, None)
     )(q_basis)
-    dE_dqd = jax.vmap(
-        lambda qdd: system._total_energy_jvp_tangent(q, qd, None, qdd)
-    )(qd_basis)
+    dE_dqd = jax.vmap(lambda qdd: system._total_energy_jvp_tangent(q, qd, None, qdd))(
+        qd_basis
+    )
     return dE_dq, dE_dqd
 
 
@@ -116,9 +114,7 @@ def _direct_jacobian(system: SoftRobot, ctx: Mapping[str, Array]) -> Array:
     return system._jacobian(ctx["q"], ctx["s"])
 
 
-def _protected_autograd_jacobian(
-    system: SoftRobot, ctx: Mapping[str, Array]
-) -> Array:
+def _protected_autograd_jacobian(system: SoftRobot, ctx: Mapping[str, Array]) -> Array:
     return SoftRobot._jacobian(system, ctx["q"], ctx["s"])
 
 
@@ -482,7 +478,9 @@ def _geomean(values: Sequence[float]) -> float:
     finite_values = [value for value in values if math.isfinite(value) and value > 0.0]
     if not finite_values:
         return float("nan")
-    return math.exp(sum(math.log(value) for value in finite_values) / len(finite_values))
+    return math.exp(
+        sum(math.log(value) for value in finite_values) / len(finite_values)
+    )
 
 
 def _format_ratio(value: float) -> str:
@@ -632,7 +630,10 @@ def _write_markdown_summary(results: Sequence[Mapping[str, Any]], path: Path) ->
             and str(row["case"]) not in SYSTEM_SUMMARY_EXCLUDED_CASES
         ]
         system_groups = sorted(
-            {(str(row["case"]), str(row.get("gauss_points", ""))) for row in system_rows}
+            {
+                (str(row["case"]), str(row.get("gauss_points", "")))
+                for row in system_rows
+            }
         )
         public_ratios: list[float] = []
         public_ratios_largest: list[float] = []
@@ -733,7 +734,9 @@ def _write_markdown_summary(results: Sequence[Mapping[str, Any]], path: Path) ->
 
         max_abs_diff = max(float(row["max_abs_diff"]) for row in group_rows)
         max_rel_diff = max(float(row["max_rel_diff"]) for row in group_rows)
-        gauss_suffix = "" if gauss_values == ["None"] else f" ({','.join(gauss_values)})"
+        gauss_suffix = (
+            "" if gauss_values == ["None"] else f" ({','.join(gauss_values)})"
+        )
         lines.append(
             "| "
             f"{system}{gauss_suffix} | {case} | "
@@ -820,9 +823,7 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     if not 0.0 < args.arc_length_fraction < 1.0:
         parser.error("--arc-length-fraction must be strictly between 0 and 1.")
 
-    allowed_public = {
-        f"public_custom_jvp_{mode}" for mode in args.custom_jvp_modes
-    }
+    allowed_public = {f"public_custom_jvp_{mode}" for mode in args.custom_jvp_modes}
     args.strategies = [
         strategy
         for strategy in args.strategies

--- a/tools/benchmarks/visualize_batch_scaling_results.py
+++ b/tools/benchmarks/visualize_batch_scaling_results.py
@@ -353,7 +353,9 @@ def _plot(
         ax_per_env.legend()
 
     axes[0, 0].set_ylabel(r"Simulated time / wall time (per env)")
-    axes[1, 0].set_ylabel(r"Total simulated time / wall time ($r_{\mathrm{s}/\mathrm{w}}$)")
+    axes[1, 0].set_ylabel(
+        r"Total simulated time / wall time ($r_{\mathrm{s}/\mathrm{w}}$)"
+    )
     fig.tight_layout()
 
     if output is not None:
@@ -416,7 +418,9 @@ def _plot_total_throughput(
             ax.set_yscale("log")
         ax.legend()
 
-    axes[0, 0].set_ylabel(r"Total simulated time / wall time ($r_{\mathrm{s}/\mathrm{w}}$)")
+    axes[0, 0].set_ylabel(
+        r"Total simulated time / wall time ($r_{\mathrm{s}/\mathrm{w}}$)"
+    )
     fig.tight_layout()
 
     if output is not None:


### PR DESCRIPTION
## Summary

- Apply Ruff formatting and safe lint fixes across scripts, examples, source, tests, and benchmark tools.
- Resolve remaining Ruff diagnostics manually, including unused locals, closure binding in tests, explicit GVS exports, JAX config import-order waivers, and a finite-difference undefined-name issue.
- Preserve existing public API names where needed with targeted noqa comments.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check .`