### PR TITLE
Align actuation space dynamics interface

### DIFF
--- a/src/soromox/coordinate_transformations/actuation_space.py
+++ b/src/soromox/coordinate_transformations/actuation_space.py
@@ -405,6 +405,27 @@ class ActuationSpaceDynamics(eqx.Module):
         return eta_y
 
     @eqx.filter_jit
+    def coriolis_force(self, q: Array, qd: Array) -> Array:
+        """
+        Compute the actuation space Coriolis/centrifugal force.
+
+        The actuation space Coriolis force is defined as:
+            tau_c_y = eta_y @ yd
+
+        Args:
+            q: Generalized coordinates of shape (num_dofs,).
+            qd: Generalized velocities of shape (num_dofs,).
+
+        Returns:
+            tau_c_y: Actuation space Coriolis force of shape (num_dofs,).
+        """
+        eta_y = self.coriolis_matrix(q, qd)
+        J = self.jacobian(q)
+        yd = J @ qd
+
+        return eta_y @ yd
+
+    @eqx.filter_jit
     def damping_matrix(self, q: Array) -> Array:
         """
         Compute the actuation space damping matrix.
@@ -431,6 +452,26 @@ class ActuationSpaceDynamics(eqx.Module):
     # =========================================================================
     # Forces in actuation space
     # =========================================================================
+
+    @eqx.filter_jit
+    def damping_force(self, q: Array, qd: Array) -> Array:
+        """
+        Compute the actuation space damping force.
+
+        The actuation space damping force is defined as:
+            tau_d_y = D_y @ yd = J^{-T} @ D @ qd
+
+        Args:
+            q: Generalized coordinates of shape (num_dofs,).
+            qd: Generalized velocities of shape (num_dofs,).
+
+        Returns:
+            tau_d_y: Actuation space damping force of shape (num_dofs,).
+        """
+        J_inv = self.jacobian_inverse(q)
+        D = self.robot.damping_matrix(q)
+
+        return J_inv.T @ D @ qd
 
     @eqx.filter_jit
     def elastic_force(self, q: Array) -> Array:
@@ -475,45 +516,43 @@ class ActuationSpaceDynamics(eqx.Module):
         return J_inv.T @ G
 
     @eqx.filter_jit
-    def damping_force(self, q: Array, qd: Array) -> Array:
+    def potential_force(self, q: Array) -> Array:
         """
-        Compute the actuation space damping force.
+        Compute the total conservative actuation space force.
 
-        The actuation space damping force is defined as:
-            tau_d_y = D_y @ yd = J^{-T} @ D @ qd
+        This is the sum of gravitational and elastic forces.
 
         Args:
             q: Generalized coordinates of shape (num_dofs,).
-            qd: Generalized velocities of shape (num_dofs,).
 
         Returns:
-            tau_d_y: Actuation space damping force of shape (num_dofs,).
+            tau_pot_y: Conservative actuation space force of shape (num_dofs,).
         """
-        J_inv = self.jacobian_inverse(q)
-        D = self.robot.damping_matrix(q)
-
-        return J_inv.T @ D @ qd
+        return self.gravitational_force(q) + self.elastic_force(q)
 
     @eqx.filter_jit
-    def coriolis_force(self, q: Array, qd: Array) -> Array:
+    def dynamics_terms(self, q: Array, qd: Array) -> tuple[Array, Array, Array]:
         """
-        Compute the actuation space Coriolis/centrifugal force.
+        Return actuation-space dynamics terms ``(M_y, Cyd, G_y)``.
 
-        The actuation space Coriolis force is defined as:
-            tau_c_y = eta_y @ yd
+        ``Cyd`` is the actuation-space Coriolis/centrifugal force vector.
+        ``G_y`` is the actuation-space gravitational force, matching the
+        ``SoftRobot.dynamics_terms`` convention of returning gravity separately
+        from elastic forces.
 
         Args:
             q: Generalized coordinates of shape (num_dofs,).
             qd: Generalized velocities of shape (num_dofs,).
 
         Returns:
-            tau_c_y: Actuation space Coriolis force of shape (num_dofs,).
+            M_y: Actuation space inertia matrix of shape (num_dofs, num_dofs).
+            Cyd: Actuation space Coriolis/centrifugal force of shape (num_dofs,).
+            G_y: Actuation space gravitational force of shape (num_dofs,).
         """
-        eta_y = self.coriolis_matrix(q, qd)
-        J = self.jacobian(q)
-        yd = J @ qd
-
-        return eta_y @ yd
+        M_y = self.inertia_matrix(q)
+        Cyd = self.coriolis_force(q, qd)
+        G_y = self.gravitational_force(q)
+        return M_y, Cyd, G_y
 
     # =========================================================================
     # Actuation matrix in actuation space

--- a/tests/coordinate_transformations/test_actuation_space_dynamics.py
+++ b/tests/coordinate_transformations/test_actuation_space_dynamics.py
@@ -491,6 +491,18 @@ class TestForces:
         expected = J_inv.T @ D @ qd
         assert_allclose(tau_d_y, expected, rtol=1e-10)
 
+    def test_potential_force_sums_conservative_forces(self, underactuated_pendulum):
+        """Test that potential_force sums gravitational and elastic forces."""
+        robot = underactuated_pendulum
+        asd = ActuationSpaceDynamics(robot)
+
+        q = jnp.array([0.1, 0.2, 0.3])
+        tau_pot_y = asd.potential_force(q)
+        expected = asd.gravitational_force(q) + asd.elastic_force(q)
+
+        assert tau_pot_y.shape == (robot.num_dofs,)
+        assert_allclose(tau_pot_y, expected, rtol=1e-10)
+
 
 # -----------------------
 # Actuation matrix tests
@@ -580,6 +592,22 @@ class TestIntegration:
         assert G_y.shape == (3,)
         assert tau_el_y.shape == (3,)
 
+    def test_dynamics_terms_match_individual_methods(self, underactuated_pendulum):
+        """Test dynamics_terms returns the individual actuation-space terms."""
+        robot = underactuated_pendulum
+        asd = ActuationSpaceDynamics(robot)
+
+        q = jnp.array([0.1, 0.2, 0.3])
+        qd = jnp.array([0.01, 0.02, 0.03])
+        M_y, Cyd, G_y = asd.dynamics_terms(q, qd)
+
+        assert M_y.shape == (3, 3)
+        assert Cyd.shape == (3,)
+        assert G_y.shape == (3,)
+        assert_allclose(M_y, asd.inertia_matrix(q), rtol=1e-10)
+        assert_allclose(Cyd, asd.coriolis_force(q, qd), rtol=1e-10)
+        assert_allclose(G_y, asd.gravitational_force(q), rtol=1e-10)
+
     def test_jit_compilation(self, underactuated_pendulum):
         """Test that all methods work correctly (they are already JIT-compiled via @eqx.filter_jit)."""
         robot = underactuated_pendulum
@@ -599,8 +627,10 @@ class TestIntegration:
         _ = asd.damping_matrix(q)
         _ = asd.elastic_force(q)
         _ = asd.gravitational_force(q)
+        _ = asd.potential_force(q)
         _ = asd.damping_force(q, qd)
         _ = asd.coriolis_force(q, qd)
+        _ = asd.dynamics_terms(q, qd)
         _ = asd.actuation_matrix(q)
 
 
@@ -1221,8 +1251,10 @@ class TestActuationSpaceDynamicsSystemIndependent:
         _ = asd.damping_matrix(q)
         _ = asd.elastic_force(q)
         _ = asd.gravitational_force(q)
+        _ = asd.potential_force(q)
         _ = asd.damping_force(q, qd)
         _ = asd.coriolis_force(q, qd)
+        _ = asd.dynamics_terms(q, qd)
         _ = asd.actuation_matrix(q)
 
     def test_dynamics_shapes_consistent(self, robot):
@@ -1237,9 +1269,15 @@ class TestActuationSpaceDynamicsSystemIndependent:
         D_y = asd.damping_matrix(q)
         G_y = asd.gravitational_force(q)
         tau_el_y = asd.elastic_force(q)
+        tau_pot_y = asd.potential_force(q)
+        M_terms, Cyd, G_terms = asd.dynamics_terms(q, qd)
 
         assert M_y.shape == (n_dof, n_dof)
         assert eta_y.shape == (n_dof, n_dof)
         assert D_y.shape == (n_dof, n_dof)
         assert G_y.shape == (n_dof,)
         assert tau_el_y.shape == (n_dof,)
+        assert tau_pot_y.shape == (n_dof,)
+        assert M_terms.shape == (n_dof, n_dof)
+        assert Cyd.shape == (n_dof,)
+        assert G_terms.shape == (n_dof,)


### PR DESCRIPTION
## Summary
- add `ActuationSpaceDynamics.potential_force` to match the conservative-force helper exposed by `SoftRobot`
- add `ActuationSpaceDynamics.dynamics_terms` returning `(M_y, Cyd, G_y)` with gravity kept separate from elastic force
- move `coriolis_force` next to the Coriolis matrix helpers without changing its formula

## Validation
- `uv run pytest tests/coordinate_transformations/test_actuation_space_dynamics.py`