### PR TITLE
Generalize renderer actuator visuals

### DIFF
--- a/docs/api/rendering/configuration.md
+++ b/docs/api/rendering/configuration.md
@@ -62,7 +62,7 @@ Alpha values in per-robot colors propagate to more specific colors when those om
 Main color configuration container for all renderers.
 
 ```python
-from soromox.rendering import BackboneColorConfig, RendererColorConfig
+from soromox.rendering import ActuatorStyleConfig, BackboneColorConfig, RendererColorConfig
 
 color_config = RendererColorConfig(
     backbone=BackboneColorConfig(
@@ -70,7 +70,7 @@ color_config = RendererColorConfig(
         segment_palette="soromox:ember",
     ),
     base_plate_color=(0.5, 0.5, 0.5),
-    tendon_color=(0.8, 0.2, 0.2),
+    actuators=ActuatorStyleConfig(default_color=(0.8, 0.2, 0.2)),
 )
 
 renderer.show(q, color_config=color_config)

--- a/docs/api/rendering/renderers.md
+++ b/docs/api/rendering/renderers.md
@@ -245,7 +245,7 @@ Set `segment_palette=None` to fall back to solid per-robot colors.
 `RendererColorConfig` also provides renderer-specific colors:
 
 - `base_plate_color` (Open3D, Viser)
-- `tendon_color` (Matplotlib, Open3D, Viser)
+- `actuators.default_color` and `actuators.scalar_colormap`
 
 ### Camera configuration
 
@@ -299,9 +299,20 @@ Matplotlib, Open3D, and Viser accept batched inputs:
 Use `base_offsets` or `grid_spacing` to control placement. Viser additionally
 supports `multi_robot_layout="overlay"` to stack robots at the same base pose.
 
-### Tendons and helper geometry
+### Actuators and helper geometry
 
-If the robot exposes `forward_kinematics_tendons`, tendon rendering can be enabled with `render_tendons=True`.
+If the robot exposes `actuator_visual_layers(q, s_points, *, actuator_inputs=None)`,
+actuator rendering can be enabled with `render_actuators=True`. The hook should
+return one or more `ActuatorVisualLayer` objects with points shaped
+`(num_actuators_in_layer, num_points, dim)`.
+
+For large batches or trajectories, robots can optionally provide
+`actuator_visual_layers_batched(q_batch, s_points, *, actuator_inputs=None)` with
+points shaped `(N, num_actuators_in_layer, num_points, dim)` or
+`actuator_visual_layers_trajectory(q_ts, s_points, *, actuator_inputs=None)` with
+points shaped `(N, T, num_actuators_in_layer, num_points, dim)`. The base
+renderer uses these hooks directly when available and falls back to the single
+hook otherwise.
 
 Open3D and Viser also support helper spheres:
 
@@ -320,7 +331,7 @@ sizing is controlled with `base_plate_radius_scale` and `base_plate_thickness`.
 `ViserRenderer.render_sequence()` can add Plotly panels:
 
 - `plot_configurations=True`
-- `plot_tendon_positions=True`
+- `plot_actuator_positions=True`
 - `custom_plots={"My Plot": (figure, aspect)}`
 
 Plot panels require `plotly`. `ViserRenderer.render_frame()` also requires at

--- a/docs/development/extending.md
+++ b/docs/development/extending.md
@@ -647,8 +647,8 @@ class BaseSoftRobotRenderer:
         """Compute backbone points from configuration."""
         ...
 
-    def compute_tendon_curves(self, q):
-        """Compute tendon paths if supported."""
+    def compute_actuator_visual_layers(self, q):
+        """Compute actuator visual layers if supported."""
         ...
 
     # Abstract methods (must implement)
@@ -778,9 +778,14 @@ The base class provides useful helpers:
 backbone = self.compute_backbone_curve(q)
 # Returns: (num_points, 2) for 2D or (num_points, 3) for 3D
 
-# Get tendon curves (if robot supports tendons)
-tendons = self.compute_tendon_curves(q)
-# Returns: list of (num_points, 2/3) arrays
+# Get actuator visual layers (if robot exposes actuator_visual_layers)
+actuator_layers = self.compute_actuator_visual_layers(q)
+# Returns: tuple of ActuatorVisualLayer objects
+
+# Batched and trajectory actuator visual helpers use optional robot fast paths
+# named actuator_visual_layers_batched(...) and
+# actuator_visual_layers_trajectory(...) when available. Otherwise they fall
+# back to repeated calls to the single-configuration actuator_visual_layers(...).
 
 # Resolve colors with hierarchy
 colors = self.resolve_backbone_colors(num_robots=1, color_config=color_config)

--- a/examples/control/operational_space/control_pcs_with_cf_cbf_clf.py
+++ b/examples/control/operational_space/control_pcs_with_cf_cbf_clf.py
@@ -509,7 +509,7 @@ if __name__ == "__main__":
         width=1280,
         height=800,
         backbone_style="discrete",
-        tendon_line_width=2.0,
+        actuator_line_width=2.0,
     )
     renderer.render_sequence(
         ts=ts[::render_stride],
@@ -517,7 +517,7 @@ if __name__ == "__main__":
         playback_speed=1.0,
         loop=True,
         record_path="videos/clf_cbf_rollout.mp4",
-        render_tendons=True,
+        render_actuators=True,
         static_spheres_positions=static_spheres_positions,
         static_spheres_radii=static_spheres_radii,
         static_spheres_colors=static_spheres_colors,

--- a/examples/simulation/pcs/simulate_batched_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_batched_tendon_actuated_pcs.py
@@ -11,6 +11,7 @@ jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 
 from soromox.rendering import (
+    ActuatorStyleConfig,
     BackboneColorConfig,
     MatplotlibRenderer,
     Open3DRenderer,
@@ -133,10 +134,10 @@ def main():
         num_points=60,
         line_width=2.5,
         grid_spacing=grid_spacing,
-        tendon_line_width=2.0,
+        actuator_line_width=2.0,
         color_config=RendererColorConfig(
             backbone=BackboneColorConfig(robot_palette="plasma"),
-            tendon_color=(0.9, 0.1, 0.1),
+            actuators=ActuatorStyleConfig(default_color=(0.9, 0.1, 0.1)),
         ),
     )
     # q_ts_batched is (N, T, DOF); animate in slider mode for quick inspection
@@ -174,7 +175,7 @@ def main():
         playback_speed=1.0,
         autoplay=True,
         loop=True,
-        render_tendons=True,
+        render_actuators=True,
         record_path="videos/batched_tendon_actuated_pcs_viser.mp4",
     )
 

--- a/examples/simulation/pcs/simulate_pcs.py
+++ b/examples/simulation/pcs/simulate_pcs.py
@@ -8,6 +8,7 @@ from diffrax import Tsit5
 
 jax.config.update("jax_enable_x64", True)  # double precision
 from soromox.rendering import (
+    ActuatorStyleConfig,
     BackboneColorConfig,
     MatplotlibRenderer,
     Open3DRenderer,
@@ -169,7 +170,7 @@ if __name__ == "__main__":
         color_config=RendererColorConfig(
             backbone=BackboneColorConfig(point_palette="soromox:glacier"),
             base_plate_color=(0.15, 0.15, 0.15),
-            tendon_color=(0.2, 0.4, 0.8),
+            actuators=ActuatorStyleConfig(default_color=(0.2, 0.4, 0.8)),
         ),
     )
 

--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -8,6 +8,7 @@ import plotly.graph_objects as go
 from diffrax import Tsit5
 
 from soromox.rendering import (
+    ActuatorStyleConfig,
     MatplotlibRenderer,
     Open3DRenderer,
     RendererColorConfig,
@@ -219,12 +220,14 @@ if __name__ == "__main__":
         robot,
         num_points=60,
         line_width=2.5,
-        tendon_line_width=2.0,
-        color_config=RendererColorConfig(tendon_color=(0.9, 0.1, 0.1)),
+        actuator_line_width=2.0,
+        color_config=RendererColorConfig(
+            actuators=ActuatorStyleConfig(default_color=(0.9, 0.1, 0.1))
+        ),
     )
     # q_ts is (T, DOF); animate in slider mode for quick inspection
     matplotlib_renderer.animate(
-        ts=ts, q_ts=q_ts, mode="slider", show=True, render_tendons=True
+        ts=ts, q_ts=q_ts, mode="slider", show=True, render_actuators=True
     )
 
     # render using the Open3DRenderer
@@ -291,9 +294,9 @@ if __name__ == "__main__":
         playback_speed=1.0,
         loop=True,
         autoplay=True,
-        render_tendons=True,
+        render_actuators=True,
         plot_configurations=False,
-        plot_tendon_positions=True,
+        plot_actuator_positions=True,
         custom_plots={
             "Rotational Strains": (fig_rot, 2.0),
             "Linear Strains": (fig_lin, 2.0),

--- a/src/soromox/rendering/__init__.py
+++ b/src/soromox/rendering/__init__.py
@@ -10,9 +10,15 @@ This module provides various backends for visualizing robots:
 - OpenCVPlanarRenderer: Generic renderer for planar robots
 """
 
+from soromox.rendering.actuators import (
+    ActuatorVisualLayer,
+    BatchedActuatorVisualLayer,
+    TrajectoryActuatorVisualLayer,
+)
 from soromox.rendering.base import BaseSoftRobotRenderer
 from soromox.rendering.camera_config import CameraConfig
 from soromox.rendering.color_config import (
+    ActuatorStyleConfig,
     BackboneColorConfig,
     ColorLegend,
     RendererColorConfig,
@@ -56,6 +62,7 @@ __all__ = [
     "BaseSoftRobotRenderer",
     # Configuration
     "CameraConfig",
+    "ActuatorStyleConfig",
     "BackboneColorConfig",
     "RendererColorConfig",
     "ColorLegend",
@@ -63,6 +70,9 @@ __all__ = [
     "list_builtin_themes",
     "get_color_theme",
     "VideoEncodingConfig",
+    "ActuatorVisualLayer",
+    "BatchedActuatorVisualLayer",
+    "TrajectoryActuatorVisualLayer",
     # Generic renderers
     "MatplotlibRenderer",
     "Open3DRenderer",

--- a/src/soromox/rendering/actuators.py
+++ b/src/soromox/rendering/actuators.py
@@ -1,0 +1,294 @@
+"""Renderer-facing actuator visual primitives.
+
+An actuator visual layer is a renderer-side grouping of actuator paths that
+share one semantic role and visual treatment, such as all active tendons or all
+McKibben muscles. It is not a dynamics object: the layer only describes the
+geometry and optional display data needed to draw those actuators.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from typing import Literal
+
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+
+ActuatorVisualKind = Literal["tendon", "muscle", "pneumatic", "cable", "generic"]
+
+
+@dataclass(frozen=True)
+class ActuatorVisualLayer:
+    """Visual geometry for one semantic actuator group.
+
+    A layer groups actuators that can be drawn with the same renderer policy.
+    Examples are an ``active_tendons`` layer containing sampled tendon paths or
+    a ``mckibben_muscles`` layer containing two-point muscle segments.
+
+    ``points`` stores one polyline per actuator with shape
+    ``(num_actuators_in_layer, num_points, dim)``. Renderers may draw two-point
+    lines as straight actuator segments or sampled polylines as routed actuators.
+    """
+
+    name: str
+    kind: ActuatorVisualKind
+    points: Array
+    radius: float | Array | None = None
+    line_width: float | None = None
+    colors: Array | np.ndarray | list | tuple | None = None
+    scalar_fields: Mapping[str, Array] = field(default_factory=dict)
+
+    def with_points(self, points: Array) -> "ActuatorVisualLayer":
+        """Return a copy with replaced geometry points."""
+        return replace(self, points=points)
+
+
+@dataclass(frozen=True)
+class BatchedActuatorVisualLayer:
+    """Batched actuator visual geometry.
+
+    ``points`` has shape ``(num_robots, num_actuators, num_points, dim)``.
+    """
+
+    name: str
+    kind: ActuatorVisualKind
+    points: Array
+    radius: float | Array | None = None
+    line_width: float | None = None
+    colors: Array | np.ndarray | list | tuple | None = None
+    scalar_fields: Mapping[str, Array] = field(default_factory=dict)
+
+    def with_points(self, points: Array) -> "BatchedActuatorVisualLayer":
+        """Return a copy with replaced geometry points."""
+        return replace(self, points=points)
+
+
+@dataclass(frozen=True)
+class TrajectoryActuatorVisualLayer:
+    """Trajectory actuator visual geometry.
+
+    ``points`` has shape ``(num_robots, num_steps, num_actuators, num_points, dim)``.
+    """
+
+    name: str
+    kind: ActuatorVisualKind
+    points: Array
+    radius: float | Array | None = None
+    line_width: float | None = None
+    colors: Array | np.ndarray | list | tuple | None = None
+    scalar_fields: Mapping[str, Array] = field(default_factory=dict)
+
+    def with_points(self, points: Array) -> "TrajectoryActuatorVisualLayer":
+        """Return a copy with replaced geometry points."""
+        return replace(self, points=points)
+
+
+def validate_actuator_visual_layer(layer: ActuatorVisualLayer) -> None:
+    """Validate the common actuator visual layer contract."""
+    points = jnp.asarray(layer.points)
+    if points.ndim != 3:
+        raise ValueError(
+            f"Actuator layer {layer.name!r} points must have shape "
+            f"(num_actuators, num_points, dim), got {points.shape}."
+        )
+    if points.shape[-1] not in (2, 3):
+        raise ValueError(
+            f"Actuator layer {layer.name!r} point dimension must be 2 or 3, "
+            f"got {points.shape[-1]}."
+        )
+    if points.shape[-2] < 2 and points.shape[-3] > 0:
+        raise ValueError(
+            f"Actuator layer {layer.name!r} needs at least two points per actuator, "
+            f"got {points.shape[-2]}."
+        )
+
+
+def validate_batched_actuator_visual_layer(
+    layer: BatchedActuatorVisualLayer,
+    *,
+    num_robots: int | None = None,
+) -> None:
+    """Validate the batched actuator visual layer contract."""
+    points = jnp.asarray(layer.points)
+    if points.ndim != 4:
+        raise ValueError(
+            f"Batched actuator layer {layer.name!r} points must have shape "
+            f"(num_robots, num_actuators, num_points, dim), got {points.shape}."
+        )
+    if num_robots is not None and int(points.shape[0]) != int(num_robots):
+        raise ValueError(
+            f"Batched actuator layer {layer.name!r} first dimension must match "
+            f"num_robots={num_robots}, got {points.shape[0]}."
+        )
+    if points.shape[-1] not in (2, 3):
+        raise ValueError(
+            f"Batched actuator layer {layer.name!r} point dimension must be 2 or 3, "
+            f"got {points.shape[-1]}."
+        )
+    if points.shape[-2] < 2 and points.shape[-3] > 0:
+        raise ValueError(
+            f"Batched actuator layer {layer.name!r} needs at least two points per "
+            f"actuator, got {points.shape[-2]}."
+        )
+
+
+def validate_trajectory_actuator_visual_layer(
+    layer: TrajectoryActuatorVisualLayer,
+    *,
+    num_robots: int | None = None,
+    num_steps: int | None = None,
+) -> None:
+    """Validate the trajectory actuator visual layer contract."""
+    points = jnp.asarray(layer.points)
+    if points.ndim != 5:
+        raise ValueError(
+            f"Trajectory actuator layer {layer.name!r} points must have shape "
+            "(num_robots, num_steps, num_actuators, num_points, dim), "
+            f"got {points.shape}."
+        )
+    if num_robots is not None and int(points.shape[0]) != int(num_robots):
+        raise ValueError(
+            f"Trajectory actuator layer {layer.name!r} first dimension must match "
+            f"num_robots={num_robots}, got {points.shape[0]}."
+        )
+    if num_steps is not None and int(points.shape[1]) != int(num_steps):
+        raise ValueError(
+            f"Trajectory actuator layer {layer.name!r} second dimension must match "
+            f"num_steps={num_steps}, got {points.shape[1]}."
+        )
+    if points.shape[-1] not in (2, 3):
+        raise ValueError(
+            f"Trajectory actuator layer {layer.name!r} point dimension must be 2 or 3, "
+            f"got {points.shape[-1]}."
+        )
+    if points.shape[-2] < 2 and points.shape[-3] > 0:
+        raise ValueError(
+            f"Trajectory actuator layer {layer.name!r} needs at least two points per "
+            f"actuator, got {points.shape[-2]}."
+        )
+
+
+def normalize_actuator_layers(
+    layers: tuple[ActuatorVisualLayer, ...] | list[ActuatorVisualLayer] | None,
+) -> tuple[ActuatorVisualLayer, ...]:
+    """Return a validated tuple of actuator visual layers."""
+    if layers is None:
+        return ()
+    normalized = tuple(layers)
+    for layer in normalized:
+        validate_actuator_visual_layer(layer)
+    return normalized
+
+
+def normalize_batched_actuator_layers(
+    layers: tuple[BatchedActuatorVisualLayer, ...]
+    | list[BatchedActuatorVisualLayer]
+    | None,
+    *,
+    num_robots: int | None = None,
+) -> tuple[BatchedActuatorVisualLayer, ...]:
+    """Return a validated tuple of batched actuator visual layers."""
+    if layers is None:
+        return ()
+    normalized = tuple(layers)
+    for layer in normalized:
+        validate_batched_actuator_visual_layer(layer, num_robots=num_robots)
+    return normalized
+
+
+def normalize_trajectory_actuator_layers(
+    layers: tuple[TrajectoryActuatorVisualLayer, ...]
+    | list[TrajectoryActuatorVisualLayer]
+    | None,
+    *,
+    num_robots: int | None = None,
+    num_steps: int | None = None,
+) -> tuple[TrajectoryActuatorVisualLayer, ...]:
+    """Return a validated tuple of trajectory actuator visual layers."""
+    if layers is None:
+        return ()
+    normalized = tuple(layers)
+    for layer in normalized:
+        validate_trajectory_actuator_visual_layer(
+            layer, num_robots=num_robots, num_steps=num_steps
+        )
+    return normalized
+
+
+def _as_rgba(color: np.ndarray) -> np.ndarray:
+    arr = np.asarray(color, dtype=np.float64)
+    if arr.shape[-1] == 3:
+        alpha = np.ones((*arr.shape[:-1], 1), dtype=np.float64)
+        arr = np.concatenate([arr, alpha], axis=-1)
+    if arr.shape[-1] != 4:
+        raise ValueError(f"Colors must have 3 or 4 channels, got shape {arr.shape}.")
+    return np.clip(arr, 0.0, 1.0)
+
+
+def _colormap_values(values: np.ndarray, colormap: str) -> np.ndarray:
+    values = np.asarray(values, dtype=np.float64)
+    if values.size == 0:
+        return np.zeros((*values.shape, 4), dtype=np.float64)
+    v_min = float(np.nanmin(values))
+    v_max = float(np.nanmax(values))
+    denom = max(v_max - v_min, 1e-12)
+    scaled = np.clip((values - v_min) / denom, 0.0, 1.0)
+    try:
+        import matplotlib
+
+        cmap = matplotlib.colormaps[colormap]
+        rgba = cmap(scaled)
+        return np.asarray(rgba, dtype=np.float64)
+    except Exception:
+        low = np.array([0.12, 0.38, 0.72, 1.0], dtype=np.float64)
+        high = np.array([0.90, 0.22, 0.12, 1.0], dtype=np.float64)
+        return low + (high - low) * scaled[..., None]
+
+
+def resolve_actuator_rgba(
+    layer: ActuatorVisualLayer | BatchedActuatorVisualLayer | TrajectoryActuatorVisualLayer,
+    *,
+    default_color: tuple[float, float, float],
+    scalar_field: str | None = None,
+    scalar_colormap: str = "viridis",
+) -> np.ndarray:
+    """Resolve per-actuator RGBA colors for a visual layer.
+
+    The returned array follows the leading actuator axes of ``layer.points``
+    excluding the polyline-point and coordinate axes.
+    """
+    points = np.asarray(layer.points)
+    target_shape = points.shape[:-2]
+    if layer.colors is not None:
+        colors = _as_rgba(np.asarray(layer.colors, dtype=np.float64))
+        if colors.shape[:-1] == target_shape:
+            return colors
+        if colors.shape[:-1] == target_shape[-1:]:
+            reps = target_shape[:-1] + (1, 1)
+            return np.tile(colors, reps)
+        try:
+            return np.broadcast_to(colors, (*target_shape, 4)).copy()
+        except ValueError as exc:
+            raise ValueError(
+                f"Colors for actuator layer {layer.name!r} must broadcast to "
+                f"{(*target_shape, 4)}, got {colors.shape}."
+            ) from exc
+
+    if layer.scalar_fields:
+        chosen_field = scalar_field
+        if chosen_field is None or chosen_field not in layer.scalar_fields:
+            chosen_field = next(iter(layer.scalar_fields))
+        values = np.asarray(layer.scalar_fields[chosen_field], dtype=np.float64)
+        try:
+            values = np.broadcast_to(values, target_shape)
+        except ValueError as exc:
+            raise ValueError(
+                f"Scalar field {chosen_field!r} for actuator layer {layer.name!r} "
+                f"must broadcast to {target_shape}, got {values.shape}."
+            ) from exc
+        return _colormap_values(values, scalar_colormap)
+
+    base = _as_rgba(np.asarray(default_color, dtype=np.float64))
+    return np.broadcast_to(base, (*target_shape, 4)).copy()

--- a/src/soromox/rendering/base.py
+++ b/src/soromox/rendering/base.py
@@ -10,6 +10,14 @@ import jax.numpy as jnp
 import numpy as np
 from jax import Array
 
+from soromox.rendering.actuators import (
+    ActuatorVisualLayer,
+    BatchedActuatorVisualLayer,
+    TrajectoryActuatorVisualLayer,
+    normalize_actuator_layers,
+    normalize_batched_actuator_layers,
+    normalize_trajectory_actuator_layers,
+)
 from soromox.rendering.color_config import (
     DEFAULT_ROBOT_PALETTE,
     DEFAULT_SEGMENT_PALETTE,
@@ -87,12 +95,18 @@ class BaseSoftRobotRenderer(ABC):
         # Total robot length
         self.L_max = float(jnp.asarray(robot.length))
 
-        # Cache tendon FK if available
-        self._has_tendons = hasattr(robot, "forward_kinematics_tendons")
-        if self._has_tendons:
-            self._batched_fk_tendons = jax.vmap(
-                robot.forward_kinematics_tendons, in_axes=(None, 0), out_axes=1
-            )
+        self._has_actuator_visual_layers = hasattr(robot, "actuator_visual_layers")
+        self._has_batched_actuator_visual_layers = hasattr(
+            robot, "actuator_visual_layers_batched"
+        )
+        self._has_trajectory_actuator_visual_layers = hasattr(
+            robot, "actuator_visual_layers_trajectory"
+        )
+        self._has_actuator_visuals = (
+            self._has_actuator_visual_layers
+            or self._has_batched_actuator_visual_layers
+            or self._has_trajectory_actuator_visual_layers
+        )
 
     def _base_position(self, dim: int | None = None) -> np.ndarray:
         """Return the configured base translation in renderer coordinates.
@@ -270,33 +284,315 @@ class BaseSoftRobotRenderer(ABC):
 
         return curve
 
-    def compute_tendon_curves(self, q: Array) -> Array | None:
-        """Compute tendon paths if the robot supports tendon kinematics."""
-        if not self._has_tendons:
-            return None
+    def compute_actuator_visual_layers(
+        self,
+        q: Array,
+        *,
+        actuator_inputs: Array | None = None,
+    ) -> tuple[ActuatorVisualLayer, ...]:
+        """Compute renderer-facing actuator visual layers for one robot."""
+        if not self._has_actuator_visual_layers:
+            return ()
         s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
-        return self._batched_fk_tendons(q, s_ps)
+        layers = self.robot.actuator_visual_layers(  # type: ignore[attr-defined]
+            q, s_ps, actuator_inputs=actuator_inputs
+        )
+        return normalize_actuator_layers(layers)
 
-    def compute_tendon_curves_batched(
-        self, q_batch: Array, base_offsets: Array
+    def _offset_batched_actuator_layers(
+        self,
+        layers: tuple[BatchedActuatorVisualLayer, ...],
+        base_offsets: Array | np.ndarray,
+    ) -> tuple[BatchedActuatorVisualLayer, ...]:
+        """Apply per-robot base offsets to batched actuator layer points."""
+        offset_layers: list[BatchedActuatorVisualLayer] = []
+        for layer in layers:
+            points = jnp.asarray(layer.points)
+            offsets = self._normalize_base_offsets(
+                base_offsets,
+                num_robots=int(points.shape[0]),
+                target_dim=int(points.shape[-1]),
+            )
+            offset_layers.append(
+                layer.with_points(points + offsets[:, None, None, :])
+            )
+        return tuple(offset_layers)
+
+    def _offset_trajectory_actuator_layers(
+        self,
+        layers: tuple[TrajectoryActuatorVisualLayer, ...],
+        base_offsets: Array | np.ndarray,
+    ) -> tuple[TrajectoryActuatorVisualLayer, ...]:
+        """Apply per-robot base offsets to trajectory actuator layer points."""
+        offset_layers: list[TrajectoryActuatorVisualLayer] = []
+        for layer in layers:
+            points = jnp.asarray(layer.points)
+            offsets = self._normalize_base_offsets(
+                base_offsets,
+                num_robots=int(points.shape[0]),
+                target_dim=int(points.shape[-1]),
+            )
+            offset_layers.append(
+                layer.with_points(points + offsets[:, None, None, None, :])
+            )
+        return tuple(offset_layers)
+
+    @staticmethod
+    def _stack_optional_arrays(
+        values: list[Array | np.ndarray | list | tuple | None],
+        *,
+        name: str,
+        layer_name: str,
     ) -> Array | None:
-        """Compute tendon paths for multiple robots with base offsets."""
-        if not self._has_tendons:
+        if all(value is None for value in values):
             return None
+        if any(value is None for value in values):
+            raise ValueError(
+                f"{name} for actuator layer {layer_name!r} must be provided for "
+                "all robots/timesteps or none."
+            )
+        return jnp.stack([jnp.asarray(value) for value in values])
+
+    @staticmethod
+    def _stack_radius(values: list[float | Array | None]) -> float | Array | None:
+        if all(value is None for value in values):
+            return None
+        first = values[0]
+        if first is None:
+            return None
+        if np.asarray(first).ndim == 0:
+            return first
+        return jnp.stack([jnp.asarray(value) for value in values])
+
+    @staticmethod
+    def _stack_scalar_fields(
+        layers: list[ActuatorVisualLayer | BatchedActuatorVisualLayer],
+    ) -> dict[str, Array]:
+        first_keys = tuple(layers[0].scalar_fields.keys())
+        stacked: dict[str, Array] = {}
+        for layer in layers[1:]:
+            if tuple(layer.scalar_fields.keys()) != first_keys:
+                raise ValueError(
+                    f"Actuator layer {layers[0].name!r} scalar field keys must "
+                    "match across robots/timesteps."
+                )
+        for key in first_keys:
+            stacked[key] = jnp.stack(
+                [jnp.asarray(layer.scalar_fields[key]) for layer in layers]
+            )
+        return stacked
+
+    @staticmethod
+    def _validate_matching_layers(
+        reference: tuple[ActuatorVisualLayer, ...],
+        candidate: tuple[ActuatorVisualLayer, ...],
+    ) -> None:
+        if len(candidate) != len(reference):
+            raise ValueError(
+                "All robots must expose the same number of actuator visual layers."
+            )
+        for ref_layer, layer in zip(reference, candidate):
+            if (layer.name, layer.kind) != (ref_layer.name, ref_layer.kind):
+                raise ValueError(
+                    "Actuator visual layer names and kinds must match across "
+                    "robots/timesteps."
+                )
+            if jnp.asarray(layer.points).shape != jnp.asarray(ref_layer.points).shape:
+                raise ValueError(
+                    f"Actuator visual layer {layer.name!r} shape changed from "
+                    f"{jnp.asarray(ref_layer.points).shape} to "
+                    f"{jnp.asarray(layer.points).shape}."
+                )
+
+    @staticmethod
+    def _actuator_inputs_for_batch(
+        actuator_inputs: Array | np.ndarray | None,
+        *,
+        num_robots: int,
+    ) -> list[Array | None]:
+        if actuator_inputs is None:
+            return [None] * num_robots
+        inputs = jnp.asarray(actuator_inputs)
+        if inputs.ndim >= 2 and inputs.shape[0] == num_robots:
+            return [inputs[i] for i in range(num_robots)]
+        if num_robots == 1:
+            return [inputs]
+        raise ValueError(
+            "Batched actuator_inputs must have leading dimension matching the "
+            f"number of robots ({num_robots}), got {inputs.shape}."
+        )
+
+    @staticmethod
+    def _actuator_inputs_for_timestep(
+        actuator_inputs: Array | np.ndarray | None,
+        *,
+        num_robots: int,
+        num_steps: int,
+        frame_idx: int,
+    ) -> Array | np.ndarray | None:
+        if actuator_inputs is None:
+            return None
+        inputs = jnp.asarray(actuator_inputs)
+        if inputs.ndim >= 3 and inputs.shape[:2] == (num_robots, num_steps):
+            return inputs[:, frame_idx]
+        if inputs.ndim >= 2 and inputs.shape[0] == num_steps:
+            return inputs[frame_idx]
+        return inputs
+
+    def compute_actuator_visual_layers_batched(
+        self,
+        q_batch: Array,
+        base_offsets: Array,
+        *,
+        actuator_inputs: Array | np.ndarray | None = None,
+    ) -> tuple[BatchedActuatorVisualLayer, ...]:
+        """Compute actuator visual layers for multiple robots with base offsets."""
+        if not self._has_actuator_visuals:
+            return ()
 
         q_batch = jnp.asarray(q_batch)
         if q_batch.ndim != 2:
             raise ValueError(
                 f"q_batch must have shape (N, DOF), got {q_batch.shape} with ndim={q_batch.ndim}"
             )
-        s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
-        tendon_curves = jax.vmap(lambda q: self._batched_fk_tendons(q, s_ps))(q_batch)
-        base_offsets = self._normalize_base_offsets(
-            base_offsets,
-            num_robots=int(q_batch.shape[0]),
-            target_dim=int(tendon_curves.shape[-1]),
+        num_robots = int(q_batch.shape[0])
+
+        if self._has_batched_actuator_visual_layers:
+            s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
+            raw_layers = self.robot.actuator_visual_layers_batched(  # type: ignore[attr-defined]
+                q_batch,
+                s_ps,
+                actuator_inputs=actuator_inputs,
+            )
+            layers = normalize_batched_actuator_layers(
+                raw_layers, num_robots=num_robots
+            )
+            return self._offset_batched_actuator_layers(layers, base_offsets)
+
+        if not self._has_actuator_visual_layers:
+            return ()
+
+        inputs_by_robot = self._actuator_inputs_for_batch(
+            actuator_inputs, num_robots=num_robots
         )
-        return tendon_curves + base_offsets[:, None, None, :]
+        layers_by_robot = [
+            self.compute_actuator_visual_layers(
+                q_batch[i], actuator_inputs=inputs_by_robot[i]
+            )
+            for i in range(num_robots)
+        ]
+        if not layers_by_robot or not layers_by_robot[0]:
+            return ()
+        reference = layers_by_robot[0]
+        for layers in layers_by_robot[1:]:
+            self._validate_matching_layers(reference, layers)
+
+        batched_layers: list[BatchedActuatorVisualLayer] = []
+        for layer_idx, ref_layer in enumerate(reference):
+            robot_layers = [layers[layer_idx] for layers in layers_by_robot]
+            points = jnp.stack([jnp.asarray(layer.points) for layer in robot_layers])
+            colors = self._stack_optional_arrays(
+                [layer.colors for layer in robot_layers],
+                name="colors",
+                layer_name=ref_layer.name,
+            )
+            scalar_fields = self._stack_scalar_fields(robot_layers)
+            batched_layers.append(
+                BatchedActuatorVisualLayer(
+                    name=ref_layer.name,
+                    kind=ref_layer.kind,
+                    points=points,
+                    radius=self._stack_radius([layer.radius for layer in robot_layers]),
+                    line_width=ref_layer.line_width,
+                    colors=colors,
+                    scalar_fields=scalar_fields,
+                )
+            )
+        return self._offset_batched_actuator_layers(tuple(batched_layers), base_offsets)
+
+    def compute_actuator_visual_layers_trajectory(
+        self,
+        q_ts: Array,
+        base_offsets: Array,
+        *,
+        actuator_inputs: Array | np.ndarray | None = None,
+    ) -> tuple[TrajectoryActuatorVisualLayer, ...]:
+        """Compute actuator visual layers for ``(N, T, DOF)`` trajectories."""
+        q_ts = jnp.asarray(q_ts)
+        if q_ts.ndim != 3:
+            raise ValueError(
+                f"q_ts must have shape (N, T, DOF), got {q_ts.shape} with ndim={q_ts.ndim}"
+            )
+        num_robots, num_steps, _ = q_ts.shape
+
+        if self._has_trajectory_actuator_visual_layers:
+            s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
+            raw_layers = self.robot.actuator_visual_layers_trajectory(  # type: ignore[attr-defined]
+                q_ts,
+                s_ps,
+                actuator_inputs=actuator_inputs,
+            )
+            layers = normalize_trajectory_actuator_layers(
+                raw_layers,
+                num_robots=int(num_robots),
+                num_steps=int(num_steps),
+            )
+            return self._offset_trajectory_actuator_layers(layers, base_offsets)
+
+        if not (
+            self._has_batched_actuator_visual_layers
+            or self._has_actuator_visual_layers
+        ):
+            return ()
+
+        layers_by_time = []
+        for frame_idx in range(int(num_steps)):
+            frame_inputs = self._actuator_inputs_for_timestep(
+                actuator_inputs,
+                num_robots=int(num_robots),
+                num_steps=int(num_steps),
+                frame_idx=frame_idx,
+            )
+            layers_by_time.append(
+                self.compute_actuator_visual_layers_batched(
+                    q_ts[:, frame_idx, :],
+                    base_offsets,
+                    actuator_inputs=frame_inputs,
+                )
+            )
+        if not layers_by_time or not layers_by_time[0]:
+            return ()
+
+        trajectory_layers: list[TrajectoryActuatorVisualLayer] = []
+        for layer_idx, ref_layer in enumerate(layers_by_time[0]):
+            time_layers = [layers[layer_idx] for layers in layers_by_time]
+            points = jnp.stack([layer.points for layer in time_layers], axis=1)
+            colors = self._stack_optional_arrays(
+                [layer.colors for layer in time_layers],
+                name="colors",
+                layer_name=ref_layer.name,
+            )
+            if colors is not None:
+                colors = jnp.moveaxis(colors, 0, 1)
+            scalar_fields = {
+                key: jnp.stack(
+                    [jnp.asarray(layer.scalar_fields[key]) for layer in time_layers],
+                    axis=1,
+                )
+                for key in ref_layer.scalar_fields
+            }
+            trajectory_layers.append(
+                TrajectoryActuatorVisualLayer(
+                    name=ref_layer.name,
+                    kind=ref_layer.kind,
+                    points=points,
+                    radius=ref_layer.radius,
+                    line_width=ref_layer.line_width,
+                    colors=colors,
+                    scalar_fields=scalar_fields,
+                )
+            )
+        return tuple(trajectory_layers)
 
     def _extract_positions(self, poses: Array) -> Array:
         """Extract xyz or xy positions from FK poses.

--- a/src/soromox/rendering/color_config.py
+++ b/src/soromox/rendering/color_config.py
@@ -40,12 +40,20 @@ class BackboneColorConfig:
 
 
 @dataclass(frozen=True)
+class ActuatorStyleConfig:
+    """Default style configuration for rendered actuator visual layers."""
+
+    default_color: tuple[float, float, float] = (0.9, 0.15, 0.15)
+    scalar_colormap: str = "viridis"
+
+
+@dataclass(frozen=True)
 class RendererColorConfig:
     """Shared renderer colors with sensible defaults."""
 
     backbone: BackboneColorConfig = field(default_factory=BackboneColorConfig)
     base_plate_color: tuple[float, float, float] = (0.2, 0.2, 0.2)
-    tendon_color: tuple[float, float, float] = (0.9, 0.15, 0.15)
+    actuators: ActuatorStyleConfig = field(default_factory=ActuatorStyleConfig)
 
 
 @dataclass(frozen=True)
@@ -163,7 +171,7 @@ BUILTIN_THEMES: dict[str, RendererColorConfig] = {
             robot_palette="soromox:okabe-ito",
         ),
         base_plate_color=(0.2, 0.2, 0.2),
-        tendon_color=(0.8, 0.2, 0.2),
+        actuators=ActuatorStyleConfig(default_color=(0.8, 0.2, 0.2)),
     ),
     "soromox:cool": RendererColorConfig(
         backbone=BackboneColorConfig(
@@ -171,7 +179,7 @@ BUILTIN_THEMES: dict[str, RendererColorConfig] = {
             robot_palette="soromox:tol-muted",
         ),
         base_plate_color=(0.15, 0.2, 0.25),
-        tendon_color=(0.2, 0.45, 0.7),
+        actuators=ActuatorStyleConfig(default_color=(0.2, 0.45, 0.7)),
     ),
     "soromox:mono": RendererColorConfig(
         backbone=BackboneColorConfig(
@@ -179,7 +187,7 @@ BUILTIN_THEMES: dict[str, RendererColorConfig] = {
             robot_palette="soromox:slate",
         ),
         base_plate_color=(0.2, 0.2, 0.2),
-        tendon_color=(0.35, 0.35, 0.35),
+        actuators=ActuatorStyleConfig(default_color=(0.35, 0.35, 0.35)),
     ),
 }
 

--- a/src/soromox/rendering/matplotlib_renderer.py
+++ b/src/soromox/rendering/matplotlib_renderer.py
@@ -21,6 +21,10 @@ if TYPE_CHECKING:
 else:
     AnimateReturn = Any | FuncAnimation | None
 
+from soromox.rendering.actuators import (
+    TrajectoryActuatorVisualLayer,
+    resolve_actuator_rgba,
+)
 from soromox.rendering.base import BaseSoftRobotRenderer
 from soromox.rendering.camera_config import CameraConfig
 from soromox.rendering.color_config import RendererColorConfig
@@ -51,7 +55,7 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         line_width: float = 4.0,
         grid_spacing: tuple[float, float] = (0.3, 0.3),
         base_offsets: Array | None = None,
-        tendon_line_width: float = 2.0,
+        actuator_line_width: float = 2.0,
     ):
         """Initialize Matplotlib renderer.
 
@@ -65,7 +69,7 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             line_width: Width of backbone line
             grid_spacing: (x, y) spacing for batched layouts
             base_offsets: Optional explicit base offsets for batched layouts
-            tendon_line_width: Line width for tendon polylines
+            actuator_line_width: Line width for actuator polylines
         """
         super().__init__(
             robot,
@@ -78,7 +82,7 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         self.line_width = line_width
         self.grid_spacing = grid_spacing
         self._base_offsets = base_offsets
-        self.tendon_line_width = tendon_line_width
+        self.actuator_line_width = actuator_line_width
 
     def render_frame(
         self,
@@ -87,7 +91,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         base_offsets: Array | None = None,
         color_config: RendererColorConfig | None = None,
         camera_config: CameraConfig | None = None,
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
     ) -> np.ndarray:
         """Render configuration(s) to an RGB image array.
 
@@ -100,7 +105,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             color_config: Shared renderer color configuration.
             camera_config: Camera configuration. Note: For Matplotlib, only position
                 and look_at are used to set view angle for 3D plots.
-            render_tendons: Whether to render tendons if available.
+            render_actuators: Whether to render actuator visual layers if available.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
 
         Returns:
             img (np.ndarray): RGB image of shape (height, width, 3), dtype uint8.
@@ -156,18 +162,25 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             width_m = self.L_max * 3
 
         curves_np = np.array(curves)
-        tendon_curves_np = None
-        if render_tendons and self._has_tendons:
+        actuator_layers = ()
+        if render_actuators and self._has_actuator_visuals:
             if batched:
-                tendon_curves_np = np.array(
-                    self.compute_tendon_curves_batched(q_arr, base_offsets_arr)
+                actuator_layers = self.compute_actuator_visual_layers_batched(
+                    q_arr,
+                    base_offsets_arr,
+                    actuator_inputs=actuator_inputs,
                 )
             else:
-                tendon_curves_np = np.array(self.compute_tendon_curves(q_arr))[
-                    None, ...
-                ]
-                if single_offset is not None:
-                    tendon_curves_np = tendon_curves_np + np.asarray(single_offset)
+                actuator_offsets = (
+                    jnp.zeros((1, int(curves.shape[-1])), dtype=q_arr.dtype)
+                    if single_offset is None
+                    else jnp.asarray(single_offset).reshape(1, -1)
+                )
+                actuator_layers = self.compute_actuator_visual_layers_batched(
+                    q_arr[None, :],
+                    actuator_offsets,
+                    actuator_inputs=actuator_inputs,
+                )
 
         fig = plt.figure(figsize=(self.width / 100, self.height / 100), dpi=100)
         fig.patch.set_facecolor(self.background_color)
@@ -196,25 +209,7 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         self._plot_backbone(ax, curves_np, resolved_colors.per_robot_point_rgba)
         self._plot_base_markers(ax, curves_np, cfg.base_plate_color)
 
-        if tendon_curves_np is not None:
-            for idx in range(num_robots):
-                tc = tendon_curves_np[idx]
-                for k in range(tc.shape[0]):
-                    if self.is_3d:
-                        ax.plot(
-                            tc[k, :, 0],
-                            tc[k, :, 1],
-                            tc[k, :, 2],
-                            lw=self.tendon_line_width,
-                            color=cfg.tendon_color,
-                        )
-                    else:
-                        ax.plot(
-                            tc[k, :, 0],
-                            tc[k, :, 1],
-                            lw=self.tendon_line_width,
-                            color=cfg.tendon_color,
-                        )
+        self._plot_actuator_layers(ax, actuator_layers, cfg)
 
         ax.set_facecolor(self.background_color)
         plt.tight_layout()
@@ -242,7 +237,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         base_offsets: Array | None = None,
         color_config: RendererColorConfig | None = None,
         camera_config: CameraConfig | None = None,
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
     ) -> None:  # type: ignore[override]
         """Display a single frame interactively (supports batched inputs).
 
@@ -253,7 +249,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             color_config: Shared renderer color configuration.
             camera_config: Camera configuration. Note: For Matplotlib, only position
                 and look_at are used to set view angle for 3D plots.
-            render_tendons: Whether to render tendons if available.
+            render_actuators: Whether to render actuator visual layers if available.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
 
         Returns:
             None
@@ -263,7 +260,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             base_offsets=base_offsets,
             color_config=color_config,
             camera_config=camera_config,
-            render_tendons=render_tendons,
+            render_actuators=render_actuators,
+            actuator_inputs=actuator_inputs,
         )
         plt.figure(figsize=(self.width / 100, self.height / 100))
         plt.imshow(img)
@@ -283,7 +281,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         base_offsets: Array | None = None,
         color_config: RendererColorConfig | None = None,
         camera_config: CameraConfig | None = None,
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
     ) -> AnimateReturn:
         """Interactive matplotlib animation with slider or auto-play.
 
@@ -299,7 +298,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             color_config: Shared renderer color configuration.
             camera_config: Camera configuration. Note: For Matplotlib, only position
                 and look_at are used to set view angle for 3D plots.
-            render_tendons: Whether to render tendons if available
+            render_actuators: Whether to render actuator visual layers if available
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
 
         Returns:
             HTML object for Jupyter display (animation mode only)
@@ -323,7 +323,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
                 show=show,
                 base_offsets=base_offsets,
                 color_config=color_config,
-                render_tendons=render_tendons,
+                render_actuators=render_actuators,
+                actuator_inputs=actuator_inputs,
                 record_path=record_path,
                 playback_speed=playback_speed,
                 camera_config=camera_config,
@@ -337,7 +338,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
                 show=show,
                 base_offsets=base_offsets,
                 color_config=color_config,
-                render_tendons=render_tendons,
+                render_actuators=render_actuators,
+                actuator_inputs=actuator_inputs,
                 record_path=record_path,
                 playback_speed=playback_speed,
                 camera_config=camera_config,
@@ -356,7 +358,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         show: bool,
         base_offsets: Array | None,
         color_config: RendererColorConfig | None,
-        render_tendons: bool,
+        render_actuators: bool,
+        actuator_inputs: Array | None,
         record_path: str | None,
         playback_speed: float,
         camera_config: CameraConfig | None,
@@ -371,7 +374,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             show: Whether to display the plot.
             base_offsets: Optional base offset of shape (dim,) or (1, dim) applied to the robot.
             color_config: Shared renderer color configuration.
-            render_tendons: Whether to render tendons if available.
+            render_actuators: Whether to render actuator visual layers if available.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
             record_path: Optional path to save animation (mp4/gif depending on writer).
             playback_speed: Playback speed multiplier (>0).
 
@@ -392,13 +396,18 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         if single_offset is not None:
             curves = curves + single_offset
         all_curves = curves[None, ...]  # (1, T, P, dim)
-        tendon_curves = None
-        if render_tendons and self._has_tendons:
-            tendon_curves = np.array(
-                jax.vmap(self.compute_tendon_curves)(q_ts), dtype=np.float64
-            )[None, ...]  # (1, T, n_tendon, P, dim)
-            if single_offset is not None:
-                tendon_curves = tendon_curves + np.asarray(single_offset)
+        actuator_layers = ()
+        if render_actuators and self._has_actuator_visuals:
+            actuator_offsets = (
+                jnp.zeros((1, int(curves.shape[-1])), dtype=q_ts.dtype)
+                if single_offset is None
+                else jnp.asarray(single_offset).reshape(1, -1)
+            )
+            actuator_layers = self.compute_actuator_visual_layers_trajectory(
+                q_ts[None, ...],
+                actuator_offsets,
+                actuator_inputs=actuator_inputs,
+            )
 
         cfg = color_config or self.color_config
         resolved_colors = self.resolve_backbone_colors(1, color_config=cfg)
@@ -411,10 +420,9 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             mode=mode,
             show=show,
             center_origin=False,
-            tendon_curves=tendon_curves,
+            actuator_layers=actuator_layers,
             record_path=record_path,
             base_plate_color=cfg.base_plate_color,
-            tendon_color=cfg.tendon_color,
             playback_speed=playback_speed,
             camera_config=camera_config,
         )
@@ -428,7 +436,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         show: bool,
         base_offsets: Array | None,
         color_config: RendererColorConfig | None,
-        render_tendons: bool,
+        render_actuators: bool,
+        actuator_inputs: Array | None,
         record_path: str | None,
         playback_speed: float,
         camera_config: CameraConfig | None,
@@ -443,7 +452,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             show: Whether to display the plot.
             base_offsets: Optional base offsets of shape (N, 2/3) for batched layouts.
             color_config: Shared renderer color configuration.
-            render_tendons: Whether to render tendons if available.
+            render_actuators: Whether to render actuator visual layers if available.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
             record_path: Optional path to save animation (mp4/gif depending on writer).
             playback_speed: Playback speed multiplier (>0).
 
@@ -497,16 +507,13 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             int(num_robots), color_config=cfg
         )
 
-        tendon_curves = None
-        if render_tendons and self._has_tendons:
-            tendons = np.array(
-                jax.vmap(
-                    lambda q_batch: self.compute_tendon_curves_batched(
-                        q_batch, base_offsets_arr
-                    )
-                )(q_ts_time_first)
-            )  # (T, N, n_t, P, dim)
-            tendon_curves = tendons.transpose(1, 0, 2, 3, 4)  # (N, T, n_t, P, dim)
+        actuator_layers = ()
+        if render_actuators and self._has_actuator_visuals:
+            actuator_layers = self.compute_actuator_visual_layers_trajectory(
+                q_ts,
+                base_offsets_arr,
+                actuator_inputs=actuator_inputs,
+            )
 
         return self._animate_backbone_curves(
             ts=np.asarray(ts),
@@ -516,10 +523,9 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             mode=mode,
             show=show,
             center_origin=True,
-            tendon_curves=tendon_curves,
+            actuator_layers=actuator_layers,
             record_path=record_path,
             base_plate_color=cfg.base_plate_color,
-            tendon_color=cfg.tendon_color,
             playback_speed=playback_speed,
             camera_config=camera_config,
         )
@@ -533,17 +539,15 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         mode: str,
         show: bool,
         center_origin: bool,
-        tendon_curves: np.ndarray | None = None,
+        actuator_layers: tuple[TrajectoryActuatorVisualLayer, ...] = (),
         record_path: str | None = None,
         base_plate_color: tuple[float, float, float] | None = None,
-        tendon_color: tuple[float, float, float] | None = None,
         playback_speed: float = 1.0,
         camera_config: CameraConfig | None = None,
     ):
         """Shared Matplotlib animation for one or more robots."""
         num_robots, num_steps, _, _ = all_curves.shape
         base_plate_color = base_plate_color or self.color_config.base_plate_color
-        tendon_color = tendon_color or self.color_config.tendon_color
 
         max_extent = float(np.max(np.abs(all_curves))) if all_curves.size else 0.0
         width_m = max(self.L_max * 3, 2.0 * max_extent * 1.1)
@@ -598,29 +602,27 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
 
         base_artists = self._plot_base_markers(ax, all_curves[:, 0], base_plate_color)
 
-        tendon_lines: list[list] = []
-        if tendon_curves is not None:
-            for _idx in range(num_robots):
-                robot_lines = []
-                n_tend = tendon_curves.shape[2]
-                for _ in range(n_tend):
+        actuator_artists = []
+        actuator_colors = [
+            resolve_actuator_rgba(
+                layer,
+                default_color=self.color_config.actuators.default_color,
+                scalar_colormap=self.color_config.actuators.scalar_colormap,
+            )
+            for layer in actuator_layers
+        ]
+        for layer_idx, layer in enumerate(actuator_layers):
+            points = np.asarray(layer.points)
+            line_width = layer.line_width or self.actuator_line_width
+            for robot_idx in range(num_robots):
+                for actuator_idx in range(points.shape[2]):
                     if self.is_3d:
-                        (tl,) = ax.plot(
-                            [],
-                            [],
-                            [],
-                            lw=self.tendon_line_width,
-                            color=tendon_color,
-                        )
+                        (artist,) = ax.plot([], [], [], lw=line_width)
                     else:
-                        (tl,) = ax.plot(
-                            [],
-                            [],
-                            lw=self.tendon_line_width,
-                            color=tendon_color,
-                        )
-                    robot_lines.append(tl)
-                tendon_lines.append(robot_lines)
+                        (artist,) = ax.plot([], [], lw=line_width)
+                    actuator_artists.append(
+                        (layer_idx, robot_idx, actuator_idx, artist)
+                    )
 
         def _update_lines(frame_idx: int):
             curves_frame = all_curves[:, frame_idx]  # (N, P, dim)
@@ -628,13 +630,13 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
                 segments = self._curve_to_segments(curves_frame[idx])
                 line.set_segments(segments)
             self._update_base_markers(base_artists, curves_frame)
-            if tendon_curves is not None:
-                for idx, tc in enumerate(tendon_curves):
-                    tend_frame = tc[frame_idx]
-                    for k, tl in enumerate(tendon_lines[idx]):
-                        tl.set_data(tend_frame[k, :, 0], tend_frame[k, :, 1])
-                        if self.is_3d:
-                            tl.set_3d_properties(tend_frame[k, :, 2])
+            for layer_idx, robot_idx, actuator_idx, artist in actuator_artists:
+                layer = actuator_layers[layer_idx]
+                pts = np.asarray(layer.points)[robot_idx, frame_idx, actuator_idx]
+                artist.set_data(pts[:, 0], pts[:, 1])
+                if self.is_3d:
+                    artist.set_3d_properties(pts[:, 2])
+                artist.set_color(actuator_colors[layer_idx][robot_idx, frame_idx, actuator_idx])
 
         if mode == "animation":
 
@@ -645,20 +647,19 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
                     else:
                         line.set_segments(np.zeros((0, 2, 2)))
                 title_text.set_text("t = 0.00 s")
-                for robot_lines in tendon_lines:
-                    for tl in robot_lines:
-                        tl.set_data([], [])
-                        if self.is_3d:
-                            tl.set_3d_properties([])
-                flat_tendon = [tl for sub in tendon_lines for tl in sub]
-                return lines + flat_tendon + base_artists + [title_text]
+                for _, _, _, artist in actuator_artists:
+                    artist.set_data([], [])
+                    if self.is_3d:
+                        artist.set_3d_properties([])
+                flat_actuators = [artist for _, _, _, artist in actuator_artists]
+                return lines + flat_actuators + base_artists + [title_text]
 
             def update(frame_idx):
                 frame_idx_int = int(frame_idx)
                 _update_lines(frame_idx_int)
                 title_text.set_text(f"t = {float(ts[frame_idx_int]):.2f} s")
-                flat_tendon = [tl for sub in tendon_lines for tl in sub]
-                return lines + flat_tendon + base_artists + [title_text]
+                flat_actuators = [artist for _, _, _, artist in actuator_artists]
+                return lines + flat_actuators + base_artists + [title_text]
 
             actual_interval = max(1, int(round(interval / playback_speed)))
             ani = FuncAnimation(
@@ -730,7 +731,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         playback_speed: float = 1.0,
         camera_config: CameraConfig | None = None,
         color_config: RendererColorConfig | None = None,
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
         show: bool = False,
     ) -> None:
         """Render an animated sequence (optionally saving to disk).
@@ -746,7 +748,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             camera_config: Camera configuration. Note: For Matplotlib, only position
                 and look_at are used to set view angle for 3D plots.
             color_config: Shared renderer color configuration.
-            render_tendons: Whether to render tendons if available
+            render_actuators: Whether to render actuator visual layers if available
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
             show: Whether to display the animation
         """
         self.animate(
@@ -759,7 +762,8 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
             playback_speed=playback_speed,
             camera_config=camera_config,
             color_config=color_config,
-            render_tendons=render_tendons,
+            render_actuators=render_actuators,
+            actuator_inputs=actuator_inputs,
         )
 
     @staticmethod
@@ -806,6 +810,41 @@ class MatplotlibRenderer(BaseSoftRobotRenderer):
         return base[None, :] + radius * (
             np.cos(angles)[:, None] * u[None, :] + np.sin(angles)[:, None] * v
         )
+
+    def _plot_actuator_layers(
+        self,
+        ax,
+        actuator_layers,
+        color_config: RendererColorConfig,
+    ) -> None:
+        """Plot batched actuator visual layers on a Matplotlib axis."""
+        for layer in actuator_layers:
+            points = np.asarray(layer.points, dtype=np.float64)
+            colors = resolve_actuator_rgba(
+                layer,
+                default_color=color_config.actuators.default_color,
+                scalar_colormap=color_config.actuators.scalar_colormap,
+            )
+            line_width = layer.line_width or self.actuator_line_width
+            for robot_idx in range(points.shape[0]):
+                for actuator_idx in range(points.shape[1]):
+                    pts = points[robot_idx, actuator_idx]
+                    color = colors[robot_idx, actuator_idx]
+                    if self.is_3d:
+                        ax.plot(
+                            pts[:, 0],
+                            pts[:, 1],
+                            pts[:, 2],
+                            lw=line_width,
+                            color=color,
+                        )
+                    else:
+                        ax.plot(
+                            pts[:, 0],
+                            pts[:, 1],
+                            lw=line_width,
+                            color=color,
+                        )
 
     def _plot_base_markers(
         self,

--- a/src/soromox/rendering/open3d_renderer.py
+++ b/src/soromox/rendering/open3d_renderer.py
@@ -2,7 +2,7 @@
 
 Provides 3D visualization with:
 - Backbone as spheres (per-segment colors & radii)
-- Tendons as polyline LineSets (if robot supports forward_kinematics_tendons)
+- Actuators as polyline LineSets (if robot exposes actuator visual layers)
 - Recording frames to PNGs
 - Interactive camera controls
 
@@ -25,7 +25,6 @@ import os
 import time
 import warnings
 from dataclasses import dataclass
-from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -39,6 +38,10 @@ try:
 except ImportError:
     OPEN3D_AVAILABLE = False
 
+from soromox.rendering.actuators import (
+    TrajectoryActuatorVisualLayer,
+    resolve_actuator_rgba,
+)
 from soromox.rendering.base import BaseSoftRobotRenderer
 from soromox.rendering.camera_config import CameraConfig
 from soromox.rendering.color_config import RendererColorConfig, ensure_rgba
@@ -407,7 +410,7 @@ class SceneData:
     ts: np.ndarray  # (T,)
     layout: SegmentLayout
     segment_colors_rgba: np.ndarray  # (N, S, 4)
-    tendon_curves: np.ndarray | None = None  # (N, T, n_tend, P, 3)
+    actuator_layers: tuple[TrajectoryActuatorVisualLayer, ...] = ()
     static_spheres: SphereSet | None = None
     dynamic_spheres: DynamicSpheres | None = None
 
@@ -432,7 +435,7 @@ class RecordingConfig:
 class SceneHandles:
     base_meshes: list
     backbone_meshes: list[list[list[CachedMesh]]]
-    tendon_lines: list[list]
+    actuator_lines: list[list[list]]
     static_meshes: list
     dynamic_meshes: list
     dynamic_trajs: list[np.ndarray]
@@ -447,7 +450,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
     """Open3D visualization for any continuum soft robot.
 
     Provides interactive 3D visualization with spheres for backbone,
-    optional tendon rendering, and keyboard controls.
+    optional actuator rendering, and keyboard controls.
 
     Example:
         >>> renderer = Open3DRenderer(robot)
@@ -472,7 +475,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         base_plate_thickness: float = 0.06,
         grid_spacing: tuple[float, float] = (0.5, 0.5),
         base_offsets: Array | None = None,
-        tendon_line_width: float = 2.0,
+        actuator_line_width: float = 2.0,
         camera_margin_ratio: float = 0.05,
     ):
         """Initialize Open3D renderer.
@@ -492,7 +495,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             base_plate_thickness: Absolute thickness of the base plate geometry
             grid_spacing: (x, y) spacing between robot bases for batched rendering
             base_offsets: Explicit base offsets of shape (N, 2) or (N, 3) for batched rendering
-            tendon_line_width: Width of tendon lines
+            actuator_line_width: Width of actuator lines
             camera_margin_ratio: Margin ratio for camera bounding box
         """
         if not OPEN3D_AVAILABLE:
@@ -517,7 +520,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         self.tube_resolution = int(tube_resolution)
         self.grid_spacing = grid_spacing
         self._base_offsets = base_offsets
-        self.tendon_line_width = tendon_line_width
+        self.actuator_line_width = actuator_line_width
         self.camera_margin_ratio = camera_margin_ratio
         self.base_plate_radius_scale = float(base_plate_radius_scale)
         self.base_plate_thickness = float(base_plate_thickness)
@@ -835,7 +838,8 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         *,
         base_offsets: Array | None,
         color_config: RendererColorConfig | None,
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
         static_spheres_positions: Array | None,
         static_spheres_radii: Array | None,
         static_spheres_colors: Array | None,
@@ -843,7 +847,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         dynamic_spheres_radii: Array | None,
         dynamics_spheres_colors: Array | None,
     ) -> SceneData:
-        """Compute curves/tendons and validate auxiliary geometry."""
+        """Compute curves/actuators and validate auxiliary geometry."""
         ts_np = np.asarray(ts, dtype=np.float64).reshape(-1)
         q_ts_arr = jnp.asarray(q_ts)
 
@@ -894,20 +898,12 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             int(N), color_config=color_config
         )
 
-        tendon_curves = None
-        if render_tendons and self._has_tendons:
-            # Use batched computation for all robots at each timestep
-            # Since _has_tendons is True, compute_tendon_curves_batched will not return None
-            def _compute_tendons_for_timestep(q_batch: jax.Array) -> jax.Array:
-                result = self.compute_tendon_curves_batched(q_batch, offsets)
-                # Type cast: result cannot be None when _has_tendons is True
-                return cast(jax.Array, result)
-
-            all_tendons_time_first = jax.vmap(_compute_tendons_for_timestep)(
-                q_ts_time_first
-            )
-            tendon_curves = np.array(
-                all_tendons_time_first.transpose(1, 0, 2, 3, 4), dtype=np.float64
+        actuator_layers = ()
+        if render_actuators and self._has_actuator_visuals:
+            actuator_layers = self.compute_actuator_visual_layers_trajectory(
+                q_ts_arr,
+                offsets,
+                actuator_inputs=actuator_inputs,
             )
 
         static_spheres = self._prepare_static_spheres(
@@ -926,7 +922,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             ts=ts_np,
             layout=layout,
             segment_colors_rgba=resolved_colors.per_robot_segment_rgba,
-            tendon_curves=tendon_curves,
+            actuator_layers=actuator_layers,
             static_spheres=static_spheres,
             dynamic_spheres=dynamic_spheres,
         )
@@ -1095,16 +1091,24 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                                 mat_for(raw_color_rgba),
                             )
 
-            if scene_data.tendon_curves is not None:
-                robot_tendons = scene_data.tendon_curves[robot_idx, frame_idx]
-                for k in range(robot_tendons.shape[0]):
-                    ls = _make_polyline_lineset(
-                        robot_tendons[k], color=cfg.tendon_color
-                    )
+            for layer_idx, layer in enumerate(scene_data.actuator_layers):
+                colors = resolve_actuator_rgba(
+                    layer,
+                    default_color=cfg.actuators.default_color,
+                    scalar_colormap=cfg.actuators.scalar_colormap,
+                )
+                robot_actuators = np.asarray(layer.points)[robot_idx, frame_idx]
+                for actuator_idx in range(robot_actuators.shape[0]):
+                    color = tuple(colors[robot_idx, frame_idx, actuator_idx, :3])
+                    ls = _make_polyline_lineset(robot_actuators[actuator_idx], color=color)
                     mat_line = o3d.visualization.MaterialRecord()
                     mat_line.shader = "unlitLine"
-                    mat_line.line_width = self.tendon_line_width
-                    scene.add_geometry(f"tendon_{robot_idx}_{k}", ls, mat_line)
+                    mat_line.line_width = layer.line_width or self.actuator_line_width
+                    scene.add_geometry(
+                        f"actuator_{robot_idx}_{layer_idx}_{actuator_idx}",
+                        ls,
+                        mat_line,
+                    )
 
         if scene_data.static_spheres is not None:
             static_set = scene_data.static_spheres
@@ -1150,7 +1154,8 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         base_offsets: Array | None = None,
         color_config: RendererColorConfig | None = None,
         camera_config: CameraConfig | None = None,
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
         static_spheres_positions: Array | None = None,
         static_spheres_radii: Array | None = None,
         static_spheres_colors: Array | None = None,
@@ -1165,7 +1170,8 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             base_offsets: Optional base offsets of shape (N, 2/3) for batched layouts.
             color_config: Optional shared renderer color configuration.
             camera_config: Camera configuration (fov, position, look_at, etc.)
-            render_tendons: Whether to render tendons if available.
+            render_actuators: Whether to render actuator visual layers if available.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
             static_spheres_positions: Optional static sphere centers, shape (M, 3).
             static_spheres_radii: Optional static sphere radii, length M.
             static_spheres_colors: Optional static sphere colors, shape (M, 3/4).
@@ -1181,7 +1187,8 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             q_ts=jnp.asarray(q),
             base_offsets=base_offsets,
             color_config=color_config,
-            render_tendons=render_tendons,
+            render_actuators=render_actuators,
+            actuator_inputs=actuator_inputs,
             static_spheres_positions=static_spheres_positions,
             static_spheres_radii=static_spheres_radii,
             static_spheres_colors=static_spheres_colors,
@@ -1227,7 +1234,8 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         base_offsets: Array | None = None,
         color_config: RendererColorConfig | None = None,
         camera_config: CameraConfig | None = None,
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
         static_spheres_positions: Array | None = None,
         static_spheres_radii: Array | None = None,
         static_spheres_colors: Array | None = None,
@@ -1242,7 +1250,8 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             base_offsets: Optional base offsets of shape (N, 2/3) for batched layouts.
             color_config: Optional shared renderer color configuration.
             camera_config: Camera configuration (fov, position, look_at, etc.)
-            render_tendons: Whether to render tendons if available.
+            render_actuators: Whether to render actuator visual layers if available.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
             static_spheres_positions: Optional static sphere centers, shape (M, 3).
             static_spheres_radii: Optional static sphere radii, length M.
             static_spheres_colors: Optional static sphere colors, shape (M, 3/4).
@@ -1264,7 +1273,8 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             base_offsets=base_offsets,
             color_config=color_config,
             camera_config=camera_config,
-            render_tendons=render_tendons,
+            render_actuators=render_actuators,
+            actuator_inputs=actuator_inputs,
             static_spheres_positions=static_spheres_positions,
             static_spheres_radii=static_spheres_radii,
             static_spheres_colors=static_spheres_colors,
@@ -1288,7 +1298,8 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         camera_config: CameraConfig | None = None,
         base_offsets: Array | None = None,
         color_config: RendererColorConfig | None = None,
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
         static_spheres_positions: Array | None = None,
         static_spheres_radii: Array | None = None,
         static_spheres_colors: Array | None = None,
@@ -1313,7 +1324,8 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                 Note: For interactive viewing, user can adjust camera with mouse.
             base_offsets: Optional base offsets of shape (N, 2/3) for batched layouts.
             color_config: Optional shared renderer color configuration.
-            render_tendons: Whether to render tendons if available.
+            render_actuators: Whether to render actuator visual layers if available.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
             static_spheres_positions: Optional static sphere centers, shape (M, 3).
             static_spheres_radii: Optional static sphere radii, length M.
             static_spheres_colors: Optional static sphere colors, shape (M, 3/4).
@@ -1335,7 +1347,8 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             q_ts=q_ts,
             base_offsets=base_offsets,
             color_config=color_config,
-            render_tendons=render_tendons,
+            render_actuators=render_actuators,
+            actuator_inputs=actuator_inputs,
             static_spheres_positions=static_spheres_positions,
             static_spheres_radii=static_spheres_radii,
             static_spheres_colors=static_spheres_colors,
@@ -1371,7 +1384,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
 
         opt = vis.get_render_option()
         opt.background_color = np.array(self.background_color, dtype=np.float64)
-        opt.line_width = self.tendon_line_width
+        opt.line_width = self.actuator_line_width
         return vis, vis.get_view_control()
 
     def _setup_interactive_camera(
@@ -1664,18 +1677,26 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             base_meshes.append(base_mesh)
             backbone_meshes.append(groups)
 
-        tendon_lines: list[list] = []
-        if scene_data.tendon_curves is not None:
+        actuator_lines: list[list[list]] = []
+        for layer in scene_data.actuator_layers:
+            layer_lines: list[list] = []
+            colors = resolve_actuator_rgba(
+                layer,
+                default_color=cfg.actuators.default_color,
+                scalar_colormap=cfg.actuators.scalar_colormap,
+            )
             for robot_idx in range(scene_data.num_robots):
                 robot_lines: list = []
-                robot_tendons = scene_data.tendon_curves[robot_idx, frame_idx]
-                for k in range(robot_tendons.shape[0]):
+                robot_actuators = np.asarray(layer.points)[robot_idx, frame_idx]
+                for actuator_idx in range(robot_actuators.shape[0]):
+                    color = tuple(colors[robot_idx, frame_idx, actuator_idx, :3])
                     ls = _make_polyline_lineset(
-                        robot_tendons[k], color=cfg.tendon_color
+                        robot_actuators[actuator_idx], color=color
                     )
                     robot_lines.append(ls)
                     vis.add_geometry(ls)
-                tendon_lines.append(robot_lines)
+                layer_lines.append(robot_lines)
+            actuator_lines.append(layer_lines)
 
         static_meshes: list = []
         if scene_data.static_spheres is not None:
@@ -1713,7 +1734,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         return SceneHandles(
             base_meshes=base_meshes,
             backbone_meshes=backbone_meshes,
-            tendon_lines=tendon_lines,
+            actuator_lines=actuator_lines,
             static_meshes=static_meshes,
             dynamic_meshes=dynamic_meshes,
             dynamic_trajs=dynamic_trajs,
@@ -1725,8 +1746,11 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         scene_data: SceneData,
         handles: SceneHandles,
         frame_idx: int,
+        *,
+        color_config: RendererColorConfig | None = None,
     ) -> None:
         """Update geometry positions for a given frame."""
+        cfg = color_config or self.color_config
         layout = scene_data.layout
 
         for robot_idx in range(scene_data.num_robots):
@@ -1739,12 +1763,24 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                 layout,
             )
 
-        if scene_data.tendon_curves is not None:
-            for robot_idx, robot_lines in enumerate(handles.tendon_lines):
-                robot_tendons = scene_data.tendon_curves[robot_idx, frame_idx]
-                for k, ls in enumerate(robot_lines):
-                    t_pts = np.array(robot_tendons[k], dtype=np.float64, copy=True)
+        for layer_idx, layer in enumerate(scene_data.actuator_layers):
+            colors = resolve_actuator_rgba(
+                layer,
+                default_color=cfg.actuators.default_color,
+                scalar_colormap=cfg.actuators.scalar_colormap,
+            )
+            for robot_idx, robot_lines in enumerate(handles.actuator_lines[layer_idx]):
+                robot_actuators = np.asarray(layer.points)[robot_idx, frame_idx]
+                for actuator_idx, ls in enumerate(robot_lines):
+                    t_pts = np.array(
+                        robot_actuators[actuator_idx], dtype=np.float64, copy=True
+                    )
                     ls.points = o3d.utility.Vector3dVector(t_pts)
+                    color = colors[robot_idx, frame_idx, actuator_idx, :3]
+                    line_count = np.asarray(ls.lines).shape[0]
+                    ls.colors = o3d.utility.Vector3dVector(
+                        np.tile(color[None, :], (line_count, 1))
+                    )
                     vis.update_geometry(ls)
 
         for mesh, traj in zip(handles.dynamic_meshes, handles.dynamic_trajs):
@@ -1886,7 +1922,13 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             i = max(0, min(scene_data.num_frames - 1, i))
             state["idx"] = i
 
-            self._update_scene(vis, scene_data, handles, frame_idx=i)
+            self._update_scene(
+                vis,
+                scene_data,
+                handles,
+                frame_idx=i,
+                color_config=color_config,
+            )
 
             vis.poll_events()
             vis.update_renderer()

--- a/src/soromox/rendering/opencv_planar_renderer.py
+++ b/src/soromox/rendering/opencv_planar_renderer.py
@@ -36,6 +36,8 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
         base_color: tuple[int, int, int] = (0, 255, 0),
         backbone_color: tuple[int, int, int] = (0, 0, 0),
         backbone_thickness: int | None = None,
+        actuator_color: tuple[int, int, int] = (40, 40, 230),
+        actuator_thickness: int = 2,
         base_radius_scale: float = 2.0,
         length_scale: float = 2.0,
         origin_uv: tuple[int, int] | None = None,
@@ -51,6 +53,8 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
             base_color: BGR color for base marker
             backbone_color: BGR color for backbone
             backbone_thickness: Line thickness for backbone (None = auto)
+            actuator_color: BGR color for actuator visual layers
+            actuator_thickness: Line thickness for actuator visual layers
             base_radius_scale: Multiplier applied to the cross-section span for the base marker
             length_scale: Scale factor for robot in image (robot occupies height/length_scale)
             origin_uv: Pixel coordinates of world origin (None = center of image)
@@ -60,6 +64,8 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
         self.base_color = base_color
         self.backbone_color = backbone_color
         self.backbone_thickness = backbone_thickness
+        self.actuator_color = actuator_color
+        self.actuator_thickness = int(actuator_thickness)
         self.base_radius_scale = float(base_radius_scale)
         self.length_scale = length_scale
         self.origin_uv = origin_uv
@@ -134,6 +140,8 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
         q: Array,
         *,
         base_offsets: Array | None = None,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
     ) -> np.ndarray:
         """Render single configuration to BGR image array.
 
@@ -141,6 +149,8 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
             q: Robot configuration array of shape (DOF,) for a single robot.
             base_offsets: Optional positional offset with shape ``(2,)`` or
                 ``(3,)``. The z component is ignored for this planar renderer.
+            render_actuators: Whether to render actuator visual layers if available.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
 
         Returns:
             img (np.ndarray): BGR image of shape (height, width, 3), dtype uint8.
@@ -207,6 +217,34 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
                     thickness=int(uniform_thickness),
                 )
 
+        if render_actuators and self._has_actuator_visuals:
+            actuator_offset = (
+                np.zeros((1, 2), dtype=float)
+                if offset is None
+                else np.asarray(offset, dtype=float).reshape(1, -1)
+            )
+            actuator_layers = self.compute_actuator_visual_layers_batched(
+                np.asarray(q).reshape(1, -1),
+                actuator_offset,
+                actuator_inputs=actuator_inputs,
+            )
+            for layer in actuator_layers:
+                points = np.asarray(layer.points, dtype=float)
+                for actuator_idx in range(points.shape[1]):
+                    path_uv = self._world_to_pixel(
+                        points[0, actuator_idx, :, :2],
+                        origin_uv=origin_uv,
+                        ppm=ppm,
+                    )
+                    if path_uv.shape[0] > 1:
+                        cv2.polylines(
+                            img,
+                            [path_uv],
+                            isClosed=False,
+                            color=self.actuator_color,
+                            thickness=max(1, self.actuator_thickness),
+                        )
+
         # Draw base marker at the transformed base position after the backbone
         # so it remains visible.
         base_radius = self._base_radius_px(ppm, q)
@@ -214,15 +252,29 @@ class OpenCVPlanarRenderer(BaseOpenCVRenderer):
 
         return img
 
-    def show(self, q: Array, *, base_offsets: Array | None = None) -> None:
+    def show(
+        self,
+        q: Array,
+        *,
+        base_offsets: Array | None = None,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
+    ) -> None:
         """Display single frame in OpenCV window.
 
         Args:
             q: Robot configuration array of shape (DOF,).
             base_offsets: Optional positional offset with shape ``(2,)`` or
                 ``(3,)``.
+            render_actuators: Whether to render actuator visual layers if available.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
         """
-        img = self.render_frame(q, base_offsets=base_offsets)
+        img = self.render_frame(
+            q,
+            base_offsets=base_offsets,
+            render_actuators=render_actuators,
+            actuator_inputs=actuator_inputs,
+        )
         win = "Planar Renderer"
         cv2.namedWindow(win, cv2.WINDOW_NORMAL)
         cv2.imshow(win, img)

--- a/src/soromox/rendering/umarm/viser_renderer.py
+++ b/src/soromox/rendering/umarm/viser_renderer.py
@@ -48,7 +48,7 @@ class UMArmViserRenderer(ViserRenderer):
         end_effector_radius: float = 0.010,
         end_effector_sphere_radius: float = 0.019,
         ujoint_disk_thickness: float = 0.010,
-        tendon_disk_thickness: float = 0.010,
+        actuator_disk_thickness: float = 0.010,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -56,7 +56,6 @@ class UMArmViserRenderer(ViserRenderer):
             raise TypeError(
                 "UMArmViserRenderer requires a robot with mckibben_actuator_segments(q)."
         )
-        self._has_tendons = True
         self._actuator_color_mode = actuator_color_mode
         self._actuator_radius = actuator_radius
         self._rod_core_radius_scale = rod_core_radius_scale
@@ -64,31 +63,16 @@ class UMArmViserRenderer(ViserRenderer):
         self._end_effector_radius = end_effector_radius
         self._end_effector_sphere_radius = end_effector_sphere_radius
         self._ujoint_disk_thickness = ujoint_disk_thickness
-        self._tendon_disk_thickness = tendon_disk_thickness
+        self._actuator_disk_thickness = actuator_disk_thickness
         self._actuator_line_width = (
             actuator_line_width
             if actuator_line_width is not None
-            else self._tendon_line_width
+            else self._actuator_line_width
         )
         self._actuator_pressures: Array | None = None
         self._actuator_frame_idx = 0
         self._current_geometry_q: Array | None = None
         self._umarm_rigid_specs: list[_UMArmRigidSpecs] = []
-
-    def compute_tendon_curves_batched(
-        self, q_batch: Array, base_offsets: Array
-    ) -> Array | None:
-        """Return McKibben actuator endpoint segments as two-point curves."""
-        q_batch = jnp.asarray(q_batch)
-        if q_batch.ndim != 2:
-            raise ValueError(f"q_batch must have shape (N, DOF), got {q_batch.shape}.")
-        segments = jax.vmap(self.robot.mckibben_actuator_segments)(q_batch)
-        offsets = self._normalize_base_offsets(
-            base_offsets,
-            num_robots=int(q_batch.shape[0]),
-            target_dim=int(segments.shape[-1]),
-        )
-        return segments + offsets[:, None, None, :]
 
     def show(self, q: Array, *, pressures: Array | None = None, **kwargs) -> None:
         """Display a UMArm frame, optionally coloring actuators by pressure or force."""
@@ -97,7 +81,9 @@ class UMArmViserRenderer(ViserRenderer):
         self._actuator_pressures = None if pressures is None else jnp.asarray(pressures)
         self._actuator_frame_idx = 0
         kwargs.setdefault("camera_config", self._default_umarm_camera_config())
-        kwargs.setdefault("render_tendons", True)
+        kwargs.setdefault("render_actuators", True)
+        if pressures is not None:
+            kwargs.setdefault("actuator_inputs", pressures)
         super().show(q, **kwargs)
 
     def render_sequence(
@@ -119,7 +105,9 @@ class UMArmViserRenderer(ViserRenderer):
             self._actuator_color_mode = actuator_color_mode
         try:
             kwargs.setdefault("camera_config", self._default_umarm_camera_config())
-            kwargs.setdefault("render_tendons", True)
+            kwargs.setdefault("render_actuators", True)
+            if pressures is not None:
+                kwargs.setdefault("actuator_inputs", pressures)
             super().render_sequence(ts, q_ts, **kwargs)
         finally:
             self._actuator_color_mode = old_mode
@@ -348,14 +336,14 @@ class UMArmViserRenderer(ViserRenderer):
                     self.robot.mckibben_fixed_points[group_idx + 1, 0, 2]
                 )
                 for label, z_center in (
-                    ("upper_tendon_disk", upper_disk_z),
-                    ("lower_tendon_disk", lower_disk_z),
+                    ("upper_actuator_disk", upper_disk_z),
+                    ("lower_actuator_disk", lower_disk_z),
                 ):
                     handle = self._add_local_z_cylinder(
                         f"/robots/robot_{robot_idx}/umarm/{label}_{rod_link_idx}",
                         link_frame,
                         z_center,
-                        length=self._tendon_disk_thickness,
+                        length=self._actuator_disk_thickness,
                         radius=rod_radius,
                         color=disk_color,
                         handles=robot_handles,
@@ -366,7 +354,7 @@ class UMArmViserRenderer(ViserRenderer):
                         link_indices.append(int(rod_link_idx))
                         local_endpoints.append(
                             self._local_z_endpoints(
-                                float(z_center), self._tendon_disk_thickness
+                                float(z_center), self._actuator_disk_thickness
                             )
                         )
 
@@ -540,7 +528,15 @@ class UMArmViserRenderer(ViserRenderer):
         controller.start()
         return controller
 
-    def _pressures_for_frame(self, q: Array) -> Array | None:
+    def _pressures_for_frame(
+        self, q: Array, actuator_inputs: Array | None = None
+    ) -> Array | None:
+        if actuator_inputs is not None:
+            pressures = jnp.asarray(actuator_inputs)
+            if pressures.ndim == 1:
+                return jnp.broadcast_to(pressures, (q.shape[0], pressures.shape[0]))
+            if pressures.ndim == 2:
+                return pressures
         if self._actuator_pressures is None:
             return None
         pressures = self._actuator_pressures
@@ -573,14 +569,15 @@ class UMArmViserRenderer(ViserRenderer):
         self,
         q: Array,
         fallback_color: tuple[float, float, float] | None,
+        actuator_inputs: Array | None = None,
     ) -> np.ndarray:
         fallback = (
             np.asarray(fallback_color, dtype=np.float64)
             if fallback_color is not None
-            else np.asarray(self.color_config.tendon_color, dtype=np.float64)
+            else np.asarray(self.color_config.actuators.default_color, dtype=np.float64)
         )
         uniform = np.tile(_rgb255(fallback), (q.shape[0], self.robot.num_actuators, 1))
-        pressures = self._pressures_for_frame(q)
+        pressures = self._pressures_for_frame(q, actuator_inputs=actuator_inputs)
         if pressures is None or self._actuator_color_mode == "uniform":
             return uniform
         if self._actuator_color_mode == "pressure":
@@ -592,29 +589,37 @@ class UMArmViserRenderer(ViserRenderer):
             "actuator_color_mode must be one of 'uniform', 'pressure', or 'force'."
         )
 
-    def _build_tendon_geometry(
+    def _build_actuator_geometry(
         self,
         q: Array,
         base_offsets: np.ndarray,
         num_robots: int,
         *,
-        tendon_color: tuple[float, float, float] | None = None,
+        color_config=None,
+        actuator_inputs: Array | None = None,
     ) -> None:
         if self._server is None or self._scene_handles is None:
             return
 
         q = jnp.asarray(q)
-        actuator_segments = self.compute_tendon_curves_batched(q, jnp.asarray(base_offsets))
-        if actuator_segments is None:
-            return
+        actuator_segments = self.compute_actuator_visual_layers_batched(
+            q,
+            jnp.asarray(base_offsets),
+            actuator_inputs=actuator_inputs,
+        )[0].points
         actuator_segments_np = np.asarray(actuator_segments)
-        colors = self._actuator_colors(q, tendon_color)
+        cfg = color_config or self.color_config
+        colors = self._actuator_colors(
+            q,
+            cfg.actuators.default_color,
+            actuator_inputs=actuator_inputs,
+        )
 
-        if len(self._scene_handles.tendon_lines) > num_robots:
-            for handle in self._scene_handles.tendon_lines[num_robots:]:
+        if len(self._scene_handles.actuator_lines) > num_robots:
+            for handle in self._scene_handles.actuator_lines[num_robots:]:
                 if hasattr(handle, "remove"):
                     handle.remove()
-            self._scene_handles.tendon_lines = self._scene_handles.tendon_lines[
+            self._scene_handles.actuator_lines = self._scene_handles.actuator_lines[
                 :num_robots
             ]
 
@@ -625,8 +630,8 @@ class UMArmViserRenderer(ViserRenderer):
                 2,
                 axis=1,
             )
-            if robot_idx < len(self._scene_handles.tendon_lines):
-                handle = self._scene_handles.tendon_lines[robot_idx]
+            if robot_idx < len(self._scene_handles.actuator_lines):
+                handle = self._scene_handles.actuator_lines[robot_idx]
                 handle.points = points
                 handle.colors = segment_colors
                 handle.line_width = self._actuator_line_width
@@ -637,7 +642,7 @@ class UMArmViserRenderer(ViserRenderer):
                     colors=segment_colors,
                     line_width=self._actuator_line_width,
                 )
-                self._scene_handles.tendon_lines.append(handle)
+                self._scene_handles.actuator_lines.append(handle)
 
 
 class UMArmLiveModeController(LiveModeController):
@@ -723,10 +728,11 @@ class UMArmLiveModeController(LiveModeController):
                 self._resolved_colors.per_robot_point_rgba,
                 base_plate_color=self._renderer.color_config.base_plate_color,
             )
-        if self._renderer._has_tendons:
-            self._renderer._build_tendon_geometry(
+        if self._renderer._has_actuator_visuals:
+            self._renderer._build_actuator_geometry(
                 q,
                 np.asarray(base_offsets),
                 num_robots,
-                tendon_color=self._renderer.color_config.tendon_color,
+                color_config=self._renderer.color_config,
+                actuator_inputs=self._renderer._pressures_for_frame(q),
             )

--- a/src/soromox/rendering/viser_renderer.py
+++ b/src/soromox/rendering/viser_renderer.py
@@ -42,6 +42,7 @@ except ImportError:
     VISER_AVAILABLE = False
     go = None
 
+from soromox.rendering.actuators import resolve_actuator_rgba
 from soromox.rendering.base import BaseSoftRobotRenderer
 from soromox.rendering.camera_config import CameraConfig
 from soromox.rendering.color_config import RendererColorConfig, ensure_rgba
@@ -80,7 +81,8 @@ class SceneHandles:
     # Robot geometry handles - indexed [robot_idx][point_idx]
     base_plates: list = field(default_factory=list)
     backbone_points: list[list] = field(default_factory=list)
-    tendon_lines: list = field(default_factory=list)
+    actuator_lines: list = field(default_factory=list)
+    actuator_line_keys: list[str] = field(default_factory=list)
 
     # Track if geometry has been initially built (for efficient updates)
     geometry_initialized: bool = False
@@ -205,7 +207,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         base_offsets: Array | None = None,
         base_plate_radius_scale: float = 2.0,
         base_plate_thickness: float = 0.06,
-        tendon_line_width: float = 3.0,
+        actuator_line_width: float = 3.0,
         camera_fov: float = 75.0,
         # Lighting parameters
         enable_default_lights: bool = True,
@@ -245,7 +247,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
             base_offsets: Explicit base position offsets (N, 3)
             base_plate_radius_scale: Base plate radius relative to robot radius
             base_plate_thickness: Base plate thickness in meters
-            tendon_line_width: Line width for tendon visualization
+            actuator_line_width: Line width for actuator visualization
             camera_fov: Camera field of view in degrees
             enable_default_lights: Enable Viser's default lighting
             add_directional_light: Add custom directional light
@@ -288,7 +290,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         self._base_offsets = base_offsets
         self._base_plate_radius_scale = base_plate_radius_scale
         self._base_plate_thickness = base_plate_thickness
-        self._tendon_line_width = tendon_line_width
+        self._actuator_line_width = actuator_line_width
         self._camera_fov = camera_fov
         self._open_browser = open_browser
 
@@ -577,71 +579,123 @@ class ViserRenderer(BaseSoftRobotRenderer):
             wxyz=base_wxyz,
         )
 
-    def _build_tendon_geometry(
+    def _build_actuator_geometry(
         self,
         q: Array,
         base_offsets: np.ndarray,
         num_robots: int,
         *,
-        tendon_color: tuple[float, float, float] | None = None,
+        color_config: RendererColorConfig | None = None,
+        actuator_inputs: Array | None = None,
     ) -> None:
-        """Build tendon line geometry in the scene.
+        """Build actuator line geometry in the scene.
 
         Args:
             q: Robot configurations (num_robots, DOF)
             base_offsets: Base position offsets (num_robots, 3)
             num_robots: Number of robots
+            color_config: Shared renderer color configuration.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
         """
-        if not self._has_tendons or self._server is None or self._scene_handles is None:
+        if (
+            not self._has_actuator_visuals
+            or self._server is None
+            or self._scene_handles is None
+        ):
             return
 
-        # Clear existing tendon geometry
-        self._scene_handles.tendon_lines = []
-
-        # Compute tendon curves for all robots at once using batched method
-        # Returns shape (num_robots, num_tendons, num_points, 3) or None
-        tendon_curves = self.compute_tendon_curves_batched(q, jnp.asarray(base_offsets))
-
-        if tendon_curves is None:
-            return
-
-        tendon_curves = np.asarray(
-            tendon_curves
-        )  # (num_robots, num_tendons, num_points, 3)
-
-        color_arr = (
-            np.array(tendon_color)
-            if tendon_color is not None
-            else np.array(self.color_config.tendon_color)
+        actuator_layers = self.compute_actuator_visual_layers_batched(
+            q,
+            jnp.asarray(base_offsets),
+            actuator_inputs=actuator_inputs,
         )
-        color = _rgb_to_viser_color(color_arr)
+        cfg = color_config or self.color_config
+        line_specs = []
 
-        # Process all robots and tendons
-        for robot_idx in range(num_robots):
-            robot_tendon_curves = tendon_curves[
-                robot_idx
-            ]  # (num_tendons, num_points, 3)
-            num_tendons = robot_tendon_curves.shape[0]
+        if len(self._scene_handles.actuator_line_keys) > len(
+            self._scene_handles.actuator_lines
+        ):
+            self._scene_handles.actuator_line_keys = (
+                self._scene_handles.actuator_line_keys[
+                    : len(self._scene_handles.actuator_lines)
+                ]
+            )
 
-            for tendon_idx in range(num_tendons):
-                tendon_curve = robot_tendon_curves[tendon_idx]  # (num_points, 3)
-
-                # Create line segments for each tendon
-                # Viser expects shape (N, 2, 3) for N line segments
-                num_segments = len(tendon_curve) - 1
-                if num_segments > 0:
-                    # Reshape to (N, 2, 3) where each segment has start and end points
+        for layer_idx, layer in enumerate(actuator_layers):
+            layer_points = np.asarray(layer.points)
+            layer_colors = resolve_actuator_rgba(
+                layer,
+                default_color=cfg.actuators.default_color,
+                scalar_colormap=cfg.actuators.scalar_colormap,
+            )
+            line_width = layer.line_width or self._actuator_line_width
+            for robot_idx in range(num_robots):
+                for actuator_idx in range(layer_points.shape[1]):
+                    curve = layer_points[robot_idx, actuator_idx]
+                    num_segments = len(curve) - 1
+                    if num_segments <= 0:
+                        continue
                     points = np.stack(
-                        [tendon_curve[:-1], tendon_curve[1:]], axis=1
-                    )  # (num_segments, 2, 3)
-
-                    handle = self._server.scene.add_line_segments(
-                        name=f"/robots/robot_{robot_idx}/tendons/tendon_{tendon_idx}",
-                        points=points,
-                        colors=np.tile(color, (num_segments, 2, 1)).astype(np.uint8),
-                        line_width=self._tendon_line_width,
+                        [curve[:-1], curve[1:]], axis=1
                     )
-                    self._scene_handles.tendon_lines.append(handle)
+                    color = _rgb_to_viser_color(
+                        layer_colors[robot_idx, actuator_idx, :3]
+                    )
+                    line_specs.append(
+                        (
+                            (
+                                f"/robots/robot_{robot_idx}/actuators/"
+                                f"{layer_idx}_{layer.name}_{actuator_idx}"
+                            ),
+                            points.astype(np.float32),
+                            np.tile(color, (num_segments, 2, 1)).astype(np.uint8),
+                            line_width,
+                        )
+                    )
+
+        if len(self._scene_handles.actuator_lines) > len(line_specs):
+            for handle in self._scene_handles.actuator_lines[len(line_specs) :]:
+                if hasattr(handle, "remove"):
+                    handle.remove()
+            self._scene_handles.actuator_lines = self._scene_handles.actuator_lines[
+                : len(line_specs)
+            ]
+            self._scene_handles.actuator_line_keys = (
+                self._scene_handles.actuator_line_keys[: len(line_specs)]
+            )
+
+        for line_idx, (name, points, colors, line_width) in enumerate(line_specs):
+            if (
+                line_idx < len(self._scene_handles.actuator_lines)
+                and line_idx < len(self._scene_handles.actuator_line_keys)
+                and self._scene_handles.actuator_line_keys[line_idx] == name
+            ):
+                handle = self._scene_handles.actuator_lines[line_idx]
+                handle.points = points
+                handle.colors = colors
+                handle.line_width = line_width
+                continue
+
+            if line_idx < len(self._scene_handles.actuator_lines):
+                handle = self._scene_handles.actuator_lines[line_idx]
+                if hasattr(handle, "remove"):
+                    handle.remove()
+
+            handle = self._server.scene.add_line_segments(
+                name=name,
+                points=points,
+                colors=colors,
+                line_width=line_width,
+            )
+            if line_idx < len(self._scene_handles.actuator_lines):
+                self._scene_handles.actuator_lines[line_idx] = handle
+                if line_idx < len(self._scene_handles.actuator_line_keys):
+                    self._scene_handles.actuator_line_keys[line_idx] = name
+                else:
+                    self._scene_handles.actuator_line_keys.append(name)
+            else:
+                self._scene_handles.actuator_lines.append(handle)
+                self._scene_handles.actuator_line_keys.append(name)
 
     def _make_cylinder_trimesh(
         self,
@@ -949,6 +1003,8 @@ class ViserRenderer(BaseSoftRobotRenderer):
         base_offsets: Array | None = None,
         color_config: RendererColorConfig | None = None,
         camera_config: CameraConfig | None = None,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
         static_spheres_positions: Array | None = None,
         static_spheres_radii: Array | None = None,
         static_spheres_colors: Array | None = None,
@@ -963,6 +1019,8 @@ class ViserRenderer(BaseSoftRobotRenderer):
             base_offsets: Base position offsets (N, 3)
             color_config: Shared renderer color configuration
             camera_config: Camera configuration (fov, position, look_at, etc.)
+            render_actuators: If True, render actuator visual layers.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
             static_spheres_positions: Static sphere positions (M, 3)
             static_spheres_radii: Static sphere radii (M,)
             static_spheres_colors: Static sphere colors (M, 3)
@@ -1012,6 +1070,15 @@ class ViserRenderer(BaseSoftRobotRenderer):
             base_plate_color=cfg.base_plate_color,
         )
 
+        if render_actuators and self._has_actuator_visuals:
+            self._build_actuator_geometry(
+                q,
+                np.asarray(base_offsets),
+                num_robots,
+                color_config=cfg,
+                actuator_inputs=actuator_inputs,
+            )
+
         # Add static spheres if provided
         if static_spheres_positions is not None:
             self._build_static_spheres(
@@ -1050,7 +1117,8 @@ class ViserRenderer(BaseSoftRobotRenderer):
         base_offsets: Array | None = None,
         color_config: RendererColorConfig | None = None,
         camera_config: CameraConfig | None = None,
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
         static_spheres_positions: Array | None = None,
         static_spheres_radii: Array | None = None,
         static_spheres_colors: Array | None = None,
@@ -1065,7 +1133,8 @@ class ViserRenderer(BaseSoftRobotRenderer):
             base_offsets: Base position offsets (N, 3)
             color_config: Shared renderer color configuration
             camera_config: Camera configuration (fov, position, look_at, etc.)
-            render_tendons: If True, render tendons (if available)
+            render_actuators: If True, render actuator visual layers.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
             static_spheres_positions: Static sphere positions (M, 3)
             static_spheres_radii: Static sphere radii (M,)
             static_spheres_colors: Static sphere colors (M, 3)
@@ -1112,10 +1181,13 @@ class ViserRenderer(BaseSoftRobotRenderer):
             base_plate_color=cfg.base_plate_color,
         )
 
-        # Add tendon visualization if available and requested
-        if render_tendons and self._has_tendons:
-            self._build_tendon_geometry(
-                q, np.asarray(base_offsets), num_robots, tendon_color=cfg.tendon_color
+        if render_actuators and self._has_actuator_visuals:
+            self._build_actuator_geometry(
+                q,
+                np.asarray(base_offsets),
+                num_robots,
+                color_config=cfg,
+                actuator_inputs=actuator_inputs,
             )
 
         # Add static spheres if provided
@@ -1163,7 +1235,8 @@ class ViserRenderer(BaseSoftRobotRenderer):
         camera_config: CameraConfig | None = None,
         base_offsets: Array | None = None,
         color_config: RendererColorConfig | None = None,
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
         multi_robot_layout: Literal["grid", "overlay"] = "grid",
         static_spheres_positions: Array | None = None,
         static_spheres_radii: Array | None = None,
@@ -1173,7 +1246,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         dynamic_spheres_colors: Array | None = None,
         blocking: bool = True,
         plot_configurations: bool = False,
-        plot_tendon_positions: bool = False,
+        plot_actuator_positions: bool = False,
         custom_plots: dict[str, tuple] | None = None,
         robot_name: str = "Robot",
     ) -> None:
@@ -1191,7 +1264,8 @@ class ViserRenderer(BaseSoftRobotRenderer):
             camera_config: Camera configuration (fov, position, look_at, etc.)
             base_offsets: Base position offsets (N, 2/3)
             color_config: Shared renderer color configuration
-            render_tendons: If True, render tendons (if available)
+            render_actuators: If True, render actuator visual layers.
+            actuator_inputs: Optional actuator inputs for scalar-colored layers.
             multi_robot_layout: "grid" for side-by-side, "overlay" for same position
             static_spheres_positions: Static sphere positions
             static_spheres_radii: Static sphere radii
@@ -1201,7 +1275,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
             dynamic_spheres_colors: Time-varying sphere colors
             blocking: If True, block until viewer closes
             plot_configurations: If True, add configuration vs time plot to GUI
-            plot_tendon_positions: If True, add tendon position plot to GUI
+            plot_actuator_positions: If True, add actuator coordinate plot to GUI
             custom_plots: Dictionary mapping plot names to (figure, aspect) tuples
                          for custom plotly figures to add to the GUI
             robot_name: Name for plot titles
@@ -1212,9 +1286,9 @@ class ViserRenderer(BaseSoftRobotRenderer):
         ts = np.asarray(ts)
         q_ts = jnp.asarray(q_ts)
 
-        if q_ts.ndim == 3 and (plot_configurations or plot_tendon_positions):
+        if q_ts.ndim == 3 and (plot_configurations or plot_actuator_positions):
             raise ValueError(
-                "Plotting configurations or tendon positions requires q_ts with shape "
+                "Plotting configurations or actuator positions requires q_ts with shape "
                 "(T, DOF); got batched (N, T, DOF)."
             )
 
@@ -1276,13 +1350,18 @@ class ViserRenderer(BaseSoftRobotRenderer):
             base_plate_color=cfg.base_plate_color,
         )
 
-        # Add tendon visualization if available and requested
-        if render_tendons and self._has_tendons:
-            self._build_tendon_geometry(
+        if render_actuators and self._has_actuator_visuals:
+            self._build_actuator_geometry(
                 q_ts[:, 0, :],
                 np.asarray(base_offsets),
                 num_robots,
-                tendon_color=cfg.tendon_color,
+                color_config=cfg,
+                actuator_inputs=self._actuator_inputs_for_timestep(
+                    actuator_inputs,
+                    num_robots=int(num_robots),
+                    num_steps=int(num_frames),
+                    frame_idx=0,
+                ),
             )
 
         # Add static spheres
@@ -1330,7 +1409,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         self._setup_playback_gui()
 
         # Add plots after playback controls (so they appear at the end)
-        if plot_configurations or plot_tendon_positions or custom_plots:
+        if plot_configurations or plot_actuator_positions or custom_plots:
             with self._server.gui.add_folder("Plots"):
                 if plot_configurations:
                     config_fig = self.create_configuration_plot(
@@ -1338,11 +1417,11 @@ class ViserRenderer(BaseSoftRobotRenderer):
                     )
                     self.add_gui_plotly("Configurations", config_fig, aspect=2.0)
 
-                if plot_tendon_positions and hasattr(self.robot, "tendon_length"):
-                    tendon_fig = self.create_tendon_position_plot(
+                if plot_actuator_positions:
+                    actuator_fig = self.create_actuator_position_plot(
                         ts, q_ts_for_plots, self.robot, robot_name=robot_name
                     )
-                    self.add_gui_plotly("Tendon Positions", tendon_fig, aspect=2.0)
+                    self.add_gui_plotly("Actuator Coordinates", actuator_fig, aspect=2.0)
 
                 # Add custom plots
                 if custom_plots:
@@ -1404,8 +1483,14 @@ class ViserRenderer(BaseSoftRobotRenderer):
                                     base_offsets,
                                     resolved_colors.per_robot_point_rgba,
                                     base_plate_color=cfg.base_plate_color,
-                                    tendon_color=cfg.tendon_color,
-                                    render_tendons=render_tendons,
+                                    render_actuators=render_actuators,
+                                    actuator_inputs=self._actuator_inputs_for_timestep(
+                                        actuator_inputs,
+                                        num_robots=int(num_robots),
+                                        num_steps=int(num_frames),
+                                        frame_idx=next_idx,
+                                    ),
+                                    color_config=cfg,
                                 )
 
                                 # Record frame
@@ -1446,8 +1531,9 @@ class ViserRenderer(BaseSoftRobotRenderer):
         point_colors: np.ndarray,
         *,
         base_plate_color: tuple[float, float, float],
-        tendon_color: tuple[float, float, float],
-        render_tendons: bool = True,
+        render_actuators: bool = True,
+        actuator_inputs: Array | None = None,
+        color_config: RendererColorConfig | None = None,
     ) -> None:
         """Update scene for given frame index.
 
@@ -1478,13 +1564,13 @@ class ViserRenderer(BaseSoftRobotRenderer):
                 curves, point_colors, base_plate_color=base_plate_color
             )
 
-        # Update tendon geometry if available and requested
-        if render_tendons and self._has_tendons:
-            self._build_tendon_geometry(
+        if render_actuators and self._has_actuator_visuals:
+            self._build_actuator_geometry(
                 q_frame,
                 np.asarray(base_offsets),
                 num_robots,
-                tendon_color=tendon_color,
+                color_config=color_config,
+                actuator_inputs=actuator_inputs,
             )
 
         # Update dynamic spheres
@@ -1634,19 +1720,19 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         return fig
 
-    def create_tendon_position_plot(
+    def create_actuator_position_plot(
         self,
         ts: Array | np.ndarray,
         q_ts: Array | np.ndarray,
         robot: SoftRobot,
         robot_name: str = "Robot",
     ) -> PlotlyFigure:
-        """Create a plotly figure showing tendon positions over time.
+        """Create a plotly figure showing actuator coordinates over time.
 
         Args:
             ts: Time array (T,)
             q_ts: Configuration array (T, DOF)
-            robot: Robot instance with tendon_length method
+            robot: Robot instance with actuated_coordinates or tendon_length method
             robot_name: Name for the plot title
 
         Returns:
@@ -1655,33 +1741,39 @@ class ViserRenderer(BaseSoftRobotRenderer):
         if go is None:
             raise ImportError("plotly is required. Install with: pip install plotly")
 
-        if not hasattr(robot, "tendon_length"):
-            raise AttributeError("Robot does not have tendon_length method")
+        if hasattr(robot, "actuated_coordinates"):
+            coordinate_fn = robot.actuated_coordinates
+            yaxis_title = "Actuated coordinate"
+        elif hasattr(robot, "tendon_length"):
+            coordinate_fn = robot.tendon_length
+            yaxis_title = "Actuator length [m]"
+        else:
+            raise AttributeError(
+                "Robot does not have actuated_coordinates or tendon_length method"
+            )
 
         ts = np.asarray(ts)
         q_ts = jnp.asarray(q_ts)
         fig = go.Figure()
 
-        # Compute tendon lengths for all timesteps using vmap
-        tendon_lengths_ts = jax.vmap(robot.tendon_length)(q_ts)
-        tendon_lengths_ts = np.asarray(tendon_lengths_ts)  # (T, num_tendons)
-        num_tendons = tendon_lengths_ts.shape[1]
+        actuator_coordinates_ts = jax.vmap(coordinate_fn)(q_ts)
+        actuator_coordinates_ts = np.asarray(actuator_coordinates_ts)
+        num_actuators = actuator_coordinates_ts.shape[1]
 
-        # Plot each tendon
-        for i in range(num_tendons):
+        for i in range(num_actuators):
             fig.add_trace(
                 go.Scatter(
                     x=ts,
-                    y=tendon_lengths_ts[:, i],
+                    y=actuator_coordinates_ts[:, i],
                     mode="lines",
-                    name=f"Tendon {i}",
+                    name=f"Actuator {i}",
                 )
             )
 
         fig.update_layout(
-            title=f"{robot_name} - Tendon Positions vs Time",
+            title=f"{robot_name} - Actuator Coordinates vs Time",
             xaxis_title="Time [s]",
-            yaxis_title="Tendon Length [m]",
+            yaxis_title=yaxis_title,
             height=400,
             margin={"l": 50, "r": 50, "t": 50, "b": 50},
         )

--- a/src/soromox/systems/articulated/mckibben_actuated_umarm.py
+++ b/src/soromox/systems/articulated/mckibben_actuated_umarm.py
@@ -18,6 +18,7 @@ import jax
 from jax import Array
 from jax import numpy as jnp
 
+from soromox.rendering.actuators import ActuatorVisualLayer
 from soromox.systems.articulated.articulated_soft_robot import ArticulatedSoftRobot
 from soromox.systems.articulated.params import McKibbenActuatedUMArmParams
 
@@ -312,6 +313,29 @@ class McKibbenActuatedUMArm(ArticulatedSoftRobot):
             + translations[:, None, None, :]
         )
         return world_segments.reshape((self.num_actuators, 2, 3))
+
+    def actuator_visual_layers(
+        self,
+        q: Array,
+        s_points: Array,
+        *,
+        actuator_inputs: Array | None = None,
+    ) -> tuple[ActuatorVisualLayer, ...]:
+        """Return renderer-facing McKibben muscle segments."""
+        del s_points
+        scalar_fields = {}
+        if actuator_inputs is not None:
+            pressures = jnp.asarray(actuator_inputs).reshape((self.num_actuators,))
+            scalar_fields["pressure"] = pressures
+            scalar_fields["force"] = self.actuator_forces(q, pressures)
+        return (
+            ActuatorVisualLayer(
+                name="mckibben_muscles",
+                kind="muscle",
+                points=self.mckibben_actuator_segments(q),
+                scalar_fields=scalar_fields,
+            ),
+        )
 
     @eqx.filter_jit
     def effective_lengths(self, q: Array) -> Array:

--- a/src/soromox/systems/gvs/tendon_actuated_gvs.py
+++ b/src/soromox/systems/gvs/tendon_actuated_gvs.py
@@ -6,6 +6,7 @@ from jax import Array, vmap
 from jax import numpy as jnp
 
 import soromox.actuation.tendon_actuation as act
+from soromox.rendering.actuators import ActuatorVisualLayer
 from soromox.systems.gvs.params import TendonActuatedGVSParams
 from soromox.systems.gvs.structures import GVSStructure
 from soromox.systems.params import (
@@ -577,6 +578,40 @@ class TendonActuatedGVS(GVS):
         if passive_pos.size == 0:
             return active_pos
         return jnp.concatenate([active_pos, passive_pos], axis=0)
+
+    def actuator_visual_layers(
+        self,
+        q: Array,
+        s_points: Array,
+        *,
+        actuator_inputs: Array | None = None,
+    ) -> tuple[ActuatorVisualLayer, ...]:
+        """Return renderer-facing actuator geometry for active and passive tendons."""
+        del actuator_inputs
+        layers: list[ActuatorVisualLayer] = []
+        if self.active_tendon_routing.num_tendons > 0:
+            active_points = vmap(
+                lambda s: self.forward_kinematics_active_tendons(q, s)
+            )(s_points)
+            layers.append(
+                ActuatorVisualLayer(
+                    name="active_tendons",
+                    kind="tendon",
+                    points=active_points.transpose(1, 0, 2),
+                )
+            )
+        if self.passive_tendon_routing.num_tendons > 0:
+            passive_points = vmap(
+                lambda s: self.forward_kinematics_passive_tendons(q, s)
+            )(s_points)
+            layers.append(
+                ActuatorVisualLayer(
+                    name="passive_tendons",
+                    kind="tendon",
+                    points=passive_points.transpose(1, 0, 2),
+                )
+            )
+        return tuple(layers)
 
     @eqx.filter_jit
     def _forward_kinematics_tendons(

--- a/src/soromox/systems/pcs/tendon_actuated_pcs.py
+++ b/src/soromox/systems/pcs/tendon_actuated_pcs.py
@@ -7,6 +7,7 @@ from jax import Array, vmap
 from jax import numpy as jnp
 
 import soromox.actuation.tendon_actuation as act
+from soromox.rendering.actuators import ActuatorVisualLayer
 from soromox.systems.params import (
     BaseTendonRoutingParams,
     PassiveTendonParams,
@@ -689,6 +690,40 @@ class TendonActuatedPCS(PCS):
         if passive_pos.size == 0:
             return active_pos
         return jnp.concatenate([active_pos, passive_pos], axis=0)
+
+    def actuator_visual_layers(
+        self,
+        q: Array,
+        s_points: Array,
+        *,
+        actuator_inputs: Array | None = None,
+    ) -> tuple[ActuatorVisualLayer, ...]:
+        """Return renderer-facing actuator geometry for active and passive tendons."""
+        del actuator_inputs
+        layers: list[ActuatorVisualLayer] = []
+        if self.active_tendon_routing.num_tendons > 0:
+            active_points = vmap(
+                lambda s: self.forward_kinematics_active_tendons(q, s)
+            )(s_points)
+            layers.append(
+                ActuatorVisualLayer(
+                    name="active_tendons",
+                    kind="tendon",
+                    points=active_points.transpose(1, 0, 2),
+                )
+            )
+        if self.passive_tendon_routing.num_tendons > 0:
+            passive_points = vmap(
+                lambda s: self.forward_kinematics_passive_tendons(q, s)
+            )(s_points)
+            layers.append(
+                ActuatorVisualLayer(
+                    name="passive_tendons",
+                    kind="tendon",
+                    points=passive_points.transpose(1, 0, 2),
+                )
+            )
+        return tuple(layers)
 
     @eqx.filter_jit
     def _forward_kinematics_tendons(

--- a/src/soromox/systems/pcs/tendon_actuated_planar_pcs.py
+++ b/src/soromox/systems/pcs/tendon_actuated_planar_pcs.py
@@ -6,6 +6,7 @@ import equinox as eqx
 import jax.numpy as jnp
 from jax import Array, vmap
 
+from soromox.rendering.actuators import ActuatorVisualLayer
 from soromox.systems.pcs.params import TendonActuatedPlanarPCSParams
 from soromox.systems.pcs.structures import PlanarPCSStructure
 
@@ -297,3 +298,38 @@ class TendonActuatedPlanarPCS(PlanarPCS):
         tendon_lengths = cumulative_lengths[self.segment_indices_to_actuate]
 
         return tendon_lengths.reshape(-1)
+
+    def actuator_visual_layers(
+        self,
+        q: Array,
+        s_points: Array,
+        *,
+        actuator_inputs: Array | None = None,
+    ) -> tuple[ActuatorVisualLayer, ...]:
+        """Return renderer-facing actuator geometry for planar routed tendons."""
+        del actuator_inputs
+        num_tendons_per_segment = self.d.shape[1]
+        attachment_indices = jnp.repeat(
+            self.segment_indices_to_actuate, num_tendons_per_segment
+        )
+        distances = self.d[self.segment_indices_to_actuate].reshape(-1)
+
+        def tendon_path(segment_idx: Array, distance: Array) -> Array:
+            attachment_s = self.L_cum[segment_idx + 1]
+
+            def tendon_point(s: Array) -> Array:
+                pose = self.forward_kinematics(q, jnp.clip(s, 0.0, attachment_s))
+                theta = pose[0]
+                normal = jnp.array([-jnp.sin(theta), jnp.cos(theta)])
+                return pose[1:3] + distance * normal
+
+            return vmap(tendon_point)(s_points)
+
+        points = vmap(tendon_path)(attachment_indices, distances)
+        return (
+            ActuatorVisualLayer(
+                name="active_tendons",
+                kind="tendon",
+                points=points,
+            ),
+        )

--- a/tests/rendering/test_base_renderer.py
+++ b/tests/rendering/test_base_renderer.py
@@ -3,6 +3,11 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
+from soromox.rendering.actuators import (
+    ActuatorVisualLayer,
+    BatchedActuatorVisualLayer,
+    TrajectoryActuatorVisualLayer,
+)
 from soromox.rendering.base import BaseSoftRobotRenderer
 from soromox.rendering.camera_config import CameraConfig
 from soromox.rendering.matplotlib_renderer import MatplotlibRenderer
@@ -53,6 +58,137 @@ class DummySpatialRobot:
 
     def cross_section_geometry(self, q, s):
         return CrossSectionGeometry.CIRCULAR, jnp.array([0.02])
+
+
+class DummyActuatedPlanarRobot(DummyPlanarRobot):
+    def actuator_visual_layers(self, q, s_points, *, actuator_inputs=None):
+        del q, actuator_inputs
+        points = jnp.stack(
+            [
+                s_points,
+                jnp.full_like(s_points, 0.25),
+            ],
+            axis=1,
+        )[None, ...]
+        return (ActuatorVisualLayer(name="offset_cable", kind="cable", points=points),)
+
+
+class DummyActuatedSpatialRobot(DummySpatialRobot):
+    def actuator_visual_layers(self, q, s_points, *, actuator_inputs=None):
+        del q
+        tendon = jnp.stack(
+            [
+                s_points,
+                jnp.full_like(s_points, 0.1),
+                jnp.zeros_like(s_points),
+            ],
+            axis=1,
+        )[None, ...]
+        muscles = jnp.array(
+            [
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+                [[0.0, 0.2, 0.0], [1.0, 0.2, 0.0]],
+            ]
+        )
+        pressure = (
+            jnp.zeros((2,))
+            if actuator_inputs is None
+            else jnp.asarray(actuator_inputs).reshape((2,))
+        )
+        return (
+            ActuatorVisualLayer(name="sampled_tendon", kind="tendon", points=tendon),
+            ActuatorVisualLayer(
+                name="mckibben_pair",
+                kind="muscle",
+                points=muscles,
+                scalar_fields={"pressure": pressure},
+            ),
+        )
+
+
+class DummyBatchedActuatedSpatialRobot(DummySpatialRobot):
+    def __init__(self, base_pose: jnp.ndarray):
+        super().__init__(base_pose)
+        self.single_calls = 0
+        self.batched_calls = 0
+
+    def actuator_visual_layers(self, q, s_points, *, actuator_inputs=None):
+        del q, s_points, actuator_inputs
+        self.single_calls += 1
+        raise AssertionError("single actuator hook should not be used")
+
+    def actuator_visual_layers_batched(self, q_batch, s_points, *, actuator_inputs=None):
+        self.batched_calls += 1
+        num_robots = int(q_batch.shape[0])
+        base_paths = jnp.stack(
+            [
+                jnp.stack(
+                    [
+                        s_points,
+                        jnp.full_like(s_points, 0.1),
+                        jnp.zeros_like(s_points),
+                    ],
+                    axis=1,
+                ),
+                jnp.stack(
+                    [
+                        s_points,
+                        jnp.full_like(s_points, 0.2),
+                        jnp.zeros_like(s_points),
+                    ],
+                    axis=1,
+                ),
+            ],
+            axis=0,
+        )
+        points = jnp.broadcast_to(base_paths, (num_robots, *base_paths.shape))
+        pressure = (
+            jnp.zeros((num_robots, 2))
+            if actuator_inputs is None
+            else jnp.asarray(actuator_inputs).reshape((num_robots, 2))
+        )
+        return (
+            BatchedActuatorVisualLayer(
+                name="batched_cables",
+                kind="cable",
+                points=points,
+                scalar_fields={"pressure": pressure},
+            ),
+        )
+
+
+class DummyTrajectoryActuatedSpatialRobot(DummySpatialRobot):
+    def __init__(self, base_pose: jnp.ndarray):
+        super().__init__(base_pose)
+        self.trajectory_calls = 0
+
+    def actuator_visual_layers_trajectory(
+        self, q_ts, s_points, *, actuator_inputs=None
+    ):
+        self.trajectory_calls += 1
+        num_robots, num_steps = int(q_ts.shape[0]), int(q_ts.shape[1])
+        path = jnp.stack(
+            [
+                s_points,
+                jnp.full_like(s_points, 0.3),
+                jnp.zeros_like(s_points),
+            ],
+            axis=1,
+        )[None, ...]
+        points = jnp.broadcast_to(path, (num_robots, num_steps, *path.shape))
+        pressure = (
+            jnp.zeros((num_robots, num_steps, 1))
+            if actuator_inputs is None
+            else jnp.asarray(actuator_inputs).reshape((num_robots, num_steps, 1))
+        )
+        return (
+            TrajectoryActuatorVisualLayer(
+                name="trajectory_muscle",
+                kind="muscle",
+                points=points,
+                scalar_fields={"pressure": pressure},
+            ),
+        )
 
 
 class DummyRenderer(BaseSoftRobotRenderer):
@@ -152,6 +288,38 @@ class FakeViserServer:
     def on_client_connect(self, callback):
         self.on_client_connect_callback = callback
         return callback
+
+
+class FakeViserLineHandle:
+    def __init__(self, *, name, points, colors, line_width):
+        self.name = name
+        self.points = points
+        self.colors = colors
+        self.line_width = line_width
+        self.remove_count = 0
+
+    def remove(self):
+        self.remove_count += 1
+
+
+class FakeViserScene:
+    def __init__(self):
+        self.line_segments = []
+
+    def add_line_segments(self, *, name, points, colors, line_width):
+        handle = FakeViserLineHandle(
+            name=name,
+            points=points,
+            colors=colors,
+            line_width=line_width,
+        )
+        self.line_segments.append(handle)
+        return handle
+
+
+class FakeViserActuatorServer:
+    def __init__(self):
+        self.scene = FakeViserScene()
 
 
 def test_renderer_exposes_base_pose_transform_and_axis():
@@ -338,6 +506,40 @@ def test_viser_default_camera_uses_backend_specific_distance():
     assert_allclose(client.camera.fov, np.deg2rad(75.0), atol=1e-12)
 
 
+def test_viser_actuator_geometry_updates_existing_line_handles():
+    pytest.importorskip("viser")
+    from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
+
+    robot = DummyActuatedSpatialRobot(
+        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    )
+    renderer = ViserRenderer(robot, auto_start=False)
+    renderer._server = FakeViserActuatorServer()
+    renderer._scene_handles = SceneHandles()
+
+    renderer._build_actuator_geometry(
+        jnp.zeros((1, 0)),
+        np.zeros((1, 3)),
+        1,
+    )
+
+    first_handles = tuple(renderer._scene_handles.actuator_lines)
+    assert len(first_handles) == 3
+    assert len(renderer._server.scene.line_segments) == 3
+
+    renderer._build_actuator_geometry(
+        jnp.zeros((1, 0)),
+        np.array([[1.0, 0.0, 0.0]]),
+        1,
+        actuator_inputs=jnp.array([[1.0, 2.0]]),
+    )
+
+    assert tuple(renderer._scene_handles.actuator_lines) == first_handles
+    assert len(renderer._server.scene.line_segments) == 3
+    assert all(handle.remove_count == 0 for handle in first_handles)
+    assert_allclose(first_handles[0].points[0, 0], np.array([1.0, 0.1, 0.0]))
+
+
 def test_renderer_normalizes_base_offsets_to_curve_dimension():
     robot = DummyPlanarRobot(jnp.array([0.0, 0.0, 0.0]))
     renderer = DummyRenderer(robot)
@@ -377,6 +579,132 @@ def test_renderer_rejects_extra_explicit_base_offsets_by_default():
             num_robots=1,
             target_dim=2,
         )
+
+
+def test_renderer_computes_actuator_visual_layers_single_and_batched():
+    robot = DummyActuatedSpatialRobot(
+        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    )
+    renderer = DummyRenderer(robot, num_points=5)
+
+    single = renderer.compute_actuator_visual_layers(jnp.array([]))
+
+    assert len(single) == 2
+    assert single[0].points.shape == (1, 5, 3)
+    assert single[1].points.shape == (2, 2, 3)
+
+    batched = renderer.compute_actuator_visual_layers_batched(
+        jnp.zeros((2, 0)),
+        jnp.array([[0.0, 0.0, 0.0], [1.0, -1.0, 0.5]]),
+        actuator_inputs=jnp.array([[1.0, 2.0], [3.0, 4.0]]),
+    )
+
+    assert len(batched) == 2
+    assert batched[0].points.shape == (2, 1, 5, 3)
+    assert batched[1].points.shape == (2, 2, 2, 3)
+    assert_allclose(batched[0].points[1, 0, 0], jnp.array([1.0, -0.9, 0.5]))
+    assert_allclose(
+        batched[1].scalar_fields["pressure"],
+        jnp.array([[1.0, 2.0], [3.0, 4.0]]),
+    )
+
+
+def test_renderer_uses_batched_actuator_visual_fast_path():
+    robot = DummyBatchedActuatedSpatialRobot(
+        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    )
+    renderer = DummyRenderer(robot, num_points=5)
+
+    layers = renderer.compute_actuator_visual_layers_batched(
+        jnp.zeros((3, 0)),
+        jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, -1.0, 0.5],
+                [2.0, 0.0, -0.5],
+            ]
+        ),
+        actuator_inputs=jnp.arange(6.0).reshape(3, 2),
+    )
+
+    assert robot.batched_calls == 1
+    assert robot.single_calls == 0
+    assert len(layers) == 1
+    assert layers[0].points.shape == (3, 2, 5, 3)
+    assert_allclose(layers[0].points[1, 0, 0], jnp.array([1.0, -0.9, 0.5]))
+    assert_allclose(layers[0].scalar_fields["pressure"], jnp.arange(6.0).reshape(3, 2))
+
+
+def test_renderer_computes_trajectory_actuator_visual_layers():
+    robot = DummyActuatedSpatialRobot(
+        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    )
+    renderer = DummyRenderer(robot, num_points=4)
+
+    layers = renderer.compute_actuator_visual_layers_trajectory(
+        jnp.zeros((2, 3, 0)),
+        jnp.zeros((2, 3)),
+        actuator_inputs=jnp.arange(12.0).reshape(2, 3, 2),
+    )
+
+    assert len(layers) == 2
+    assert layers[0].points.shape == (2, 3, 1, 4, 3)
+    assert layers[1].points.shape == (2, 3, 2, 2, 3)
+    assert_allclose(
+        layers[1].scalar_fields["pressure"], jnp.arange(12.0).reshape(2, 3, 2)
+    )
+
+
+def test_renderer_uses_trajectory_actuator_visual_fast_path():
+    robot = DummyTrajectoryActuatedSpatialRobot(
+        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    )
+    renderer = DummyRenderer(robot, num_points=4)
+
+    layers = renderer.compute_actuator_visual_layers_trajectory(
+        jnp.zeros((2, 3, 0)),
+        jnp.array([[0.0, 0.0, 0.0], [1.0, -1.0, 0.5]]),
+        actuator_inputs=jnp.arange(6.0).reshape(2, 3, 1),
+    )
+
+    assert robot.trajectory_calls == 1
+    assert len(layers) == 1
+    assert layers[0].points.shape == (2, 3, 1, 4, 3)
+    assert_allclose(layers[0].points[1, 2, 0, 0], jnp.array([1.0, -0.7, 0.5]))
+    assert_allclose(
+        layers[0].scalar_fields["pressure"], jnp.arange(6.0).reshape(2, 3, 1)
+    )
+
+
+def test_matplotlib_actuator_overlay_changes_rendered_frame():
+    robot = DummyActuatedSpatialRobot(
+        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    )
+    renderer = MatplotlibRenderer(robot, width=240, height=180, num_points=8)
+
+    without_actuators = renderer.render_frame(jnp.array([]), render_actuators=False)
+    with_actuators = renderer.render_frame(jnp.array([]), render_actuators=True)
+
+    assert without_actuators.shape == with_actuators.shape
+    assert np.any(without_actuators != with_actuators)
+
+
+def test_opencv_planar_actuator_overlay_draws_configured_color():
+    robot = DummyActuatedPlanarRobot(jnp.array([0.0, 0.0, 0.0]))
+    renderer = OpenCVPlanarRenderer(
+        robot,
+        width=100,
+        height=100,
+        num_points=5,
+        actuator_color=(0, 0, 255),
+        actuator_thickness=2,
+        length_scale=2.0,
+        origin_uv=(20, 50),
+    )
+
+    img = renderer.render_frame(jnp.array([]), render_actuators=True)
+
+    assert np.any(np.all(img == np.array([0, 0, 255], dtype=np.uint8), axis=-1))
 
 
 def test_matplotlib_2d_base_marker_is_perpendicular_to_base_tangent():

--- a/tests/systems/test_mckibben_umarm.py
+++ b/tests/systems/test_mckibben_umarm.py
@@ -171,9 +171,13 @@ def test_umarm_viser_renderer_smoke() -> None:
     robot = make_robot()
     renderer = UMArmViserRenderer(robot, auto_start=False, open_browser=False)
     q = jnp.zeros((robot.num_dofs,))
-    curves = renderer.compute_tendon_curves_batched(q[None, :], jnp.zeros((1, 3)))
-    assert curves is not None
-    assert curves.shape == (1, robot.num_actuators, 2, 3)
+    layers = renderer.compute_actuator_visual_layers_batched(
+        q[None, :], jnp.zeros((1, 3))
+    )
+    assert len(layers) == 1
+    assert layers[0].name == "mckibben_muscles"
+    assert layers[0].kind == "muscle"
+    assert layers[0].points.shape == (1, robot.num_actuators, 2, 3)
     backbone = np.asarray(
         renderer.compute_backbone_curves_batched(q[None, :], jnp.zeros((1, 3)))
     )
@@ -244,15 +248,15 @@ def test_umarm_viser_live_mode_smoke() -> None:
         assert renderer._current_geometry_q.shape == (1, robot.num_dofs)
         assert renderer._scene_handles is not None
         assert len(renderer._scene_handles.base_plates) == 1
-        assert len(renderer._scene_handles.tendon_lines) == 1
-        assert renderer._scene_handles.tendon_lines[0].points.shape == (
+        assert len(renderer._scene_handles.actuator_lines) == 1
+        assert renderer._scene_handles.actuator_lines[0].points.shape == (
             robot.num_actuators,
             2,
             3,
         )
         base_handle = renderer._scene_handles.base_plates[0]
         body_handle = renderer._scene_handles.backbone_points[0][0]
-        actuator_handle = renderer._scene_handles.tendon_lines[0]
+        actuator_handle = renderer._scene_handles.actuator_lines[0]
 
         q_next = q.copy()
         q_next[0] = 0.1
@@ -260,7 +264,7 @@ def test_umarm_viser_live_mode_smoke() -> None:
 
         assert renderer._scene_handles.base_plates[0] is base_handle
         assert renderer._scene_handles.backbone_points[0][0] is body_handle
-        assert renderer._scene_handles.tendon_lines[0] is actuator_handle
+        assert renderer._scene_handles.actuator_lines[0] is actuator_handle
     finally:
         controller.stop()
         renderer.stop()

--- a/tests/systems/test_tendon_actuated_gvs.py
+++ b/tests/systems/test_tendon_actuated_gvs.py
@@ -949,6 +949,13 @@ def test_passive_tendon_params_are_batched_for_gvs():
     assert robot.forward_kinematics_active_tendons(q, 0.1).shape == (2, 3)
     assert robot.forward_kinematics_passive_tendons(q, 0.1).shape == (2, 3)
     assert robot.forward_kinematics_tendons(q, 0.1).shape == (4, 3)
+    layers = robot.actuator_visual_layers(q, jnp.linspace(0.0, float(robot.length), 6))
+    assert len(layers) == 2
+    assert layers[0].name == "active_tendons"
+    assert layers[0].kind == "tendon"
+    assert layers[0].points.shape == (2, 6, 3)
+    assert layers[1].name == "passive_tendons"
+    assert layers[1].points.shape == (2, 6, 3)
     assert jnp.all(jnp.isfinite(robot.passive_tendon_length(q)))
     assert jnp.all(jnp.isfinite(robot.elastic_force(q)))
     assert jnp.all(jnp.isfinite(robot.damping_matrix(q)))

--- a/tests/systems/test_tendon_actuated_pcs.py
+++ b/tests/systems/test_tendon_actuated_pcs.py
@@ -601,6 +601,33 @@ def test_passive_tendons_contribute_to_elastic_terms():
     )
 
 
+def test_tendon_actuated_pcs_exposes_actuator_visual_layers():
+    active_params = _stacked_tendon_params(2, 3)
+    passive_routing_params = _stacked_tendon_params(2, 2)
+    passive_tendon_phys = passive_tendon_params(
+        stiffness=jnp.array([40.0, 60.0]),
+        damping=jnp.array([0.2, 0.4]),
+        rest_length_offset=jnp.array([0.0, 0.01]),
+    )
+    robot = _create_robot(
+        jnp.array([0.2, 0.25]),
+        active_params,
+        passive_tendon_routing=passive_routing_params,
+        passive_tendon=passive_tendon_phys,
+    )
+    q = jnp.zeros((int(robot.num_active_strains),), dtype=jnp.float64)
+    s_points = jnp.linspace(0.0, float(robot.length), 7)
+
+    layers = robot.actuator_visual_layers(q, s_points)
+
+    assert len(layers) == 2
+    assert layers[0].name == "active_tendons"
+    assert layers[0].kind == "tendon"
+    assert layers[0].points.shape == (3, 7, 3)
+    assert layers[1].name == "passive_tendons"
+    assert layers[1].points.shape == (2, 7, 3)
+
+
 def test_update_tendon_params():
     """Verify the update of active and passive tendon parameters."""
 


### PR DESCRIPTION
## Summary

Generalizes renderer-facing tendon visualization into actuator visual layers across the rendering stack.

- Adds `ActuatorVisualLayer`, batched/trajectory actuator layer types, validation, and color/scalar resolution helpers.
- Replaces renderer public tendon flags/config names with actuator names.
- Adds actuator visual hooks for tendon PCS/GVS/planar systems and McKibben UMArm muscles.
- Updates Matplotlib, Open3D, Viser, OpenCV planar, and UMArm Viser rendering paths.
- Adds optional batched and trajectory actuator visual fast paths for robots that can provide vectorized geometry directly.
- Fixes a Viser animation regression by updating actuator line handles in place instead of deleting and recreating them every frame.
- Updates docs, examples, and regression coverage.

## Impact

This is a breaking renderer API change: renderer-facing tendon names such as `render_tendons`, `tendon_line_width`, `tendon_color`, and `compute_tendon_curves` are replaced by actuator-oriented names. Existing dynamics/modeling tendon APIs remain untouched where they are physically meaningful.

## Validation

- `uv run python -m py_compile ...`
- `uv run pytest tests/rendering/test_base_renderer.py`
- `uv run pytest tests/systems/test_mckibben_umarm.py tests/systems/test_tendon_actuated_pcs.py::test_tendon_actuated_pcs_exposes_actuator_visual_layers tests/systems/test_tendon_actuated_gvs.py::test_passive_tendon_params_are_batched_for_gvs`
- Full suite before the final Viser handle-stability follow-up: `uv run pytest` -> `1011 passed`
- `git diff --check`
- grep check for removed renderer API names