### PR TITLE
Analytical derivatives

### DIFF
--- a/examples/simulation/pcs/test_analytical_derivative.py
+++ b/examples/simulation/pcs/test_analytical_derivative.py
@@ -1,0 +1,182 @@
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from soromox.systems import PCS, PCSParams
+
+jnp.set_printoptions(
+    threshold=jnp.inf,
+    linewidth=jnp.inf,
+    formatter={"float_kind": lambda x: "0" if x == 0 else f"{x:.2e}"},
+)
+
+
+if __name__ == "__main__":
+    num_segments = 2
+    seed = 7212
+
+    rho = 1070 * jnp.ones((num_segments,))
+    segment_lengths = 1e-1 * jnp.ones((num_segments,))
+    damping_matrix = 1e-3 * jnp.diag(
+        (
+            jnp.repeat(
+                jnp.array([[1e0, 1e0, 1e0, 1e3, 1e3, 1e3]]), num_segments, axis=0
+            )
+            * segment_lengths[:, None]
+        ).flatten()
+    )
+    params = PCSParams(
+        base_pose=jnp.array([jnp.pi / 2, jnp.pi / 2, 0.0, 0.0, 0.0, 0.0]),
+        length=segment_lengths,
+        radius=2e-2 * jnp.ones((num_segments,)),
+        density=rho,
+        gravity=jnp.array([0.0, 0.0, 9.81]),
+        young_modulus=2e3 * jnp.ones((num_segments,)),
+        shear_modulus=1e3 * jnp.ones((num_segments,)),
+        damping_matrix=damping_matrix,
+        reference_strain=jnp.tile(
+            jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), num_segments
+        ),
+    )
+
+    robot = PCS(params=params)
+
+    key_q, key_qd, key_u, key_tau = jax.random.split(jax.random.PRNGKey(seed), 4)
+    q = 0.5 * jax.random.normal(key_q, (robot.num_dofs,))
+    qd = 0.2 * jax.random.normal(key_qd, (robot.num_dofs,))
+    u = 1e-2 * jax.random.normal(key_u, (robot.num_actuators,))
+    tau_ext = 1e-2 * jax.random.normal(key_tau, (robot.num_dofs,))
+    y = jnp.concatenate([q, qd])
+    t = jnp.array(0.0)
+
+    yd = robot.forward_dynamics(t, y, (u, tau_ext))
+    _, qdd = jnp.split(yd, 2)
+
+    analytical_dID_dq, analytical_dID_dqd = robot.inverse_dynamics_derivatives(
+        q, qd, qdd
+    )
+    analytical_dtau_el_dq = robot.elastic_force_derivative_q(q)
+    analytical_dtau_damp_dq, analytical_dtau_damp_dqd = robot.damping_force_derivatives(
+        q, qd
+    )
+    analytical_dtau_u_dq = robot.actuation_force_derivative_q(q, u)
+    analytical_dtau_u_du = robot.actuation_force_derivative_u(q)
+    analytical_dqdd_dq, analytical_dqdd_dqd = robot.forward_dynamics_derivatives(
+        q, qd, qdd, u
+    )
+    analytical_dqdd_du, analytical_dqdd_dtau_ext = (
+        robot.forward_dynamics_input_derivatives(q)
+    )
+    analytical_dyd_dy = robot.forward_dynamics_state_jacobian(t, y, (u, tau_ext))
+    analytical_dyd_dy_full, analytical_dyd_du, analytical_dyd_dtau_ext = (
+        robot.forward_dynamics_jacobians(t, y, (u, tau_ext))
+    )
+
+    autodiff_dID_dq = jax.jacfwd(
+        lambda q_arg: robot.inverse_dynamics_force(q_arg, qd, qdd)
+    )(q)
+    autodiff_dID_dqd = jax.jacfwd(
+        lambda qd_arg: robot.inverse_dynamics_force(q, qd_arg, qdd)
+    )(qd)
+    autodiff_dtau_el_dq = jax.jacfwd(lambda q_arg: robot.elastic_force(q_arg))(q)
+    autodiff_dtau_damp_dq = jax.jacfwd(lambda q_arg: robot.damping_matrix(q_arg) @ qd)(
+        q
+    )
+    autodiff_dtau_damp_dqd = jax.jacfwd(
+        lambda qd_arg: robot.damping_matrix(q) @ qd_arg
+    )(qd)
+    autodiff_dtau_u_dq = jax.jacfwd(lambda q_arg: robot.actuation_force(q_arg, u))(q)
+    autodiff_dtau_u_du = jax.jacfwd(lambda u_arg: robot.actuation_force(q, u_arg))(u)
+    autodiff_dqdd_dq = jax.jacfwd(
+        lambda q_arg: jnp.split(
+            robot.forward_dynamics(t, jnp.concatenate([q_arg, qd]), (u, tau_ext)),
+            2,
+        )[1]
+    )(q)
+    autodiff_dqdd_dqd = jax.jacfwd(
+        lambda qd_arg: jnp.split(
+            robot.forward_dynamics(t, jnp.concatenate([q, qd_arg]), (u, tau_ext)),
+            2,
+        )[1]
+    )(qd)
+    autodiff_dqdd_du = jax.jacfwd(
+        lambda u_arg: jnp.split(robot.forward_dynamics(t, y, (u_arg, tau_ext)), 2)[1]
+    )(u)
+    autodiff_dqdd_dtau_ext = jax.jacfwd(
+        lambda tau_ext_arg: jnp.split(
+            robot.forward_dynamics(t, y, (u, tau_ext_arg)),
+            2,
+        )[1]
+    )(tau_ext)
+    autodiff_dyd_dy = jax.jacfwd(
+        lambda y_arg: robot.forward_dynamics(t, y_arg, (u, tau_ext))
+    )(y)
+    autodiff_dyd_du = jax.jacfwd(
+        lambda u_arg: robot.forward_dynamics(t, y, (u_arg, tau_ext))
+    )(u)
+    autodiff_dyd_dtau_ext = jax.jacfwd(
+        lambda tau_ext_arg: robot.forward_dynamics(t, y, (u, tau_ext_arg))
+    )(tau_ext)
+
+    comparisons = [
+        ("inverse_dynamics_derivatives dID/dq", analytical_dID_dq, autodiff_dID_dq),
+        ("inverse_dynamics_derivatives dID/dqd", analytical_dID_dqd, autodiff_dID_dqd),
+        ("elastic_force_derivative_q", analytical_dtau_el_dq, autodiff_dtau_el_dq),
+        (
+            "damping_force_derivatives dtau_damp/dq",
+            analytical_dtau_damp_dq,
+            autodiff_dtau_damp_dq,
+        ),
+        (
+            "damping_force_derivatives dtau_damp/dqd",
+            analytical_dtau_damp_dqd,
+            autodiff_dtau_damp_dqd,
+        ),
+        (
+            "actuation_force_derivative_q",
+            analytical_dtau_u_dq,
+            autodiff_dtau_u_dq,
+        ),
+        (
+            "actuation_force_derivative_u",
+            analytical_dtau_u_du,
+            autodiff_dtau_u_du,
+        ),
+        ("forward_dynamics_derivatives dqdd/dq", analytical_dqdd_dq, autodiff_dqdd_dq),
+        (
+            "forward_dynamics_derivatives dqdd/dqd",
+            analytical_dqdd_dqd,
+            autodiff_dqdd_dqd,
+        ),
+        (
+            "forward_dynamics_input_derivatives dqdd/du",
+            analytical_dqdd_du,
+            autodiff_dqdd_du,
+        ),
+        (
+            "forward_dynamics_input_derivatives dqdd/dtau_ext",
+            analytical_dqdd_dtau_ext,
+            autodiff_dqdd_dtau_ext,
+        ),
+        ("forward_dynamics_state_jacobian dyd/dy", analytical_dyd_dy, autodiff_dyd_dy),
+        (
+            "forward_dynamics_jacobians dyd/dy",
+            analytical_dyd_dy_full,
+            autodiff_dyd_dy,
+        ),
+        ("forward_dynamics_jacobians dyd/du", analytical_dyd_du, autodiff_dyd_du),
+        (
+            "forward_dynamics_jacobians dyd/dtau_ext",
+            analytical_dyd_dtau_ext,
+            autodiff_dyd_dtau_ext,
+        ),
+    ]
+
+    for name, analytical, autodiff in comparisons:
+        max_abs_error = jnp.max(jnp.abs(analytical - autodiff))
+        rel_error = max_abs_error / jnp.maximum(1.0, jnp.max(jnp.abs(autodiff)))
+        print(
+            f"{name}: rel error = {float(rel_error):.6e}, "
+            f"max abs error = {float(max_abs_error):.6e}"
+        )

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -2691,7 +2691,6 @@ class PCS(SoftRobot):
         etad = J_local @ qdd + Jd_local @ qd
 
         return eta, etad, J_local, Jd_local
-    
 
     @eqx.filter_jit
     def _pcs_soft_joint_differential_kinematics(
@@ -2732,13 +2731,9 @@ class PCS(SoftRobot):
             Omega, Z, g_step, T, S, Sd, f, fd, adjOmegap,
             dS_dq_qd, dS_dq_qdd, dSd_dq_qd.
         """
-        Phi_i = lax.dynamic_slice_in_dim(
-            self.B_xi, 6 * i, 6, axis=0
-        )
+        Phi_i = lax.dynamic_slice_in_dim(self.B_xi, 6 * i, 6, axis=0)
 
-        xi_star_i = lax.dynamic_slice_in_dim(
-            self.xi_ref, 6 * i, 6, axis=0
-        )
+        xi_star_i = lax.dynamic_slice_in_dim(self.xi_ref, 6 * i, 6, axis=0)
 
         (
             Omega,
@@ -2779,6 +2774,124 @@ class PCS(SoftRobot):
         )
 
     @eqx.filter_jit
+    def _pcs_R_L_Q_Y_step_terms(
+        self,
+        g_prev: Array,
+        eta_prev: Array,
+        etad_prev: Array,
+        i: Array,
+        H: Array,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[Array, Array, Array, Array, Array, Array, Array, Array, Array, Array]:
+        """
+        Return the local PCS interval terms used by the forward and backward passes.
+
+        ``eta_plus`` and ``etad_plus`` are expressed in the frame before the step,
+        matching the MATLAB recursion immediately before multiplying by
+        ``Adgstepinv``.
+        """
+        zero_H = jnp.abs(H) <= self.global_eps
+
+        zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
+
+        def zero_step(
+            _: None,
+        ) -> tuple[
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+        ]:
+            return (
+                jnp.eye(4, dtype=q.dtype),
+                jnp.eye(6, dtype=q.dtype),
+                zeros_6n,
+                zeros_6n,
+                zeros_6n,
+                zeros_6n,
+                zeros_6n,
+                zeros_6n,
+                eta_prev,
+                etad_prev,
+            )
+
+        def finite_step(
+            _: None,
+        ) -> tuple[
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+        ]:
+            (
+                _,
+                _,
+                g_step,
+                _,
+                S,
+                Sd,
+                _,
+                _,
+                _,
+                dS_dq_qd,
+                dS_dq_qdd,
+                dSd_dq_qd,
+            ) = self._pcs_soft_joint_differential_kinematics(i, H, q, qd, qdd)
+
+            Ad_step_inv = lie.Adjoint_g_inv_SE3(g_step)
+            adj_eta_prev = lie.adjoint_se3(eta_prev)
+
+            eta_plus = eta_prev + S @ qd
+            etad_plus = etad_prev + S @ qdd + adj_eta_prev @ (S @ qd) + Sd @ qd
+
+            R = lie.adjoint_se3(eta_plus) @ S + dS_dq_qd
+            L = (
+                lie.adjoint_se3(etad_plus) @ S
+                + lie.adjoint_se3(eta_plus) @ R
+                + adj_eta_prev @ dS_dq_qd
+                + dSd_dq_qd
+                + dS_dq_qdd
+            )
+
+            g_body = lie.Adjoint_g_inv_SE3(g_prev) @ self.g
+            Q = L - lie.adjoint_se3(g_body) @ S
+            Y = R + Sd + adj_eta_prev @ S
+
+            return (
+                g_step,
+                Ad_step_inv,
+                S,
+                Sd,
+                R,
+                L,
+                Q,
+                Y,
+                eta_plus,
+                etad_plus,
+            )
+
+        return lax.cond(
+            zero_H,
+            zero_step,
+            finite_step,
+            operand=None,
+        )
+
+    @eqx.filter_jit
     def _integrate_R_L_Q_Y_step(
         self,
         g_prev: Array,
@@ -2808,9 +2921,9 @@ class PCS(SoftRobot):
 
         zero_H = jnp.abs(H) <= self.global_eps
 
-        def zero_step(_: None) -> tuple[
-            Array, Array, Array, Array, Array, Array, Array, Array, Array
-        ]:
+        def zero_step(
+            _: None,
+        ) -> tuple[Array, Array, Array, Array, Array, Array, Array, Array, Array]:
             Y_B_prev = R_B_prev + Jd_prev
             return (
                 g_prev,
@@ -2824,55 +2937,30 @@ class PCS(SoftRobot):
                 Y_B_prev,
             )
 
-        def finite_step(_: None) -> tuple[
-            Array, Array, Array, Array, Array, Array, Array, Array, Array
-        ]:
+        def finite_step(
+            _: None,
+        ) -> tuple[Array, Array, Array, Array, Array, Array, Array, Array, Array]:
             (
-                _,
-                _,
                 g_step,
-                _,
+                Ad_step_inv,
                 S,
                 Sd,
+                R,
+                L,
+                Q,
                 _,
-                _,
-                _,
-                dS_dq_qd,
-                dS_dq_qdd,
-                dSd_dq_qd,
-            ) = self._pcs_soft_joint_differential_kinematics(
-                i, H, q, qd, qdd
+                eta_plus,
+                etad_plus,
+            ) = self._pcs_R_L_Q_Y_step_terms(
+                g_prev,
+                eta_prev,
+                etad_prev,
+                i,
+                H,
+                q,
+                qd,
+                qdd,
             )
-
-            Ad_step_inv = lie.Adjoint_g_inv_SE3(g_step)
-
-            adj_eta_prev = lie.adjoint_se3(eta_prev)
-
-            # eta_plus and etad_plus are expressed in the frame before the step.
-            eta_plus = eta_prev + S @ qd
-
-            etad_plus = (
-                etad_prev
-                + S @ qdd
-                + adj_eta_prev @ (S @ qd)
-                + Sd @ qd
-            )
-
-            # Local differential terms before transporting through g_step.
-            R = lie.adjoint_se3(eta_plus) @ S + dS_dq_qd
-
-            L = (
-                lie.adjoint_se3(etad_plus) @ S
-                + lie.adjoint_se3(eta_plus) @ R
-                + adj_eta_prev @ dS_dq_qd
-                + dSd_dq_qd
-                + dS_dq_qdd
-            )
-
-            # Gravity expressed in the current body frame, before the step.
-            g_body = lie.Adjoint_g_inv_SE3(g_prev) @ self.g
-
-            Q = L - lie.adjoint_se3(g_body) @ S
 
             # Propagate pose.
             g_next = g_prev @ g_step
@@ -2880,9 +2968,8 @@ class PCS(SoftRobot):
             # Propagate body-frame Jacobian terms.
             J_next = Ad_step_inv @ (J_prev + S)
 
-            Jd_next = Ad_step_inv @ (
-                Jd_prev + Sd + adj_eta_prev @ S
-            )
+            adj_eta_prev = lie.adjoint_se3(eta_prev)
+            Jd_next = Ad_step_inv @ (Jd_prev + Sd + adj_eta_prev @ S)
 
             eta_next = Ad_step_inv @ eta_plus
             etad_next = Ad_step_inv @ etad_plus
@@ -2994,9 +3081,7 @@ class PCS(SoftRobot):
             R_target, L_target, Q_target, Y_target = target_prev
 
             def compute_branch(_: None):
-                L_i = lax.dynamic_index_in_dim(
-                    self.L, i, axis=0, keepdims=False
-                )
+                L_i = lax.dynamic_index_in_dim(self.L, i, axis=0, keepdims=False)
                 H_i = jnp.where(i == segment_idx, s_local, L_i)
 
                 (
@@ -3141,9 +3226,7 @@ class PCS(SoftRobot):
                 Q_B_prev,
             ) = state_prev
 
-            H_i = lax.dynamic_index_in_dim(
-                self.L, i, axis=0, keepdims=False
-            )
+            H_i = lax.dynamic_index_in_dim(self.L, i, axis=0, keepdims=False)
 
             (
                 g_next,
@@ -3366,3 +3449,705 @@ class PCS(SoftRobot):
         )
 
         return R_B_ps, L_B_ps, Q_B_ps, Y_B_ps
+
+    @eqx.filter_jit
+    def _dSTdq_FC_pcs_step(self, i: Array, H: Array, q: Array, F_C: Array) -> Array:
+        """
+        Compute ``d(S(q)^T F_C) / dq``.
+        """
+        qd_basis = jnp.eye(self.num_dofs, dtype=q.dtype)
+        qdd_zero = jnp.zeros_like(q)
+
+        def projected_wrench_row(qd_unit: Array) -> Array:
+            (
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+                dS_dq_qd,
+                _,
+                _,
+            ) = self._pcs_soft_joint_differential_kinematics(
+                i,
+                H,
+                q,
+                qd_unit,
+                qdd_zero,
+            )
+            return F_C @ dS_dq_qd
+
+        return vmap(projected_wrench_row)(qd_basis)
+
+    @eqx.filter_jit
+    def _backward_pass_interval_kinematics(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+    ]:
+        Xs_nodes, Ws_nodes = vmap(
+            scale_gaussian_quadrature, in_axes=(None, None, 0, 0)
+        )(
+            self.integration_points,
+            self.integration_weights,
+            self.L_cum[:-1],
+            self.L_cum[1:],
+        )
+        s_local_nodes = Xs_nodes - self.L_cum[:-1, None]
+
+        zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
+        zeros_6 = jnp.zeros((6,), dtype=q.dtype)
+
+        state_init = (
+            self.g0,
+            zeros_6n,
+            zeros_6n,
+            zeros_6,
+            zeros_6,
+            zeros_6n,
+            zeros_6n,
+            zeros_6n,
+        )
+
+        def scan_segment(
+            state_prev: tuple[
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+            ],
+            i: Array,
+        ) -> tuple[
+            tuple[Array, Array, Array, Array, Array, Array, Array, Array],
+            tuple[
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+            ],
+        ]:
+            s_local_i = lax.dynamic_index_in_dim(
+                s_local_nodes, i, axis=0, keepdims=False
+            )
+
+            def scan_interval(
+                state_here: tuple[
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                ],
+                k: Array,
+            ) -> tuple[
+                tuple[Array, Array, Array, Array, Array, Array, Array, Array],
+                tuple[
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                ],
+            ]:
+                (
+                    g_prev,
+                    J_prev,
+                    Jd_prev,
+                    eta_prev,
+                    etad_prev,
+                    R_B_prev,
+                    L_B_prev,
+                    Q_B_prev,
+                ) = state_here
+
+                s0 = lax.dynamic_index_in_dim(s_local_i, k, axis=0, keepdims=False)
+                s1 = lax.dynamic_index_in_dim(s_local_i, k + 1, axis=0, keepdims=False)
+                H = s1 - s0
+
+                (
+                    g_step,
+                    Ad_step_inv,
+                    S,
+                    Sd,
+                    R,
+                    L,
+                    Q,
+                    Y,
+                    eta_plus,
+                    etad_plus,
+                ) = self._pcs_R_L_Q_Y_step_terms(
+                    g_prev,
+                    eta_prev,
+                    etad_prev,
+                    i,
+                    H,
+                    q,
+                    qd,
+                    qdd,
+                )
+
+                adj_eta_prev = lie.adjoint_se3(eta_prev)
+
+                g_next = g_prev @ g_step
+                J_next = Ad_step_inv @ (J_prev + S)
+                Jd_next = Ad_step_inv @ (Jd_prev + Sd + adj_eta_prev @ S)
+                eta_next = Ad_step_inv @ eta_plus
+                etad_next = Ad_step_inv @ etad_plus
+                R_B_next = Ad_step_inv @ (R_B_prev + R)
+                L_B_next = Ad_step_inv @ (L_B_prev + L)
+                Q_B_next = Ad_step_inv @ (Q_B_prev + Q)
+
+                Y_B_prev = R_B_prev + Jd_prev
+                Y_B_next = R_B_next + Jd_next
+
+                state_next = (
+                    g_next,
+                    J_next,
+                    Jd_next,
+                    eta_next,
+                    etad_next,
+                    R_B_next,
+                    L_B_next,
+                    Q_B_next,
+                )
+
+                output = (
+                    H,
+                    g_prev,
+                    J_prev,
+                    R_B_prev,
+                    Q_B_prev,
+                    Y_B_prev,
+                    g_next,
+                    J_next,
+                    Jd_next,
+                    eta_next,
+                    etad_next,
+                    R_B_next,
+                    Q_B_next,
+                    Y_B_next,
+                    Ad_step_inv,
+                    S,
+                    R,
+                    Q,
+                    Y,
+                )
+
+                return state_next, output
+
+            step_indices = jnp.arange(self.num_integration_points - 1, dtype=jnp.int32)
+            state_next, interval_outputs = lax.scan(
+                scan_interval,
+                state_prev,
+                step_indices,
+            )
+            return state_next, interval_outputs
+
+        segment_indices = jnp.arange(self.num_segments, dtype=jnp.int32)
+        _, outputs = lax.scan(scan_segment, state_init, segment_indices)
+
+        (
+            H_steps,
+            g_alpha,
+            J_alpha,
+            R_B_alpha,
+            Q_B_alpha,
+            Y_B_alpha,
+            g_ap1,
+            J_ap1,
+            Jd_ap1,
+            eta_ap1,
+            etad_ap1,
+            R_B_ap1,
+            Q_B_ap1,
+            Y_B_ap1,
+            Ad_step_inv,
+            S,
+            R,
+            Q,
+            Y,
+        ) = outputs
+
+        return (
+            Ws_nodes,
+            H_steps,
+            g_alpha,
+            J_alpha,
+            R_B_alpha,
+            Q_B_alpha,
+            Y_B_alpha,
+            g_ap1,
+            J_ap1,
+            Jd_ap1,
+            eta_ap1,
+            etad_ap1,
+            R_B_ap1,
+            Q_B_ap1,
+            Y_B_ap1,
+            Ad_step_inv,
+            S,
+            R,
+            Q,
+            Y,
+        )
+
+    @eqx.filter_jit
+    def inverse_dynamics_force(self, q: Array, qd: Array, qdd: Array) -> Array:
+        """
+        Compute the active-coordinate inverse-dynamics force ``ID``.
+
+        ``ID = B(q) qdd + C(q, qd) qd + G(q)``. Elastic, damping, actuation,
+        and externally supplied generalized forces are intentionally excluded.
+        """
+        B, Cqd, G = self.dynamics_terms(q, qd)
+        return B @ qdd + Cqd + G
+
+    @eqx.filter_jit
+    def inverse_dynamics_backward_pass(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[Array, Array, Array, Array, Array, Array, Array, Array]:
+        """
+        Serial PCS backward pass for inverse-dynamics derivatives.
+
+        Returns:
+            ``dID_dq, dID_dqd, M_C, N_C, F_C, P_S, U_S, V_S`` where the
+            composite matrices are stored for each interval in forward order
+            with shape ``(num_segments, num_integration_points - 1, ...)``.
+        """
+        (
+            Ws_nodes,
+            H_steps,
+            _,
+            J_alpha,
+            R_B_alpha,
+            Q_B_alpha,
+            Y_B_alpha,
+            g_ap1,
+            _,
+            _,
+            eta_ap1,
+            etad_ap1,
+            _,
+            _,
+            _,
+            Ad_step_inv,
+            S,
+            R,
+            Q,
+            Y,
+        ) = self._backward_pass_interval_kinematics(q, qd, qdd)
+
+        n_steps = self.num_integration_points - 1
+
+        zeros_66 = jnp.zeros((6, 6), dtype=q.dtype)
+        zeros_6 = jnp.zeros((6,), dtype=q.dtype)
+        zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
+        zeros_nn = jnp.zeros((self.num_dofs, self.num_dofs), dtype=q.dtype)
+
+        carry_init = (
+            zeros_66,
+            zeros_66,
+            zeros_6,
+            zeros_6n,
+            zeros_6n,
+            zeros_6n,
+            zeros_nn,
+            zeros_nn,
+        )
+
+        def scan_segment_backward(
+            carry: tuple[Array, Array, Array, Array, Array, Array, Array, Array],
+            segment_idx: Array,
+        ) -> tuple[
+            tuple[Array, Array, Array, Array, Array, Array, Array, Array],
+            tuple[Array, Array, Array, Array, Array, Array],
+        ]:
+            M_i = self.M_segments[segment_idx]
+
+            def scan_interval_backward(
+                interval_carry: tuple[
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                    Array,
+                ],
+                step_idx: Array,
+            ) -> tuple[
+                tuple[Array, Array, Array, Array, Array, Array, Array, Array],
+                tuple[Array, Array, Array, Array, Array, Array],
+            ]:
+                (
+                    M_C_prev,
+                    N_C_prev,
+                    F_C_prev,
+                    P_S_prev,
+                    U_S_prev,
+                    V_S_prev,
+                    dID_dq_prev,
+                    dID_dqd_prev,
+                ) = interval_carry
+
+                M_ap1 = Ws_nodes[segment_idx, step_idx + 1] * M_i
+                eta_here = eta_ap1[segment_idx, step_idx]
+                etad_here = etad_ap1[segment_idx, step_idx]
+                g_here = g_ap1[segment_idx, step_idx]
+                Ad_inv = Ad_step_inv[segment_idx, step_idx]
+                coAd = Ad_inv.T
+
+                gravity_here = lie.Adjoint_g_inv_SE3(g_here) @ self.g
+                F_ap1 = (
+                    M_ap1 @ etad_here
+                    + lie.coadjoint_se3(eta_here) @ M_ap1 @ eta_here
+                    - M_ap1 @ gravity_here
+                )
+                N_ap1 = (
+                    lie.coadjointbar_se3(M_ap1 @ eta_here)
+                    + lie.coadjoint_se3(eta_here) @ M_ap1
+                    - M_ap1 @ lie.adjoint_se3(eta_here)
+                )
+
+                M_C = coAd @ (M_ap1 + M_C_prev) @ Ad_inv
+                N_C = coAd @ (N_ap1 + N_C_prev) @ Ad_inv
+                F_C = coAd @ (F_ap1 + F_C_prev)
+
+                P_S = coAd @ P_S_prev
+                U_S = coAd @ U_S_prev
+                V_S = coAd @ V_S_prev
+
+                S_here = S[segment_idx, step_idx]
+                R_here = R[segment_idx, step_idx]
+                Q_here = Q[segment_idx, step_idx]
+                Y_here = Y[segment_idx, step_idx]
+
+                P_S = P_S + lie.coadjointbar_se3(F_C) @ S_here
+                U_S = U_S + N_C @ R_here + M_C @ Q_here
+                V_S = V_S + N_C @ S_here + M_C @ Y_here
+
+                dSTdq_FC = self._dSTdq_FC_pcs_step(
+                    segment_idx,
+                    H_steps[segment_idx, step_idx],
+                    q,
+                    F_C,
+                )
+
+                dID_dq_step = dSTdq_FC + S_here.T @ (
+                    N_C @ R_B_alpha[segment_idx, step_idx]
+                    + M_C @ Q_B_alpha[segment_idx, step_idx]
+                    + U_S
+                    + P_S
+                )
+                dID_dqd_step = S_here.T @ (
+                    N_C @ J_alpha[segment_idx, step_idx]
+                    + M_C @ Y_B_alpha[segment_idx, step_idx]
+                    + V_S
+                )
+
+                dID_dq = dID_dq_prev + dID_dq_step
+                dID_dqd = dID_dqd_prev + dID_dqd_step
+
+                interval_carry_next = (
+                    M_C,
+                    N_C,
+                    F_C,
+                    P_S,
+                    U_S,
+                    V_S,
+                    dID_dq,
+                    dID_dqd,
+                )
+                output = (M_C, N_C, F_C, P_S, U_S, V_S)
+
+                return interval_carry_next, output
+
+            reverse_step_indices = jnp.arange(n_steps - 1, -1, -1, dtype=jnp.int32)
+            carry_next, reverse_step_outputs = lax.scan(
+                scan_interval_backward,
+                carry,
+                reverse_step_indices,
+            )
+            step_outputs = tuple(jnp.flip(x, axis=0) for x in reverse_step_outputs)
+
+            return carry_next, step_outputs
+
+        reverse_segment_indices = jnp.arange(
+            self.num_segments - 1,
+            -1,
+            -1,
+            dtype=jnp.int32,
+        )
+        (
+            (
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+                dID_dq,
+                dID_dqd,
+            ),
+            reverse_segment_outputs,
+        ) = lax.scan(
+            scan_segment_backward,
+            carry_init,
+            reverse_segment_indices,
+        )
+
+        M_C_steps, N_C_steps, F_C_steps, P_S_steps, U_S_steps, V_S_steps = (
+            jnp.flip(x, axis=0) for x in reverse_segment_outputs
+        )
+
+        return (
+            dID_dq,
+            dID_dqd,
+            M_C_steps,
+            N_C_steps,
+            F_C_steps,
+            P_S_steps,
+            U_S_steps,
+            V_S_steps,
+        )
+
+    @eqx.filter_jit
+    def inverse_dynamics_derivatives(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[Array, Array]:
+        """Return ``dID/dq`` and ``dID/dqd`` from the PCS backward pass."""
+        dID_dq, dID_dqd, _, _, _, _, _, _ = self.inverse_dynamics_backward_pass(
+            q,
+            qd,
+            qdd,
+        )
+        return dID_dq, dID_dqd
+
+    @eqx.filter_jit
+    def elastic_force_derivative_q(self, q: Array) -> Array:
+        """Return the analytical derivative ``d(tau_el) / dq``."""
+        del q
+        return self.stiffness_matrix()
+
+    @eqx.filter_jit
+    def damping_force_derivatives(
+        self,
+        q: Array,
+        qd: Array,
+    ) -> tuple[Array, Array]:
+        """Return analytical derivatives of ``damping_matrix(q) @ qd``."""
+        return (
+            jnp.zeros((q.shape[0], q.shape[0]), dtype=q.dtype),
+            self.damping_matrix(q),
+        )
+
+    @eqx.filter_jit
+    def actuation_force_derivative_q(self, q: Array, u: Array) -> Array:
+        """Return the analytical derivative ``d(tau_u) / dq``."""
+        del u
+        return jnp.zeros((q.shape[0], q.shape[0]), dtype=q.dtype)
+
+    @eqx.filter_jit
+    def actuation_force_derivative_u(self, q: Array) -> Array:
+        """Return the analytical derivative ``d(tau_u) / du``."""
+        return self.actuation_matrix(q)
+
+    @eqx.filter_jit
+    def forward_dynamics_derivatives(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+        u: Array | None = None,
+    ) -> tuple[Array, Array]:
+        """
+        Return analytical ``dqdd/dq`` and ``dqdd/dqd``.
+
+        This is the unconstrained PCS equivalent of the MATLAB ``ODEJacobian``
+        solve:
+
+        ``dqdd_dq = M \\ (dtau_dq - dID_dq)``
+        ``dqdd_dqd = M \\ (dtau_dqd - dID_dqd)``
+
+        For base PCS, ``dtau_dq = -K`` and ``dtau_dqd = -D`` because the
+        actuation matrix, stiffness, and damping are configuration independent.
+        """
+        if u is None:
+            u = jnp.zeros((self.num_actuators,), dtype=q.dtype)
+
+        mass_matrix = self.inertia_matrix(q)
+        dID_dq, dID_dqd = self.inverse_dynamics_derivatives(q, qd, qdd)
+
+        d_elastic_dq = self.elastic_force_derivative_q(q)
+        d_damping_dq, d_damping_dqd = self.damping_force_derivatives(q, qd)
+        d_actuation_dq = self.actuation_force_derivative_q(q, u)
+
+        dtau_dq = d_actuation_dq - d_elastic_dq - d_damping_dq
+        dtau_dqd = -d_damping_dqd
+
+        dqdd_dq = jnp.linalg.solve(mass_matrix, dtau_dq - dID_dq)
+        dqdd_dqd = jnp.linalg.solve(mass_matrix, dtau_dqd - dID_dqd)
+
+        return dqdd_dq, dqdd_dqd
+
+    @eqx.filter_jit
+    def forward_dynamics_input_derivatives(
+        self,
+        q: Array,
+    ) -> tuple[Array, Array]:
+        """
+        Return analytical ``dqdd/du`` and ``dqdd/dtau_ext``.
+
+        ``tau_ext`` is the direct generalized-force input used by
+        ``forward_dynamics``. Its derivative is therefore ``M(q)^{-1}``.
+        """
+        mass_matrix = self.inertia_matrix(q)
+        dqdd_du = jnp.linalg.solve(mass_matrix, self.actuation_force_derivative_u(q))
+        dqdd_dtau_ext = jnp.linalg.solve(
+            mass_matrix,
+            jnp.eye(q.shape[0], dtype=q.dtype),
+        )
+
+        return dqdd_du, dqdd_dtau_ext
+
+    @eqx.filter_jit
+    def forward_dynamics_state_jacobian(
+        self,
+        t: Array,
+        y: Array,
+        actuation_args: tuple | None = None,
+    ) -> Array:
+        """
+        Return the analytical state Jacobian ``d([qd, qdd]) / d([q, qd])``.
+
+        This mirrors the output of the MATLAB ``ODEJacobian`` function for the
+        unconstrained PCS model.
+        """
+        q, qd = jnp.split(y, 2)
+
+        if actuation_args is None:
+            u, tau_ext = None, None
+        elif len(actuation_args) == 1:
+            u = actuation_args[0]
+            tau_ext = None
+        elif len(actuation_args) == 2:
+            u, tau_ext = actuation_args
+        else:
+            raise ValueError("actuation_args must be a tuple of length 1 or 2.")
+
+        if u is None:
+            u = jnp.zeros((self.num_actuators,), dtype=q.dtype)
+        if tau_ext is None:
+            tau_ext = jnp.zeros((q.shape[0],), dtype=q.dtype)
+
+        yd = self.forward_dynamics(t, y, (u, tau_ext))
+        _, qdd = jnp.split(yd, 2)
+        dqdd_dq, dqdd_dqd = self.forward_dynamics_derivatives(q, qd, qdd, u)
+
+        eye = jnp.eye(q.shape[0], dtype=q.dtype)
+        zeros = jnp.zeros_like(eye)
+        return jnp.block([[zeros, eye], [dqdd_dq, dqdd_dqd]])
+
+    @eqx.filter_jit
+    def forward_dynamics_jacobians(
+        self,
+        t: Array,
+        y: Array,
+        actuation_args: tuple | None = None,
+    ) -> tuple[Array, Array, Array]:
+        """
+        Return state, actuation-input, and external-force Jacobians.
+
+        The returned tuple is ``(dyd_dy, dyd_du, dyd_dtau_ext)`` where
+        ``yd = forward_dynamics(t, y, actuation_args)``.
+        """
+        q, _ = jnp.split(y, 2)
+
+        if actuation_args is None:
+            u = None
+        elif len(actuation_args) == 1 or len(actuation_args) == 2:
+            u = actuation_args[0]
+        else:
+            raise ValueError("actuation_args must be a tuple of length 1 or 2.")
+
+        if u is None:
+            u = jnp.zeros((self.num_actuators,), dtype=q.dtype)
+
+        dyd_dy = self.forward_dynamics_state_jacobian(t, y, actuation_args)
+        dqdd_du, dqdd_dtau_ext = self.forward_dynamics_input_derivatives(q)
+
+        zeros_du = jnp.zeros((q.shape[0], u.shape[0]), dtype=q.dtype)
+        zeros_tau = jnp.zeros((q.shape[0], q.shape[0]), dtype=q.dtype)
+        dyd_du = jnp.concatenate([zeros_du, dqdd_du], axis=0)
+        dyd_dtau_ext = jnp.concatenate([zeros_tau, dqdd_dtau_ext], axis=0)
+
+        return dyd_dy, dyd_du, dyd_dtau_ext

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -2665,3 +2665,704 @@ class PCS(SoftRobot):
         yd = jnp.concatenate([qd, qdd])
 
         return yd
+
+    @eqx.filter_jit
+    def _eta_etad_bodyframe(
+        self, q: Array, qd: Array, qdd: Array, s: Array
+    ) -> tuple[Array, Array, Array, Array]:
+        """
+        Compute body-frame velocity and acceleration twists at a point s.
+
+        Args:
+            q: Generalized coordinates, shape (num_active_strains,).
+            qd: Generalized velocity, shape (num_active_strains,).
+            qdd: Generalized acceleration, shape (num_active_strains,).
+            s: Point coordinate along the robot.
+
+        Returns:
+            eta: Body-frame velocity twist, shape (6,).
+            etad: Body-frame acceleration twist, shape (6,).
+            J_local: Body-frame Jacobian, shape (6, num_active_strains).
+            Jd_local: Body-frame Jacobian derivative, shape (6, num_active_strains).
+        """
+        J_local, Jd_local = self.jacobian_and_time_derivative_bodyframe(q, qd, s)
+
+        eta = J_local @ qd
+        etad = J_local @ qdd + Jd_local @ qd
+
+        return eta, etad, J_local, Jd_local
+    
+
+    @eqx.filter_jit
+    def _pcs_soft_joint_differential_kinematics(
+        self,
+        i: Array,
+        H: Array,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+    ]:
+        """
+        Evaluate PCS soft-joint differential kinematics for segment i over length H.
+
+        This wraps lie.pcs_SoftJointDifferentialKinematics using the local
+        strain basis of segment i.
+
+        Args:
+            i: Segment index.
+            H: Integration length inside the segment.
+            q: Generalized coordinates, shape (num_active_strains,).
+            qd: Generalized velocity, shape (num_active_strains,).
+            qdd: Generalized acceleration, shape (num_active_strains,).
+
+        Returns:
+            Omega, Z, g_step, T, S, Sd, f, fd, adjOmegap,
+            dS_dq_qd, dS_dq_qdd, dSd_dq_qd.
+        """
+        Phi_i = lax.dynamic_slice_in_dim(
+            self.B_xi, 6 * i, 6, axis=0
+        )
+
+        xi_star_i = lax.dynamic_slice_in_dim(
+            self.xi_ref, 6 * i, 6, axis=0
+        )
+
+        (
+            Omega,
+            Z,
+            g_step,
+            T,
+            S,
+            Sd,
+            f,
+            fd,
+            adjOmegap,
+            dS_dq_qd,
+            dS_dq_qdd,
+            dSd_dq_qd,
+        ) = lie.pcs_SoftJointDifferentialKinematics(
+            self.global_eps,
+            H,
+            Phi_i,
+            xi_star_i,
+            q,
+            qd,
+            qdd,
+        )
+
+        return (
+            Omega,
+            Z,
+            g_step,
+            T,
+            S,
+            Sd,
+            f,
+            fd,
+            adjOmegap,
+            dS_dq_qd,
+            dS_dq_qdd,
+            dSd_dq_qd,
+        )
+
+    @eqx.filter_jit
+    def _integrate_R_L_Q_Y_step(
+        self,
+        g_prev: Array,
+        J_prev: Array,
+        Jd_prev: Array,
+        eta_prev: Array,
+        etad_prev: Array,
+        R_B_prev: Array,
+        L_B_prev: Array,
+        Q_B_prev: Array,
+        i: Array,
+        H: Array,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[Array, Array, Array, Array, Array, Array, Array, Array, Array]:
+        """
+        Integrate one PCS segment step and propagate J, Jd, eta, etad,
+        R_B, L_B, Q_B, and Y_B.
+
+        This follows the same recursive structure as the MATLAB code.
+
+        Returns:
+            g_next, J_next, Jd_next, eta_next, etad_next,
+            R_B_next, L_B_next, Q_B_next, Y_B_next.
+        """
+
+        zero_H = jnp.abs(H) <= self.global_eps
+
+        def zero_step(_: None) -> tuple[
+            Array, Array, Array, Array, Array, Array, Array, Array, Array
+        ]:
+            Y_B_prev = R_B_prev + Jd_prev
+            return (
+                g_prev,
+                J_prev,
+                Jd_prev,
+                eta_prev,
+                etad_prev,
+                R_B_prev,
+                L_B_prev,
+                Q_B_prev,
+                Y_B_prev,
+            )
+
+        def finite_step(_: None) -> tuple[
+            Array, Array, Array, Array, Array, Array, Array, Array, Array
+        ]:
+            (
+                _,
+                _,
+                g_step,
+                _,
+                S,
+                Sd,
+                _,
+                _,
+                _,
+                dS_dq_qd,
+                dS_dq_qdd,
+                dSd_dq_qd,
+            ) = self._pcs_soft_joint_differential_kinematics(
+                i, H, q, qd, qdd
+            )
+
+            Ad_step_inv = lie.Adjoint_g_inv_SE3(g_step)
+
+            adj_eta_prev = lie.adjoint_se3(eta_prev)
+
+            # eta_plus and etad_plus are expressed in the frame before the step.
+            eta_plus = eta_prev + S @ qd
+
+            etad_plus = (
+                etad_prev
+                + S @ qdd
+                + adj_eta_prev @ (S @ qd)
+                + Sd @ qd
+            )
+
+            # Local differential terms before transporting through g_step.
+            R = lie.adjoint_se3(eta_plus) @ S + dS_dq_qd
+
+            L = (
+                lie.adjoint_se3(etad_plus) @ S
+                + lie.adjoint_se3(eta_plus) @ R
+                + adj_eta_prev @ dS_dq_qd
+                + dSd_dq_qd
+                + dS_dq_qdd
+            )
+
+            # Gravity expressed in the current body frame, before the step.
+            g_body = lie.Adjoint_g_inv_SE3(g_prev) @ self.g
+
+            Q = L - lie.adjoint_se3(g_body) @ S
+
+            # Propagate pose.
+            g_next = g_prev @ g_step
+
+            # Propagate body-frame Jacobian terms.
+            J_next = Ad_step_inv @ (J_prev + S)
+
+            Jd_next = Ad_step_inv @ (
+                Jd_prev + Sd + adj_eta_prev @ S
+            )
+
+            eta_next = Ad_step_inv @ eta_plus
+            etad_next = Ad_step_inv @ etad_plus
+
+            R_B_next = Ad_step_inv @ (R_B_prev + R)
+            L_B_next = Ad_step_inv @ (L_B_prev + L)
+            Q_B_next = Ad_step_inv @ (Q_B_prev + Q)
+            Y_B_next = R_B_next + Jd_next
+
+            return (
+                g_next,
+                J_next,
+                Jd_next,
+                eta_next,
+                etad_next,
+                R_B_next,
+                L_B_next,
+                Q_B_next,
+                Y_B_next,
+            )
+
+        return lax.cond(
+            zero_H,
+            zero_step,
+            finite_step,
+            operand=None,
+        )
+
+    @eqx.filter_jit
+    def _R_L_Q_Y_local(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+        s: Array,
+    ) -> tuple[Array, Array, Array, Array]:
+        """
+        Compute R_B, L_B, Q_B, and Y_B at a point s along the robot.
+
+        Args:
+            q: Generalized coordinates, shape (num_active_strains,).
+            qd: Generalized velocity, shape (num_active_strains,).
+            qdd: Generalized acceleration, shape (num_active_strains,).
+            s: Point coordinate along the robot.
+
+        Returns:
+            R_B: Shape (6, num_active_strains).
+            L_B: Shape (6, num_active_strains).
+            Q_B: Shape (6, num_active_strains).
+            Y_B: Shape (6, num_active_strains).
+        """
+        segment_idx, s_local = self.classify_segment(s)
+
+        zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
+        zeros_6 = jnp.zeros((6,), dtype=q.dtype)
+
+        state_init = (
+            self.g0,
+            zeros_6n,
+            zeros_6n,
+            zeros_6,
+            zeros_6,
+            zeros_6n,
+            zeros_6n,
+            zeros_6n,
+        )
+
+        target_init = (
+            zeros_6n,
+            zeros_6n,
+            zeros_6n,
+            zeros_6n,
+        )
+
+        carry_init = (
+            state_init,
+            target_init,
+            jnp.array(False, dtype=jnp.bool_),
+        )
+
+        def scan_body(
+            carry: tuple[
+                tuple[Array, Array, Array, Array, Array, Array, Array, Array],
+                tuple[Array, Array, Array, Array],
+                Array,
+            ],
+            i: Array,
+        ) -> tuple[
+            tuple[
+                tuple[Array, Array, Array, Array, Array, Array, Array, Array],
+                tuple[Array, Array, Array, Array],
+                Array,
+            ],
+            Array,
+        ]:
+            state_prev, target_prev, done = carry
+
+            (
+                g_prev,
+                J_prev,
+                Jd_prev,
+                eta_prev,
+                etad_prev,
+                R_B_prev,
+                L_B_prev,
+                Q_B_prev,
+            ) = state_prev
+
+            R_target, L_target, Q_target, Y_target = target_prev
+
+            def compute_branch(_: None):
+                L_i = lax.dynamic_index_in_dim(
+                    self.L, i, axis=0, keepdims=False
+                )
+                H_i = jnp.where(i == segment_idx, s_local, L_i)
+
+                (
+                    g_next,
+                    J_next,
+                    Jd_next,
+                    eta_next,
+                    etad_next,
+                    R_B_next,
+                    L_B_next,
+                    Q_B_next,
+                    Y_B_next,
+                ) = self._integrate_R_L_Q_Y_step(
+                    g_prev,
+                    J_prev,
+                    Jd_prev,
+                    eta_prev,
+                    etad_prev,
+                    R_B_prev,
+                    L_B_prev,
+                    Q_B_prev,
+                    i,
+                    H_i,
+                    q,
+                    qd,
+                    qdd,
+                )
+
+                is_target = i == segment_idx
+
+                R_target_next = jnp.where(is_target, R_B_next, R_target)
+                L_target_next = jnp.where(is_target, L_B_next, L_target)
+                Q_target_next = jnp.where(is_target, Q_B_next, Q_target)
+                Y_target_next = jnp.where(is_target, Y_B_next, Y_target)
+
+                done_next = jnp.logical_or(done, is_target)
+
+                state_next = (
+                    g_next,
+                    J_next,
+                    Jd_next,
+                    eta_next,
+                    etad_next,
+                    R_B_next,
+                    L_B_next,
+                    Q_B_next,
+                )
+
+                target_next = (
+                    R_target_next,
+                    L_target_next,
+                    Q_target_next,
+                    Y_target_next,
+                )
+
+                return (state_next, target_next, done_next), zeros_6
+
+            def skip_branch(_: None):
+                return carry, zeros_6
+
+            return lax.cond(done, skip_branch, compute_branch, operand=None)
+
+        indices = jnp.arange(self.num_segments, dtype=segment_idx.dtype)
+
+        (_, (R_B, L_B, Q_B, Y_B), _), _ = lax.scan(
+            scan_body,
+            carry_init,
+            indices,
+        )
+
+        return R_B, L_B, Q_B, Y_B
+
+    @eqx.filter_jit
+    def _R_L_Q_Y_state_local_tips(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+    ]:
+        """
+        Compute full differential-kinematic state at all segment tips.
+
+        Returns:
+            g_tips: Shape (num_segments, 4, 4).
+            J_tips: Shape (num_segments, 6, num_active_strains).
+            Jd_tips: Shape (num_segments, 6, num_active_strains).
+            eta_tips: Shape (num_segments, 6).
+            etad_tips: Shape (num_segments, 6).
+            R_B_tips: Shape (num_segments, 6, num_active_strains).
+            L_B_tips: Shape (num_segments, 6, num_active_strains).
+            Q_B_tips: Shape (num_segments, 6, num_active_strains).
+            Y_B_tips: Shape (num_segments, 6, num_active_strains).
+        """
+        zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
+        zeros_6 = jnp.zeros((6,), dtype=q.dtype)
+
+        state_init = (
+            self.g0,
+            zeros_6n,
+            zeros_6n,
+            zeros_6,
+            zeros_6,
+            zeros_6n,
+            zeros_6n,
+            zeros_6n,
+        )
+
+        def scan_body(
+            state_prev: tuple[
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+            ],
+            i: Array,
+        ) -> tuple[
+            tuple[Array, Array, Array, Array, Array, Array, Array, Array],
+            tuple[Array, Array, Array, Array, Array, Array, Array, Array, Array],
+        ]:
+            (
+                g_prev,
+                J_prev,
+                Jd_prev,
+                eta_prev,
+                etad_prev,
+                R_B_prev,
+                L_B_prev,
+                Q_B_prev,
+            ) = state_prev
+
+            H_i = lax.dynamic_index_in_dim(
+                self.L, i, axis=0, keepdims=False
+            )
+
+            (
+                g_next,
+                J_next,
+                Jd_next,
+                eta_next,
+                etad_next,
+                R_B_next,
+                L_B_next,
+                Q_B_next,
+                Y_B_next,
+            ) = self._integrate_R_L_Q_Y_step(
+                g_prev,
+                J_prev,
+                Jd_prev,
+                eta_prev,
+                etad_prev,
+                R_B_prev,
+                L_B_prev,
+                Q_B_prev,
+                i,
+                H_i,
+                q,
+                qd,
+                qdd,
+            )
+
+            state_next = (
+                g_next,
+                J_next,
+                Jd_next,
+                eta_next,
+                etad_next,
+                R_B_next,
+                L_B_next,
+                Q_B_next,
+            )
+
+            output_next = (
+                g_next,
+                J_next,
+                Jd_next,
+                eta_next,
+                etad_next,
+                R_B_next,
+                L_B_next,
+                Q_B_next,
+                Y_B_next,
+            )
+
+            return state_next, output_next
+
+        indices = jnp.arange(self.num_segments, dtype=jnp.int32)
+
+        _, outputs = lax.scan(scan_body, state_init, indices)
+
+        return outputs
+
+    @eqx.filter_jit
+    def _R_L_Q_Y_local_tips(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[Array, Array, Array, Array]:
+        """
+        Compute R_B, L_B, Q_B, and Y_B at all segment tips.
+
+        Returns:
+            R_B_tips: Shape (num_segments, 6, num_active_strains).
+            L_B_tips: Shape (num_segments, 6, num_active_strains).
+            Q_B_tips: Shape (num_segments, 6, num_active_strains).
+            Y_B_tips: Shape (num_segments, 6, num_active_strains).
+        """
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            R_B_tips,
+            L_B_tips,
+            Q_B_tips,
+            Y_B_tips,
+        ) = self._R_L_Q_Y_state_local_tips(q, qd, qdd)
+
+        return R_B_tips, L_B_tips, Q_B_tips, Y_B_tips
+
+    @eqx.filter_jit
+    def _R_L_Q_Y_local_batched(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+        s_ps: Array,
+    ) -> tuple[Array, Array, Array, Array]:
+        """
+        Compute R_B, L_B, Q_B, and Y_B at a batch of points.
+
+        Args:
+            q: Generalized coordinates, shape (num_active_strains,).
+            qd: Generalized velocity, shape (num_active_strains,).
+            qdd: Generalized acceleration, shape (num_active_strains,).
+            s_ps: Point coordinates along the robot, shape (N,).
+
+        Returns:
+            R_B_ps: Shape (N, 6, num_active_strains).
+            L_B_ps: Shape (N, 6, num_active_strains).
+            Q_B_ps: Shape (N, 6, num_active_strains).
+            Y_B_ps: Shape (N, 6, num_active_strains).
+        """
+        (
+            g_tips,
+            J_tips,
+            Jd_tips,
+            eta_tips,
+            etad_tips,
+            R_B_tips,
+            L_B_tips,
+            Q_B_tips,
+            _,
+        ) = self._R_L_Q_Y_state_local_tips(q, qd, qdd)
+
+        segment_indices, s_local_ps = vmap(self.classify_segment)(s_ps)
+
+        zeros_6n = jnp.zeros_like(J_tips[:1])
+        zeros_6 = jnp.zeros_like(eta_tips[:1])
+
+        g_bases = jnp.concatenate(
+            [self.g0[None, :, :], g_tips[:-1]],
+            axis=0,
+        )
+
+        J_bases = jnp.concatenate(
+            [zeros_6n, J_tips[:-1]],
+            axis=0,
+        )
+
+        Jd_bases = jnp.concatenate(
+            [zeros_6n, Jd_tips[:-1]],
+            axis=0,
+        )
+
+        eta_bases = jnp.concatenate(
+            [zeros_6, eta_tips[:-1]],
+            axis=0,
+        )
+
+        etad_bases = jnp.concatenate(
+            [zeros_6, etad_tips[:-1]],
+            axis=0,
+        )
+
+        R_B_bases = jnp.concatenate(
+            [zeros_6n, R_B_tips[:-1]],
+            axis=0,
+        )
+
+        L_B_bases = jnp.concatenate(
+            [zeros_6n, L_B_tips[:-1]],
+            axis=0,
+        )
+
+        Q_B_bases = jnp.concatenate(
+            [zeros_6n, Q_B_tips[:-1]],
+            axis=0,
+        )
+
+        def integrate_point(
+            i: Array,
+            H: Array,
+            g_base: Array,
+            J_base: Array,
+            Jd_base: Array,
+            eta_base: Array,
+            etad_base: Array,
+            R_B_base: Array,
+            L_B_base: Array,
+            Q_B_base: Array,
+        ) -> tuple[Array, Array, Array, Array]:
+            (
+                _,
+                _,
+                _,
+                _,
+                _,
+                R_B_point,
+                L_B_point,
+                Q_B_point,
+                Y_B_point,
+            ) = self._integrate_R_L_Q_Y_step(
+                g_base,
+                J_base,
+                Jd_base,
+                eta_base,
+                etad_base,
+                R_B_base,
+                L_B_base,
+                Q_B_base,
+                i,
+                H,
+                q,
+                qd,
+                qdd,
+            )
+
+            return R_B_point, L_B_point, Q_B_point, Y_B_point
+
+        R_B_ps, L_B_ps, Q_B_ps, Y_B_ps = vmap(integrate_point)(
+            segment_indices,
+            s_local_ps,
+            g_bases[segment_indices],
+            J_bases[segment_indices],
+            Jd_bases[segment_indices],
+            eta_bases[segment_indices],
+            etad_bases[segment_indices],
+            R_B_bases[segment_indices],
+            L_B_bases[segment_indices],
+            Q_B_bases[segment_indices],
+        )
+
+        return R_B_ps, L_B_ps, Q_B_ps, Y_B_ps

--- a/src/soromox/utils/lie_algebra/se3.py
+++ b/src/soromox/utils/lie_algebra/se3.py
@@ -12,6 +12,9 @@ __all__ = [
     "Adjoint_gi_se3_inv",
     "Tangent_gi_se3",
     "Tangent_derivative_gi_se3",
+    "coadjointbar_se3",
+    "gvs_SoftJointDifferentialKinematics_Z4",
+    "pcs_SoftJointDifferentialKinematics",
 ]
 
 import jax.numpy as jnp
@@ -647,6 +650,7 @@ def Tangent_derivative_gi_se3(
     )
     return Td
 
+
 def coadjointbar_se3(vec6: Array) -> Array:
     """
     Computes the co-adjoint-bar representation of a vector of se(3).
@@ -664,30 +668,13 @@ def coadjointbar_se3(vec6: Array) -> Array:
 
     return coadbar
 
+
 def gvs_SoftJointDifferentialKinematics_Z4(
-        eps,
-        H,
-        Phi_Z1,
-        Phi_Z2,
-        xi_star_Z1,
-        xi_star_Z2,
-        q,
-        qd,
-        qdd) -> tuple[
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array
-            ]:
-    
+    eps, H, Phi_Z1, Phi_Z2, xi_star_Z1, xi_star_Z2, q, qd, qdd
+) -> tuple[
+    Array, Array, Array, Array, Array, Array, Array, Array, Array, Array, Array, Array
+]:
+
     I_theta = jnp.diag(jnp.array([1, 1, 1, 0, 0, 0]))
     xi_Z1 = Phi_Z1 @ q + xi_star_Z1
     xi_Z2 = Phi_Z2 @ q + xi_star_Z2
@@ -696,19 +683,25 @@ def gvs_SoftJointDifferentialKinematics_Z4(
     xidd_Z1 = Phi_Z1 @ qdd
     xidd_Z2 = Phi_Z2 @ qdd
 
-    Omega = (H/2) * (xi_Z1 + xi_Z2) + (jnp.sqrt(3) * H**2 / 12) * (adjoint_se3(xi_Z1) @ xi_Z2)
+    Omega = (H / 2) * (xi_Z1 + xi_Z2) + (jnp.sqrt(3) * H**2 / 12) * (
+        adjoint_se3(xi_Z1) @ xi_Z2
+    )
 
-    Z = (H/2) * (Phi_Z1 + Phi_Z2) + (jnp.sqrt(3) * H**2 / 12) * (
+    Z = (H / 2) * (Phi_Z1 + Phi_Z2) + (jnp.sqrt(3) * H**2 / 12) * (
         adjoint_se3(xi_Z1) @ Phi_Z2 - adjoint_se3(xi_Z2) @ Phi_Z1
-        )
-    
-    Omegad  = Z @ qd
+    )
 
-    Zd      = (jnp.sqrt(3) * H**2 / 12) * (adjoint_se3(xid_Z1) @ Phi_Z2 - adjoint_se3(xid_Z2) @ Phi_Z1)
+    Omegad = Z @ qd
 
-    Zdd     = (jnp.sqrt(3) * H**2 / 12) * (adjoint_se3(xidd_Z1) @ Phi_Z2 - adjoint_se3(xidd_Z2) @ Phi_Z1)
+    Zd = (jnp.sqrt(3) * H**2 / 12) * (
+        adjoint_se3(xid_Z1) @ Phi_Z2 - adjoint_se3(xid_Z2) @ Phi_Z1
+    )
 
-    adjOmegap  = jnp.zeros((24, 6))
+    Zdd = (jnp.sqrt(3) * H**2 / 12) * (
+        adjoint_se3(xidd_Z1) @ Phi_Z2 - adjoint_se3(xidd_Z2) @ Phi_Z1
+    )
+
+    adjOmegap = jnp.zeros((24, 6))
     adjOmegapd = jnp.zeros((24, 6))
 
     k = Omega[:3]
@@ -726,20 +719,22 @@ def gvs_SoftJointDifferentialKinematics_Z4(
     adjOmegap = adjOmegap.at[18:24, :].set(adjOmegap[12:18, :] @ adjOmegap[0:6, :])
 
     adjOmegapd = adjOmegapd.at[0:6, :].set(adjoint_se3(Omegad))
-    adjOmegapd = adjOmegapd.at[6:12, :].set(adjOmegapd[0:6, :] @ adjOmegap[0:6, :] +
-    adjOmegap[0:6, :] @ adjOmegapd[0:6, :]
+    adjOmegapd = adjOmegapd.at[6:12, :].set(
+        adjOmegapd[0:6, :] @ adjOmegap[0:6, :] + adjOmegap[0:6, :] @ adjOmegapd[0:6, :]
     )
-    adjOmegapd = adjOmegapd.at[12:18, :].set(adjOmegapd[6:12, :] @ adjOmegap[0:6, :] +
-    adjOmegap[6:12, :] @ adjOmegapd[0:6, :]
+    adjOmegapd = adjOmegapd.at[12:18, :].set(
+        adjOmegapd[6:12, :] @ adjOmegap[0:6, :]
+        + adjOmegap[6:12, :] @ adjOmegapd[0:6, :]
     )
-    adjOmegapd = adjOmegapd.at[18:24, :].set(adjOmegapd[12:18, :] @ adjOmegap[0:6, :] +
-    adjOmegap[12:18, :] @ adjOmegapd[0:6, :]
+    adjOmegapd = adjOmegapd.at[18:24, :].set(
+        adjOmegapd[12:18, :] @ adjOmegap[0:6, :]
+        + adjOmegap[12:18, :] @ adjOmegapd[0:6, :]
     )
 
     def _g_series_branch() -> tuple[Array, Array, Array, Array, Array, Array]:
         g = jnp.eye(4) + Omegahat + Omegahatp2 / 2 + Omegahatp3 / 6
-        f = jnp.array([1/2, 1/6, 1/24, 1/120])
-        fd  = jnp.zeros((4,))
+        f = jnp.array([1 / 2, 1 / 6, 1 / 24, 1 / 120])
+        fd = jnp.zeros((4,))
         fdd = jnp.zeros((4,))
 
         T = (
@@ -758,14 +753,16 @@ def gvs_SoftJointDifferentialKinematics_Z4(
         )
 
         return (f, fd, fdd, g, T, Td)
-    
-    def _g_general_branch(theta: Array) -> tuple[Array, Array, Array, Array, Array, Array]:
-        tp2        = theta * theta
-        tp3        = tp2 * theta
-        tp4        = tp3 * theta
-        tp5        = tp4 * theta
-        tp6        = tp5 * theta
-        tp7        = tp6 * theta
+
+    def _g_general_branch(
+        theta: Array,
+    ) -> tuple[Array, Array, Array, Array, Array, Array]:
+        tp2 = theta * theta
+        tp3 = tp2 * theta
+        tp4 = tp3 * theta
+        tp5 = tp4 * theta
+        tp6 = tp5 * theta
+        tp7 = tp6 * theta
         costheta = jnp.cos(theta)
         sintheta = jnp.sin(theta)
 
@@ -776,29 +773,40 @@ def gvs_SoftJointDifferentialKinematics_Z4(
         t3d = 5 * sintheta + sintheta * (tp2 - 8) + 3 * theta * costheta
         t4d = -8 + 5 * theta * sintheta + (15 - tp2) * costheta - 7 * costheta
 
-        f = jnp.array([
-            (4 - 4 * costheta - t1) / (2 * tp2),
-            (4 * theta - 5 * sintheta + t2) / (2 * tp3),
-            (2 - 2 * costheta - t1) / (2 * tp4),
-            (2 * theta - 3 * sintheta + t2) / (2 * tp5),
-        ])
+        f = jnp.array(
+            [
+                (4 - 4 * costheta - t1) / (2 * tp2),
+                (4 * theta - 5 * sintheta + t2) / (2 * tp3),
+                (2 - 2 * costheta - t1) / (2 * tp4),
+                (2 * theta - 3 * sintheta + t2) / (2 * tp5),
+            ]
+        )
 
-        fd = jnp.array([
-            t3 / (2 * tp3),
-            t4 / (2 * tp4),
-            t3 / (2 * tp5),
-            t4 / (2 * tp6),
-        ])
+        fd = jnp.array(
+            [
+                t3 / (2 * tp3),
+                t4 / (2 * tp4),
+                t3 / (2 * tp5),
+                t4 / (2 * tp6),
+            ]
+        )
 
-        fdd = jnp.array([
-            (theta * t3d - 3 * t3) / (2 * tp4),
-            (theta * t4d - 4 * t4) / (2 * tp5),
-            (theta * t3d - 5 * t3) / (2 * tp6),
-            (theta * t4d - 6 * t4) / (2 * tp7),
-        ])
+        fdd = jnp.array(
+            [
+                (theta * t3d - 3 * t3) / (2 * tp4),
+                (theta * t4d - 4 * t4) / (2 * tp5),
+                (theta * t3d - 5 * t3) / (2 * tp6),
+                (theta * t4d - 6 * t4) / (2 * tp7),
+            ]
+        )
 
-        g = jnp.eye(4) + Omegahat + ((1 - costheta) / tp2) * Omegahatp2 + ((theta - sintheta) / tp3) * Omegahatp3
-        
+        g = (
+            jnp.eye(4)
+            + Omegahat
+            + ((1 - costheta) / tp2) * Omegahatp2
+            + ((theta - sintheta) / tp3) * Omegahatp3
+        )
+
         T = (
             jnp.eye(6)
             + f[0] * adjOmegap[0:6, :]
@@ -808,10 +816,14 @@ def gvs_SoftJointDifferentialKinematics_Z4(
         )
 
         Td = (
-            fd[0] * thetad * adjOmegap[0:6, :] + f[0] * adjOmegapd[0:6, :]
-            + fd[1] * thetad * adjOmegap[6:12, :] + f[1] * adjOmegapd[6:12, :]
-            + fd[2] * thetad * adjOmegap[12:18, :] + f[2] * adjOmegapd[12:18, :]
-            + fd[3] * thetad * adjOmegap[18:24, :] + f[3] * adjOmegapd[18:24, :]
+            fd[0] * thetad * adjOmegap[0:6, :]
+            + f[0] * adjOmegapd[0:6, :]
+            + fd[1] * thetad * adjOmegap[6:12, :]
+            + f[1] * adjOmegapd[6:12, :]
+            + fd[2] * thetad * adjOmegap[12:18, :]
+            + f[2] * adjOmegapd[12:18, :]
+            + fd[3] * thetad * adjOmegap[18:24, :]
+            + f[3] * adjOmegapd[18:24, :]
         )
 
         return (f, fd, fdd, g, T, Td)
@@ -823,10 +835,10 @@ def gvs_SoftJointDifferentialKinematics_Z4(
         operand=None,
     )
 
-    S  = T @ Z
+    S = T @ Z
     TZd = T @ Zd
     Sd = Td @ Z + TZd
-    dSdq_qd  = TZd
+    dSdq_qd = TZd
     dSdq_qdd = T @ Zdd
     dSddq_qd = Td @ Zd
 
@@ -835,10 +847,10 @@ def gvs_SoftJointDifferentialKinematics_Z4(
 
     def _block6(A: Array, k: int) -> Array:
         # k = 0,1,2,3 gives rows [0:6], [6:12], [12:18], [18:24]
-        return A[k * 6:(k + 1) * 6, :]
+        return A[k * 6 : (k + 1) * 6, :]
 
     def _S_series_branch() -> tuple[Array, Array, Array]:
-        dSdq_qd  = TZd
+        dSdq_qd = TZd
         dSdq_qdd = T @ Zdd
         dSddq_qd = Td @ Zd
         # dSdq_qd = jnp.zeros_like(Z)
@@ -850,18 +862,24 @@ def gvs_SoftJointDifferentialKinematics_Z4(
                     adjOmegap1 = jnp.eye(6)
                 else:
                     adjOmegap1 = _block6(adjOmegap, u - 2)
-                
+
                 if u == r + 1:
                     adjOmegap2 = jnp.eye(6)
                 else:
                     adjOmegap2 = _block6(adjOmegap, r - u)
-                
-                dSdq_qd = dSdq_qd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
-                dSdq_qdd = dSdq_qdd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z)
-                dSddq_qd = dSddq_qd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zdqd) @ Z) - f[r] * (
-                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Zd
-                    )
-                                
+
+                dSdq_qd = dSdq_qd - f[r] * (
+                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z
+                )
+                dSdq_qdd = dSdq_qdd - f[r] * (
+                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z
+                )
+                dSddq_qd = (
+                    dSddq_qd
+                    - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zdqd) @ Z)
+                    - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Zd)
+                )
+
                 for p in range(1, u):
                     if p == 1:
                         adjOmegap3 = jnp.eye(6)
@@ -875,10 +893,12 @@ def gvs_SoftJointDifferentialKinematics_Z4(
 
                     dSddq_qd = dSddq_qd - f[r] * (
                         adjOmegap3
-                        @ adjoint_se3(adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad)
+                        @ adjoint_se3(
+                            adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad
+                        )
                         @ Z
                     )
-                
+
                 for p in range(1, r - u + 2):
                     if p == 1:
                         adjOmegap3 = jnp.eye(6)
@@ -898,13 +918,13 @@ def gvs_SoftJointDifferentialKinematics_Z4(
                         @ Z
                     )
         return (dSdq_qd, dSdq_qdd, dSddq_qd)
-    
+
     def _S_general_branch(theta: Array) -> tuple[Array, Array, Array]:
         # dSdq_qd = jnp.zeros_like(Z)
         # dSdq_qdd = jnp.zeros_like(Z)
         # dSddq_qd = jnp.zeros_like(Z)
 
-        dSdq_qd  = TZd
+        dSdq_qd = TZd
         dSdq_qdd = T @ Zdd
         dSddq_qd = Td @ Zd
         for r in range(4):
@@ -921,9 +941,13 @@ def gvs_SoftJointDifferentialKinematics_Z4(
                 Omega @ (I_theta @ Z),
             )
 
-            term1 = (1 / theta) * fd[r] * jnp.outer(
-                adjr @ Zdqd,
-                Omega @ (I_theta @ Z),
+            term1 = (
+                (1 / theta)
+                * fd[r]
+                * jnp.outer(
+                    adjr @ Zdqd,
+                    Omega @ (I_theta @ Z),
+                )
             )
 
             term2 = (1 / theta) * jnp.outer(
@@ -931,9 +955,14 @@ def gvs_SoftJointDifferentialKinematics_Z4(
                 Omega @ (I_theta @ Z),
             )
 
-            term3 = (1 / theta) * fd[r] * jnp.outer(
-                adjr @ Omegad,
-                (Omegad - (thetad / theta) * Omega) @ (I_theta @ Z) + Omega @ (I_theta @ Zd),
+            term3 = (
+                (1 / theta)
+                * fd[r]
+                * jnp.outer(
+                    adjr @ Omegad,
+                    (Omegad - (thetad / theta) * Omega) @ (I_theta @ Z)
+                    + Omega @ (I_theta @ Zd),
+                )
             )
 
             dSddq_qd = dSddq_qd + term1 + term2 + term3
@@ -947,14 +976,20 @@ def gvs_SoftJointDifferentialKinematics_Z4(
                     adjOmegap2 = jnp.eye(6)
                 else:
                     adjOmegap2 = _block6(adjOmegap, r - u)
-                
-                dSdq_qd = dSdq_qd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
-                dSdq_qdd = dSdq_qdd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z)
+
+                dSdq_qd = dSdq_qd - f[r] * (
+                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z
+                )
+                dSdq_qdd = dSdq_qdd - f[r] * (
+                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z
+                )
 
                 dSddq_qd = (
                     dSddq_qd
                     - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zdqd) @ Z)
-                    - fd[r] * thetad * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
+                    - fd[r]
+                    * thetad
+                    * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
                     - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Zd)
                 )
 
@@ -970,8 +1005,13 @@ def gvs_SoftJointDifferentialKinematics_Z4(
                         adjOmegap4 = _block6(adjOmegap, u - p - 2)
 
                     dSddq_qd = dSddq_qd - f[r] * (
-                        adjOmegap3 @ adjoint_se3(adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad) @ Z)
-                                            
+                        adjOmegap3
+                        @ adjoint_se3(
+                            adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad
+                        )
+                        @ Z
+                    )
+
                 for p in range(1, r - u + 2):
                     if p == 1:
                         adjOmegap3 = jnp.eye(6)
@@ -983,10 +1023,13 @@ def gvs_SoftJointDifferentialKinematics_Z4(
                     else:
                         adjOmegap4 = _block6(adjOmegap, r - u - p)
 
-                    dSddq_qd = dSddq_qd - f[r] * (adjOmegap1 @ _block6(adjOmegapd, 0) @ adjOmegap3
-                        @ adjoint_se3(adjOmegap4 @ Omegad) @ Z
+                    dSddq_qd = dSddq_qd - f[r] * (
+                        adjOmegap1
+                        @ _block6(adjOmegapd, 0)
+                        @ adjOmegap3
+                        @ adjoint_se3(adjOmegap4 @ Omegad)
+                        @ Z
                     )
-
 
         return (dSdq_qd, dSdq_qdd, dSddq_qd)
 
@@ -1001,37 +1044,21 @@ def gvs_SoftJointDifferentialKinematics_Z4(
 
 
 def pcs_SoftJointDifferentialKinematics(
-        eps,
-        H,
-        Phi,
-        xi_star,
-        q,
-        qd,
-        qdd) -> tuple[
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array,
-            Array
-            ]:
-    
+    eps, H, Phi, xi_star, q, qd, qdd
+) -> tuple[
+    Array, Array, Array, Array, Array, Array, Array, Array, Array, Array, Array, Array
+]:
+
     I_theta = jnp.diag(jnp.array([1, 1, 1, 0, 0, 0]))
     xi = Phi @ q + xi_star
     Omega = H * xi
-    Z = H * Phi    
-    Omegad  = Z @ qd
+    Z = H * Phi
+    Omegad = Z @ qd
 
-    Zd      = jnp.zeros_like(Z)
-    Zdd     = jnp.zeros_like(Z)
+    Zd = jnp.zeros_like(Z)
+    Zdd = jnp.zeros_like(Z)
 
-    adjOmegap  = jnp.zeros((24, 6))
+    adjOmegap = jnp.zeros((24, 6))
     adjOmegapd = jnp.zeros((24, 6))
 
     k = Omega[:3]
@@ -1049,20 +1076,22 @@ def pcs_SoftJointDifferentialKinematics(
     adjOmegap = adjOmegap.at[18:24, :].set(adjOmegap[12:18, :] @ adjOmegap[0:6, :])
 
     adjOmegapd = adjOmegapd.at[0:6, :].set(adjoint_se3(Omegad))
-    adjOmegapd = adjOmegapd.at[6:12, :].set(adjOmegapd[0:6, :] @ adjOmegap[0:6, :] +
-    adjOmegap[0:6, :] @ adjOmegapd[0:6, :]
+    adjOmegapd = adjOmegapd.at[6:12, :].set(
+        adjOmegapd[0:6, :] @ adjOmegap[0:6, :] + adjOmegap[0:6, :] @ adjOmegapd[0:6, :]
     )
-    adjOmegapd = adjOmegapd.at[12:18, :].set(adjOmegapd[6:12, :] @ adjOmegap[0:6, :] +
-    adjOmegap[6:12, :] @ adjOmegapd[0:6, :]
+    adjOmegapd = adjOmegapd.at[12:18, :].set(
+        adjOmegapd[6:12, :] @ adjOmegap[0:6, :]
+        + adjOmegap[6:12, :] @ adjOmegapd[0:6, :]
     )
-    adjOmegapd = adjOmegapd.at[18:24, :].set(adjOmegapd[12:18, :] @ adjOmegap[0:6, :] +
-    adjOmegap[12:18, :] @ adjOmegapd[0:6, :]
+    adjOmegapd = adjOmegapd.at[18:24, :].set(
+        adjOmegapd[12:18, :] @ adjOmegap[0:6, :]
+        + adjOmegap[12:18, :] @ adjOmegapd[0:6, :]
     )
 
     def _g_series_branch() -> tuple[Array, Array, Array, Array, Array, Array]:
         g = jnp.eye(4) + Omegahat + Omegahatp2 / 2 + Omegahatp3 / 6
-        f = jnp.array([1/2, 1/6, 1/24, 1/120])
-        fd  = jnp.zeros((4,))
+        f = jnp.array([1 / 2, 1 / 6, 1 / 24, 1 / 120])
+        fd = jnp.zeros((4,))
         fdd = jnp.zeros((4,))
 
         T = (
@@ -1081,14 +1110,16 @@ def pcs_SoftJointDifferentialKinematics(
         )
 
         return (f, fd, fdd, g, T, Td)
-    
-    def _g_general_branch(theta: Array) -> tuple[Array, Array, Array, Array, Array, Array]:
-        tp2        = theta * theta
-        tp3        = tp2 * theta
-        tp4        = tp3 * theta
-        tp5        = tp4 * theta
-        tp6        = tp5 * theta
-        tp7        = tp6 * theta
+
+    def _g_general_branch(
+        theta: Array,
+    ) -> tuple[Array, Array, Array, Array, Array, Array]:
+        tp2 = theta * theta
+        tp3 = tp2 * theta
+        tp4 = tp3 * theta
+        tp5 = tp4 * theta
+        tp6 = tp5 * theta
+        tp7 = tp6 * theta
         costheta = jnp.cos(theta)
         sintheta = jnp.sin(theta)
 
@@ -1099,29 +1130,40 @@ def pcs_SoftJointDifferentialKinematics(
         t3d = 5 * sintheta + sintheta * (tp2 - 8) + 3 * theta * costheta
         t4d = -8 + 5 * theta * sintheta + (15 - tp2) * costheta - 7 * costheta
 
-        f = jnp.array([
-            (4 - 4 * costheta - t1) / (2 * tp2),
-            (4 * theta - 5 * sintheta + t2) / (2 * tp3),
-            (2 - 2 * costheta - t1) / (2 * tp4),
-            (2 * theta - 3 * sintheta + t2) / (2 * tp5),
-        ])
+        f = jnp.array(
+            [
+                (4 - 4 * costheta - t1) / (2 * tp2),
+                (4 * theta - 5 * sintheta + t2) / (2 * tp3),
+                (2 - 2 * costheta - t1) / (2 * tp4),
+                (2 * theta - 3 * sintheta + t2) / (2 * tp5),
+            ]
+        )
 
-        fd = jnp.array([
-            t3 / (2 * tp3),
-            t4 / (2 * tp4),
-            t3 / (2 * tp5),
-            t4 / (2 * tp6),
-        ])
+        fd = jnp.array(
+            [
+                t3 / (2 * tp3),
+                t4 / (2 * tp4),
+                t3 / (2 * tp5),
+                t4 / (2 * tp6),
+            ]
+        )
 
-        fdd = jnp.array([
-            (theta * t3d - 3 * t3) / (2 * tp4),
-            (theta * t4d - 4 * t4) / (2 * tp5),
-            (theta * t3d - 5 * t3) / (2 * tp6),
-            (theta * t4d - 6 * t4) / (2 * tp7),
-        ])
+        fdd = jnp.array(
+            [
+                (theta * t3d - 3 * t3) / (2 * tp4),
+                (theta * t4d - 4 * t4) / (2 * tp5),
+                (theta * t3d - 5 * t3) / (2 * tp6),
+                (theta * t4d - 6 * t4) / (2 * tp7),
+            ]
+        )
 
-        g = jnp.eye(4) + Omegahat + ((1 - costheta) / tp2) * Omegahatp2 + ((theta - sintheta) / tp3) * Omegahatp3
-        
+        g = (
+            jnp.eye(4)
+            + Omegahat
+            + ((1 - costheta) / tp2) * Omegahatp2
+            + ((theta - sintheta) / tp3) * Omegahatp3
+        )
+
         T = (
             jnp.eye(6)
             + f[0] * adjOmegap[0:6, :]
@@ -1131,10 +1173,14 @@ def pcs_SoftJointDifferentialKinematics(
         )
 
         Td = (
-            fd[0] * thetad * adjOmegap[0:6, :] + f[0] * adjOmegapd[0:6, :]
-            + fd[1] * thetad * adjOmegap[6:12, :] + f[1] * adjOmegapd[6:12, :]
-            + fd[2] * thetad * adjOmegap[12:18, :] + f[2] * adjOmegapd[12:18, :]
-            + fd[3] * thetad * adjOmegap[18:24, :] + f[3] * adjOmegapd[18:24, :]
+            fd[0] * thetad * adjOmegap[0:6, :]
+            + f[0] * adjOmegapd[0:6, :]
+            + fd[1] * thetad * adjOmegap[6:12, :]
+            + f[1] * adjOmegapd[6:12, :]
+            + fd[2] * thetad * adjOmegap[12:18, :]
+            + f[2] * adjOmegapd[12:18, :]
+            + fd[3] * thetad * adjOmegap[18:24, :]
+            + f[3] * adjOmegapd[18:24, :]
         )
 
         return (f, fd, fdd, g, T, Td)
@@ -1146,16 +1192,16 @@ def pcs_SoftJointDifferentialKinematics(
         operand=None,
     )
 
-    S  = T @ Z
+    S = T @ Z
     Sd = Td @ Z
     Zqdd = Z @ qdd
 
     def _block6(A: Array, k: int) -> Array:
         # k = 0,1,2,3 gives rows [0:6], [6:12], [12:18], [18:24]
-        return A[k * 6:(k + 1) * 6, :]
+        return A[k * 6 : (k + 1) * 6, :]
 
     def _S_series_branch() -> tuple[Array, Array, Array]:
-        dSdq_qd  = jnp.zeros_like(Z)
+        dSdq_qd = jnp.zeros_like(Z)
         dSdq_qdd = jnp.zeros_like(Z)
         dSddq_qd = jnp.zeros_like(Z)
         for r in range(4):
@@ -1164,15 +1210,19 @@ def pcs_SoftJointDifferentialKinematics(
                     adjOmegap1 = jnp.eye(6)
                 else:
                     adjOmegap1 = _block6(adjOmegap, u - 2)
-                
+
                 if u == r + 1:
                     adjOmegap2 = jnp.eye(6)
                 else:
                     adjOmegap2 = _block6(adjOmegap, r - u)
-                
-                dSdq_qd = dSdq_qd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
-                dSdq_qdd = dSdq_qdd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z)
-                
+
+                dSdq_qd = dSdq_qd - f[r] * (
+                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z
+                )
+                dSdq_qdd = dSdq_qdd - f[r] * (
+                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z
+                )
+
                 for p in range(1, u):
                     if p == 1:
                         adjOmegap3 = jnp.eye(6)
@@ -1186,10 +1236,12 @@ def pcs_SoftJointDifferentialKinematics(
 
                     dSddq_qd = dSddq_qd - f[r] * (
                         adjOmegap3
-                        @ adjoint_se3(adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad)
+                        @ adjoint_se3(
+                            adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad
+                        )
                         @ Z
                     )
-                
+
                 for p in range(1, r - u + 2):
                     if p == 1:
                         adjOmegap3 = jnp.eye(6)
@@ -1209,9 +1261,9 @@ def pcs_SoftJointDifferentialKinematics(
                         @ Z
                     )
         return (dSdq_qd, dSdq_qdd, dSddq_qd)
-    
+
     def _S_general_branch(theta: Array) -> tuple[Array, Array, Array]:
-        dSdq_qd  = jnp.zeros_like(Z)
+        dSdq_qd = jnp.zeros_like(Z)
         dSdq_qdd = jnp.zeros_like(Z)
         dSddq_qd = jnp.zeros_like(Z)
         for r in range(4):
@@ -1233,9 +1285,14 @@ def pcs_SoftJointDifferentialKinematics(
                 Omega @ (I_theta @ Z),
             )
 
-            term2 = (1 / theta) * fd[r] * jnp.outer(
-                adjr @ Omegad,
-                (Omegad - (thetad / theta) * Omega) @ (I_theta @ Z) + Omega @ (I_theta @ Zd),
+            term2 = (
+                (1 / theta)
+                * fd[r]
+                * jnp.outer(
+                    adjr @ Omegad,
+                    (Omegad - (thetad / theta) * Omega) @ (I_theta @ Z)
+                    + Omega @ (I_theta @ Zd),
+                )
             )
 
             dSddq_qd = dSddq_qd + term1 + term2
@@ -1249,10 +1306,16 @@ def pcs_SoftJointDifferentialKinematics(
                     adjOmegap2 = jnp.eye(6)
                 else:
                     adjOmegap2 = _block6(adjOmegap, r - u)
-                
-                dSdq_qd = dSdq_qd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
-                dSdq_qdd = dSdq_qdd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z)
-                dSddq_qd = (dSddq_qd- fd[r] * thetad * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z))
+
+                dSdq_qd = dSdq_qd - f[r] * (
+                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z
+                )
+                dSdq_qdd = dSdq_qdd - f[r] * (
+                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z
+                )
+                dSddq_qd = dSddq_qd - fd[r] * thetad * (
+                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z
+                )
 
                 for p in range(1, u):
                     if p == 1:
@@ -1266,8 +1329,13 @@ def pcs_SoftJointDifferentialKinematics(
                         adjOmegap4 = _block6(adjOmegap, u - p - 2)
 
                     dSddq_qd = dSddq_qd - f[r] * (
-                        adjOmegap3 @ adjoint_se3(adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad) @ Z)
-                
+                        adjOmegap3
+                        @ adjoint_se3(
+                            adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad
+                        )
+                        @ Z
+                    )
+
                 for p in range(1, r - u + 2):
                     if p == 1:
                         adjOmegap3 = jnp.eye(6)
@@ -1279,8 +1347,12 @@ def pcs_SoftJointDifferentialKinematics(
                     else:
                         adjOmegap4 = _block6(adjOmegap, r - u - p)
 
-                    dSddq_qd = dSddq_qd - f[r] * (adjOmegap1 @ _block6(adjOmegapd, 0) @ adjOmegap3
-                        @ adjoint_se3(adjOmegap4 @ Omegad) @ Z
+                    dSddq_qd = dSddq_qd - f[r] * (
+                        adjOmegap1
+                        @ _block6(adjOmegapd, 0)
+                        @ adjOmegap3
+                        @ adjoint_se3(adjOmegap4 @ Omegad)
+                        @ Z
                     )
 
         return (dSdq_qd, dSdq_qdd, dSddq_qd)

--- a/src/soromox/utils/lie_algebra/se3.py
+++ b/src/soromox/utils/lie_algebra/se3.py
@@ -646,3 +646,650 @@ def Tangent_derivative_gi_se3(
         operand=None,
     )
     return Td
+
+def coadjointbar_se3(vec6: Array) -> Array:
+    """
+    Computes the co-adjoint-bar representation of a vector of se(3).
+
+    """
+    vec6 = vec6.reshape(-1)  # Ensure vec6 is a 1D array
+
+    ang = vec6[:3].reshape((3, 1))  # Angular as a (3,1) vector
+    lin = vec6[3:].reshape((3, 1))  # Linear as a (3,1) vector
+
+    angtilde = tilde_SE3(ang)  # Tilde operator for angular part
+    lintilde = tilde_SE3(lin)  # Tilde operator for linear part
+
+    coadbar = -jnp.block([[angtilde, lintilde], [lintilde, jnp.zeros((3, 3))]])
+
+    return coadbar
+
+def gvs_SoftJointDifferentialKinematics_Z4(
+        eps,
+        H,
+        Phi_Z1,
+        Phi_Z2,
+        xi_star_Z1,
+        xi_star_Z2,
+        q,
+        qd,
+        qdd) -> tuple[
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array
+            ]:
+    
+    I_theta = jnp.diag(jnp.array([1, 1, 1, 0, 0, 0]))
+    xi_Z1 = Phi_Z1 @ q + xi_star_Z1
+    xi_Z2 = Phi_Z2 @ q + xi_star_Z2
+    xid_Z1 = Phi_Z1 @ qd
+    xid_Z2 = Phi_Z2 @ qd
+    xidd_Z1 = Phi_Z1 @ qdd
+    xidd_Z2 = Phi_Z2 @ qdd
+
+    Omega = (H/2) * (xi_Z1 + xi_Z2) + (jnp.sqrt(3) * H**2 / 12) * (adjoint_se3(xi_Z1) @ xi_Z2)
+
+    Z = (H/2) * (Phi_Z1 + Phi_Z2) + (jnp.sqrt(3) * H**2 / 12) * (
+        adjoint_se3(xi_Z1) @ Phi_Z2 - adjoint_se3(xi_Z2) @ Phi_Z1
+        )
+    
+    Omegad  = Z @ qd
+
+    Zd      = (jnp.sqrt(3) * H**2 / 12) * (adjoint_se3(xid_Z1) @ Phi_Z2 - adjoint_se3(xid_Z2) @ Phi_Z1)
+
+    Zdd     = (jnp.sqrt(3) * H**2 / 12) * (adjoint_se3(xidd_Z1) @ Phi_Z2 - adjoint_se3(xidd_Z2) @ Phi_Z1)
+
+    adjOmegap  = jnp.zeros((24, 6))
+    adjOmegapd = jnp.zeros((24, 6))
+
+    k = Omega[:3]
+    kd = Omegad[:3]
+    theta = _rotational_strain_magnitude(Omega, eps)
+    thetad = (kd @ k) / theta
+
+    Omegahat = hat_SE3(Omega)
+    Omegahatp2 = Omegahat @ Omegahat
+    Omegahatp3 = Omegahatp2 @ Omegahat
+
+    adjOmegap = adjOmegap.at[0:6, :].set(adjoint_se3(Omega))
+    adjOmegap = adjOmegap.at[6:12, :].set(adjOmegap[0:6, :] @ adjOmegap[0:6, :])
+    adjOmegap = adjOmegap.at[12:18, :].set(adjOmegap[6:12, :] @ adjOmegap[0:6, :])
+    adjOmegap = adjOmegap.at[18:24, :].set(adjOmegap[12:18, :] @ adjOmegap[0:6, :])
+
+    adjOmegapd = adjOmegapd.at[0:6, :].set(adjoint_se3(Omegad))
+    adjOmegapd = adjOmegapd.at[6:12, :].set(adjOmegapd[0:6, :] @ adjOmegap[0:6, :] +
+    adjOmegap[0:6, :] @ adjOmegapd[0:6, :]
+    )
+    adjOmegapd = adjOmegapd.at[12:18, :].set(adjOmegapd[6:12, :] @ adjOmegap[0:6, :] +
+    adjOmegap[6:12, :] @ adjOmegapd[0:6, :]
+    )
+    adjOmegapd = adjOmegapd.at[18:24, :].set(adjOmegapd[12:18, :] @ adjOmegap[0:6, :] +
+    adjOmegap[12:18, :] @ adjOmegapd[0:6, :]
+    )
+
+    def _g_series_branch() -> tuple[Array, Array, Array, Array, Array, Array]:
+        g = jnp.eye(4) + Omegahat + Omegahatp2 / 2 + Omegahatp3 / 6
+        f = jnp.array([1/2, 1/6, 1/24, 1/120])
+        fd  = jnp.zeros((4,))
+        fdd = jnp.zeros((4,))
+
+        T = (
+            jnp.eye(6)
+            + f[0] * adjOmegap[0:6, :]
+            + f[1] * adjOmegap[6:12, :]
+            + f[2] * adjOmegap[12:18, :]
+            + f[3] * adjOmegap[18:24, :]
+        )
+
+        Td = (
+            f[0] * adjOmegapd[0:6, :]
+            + f[1] * adjOmegapd[6:12, :]
+            + f[2] * adjOmegapd[12:18, :]
+            + f[3] * adjOmegapd[18:24, :]
+        )
+
+        return (f, fd, fdd, g, T, Td)
+    
+    def _g_general_branch(theta: Array) -> tuple[Array, Array, Array, Array, Array, Array]:
+        tp2        = theta * theta
+        tp3        = tp2 * theta
+        tp4        = tp3 * theta
+        tp5        = tp4 * theta
+        tp6        = tp5 * theta
+        tp7        = tp6 * theta
+        costheta = jnp.cos(theta)
+        sintheta = jnp.sin(theta)
+
+        t1 = theta * sintheta
+        t2 = theta * costheta
+        t3 = -8 + (8 - tp2) * costheta + 5 * t1
+        t4 = -8 * theta + (15 - tp2) * sintheta - 7 * t2
+        t3d = 5 * sintheta + sintheta * (tp2 - 8) + 3 * theta * costheta
+        t4d = -8 + 5 * theta * sintheta + (15 - tp2) * costheta - 7 * costheta
+
+        f = jnp.array([
+            (4 - 4 * costheta - t1) / (2 * tp2),
+            (4 * theta - 5 * sintheta + t2) / (2 * tp3),
+            (2 - 2 * costheta - t1) / (2 * tp4),
+            (2 * theta - 3 * sintheta + t2) / (2 * tp5),
+        ])
+
+        fd = jnp.array([
+            t3 / (2 * tp3),
+            t4 / (2 * tp4),
+            t3 / (2 * tp5),
+            t4 / (2 * tp6),
+        ])
+
+        fdd = jnp.array([
+            (theta * t3d - 3 * t3) / (2 * tp4),
+            (theta * t4d - 4 * t4) / (2 * tp5),
+            (theta * t3d - 5 * t3) / (2 * tp6),
+            (theta * t4d - 6 * t4) / (2 * tp7),
+        ])
+
+        g = jnp.eye(4) + Omegahat + ((1 - costheta) / tp2) * Omegahatp2 + ((theta - sintheta) / tp3) * Omegahatp3
+        
+        T = (
+            jnp.eye(6)
+            + f[0] * adjOmegap[0:6, :]
+            + f[1] * adjOmegap[6:12, :]
+            + f[2] * adjOmegap[12:18, :]
+            + f[3] * adjOmegap[18:24, :]
+        )
+
+        Td = (
+            fd[0] * thetad * adjOmegap[0:6, :] + f[0] * adjOmegapd[0:6, :]
+            + fd[1] * thetad * adjOmegap[6:12, :] + f[1] * adjOmegapd[6:12, :]
+            + fd[2] * thetad * adjOmegap[12:18, :] + f[2] * adjOmegapd[12:18, :]
+            + fd[3] * thetad * adjOmegap[18:24, :] + f[3] * adjOmegapd[18:24, :]
+        )
+
+        return (f, fd, fdd, g, T, Td)
+
+    f, fd, fdd, g, T, Td = lax.cond(
+        theta <= eps,
+        lambda _: _g_series_branch(),
+        lambda _: _g_general_branch(theta),
+        operand=None,
+    )
+
+    S  = T @ Z
+    TZd = T @ Zd
+    Sd = Td @ Z + TZd
+    dSdq_qd  = TZd
+    dSdq_qdd = T @ Zdd
+    dSddq_qd = Td @ Zd
+
+    Zqdd = Z @ qdd
+    Zdqd = Zd @ qd
+
+    def _block6(A: Array, k: int) -> Array:
+        # k = 0,1,2,3 gives rows [0:6], [6:12], [12:18], [18:24]
+        return A[k * 6:(k + 1) * 6, :]
+
+    def _S_series_branch() -> tuple[Array, Array, Array]:
+        dSdq_qd  = TZd
+        dSdq_qdd = T @ Zdd
+        dSddq_qd = Td @ Zd
+        # dSdq_qd = jnp.zeros_like(Z)
+        # dSdq_qdd = jnp.zeros_like(Z)
+        # dSddq_qd = jnp.zeros_like(Z)
+        for r in range(4):
+            for u in range(1, r + 2):
+                if u == 1:
+                    adjOmegap1 = jnp.eye(6)
+                else:
+                    adjOmegap1 = _block6(adjOmegap, u - 2)
+                
+                if u == r + 1:
+                    adjOmegap2 = jnp.eye(6)
+                else:
+                    adjOmegap2 = _block6(adjOmegap, r - u)
+                
+                dSdq_qd = dSdq_qd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
+                dSdq_qdd = dSdq_qdd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z)
+                dSddq_qd = dSddq_qd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zdqd) @ Z) - f[r] * (
+                    adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Zd
+                    )
+                                
+                for p in range(1, u):
+                    if p == 1:
+                        adjOmegap3 = jnp.eye(6)
+                    else:
+                        adjOmegap3 = _block6(adjOmegap, p - 2)
+
+                    if p == u - 1:
+                        adjOmegap4 = jnp.eye(6)
+                    else:
+                        adjOmegap4 = _block6(adjOmegap, u - p - 2)
+
+                    dSddq_qd = dSddq_qd - f[r] * (
+                        adjOmegap3
+                        @ adjoint_se3(adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad)
+                        @ Z
+                    )
+                
+                for p in range(1, r - u + 2):
+                    if p == 1:
+                        adjOmegap3 = jnp.eye(6)
+                    else:
+                        adjOmegap3 = _block6(adjOmegap, p - 2)
+
+                    if p == r - u + 1:
+                        adjOmegap4 = jnp.eye(6)
+                    else:
+                        adjOmegap4 = _block6(adjOmegap, r - u - p)
+
+                    dSddq_qd = dSddq_qd - f[r] * (
+                        adjOmegap1
+                        @ _block6(adjOmegapd, 0)
+                        @ adjOmegap3
+                        @ adjoint_se3(adjOmegap4 @ Omegad)
+                        @ Z
+                    )
+        return (dSdq_qd, dSdq_qdd, dSddq_qd)
+    
+    def _S_general_branch(theta: Array) -> tuple[Array, Array, Array]:
+        # dSdq_qd = jnp.zeros_like(Z)
+        # dSdq_qdd = jnp.zeros_like(Z)
+        # dSddq_qd = jnp.zeros_like(Z)
+
+        dSdq_qd  = TZd
+        dSdq_qdd = T @ Zdd
+        dSddq_qd = Td @ Zd
+        for r in range(4):
+            adjr = _block6(adjOmegap, r)
+            adjrd = _block6(adjOmegapd, r)
+
+            dSdq_qd = dSdq_qd + (1 / theta) * fd[r] * jnp.outer(
+                adjr @ Omegad,
+                Omega @ (I_theta @ Z),
+            )
+
+            dSdq_qdd = dSdq_qdd + (1 / theta) * fd[r] * jnp.outer(
+                adjr @ Zqdd,
+                Omega @ (I_theta @ Z),
+            )
+
+            term1 = (1 / theta) * fd[r] * jnp.outer(
+                adjr @ Zdqd,
+                Omega @ (I_theta @ Z),
+            )
+
+            term2 = (1 / theta) * jnp.outer(
+                ((fdd[r] * thetad) * adjr + fd[r] * adjrd) @ Omegad,
+                Omega @ (I_theta @ Z),
+            )
+
+            term3 = (1 / theta) * fd[r] * jnp.outer(
+                adjr @ Omegad,
+                (Omegad - (thetad / theta) * Omega) @ (I_theta @ Z) + Omega @ (I_theta @ Zd),
+            )
+
+            dSddq_qd = dSddq_qd + term1 + term2 + term3
+            for u in range(1, r + 2):
+                if u == 1:
+                    adjOmegap1 = jnp.eye(6)
+                else:
+                    adjOmegap1 = _block6(adjOmegap, u - 2)
+
+                if u == r + 1:
+                    adjOmegap2 = jnp.eye(6)
+                else:
+                    adjOmegap2 = _block6(adjOmegap, r - u)
+                
+                dSdq_qd = dSdq_qd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
+                dSdq_qdd = dSdq_qdd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z)
+
+                dSddq_qd = (
+                    dSddq_qd
+                    - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zdqd) @ Z)
+                    - fd[r] * thetad * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
+                    - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Zd)
+                )
+
+                for p in range(1, u):
+                    if p == 1:
+                        adjOmegap3 = jnp.eye(6)
+                    else:
+                        adjOmegap3 = _block6(adjOmegap, p - 2)
+
+                    if p == u - 1:
+                        adjOmegap4 = jnp.eye(6)
+                    else:
+                        adjOmegap4 = _block6(adjOmegap, u - p - 2)
+
+                    dSddq_qd = dSddq_qd - f[r] * (
+                        adjOmegap3 @ adjoint_se3(adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad) @ Z)
+                                            
+                for p in range(1, r - u + 2):
+                    if p == 1:
+                        adjOmegap3 = jnp.eye(6)
+                    else:
+                        adjOmegap3 = _block6(adjOmegap, p - 2)
+
+                    if p == r - u + 1:
+                        adjOmegap4 = jnp.eye(6)
+                    else:
+                        adjOmegap4 = _block6(adjOmegap, r - u - p)
+
+                    dSddq_qd = dSddq_qd - f[r] * (adjOmegap1 @ _block6(adjOmegapd, 0) @ adjOmegap3
+                        @ adjoint_se3(adjOmegap4 @ Omegad) @ Z
+                    )
+
+
+        return (dSdq_qd, dSdq_qdd, dSddq_qd)
+
+    dSdq_qd, dSdq_qdd, dSddq_qd = lax.cond(
+        theta <= eps,
+        lambda _: _S_series_branch(),
+        lambda _: _S_general_branch(theta),
+        operand=None,
+    )
+
+    return (Omega, Z, g, T, S, Sd, f, fd, adjOmegap, dSdq_qd, dSdq_qdd, dSddq_qd)
+
+
+def pcs_SoftJointDifferentialKinematics(
+        eps,
+        H,
+        Phi,
+        xi_star,
+        q,
+        qd,
+        qdd) -> tuple[
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array,
+            Array
+            ]:
+    
+    I_theta = jnp.diag(jnp.array([1, 1, 1, 0, 0, 0]))
+    xi = Phi @ q + xi_star
+    Omega = H * xi
+    Z = H * Phi    
+    Omegad  = Z @ qd
+
+    Zd      = jnp.zeros_like(Z)
+    Zdd     = jnp.zeros_like(Z)
+
+    adjOmegap  = jnp.zeros((24, 6))
+    adjOmegapd = jnp.zeros((24, 6))
+
+    k = Omega[:3]
+    kd = Omegad[:3]
+    theta = _rotational_strain_magnitude(Omega, eps)
+    thetad = (kd @ k) / theta
+
+    Omegahat = hat_SE3(Omega)
+    Omegahatp2 = Omegahat @ Omegahat
+    Omegahatp3 = Omegahatp2 @ Omegahat
+
+    adjOmegap = adjOmegap.at[0:6, :].set(adjoint_se3(Omega))
+    adjOmegap = adjOmegap.at[6:12, :].set(adjOmegap[0:6, :] @ adjOmegap[0:6, :])
+    adjOmegap = adjOmegap.at[12:18, :].set(adjOmegap[6:12, :] @ adjOmegap[0:6, :])
+    adjOmegap = adjOmegap.at[18:24, :].set(adjOmegap[12:18, :] @ adjOmegap[0:6, :])
+
+    adjOmegapd = adjOmegapd.at[0:6, :].set(adjoint_se3(Omegad))
+    adjOmegapd = adjOmegapd.at[6:12, :].set(adjOmegapd[0:6, :] @ adjOmegap[0:6, :] +
+    adjOmegap[0:6, :] @ adjOmegapd[0:6, :]
+    )
+    adjOmegapd = adjOmegapd.at[12:18, :].set(adjOmegapd[6:12, :] @ adjOmegap[0:6, :] +
+    adjOmegap[6:12, :] @ adjOmegapd[0:6, :]
+    )
+    adjOmegapd = adjOmegapd.at[18:24, :].set(adjOmegapd[12:18, :] @ adjOmegap[0:6, :] +
+    adjOmegap[12:18, :] @ adjOmegapd[0:6, :]
+    )
+
+    def _g_series_branch() -> tuple[Array, Array, Array, Array, Array, Array]:
+        g = jnp.eye(4) + Omegahat + Omegahatp2 / 2 + Omegahatp3 / 6
+        f = jnp.array([1/2, 1/6, 1/24, 1/120])
+        fd  = jnp.zeros((4,))
+        fdd = jnp.zeros((4,))
+
+        T = (
+            jnp.eye(6)
+            + f[0] * adjOmegap[0:6, :]
+            + f[1] * adjOmegap[6:12, :]
+            + f[2] * adjOmegap[12:18, :]
+            + f[3] * adjOmegap[18:24, :]
+        )
+
+        Td = (
+            f[0] * adjOmegapd[0:6, :]
+            + f[1] * adjOmegapd[6:12, :]
+            + f[2] * adjOmegapd[12:18, :]
+            + f[3] * adjOmegapd[18:24, :]
+        )
+
+        return (f, fd, fdd, g, T, Td)
+    
+    def _g_general_branch(theta: Array) -> tuple[Array, Array, Array, Array, Array, Array]:
+        tp2        = theta * theta
+        tp3        = tp2 * theta
+        tp4        = tp3 * theta
+        tp5        = tp4 * theta
+        tp6        = tp5 * theta
+        tp7        = tp6 * theta
+        costheta = jnp.cos(theta)
+        sintheta = jnp.sin(theta)
+
+        t1 = theta * sintheta
+        t2 = theta * costheta
+        t3 = -8 + (8 - tp2) * costheta + 5 * t1
+        t4 = -8 * theta + (15 - tp2) * sintheta - 7 * t2
+        t3d = 5 * sintheta + sintheta * (tp2 - 8) + 3 * theta * costheta
+        t4d = -8 + 5 * theta * sintheta + (15 - tp2) * costheta - 7 * costheta
+
+        f = jnp.array([
+            (4 - 4 * costheta - t1) / (2 * tp2),
+            (4 * theta - 5 * sintheta + t2) / (2 * tp3),
+            (2 - 2 * costheta - t1) / (2 * tp4),
+            (2 * theta - 3 * sintheta + t2) / (2 * tp5),
+        ])
+
+        fd = jnp.array([
+            t3 / (2 * tp3),
+            t4 / (2 * tp4),
+            t3 / (2 * tp5),
+            t4 / (2 * tp6),
+        ])
+
+        fdd = jnp.array([
+            (theta * t3d - 3 * t3) / (2 * tp4),
+            (theta * t4d - 4 * t4) / (2 * tp5),
+            (theta * t3d - 5 * t3) / (2 * tp6),
+            (theta * t4d - 6 * t4) / (2 * tp7),
+        ])
+
+        g = jnp.eye(4) + Omegahat + ((1 - costheta) / tp2) * Omegahatp2 + ((theta - sintheta) / tp3) * Omegahatp3
+        
+        T = (
+            jnp.eye(6)
+            + f[0] * adjOmegap[0:6, :]
+            + f[1] * adjOmegap[6:12, :]
+            + f[2] * adjOmegap[12:18, :]
+            + f[3] * adjOmegap[18:24, :]
+        )
+
+        Td = (
+            fd[0] * thetad * adjOmegap[0:6, :] + f[0] * adjOmegapd[0:6, :]
+            + fd[1] * thetad * adjOmegap[6:12, :] + f[1] * adjOmegapd[6:12, :]
+            + fd[2] * thetad * adjOmegap[12:18, :] + f[2] * adjOmegapd[12:18, :]
+            + fd[3] * thetad * adjOmegap[18:24, :] + f[3] * adjOmegapd[18:24, :]
+        )
+
+        return (f, fd, fdd, g, T, Td)
+
+    f, fd, fdd, g, T, Td = lax.cond(
+        theta <= eps,
+        lambda _: _g_series_branch(),
+        lambda _: _g_general_branch(theta),
+        operand=None,
+    )
+
+    S  = T @ Z
+    Sd = Td @ Z
+    Zqdd = Z @ qdd
+
+    def _block6(A: Array, k: int) -> Array:
+        # k = 0,1,2,3 gives rows [0:6], [6:12], [12:18], [18:24]
+        return A[k * 6:(k + 1) * 6, :]
+
+    def _S_series_branch() -> tuple[Array, Array, Array]:
+        dSdq_qd  = jnp.zeros_like(Z)
+        dSdq_qdd = jnp.zeros_like(Z)
+        dSddq_qd = jnp.zeros_like(Z)
+        for r in range(4):
+            for u in range(1, r + 2):
+                if u == 1:
+                    adjOmegap1 = jnp.eye(6)
+                else:
+                    adjOmegap1 = _block6(adjOmegap, u - 2)
+                
+                if u == r + 1:
+                    adjOmegap2 = jnp.eye(6)
+                else:
+                    adjOmegap2 = _block6(adjOmegap, r - u)
+                
+                dSdq_qd = dSdq_qd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
+                dSdq_qdd = dSdq_qdd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z)
+                
+                for p in range(1, u):
+                    if p == 1:
+                        adjOmegap3 = jnp.eye(6)
+                    else:
+                        adjOmegap3 = _block6(adjOmegap, p - 2)
+
+                    if p == u - 1:
+                        adjOmegap4 = jnp.eye(6)
+                    else:
+                        adjOmegap4 = _block6(adjOmegap, u - p - 2)
+
+                    dSddq_qd = dSddq_qd - f[r] * (
+                        adjOmegap3
+                        @ adjoint_se3(adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad)
+                        @ Z
+                    )
+                
+                for p in range(1, r - u + 2):
+                    if p == 1:
+                        adjOmegap3 = jnp.eye(6)
+                    else:
+                        adjOmegap3 = _block6(adjOmegap, p - 2)
+
+                    if p == r - u + 1:
+                        adjOmegap4 = jnp.eye(6)
+                    else:
+                        adjOmegap4 = _block6(adjOmegap, r - u - p)
+
+                    dSddq_qd = dSddq_qd - f[r] * (
+                        adjOmegap1
+                        @ _block6(adjOmegapd, 0)
+                        @ adjOmegap3
+                        @ adjoint_se3(adjOmegap4 @ Omegad)
+                        @ Z
+                    )
+        return (dSdq_qd, dSdq_qdd, dSddq_qd)
+    
+    def _S_general_branch(theta: Array) -> tuple[Array, Array, Array]:
+        dSdq_qd  = jnp.zeros_like(Z)
+        dSdq_qdd = jnp.zeros_like(Z)
+        dSddq_qd = jnp.zeros_like(Z)
+        for r in range(4):
+            adjr = _block6(adjOmegap, r)
+            adjrd = _block6(adjOmegapd, r)
+
+            dSdq_qd = dSdq_qd + (1 / theta) * fd[r] * jnp.outer(
+                adjr @ Omegad,
+                Omega @ (I_theta @ Z),
+            )
+
+            dSdq_qdd = dSdq_qdd + (1 / theta) * fd[r] * jnp.outer(
+                adjr @ Zqdd,
+                Omega @ (I_theta @ Z),
+            )
+
+            term1 = (1 / theta) * jnp.outer(
+                ((fdd[r] * thetad) * adjr + fd[r] * adjrd) @ Omegad,
+                Omega @ (I_theta @ Z),
+            )
+
+            term2 = (1 / theta) * fd[r] * jnp.outer(
+                adjr @ Omegad,
+                (Omegad - (thetad / theta) * Omega) @ (I_theta @ Z) + Omega @ (I_theta @ Zd),
+            )
+
+            dSddq_qd = dSddq_qd + term1 + term2
+            for u in range(1, r + 2):
+                if u == 1:
+                    adjOmegap1 = jnp.eye(6)
+                else:
+                    adjOmegap1 = _block6(adjOmegap, u - 2)
+
+                if u == r + 1:
+                    adjOmegap2 = jnp.eye(6)
+                else:
+                    adjOmegap2 = _block6(adjOmegap, r - u)
+                
+                dSdq_qd = dSdq_qd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z)
+                dSdq_qdd = dSdq_qdd - f[r] * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Zqdd) @ Z)
+                dSddq_qd = (dSddq_qd- fd[r] * thetad * (adjOmegap1 @ adjoint_se3(adjOmegap2 @ Omegad) @ Z))
+
+                for p in range(1, u):
+                    if p == 1:
+                        adjOmegap3 = jnp.eye(6)
+                    else:
+                        adjOmegap3 = _block6(adjOmegap, p - 2)
+
+                    if p == u - 1:
+                        adjOmegap4 = jnp.eye(6)
+                    else:
+                        adjOmegap4 = _block6(adjOmegap, u - p - 2)
+
+                    dSddq_qd = dSddq_qd - f[r] * (
+                        adjOmegap3 @ adjoint_se3(adjOmegap4 @ _block6(adjOmegapd, 0) @ adjOmegap2 @ Omegad) @ Z)
+                
+                for p in range(1, r - u + 2):
+                    if p == 1:
+                        adjOmegap3 = jnp.eye(6)
+                    else:
+                        adjOmegap3 = _block6(adjOmegap, p - 2)
+
+                    if p == r - u + 1:
+                        adjOmegap4 = jnp.eye(6)
+                    else:
+                        adjOmegap4 = _block6(adjOmegap, r - u - p)
+
+                    dSddq_qd = dSddq_qd - f[r] * (adjOmegap1 @ _block6(adjOmegapd, 0) @ adjOmegap3
+                        @ adjoint_se3(adjOmegap4 @ Omegad) @ Z
+                    )
+
+        return (dSdq_qd, dSdq_qdd, dSddq_qd)
+
+    dSdq_qd, dSdq_qdd, dSddq_qd = lax.cond(
+        theta <= eps,
+        lambda _: _S_series_branch(),
+        lambda _: _S_general_branch(theta),
+        operand=None,
+    )
+
+    return (Omega, Z, g, T, S, Sd, f, fd, adjOmegap, dSdq_qd, dSdq_qdd, dSddq_qd)


### PR DESCRIPTION
Added backward pass and obtained analytical derivatives.

- Fixed se3.py to use "coadjointbar_se3" and "pcs_SoftJointDifferentialKinematics".
- Added a serial inverse-dynamics backward pass returning `dID/dq` and `dID/dqd`.
- Added analytical forward-dynamics Jacobians:
  - `dyd/dy`
  - `dyd/du`
  - `dyd/dtau_ext`
- Added base PCS force derivative helpers for elastic, damping, and actuation terms.
- Added a validation file examples/simulation/pcs/test_analytical_derivative.py that compares analytical derivatives against JAX autodiff.

forward_dynamics_derivatives dqdd/dq:
rel error = 5.782666e-12
max abs error = 1.495151e-06

Codes can be further optimized for speed in the future, but they are giving correct values as per the test done. custom_jvp still not used and no comparison for speed against autodiff, but it should be feasible with the current state of the code.