### PR TITLE
Migrate planar tendon PCS routing API

### DIFF
--- a/docs/api/systems/pcs/index.md
+++ b/docs/api/systems/pcs/index.md
@@ -73,7 +73,7 @@ Core 3D PCS implementation for spatial continuum robots.
 | `PCS` | 3D | None (strain input) | General 3D continuum modeling |
 | `PlanarPCS` | 2D | None (strain input) | General 2D continuum modeling |
 | `TendonActuatedPCS` | 3D | Tendons | 3D cable-driven robots |
-| `TendonActuatedPlanarPCS` | 2D | Tendons | 2D cable-driven robots |
+| `TendonActuatedPlanarPCS` | 2D | Active/passive routed tendons | 2D cable-driven robots |
 | `PressureActuatedPlanarPCS` | 2D | Pressure | Pressure-driven soft actuators |
 | `ISupport` | 3D | Pneumatic | I-Support robot platform |
 

--- a/docs/api/systems/pcs/tendon-actuated-planar-pcs.md
+++ b/docs/api/systems/pcs/tendon-actuated-planar-pcs.md
@@ -1,10 +1,80 @@
 # Tendon Actuated Planar PCS
 
-Tendon actuated Planar PCS systems with cable-driven actuation mechanisms, extending the discrete Cosserat approach by Renda et al. (2018).
+Tendon actuated Planar PCS systems with active and passive cable-driven actuation mechanisms, extending the discrete Cosserat approach by Renda et al. (2018).
 
 ## Overview
 
-This module extends the planar PCS model (based on the discrete Cosserat approach by Renda et al., 2018) to include tendon actuation, where the robot is actuated by controlling the tension in cables or tendons. This actuation method provides precise control and is commonly used in cable-driven continuum robots.
+This module extends the planar PCS model to include routed tendons. Its public API mirrors `TendonActuatedPCS` and `TendonActuatedGVS`: the body parameters live in `PlanarPCSParams`, active tendons are provided through `active_tendon_routing`, and optional passive tendons are provided through `passive_tendon_routing` plus `PassiveTendonParams`.
+
+## Quick Start
+
+```python
+import jax.numpy as jnp
+from soromox.systems import (
+    LinearTendonRoutingParams,
+    PlanarPCSParams,
+    TendonActuatedPlanarPCS,
+    TendonActuatedPlanarPCSParams,
+)
+
+num_segments = 2
+body = PlanarPCSParams(
+    base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
+    length=0.1 * jnp.ones((num_segments,)),
+    radius=0.02 * jnp.ones((num_segments,)),
+    density=1070.0 * jnp.ones((num_segments,)),
+    gravity=jnp.array([0.0, 9.81]),
+    young_modulus=5e3 * jnp.ones((num_segments,)),
+    shear_modulus=1e3 * jnp.ones((num_segments,)),
+    damping_matrix=jnp.eye(3 * num_segments),
+    reference_strain=jnp.tile(jnp.array([0.0, 1.0, 0.0]), num_segments),
+)
+
+offsets = 0.02 * jnp.array([[1.0, -1.0], [1.0, -1.0]])
+active_routing = LinearTendonRoutingParams(
+    y_intercept=offsets.reshape(-1),
+    y_slope=jnp.zeros((4,)),
+    z_intercept=jnp.zeros((4,)),
+    z_slope=jnp.zeros((4,)),
+    attachment_segment_index=jnp.array([0, 0, 1, 1]),
+)
+
+robot = TendonActuatedPlanarPCS(
+    params=TendonActuatedPlanarPCSParams(
+        body=body,
+        active_tendon_routing=active_routing,
+    )
+)
+```
+
+## Planar Routing Return Shapes
+
+Custom routing basis functions may be compact planar functions or shared with the spatial PCS/GVS models. For a single tendon at arc length `s`, both `d_s(params, s)` and `dd_s_ds(params, s)` may return:
+
+- a scalar, interpreted as the planar offset `d(s)` or derivative `d'(s)`;
+- shape `(1,)`, where the first entry is the planar offset or derivative;
+- shape `(3,)`, using the PCS/GVS-compatible `[0, y, z]` convention. The planar model uses `y` and requires `z == 0`.
+
+Shape `(2,)` is rejected because its coordinate convention is ambiguous. Nonzero `z` routing or nonzero `z` derivative is invalid for `TendonActuatedPlanarPCS`.
+
+The built-in `LinearTendonRoutingParams` returns `[0, y, z]`. For planar use, set `z_intercept = z_slope = 0`.
+
+### Compact Scalar Routing
+
+```python
+def d_s(params, s):
+    return params.offset + params.slope * s
+
+
+def dd_s_ds(params, s):
+    return params.slope + jnp.zeros_like(s)
+
+
+robot = TendonActuatedPlanarPCS(
+    params=params,
+    active_tendon_routing_basis={"d_s": d_s, "dd_s_ds": dd_s_ds},
+)
+```
 
 ## API Reference
 

--- a/examples/control/actuation_space/setpoint_regulation_comparison.py
+++ b/examples/control/actuation_space/setpoint_regulation_comparison.py
@@ -91,13 +91,13 @@ def create_robot() -> tuple[TendonActuatedPCS, int]:
     # Tendon routing: 3 tendons at 120 degrees apart, parallel to backbone
     # Tendon positions at angles: 0°, 120°, 240° from the +z axis
     # d_y = r * sin(theta), d_z = r * cos(theta)
-    tendon_distance = 0.8 * radius  # Slightly inside the robot radius
+    tendon_offset_radius = 0.8 * radius  # Slightly inside the robot radius
     angles_deg = jnp.array([0.0, 120.0, 240.0])
     angles_rad = jnp.deg2rad(angles_deg)
 
     active_tendon_routing = LinearTendonRoutingParams(
-        y_intercept=tendon_distance * jnp.sin(angles_rad),
-        z_intercept=tendon_distance * jnp.cos(angles_rad),
+        y_intercept=tendon_offset_radius * jnp.sin(angles_rad),
+        z_intercept=tendon_offset_radius * jnp.cos(angles_rad),
         y_slope=jnp.zeros(3),
         z_slope=jnp.zeros(3),
         attachment_segment_index=jnp.array([0, 0, 0]),

--- a/examples/optimization/control_gain_optimization_with_collocated.py
+++ b/examples/optimization/control_gain_optimization_with_collocated.py
@@ -93,13 +93,13 @@ body_params = PCSParams(
 # Tendon routing: 3 tendons at 120 degrees apart, parallel to backbone
 # Tendon positions at angles: 0°, 120°, 240° from the +z axis
 # d_y = r * sin(theta), d_z = r * cos(theta)
-tendon_distance = 0.8 * radius  # Slightly inside the robot radius
+tendon_offset_radius = 0.8 * radius  # Slightly inside the robot radius
 angles_deg = jnp.array([0.0, 120.0, 240.0])
 angles_rad = jnp.deg2rad(angles_deg)
 
 active_tendon_routing = LinearTendonRoutingParams(
-    y_intercept=tendon_distance * jnp.sin(angles_rad),
-    z_intercept=tendon_distance * jnp.cos(angles_rad),
+    y_intercept=tendon_offset_radius * jnp.sin(angles_rad),
+    z_intercept=tendon_offset_radius * jnp.cos(angles_rad),
     y_slope=jnp.zeros(3),
     z_slope=jnp.zeros(3),
     attachment_segment_index=jnp.array([0, 0, 0]),

--- a/examples/optimization/control_gain_optimization_with_synergistic.py
+++ b/examples/optimization/control_gain_optimization_with_synergistic.py
@@ -97,13 +97,13 @@ body_params = PCSParams(
 # Tendon routing: 3 tendons at 120 degrees apart, parallel to backbone
 # Tendon positions at angles: 0°, 120°, 240° from the +z axis
 # d_y = r * sin(theta), d_z = r * cos(theta)
-tendon_distance = 0.8 * radius  # Slightly inside the robot radius
+tendon_offset_radius = 0.8 * radius  # Slightly inside the robot radius
 angles_deg = jnp.array([0.0, 120.0, 240.0])
 angles_rad = jnp.deg2rad(angles_deg)
 
 active_tendon_routing = LinearTendonRoutingParams(
-    y_intercept=tendon_distance * jnp.sin(angles_rad),
-    z_intercept=tendon_distance * jnp.cos(angles_rad),
+    y_intercept=tendon_offset_radius * jnp.sin(angles_rad),
+    z_intercept=tendon_offset_radius * jnp.cos(angles_rad),
     y_slope=jnp.zeros(3),
     z_slope=jnp.zeros(3),
     attachment_segment_index=jnp.array([0, 0, 0]),

--- a/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py
@@ -9,6 +9,8 @@ from jax import numpy as jnp
 jax.config.update("jax_enable_x64", True)  # double precision
 from soromox.rendering import MatplotlibRenderer
 from soromox.systems import (
+    LinearTendonRoutingParams,
+    PlanarPCSParams,
     PlanarPCSStructure,
     SystemState,
     TendonActuatedPlanarPCS,
@@ -31,7 +33,7 @@ if __name__ == "__main__":
             * segment_lengths[:, None]
         ).flatten()
     )
-    params = TendonActuatedPlanarPCSParams(
+    body = PlanarPCSParams(
         base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
         length=segment_lengths,
         radius=2e-2 * jnp.ones((num_segments,)),
@@ -41,13 +43,24 @@ if __name__ == "__main__":
         shear_modulus=1e3 * jnp.ones((num_segments,)),
         damping_matrix=damping_matrix,
         reference_strain=jnp.tile(jnp.array([0.0, 1.0, 0.0]), num_segments),
-        tendon_distance=2e-2 * jnp.array([[1.0, -1.0]]).repeat(num_segments, axis=0),
+    )
+    tendon_offsets = 2e-2 * jnp.array([[1.0, -1.0]]).repeat(num_segments, axis=0)
+    active_tendon_routing = LinearTendonRoutingParams(
+        y_intercept=tendon_offsets.reshape(-1),
+        y_slope=jnp.zeros((2 * num_segments,)),
+        z_intercept=jnp.zeros((2 * num_segments,)),
+        z_slope=jnp.zeros((2 * num_segments,)),
+        attachment_segment_index=jnp.repeat(
+            jnp.arange(num_segments, dtype=jnp.int32), 2
+        ),
+    )
+    params = TendonActuatedPlanarPCSParams(
+        body=body,
+        active_tendon_routing=active_tendon_routing,
     )
 
     # activate all strains (i.e. bending, shear, and axial)
     strain_selector = jnp.ones((3 * num_segments,), dtype=bool)
-    # actuation selector for the segments
-    segment_actuation_selector = jnp.ones((num_segments,), dtype=bool)
 
     # ======================================================
     # Robot initialization
@@ -55,7 +68,6 @@ if __name__ == "__main__":
     robot = TendonActuatedPlanarPCS(
         params=params,
         structure=PlanarPCSStructure(strain_selector=strain_selector),
-        segment_actuation_selector=segment_actuation_selector,
     )
 
     # =====================================================
@@ -111,11 +123,7 @@ if __name__ == "__main__":
     tendon_pattern = tendon_pattern.at[:, 1].set(
         jnp.where(~even_segments, segment_tensions, 0.0)
     )
-    u = jnp.take(
-        tendon_pattern,
-        robot.segment_indices_to_actuate,
-        axis=0,
-    ).reshape(-1)
+    u = tendon_pattern.reshape(-1)
     print("u =\n", u)
 
     # call the actuation mapping function

--- a/src/soromox/systems/pcs/params.py
+++ b/src/soromox/systems/pcs/params.py
@@ -130,26 +130,34 @@ class TendonActuatedPCSParams(BaseSystemParams):
             )
 
 
-class TendonActuatedPlanarPCSParams(PlanarPCSParams):
-    """Dynamic parameters for parallel-routed planar tendon PCS.
+class TendonActuatedPlanarPCSParams(BaseSystemParams):
+    """Dynamic parameters for planar tendon-actuated PCS.
 
-    ``tendon_distance`` has shape ``(num_segments, num_tendons_per_segment)``.
-    Each row defines the offsets of the parallel tendons routed through that
-    segment.
+    ``body`` contains the underlying planar PCS dynamic parameters. Active and
+    passive tendon routing fields are batched by tendon; attachment segment
+    indices define which planar segment each tendon reaches. Passive tendon
+    impedance fields are batched by passive tendon and must have the same
+    leading length as ``passive_tendon_routing``.
     """
 
-    tendon_distance: Array
+    body: PlanarPCSParams
+    active_tendon_routing: BaseTendonRoutingParams
+    passive_tendon_routing: BaseTendonRoutingParams = eqx.field(
+        default_factory=LinearTendonRoutingParams.empty
+    )
+    passive_tendon: PassiveTendonParams = eqx.field(
+        default_factory=PassiveTendonParams.empty
+    )
 
     def validate(self) -> None:
-        super().validate()
-        n_segments = self.length.shape[0]
-        if (
-            self.tendon_distance.ndim != 2
-            or self.tendon_distance.shape[0] != n_segments
-        ):
+        self.body.validate()
+        self.active_tendon_routing.validate()
+        self.passive_tendon_routing.validate()
+        self.passive_tendon.validate()
+        if self.passive_tendon.num_tendons != self.passive_tendon_routing.num_tendons:
             raise ValueError(
-                "tendon_distance must have shape "
-                f"({n_segments}, num_tendons_per_segment), got {self.tendon_distance.shape}."
+                "passive_tendon must have one impedance entry per "
+                "passive_tendon_routing entry."
             )
 
 

--- a/src/soromox/systems/pcs/tendon_actuated_planar_pcs.py
+++ b/src/soromox/systems/pcs/tendon_actuated_planar_pcs.py
@@ -1,136 +1,272 @@
 __all__ = ["TendonActuatedPlanarPCS"]
 
+from collections.abc import Callable
 from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp
 from jax import Array, vmap
 
+import soromox.actuation.tendon_actuation as act
 from soromox.rendering.actuators import ActuatorVisualLayer
+from soromox.systems.params import (
+    BaseTendonRoutingParams,
+    PassiveTendonParams,
+)
 from soromox.systems.pcs.params import TendonActuatedPlanarPCSParams
 from soromox.systems.pcs.structures import PlanarPCSStructure
+from soromox.utils.integration import scale_gaussian_quadrature
 
 from .planar_pcs import PlanarPCS
 
 
 class TendonActuatedPlanarPCS(PlanarPCS):
     """
-    Tendon-driven Planar Piecewise Constant Strain (PCS) model for 2D soft continuum robots.
+    Tendon-driven planar Piecewise Constant Strain (PCS) model.
 
-    This class implements the geometric and dynamic modeling of a 2D soft robot
-    using the Cosserat rod theory and piecewise constant strain assumption.
-    It supports computation of forward kinematics, Jacobians, dynamical matrices.
+    This model uses the planar strain convention ``[kappa_z, sigma_x, sigma_y]``
+    per segment and supports active and passive tendons. Tendons are described by
+    the same batched routing parameter objects used by ``TendonActuatedPCS`` and
+    ``TendonActuatedGVS``. Each tendon has an ``attachment_segment_index`` that
+    determines which proximal segments it spans.
 
-    This class assumes parallel routing of the tendons to the backbone centerline.
-    For other kinds of tendon routings (e.g., out-of-plane, helicoidal, etc.),
-    the `TendonActuatedPCS` should be used.
+    Routing basis functions may be shared with spatial systems or written in a
+    compact planar form. For each tendon and arc-length position ``s``, ``d_s``
+    and ``dd_s_ds`` may return:
 
-    Attributes:
-        num_segments: Number of segments (constant strain sections) along the robot.
-        num_actuators: Number of actuators (control inputs) for the robot (2 per actuated segment in the case of planar tendon-driven robots).
-        th0: Initial orientation angle of the robot in radians.
-        g: Gravitational acceleration vector (embedded in a 3D vector).
-            [0, g_x, g_y]
-        L, r, E, G, rho, D: Physical properties of each segment (length, radius, elastic/shear modulus, etc.).
-        num_active_strains: Number of active strain components (based on strain_selector).
-        num_strains: Total number of strain components (6 * num_segments).
-        B_xi: Basis matrix for projecting active strains (6 * num_segments, num_active_strains).
-        xi_ref: Reference strain (reference configuration) of the robot.
-        num_gauss_points: Requested nonzero Gauss-Legendre quadrature nodes.
-        num_integration_points: Stored integration nodes, including zero-weight endpoints.
-        integration_points, integration_weights: Quadrature nodes and weights.
-        d: Distances of the tendons from the segment's backbone.
-        segment_indices_to_actuate: Indices of the segments that are actuated.
+    - a scalar: interpreted as the planar offset ``d(s)`` or derivative
+      ``d'(s)``;
+    - shape ``(1,)``: first entry is interpreted as ``d(s)`` or ``d'(s)``;
+    - shape ``(3,)``: PCS/GVS-compatible ``[0, y, z]`` routing, where ``y`` is
+      the planar offset and ``z`` must be zero.
 
-    Notes:
-    -----
-    - The strain vector is composed of 3 components per segment:
-      [kappa_z, sigma_x, sigma_y].
-      By default, the rod is assumed to be straight and aligned with the x-axis,
-        so the reference strain is set to [0, 1, 0].
-        Thus:   - kappa_z corresponds to bending around the z-axis,
-                - sigma_x corresponds to axial strain along the x-axis,
-                - sigma_y corresponds to shear along the y-axis.
-    - This class assumes parallel routing of the tendons to the backbone centerline.
-      For other kinds of tendon routings (e.g., out-of-plane, helicoidal, etc.),
-      the `TendonActuatedPCS` should be used.
-
+    Shape ``(2,)`` is intentionally invalid because it is ambiguous whether it
+    means ``[x, y]`` or ``[y, z]``. The built-in ``LinearTendonRoutingParams``
+    uses the PCS/GVS-compatible ``[0, y, z]`` convention; planar callers should
+    set ``z_intercept = z_slope = 0``.
     """
 
+    n_p: int
     params: TendonActuatedPlanarPCSParams
-    d: Array  # distance of the tendons from the segment's backbone, shape (num_segments,)
-    segment_indices_to_actuate: Array  # indices of the segments that are actuated, shape (num_actuated_segments,)
+    active_tendon_routing: BaseTendonRoutingParams
+    passive_tendon_routing: BaseTendonRoutingParams
+    active_d_s: Callable = eqx.field(static=True)
+    active_dd_s_ds: Callable = eqx.field(static=True)
+    passive_d_s: Callable = eqx.field(static=True)
+    passive_dd_s_ds: Callable = eqx.field(static=True)
+    K_pt: Array
+    D_pt: Array
+    l_pt0: Array
 
     def __init__(
         self,
         params: TendonActuatedPlanarPCSParams,
         structure: PlanarPCSStructure | None = None,
-        segment_actuation_selector: Array | None = None,
+        active_tendon_routing_basis: dict[str, Callable] | None = None,
+        passive_tendon_routing_basis: dict[str, Callable] | None = None,
         **kwargs: Any,
     ):
         """
-        Initialize the TendonActuatedPlanarPCS class
+        Initialize a tendon-actuated planar PCS model.
 
         Args:
-            params: Dynamic tendon-actuated planar PCS parameters.
-            structure: Static planar PCS layout. If omitted, the default planar
-                PCS structure is used.
-            segment_actuation_selector: Boolean array selecting the actuated
-                segments. Defaults to all segments active.
-            **kwargs: Additional keyword arguments.
+            params: Typed dynamic parameters. ``params.body`` stores the planar
+                PCS body, and active/passive routing fields store one leading
+                entry per tendon.
+            structure: Static planar PCS layout. Changing the number of
+                segments, active strains, or quadrature layout requires
+                reconstruction.
+            active_tendon_routing_basis: Routing functions for active tendons.
+                Defaults to linear routing. Custom functions may return scalar,
+                ``(1,)``, or PCS/GVS-compatible ``(3,)`` values as documented in
+                the class docstring.
+            passive_tendon_routing_basis: Routing functions for passive tendons.
+                The same planar return-shape rules apply.
+            **kwargs: Additional keyword arguments for ``PlanarPCS``.
         """
         if not isinstance(params, TendonActuatedPlanarPCSParams):
             raise TypeError("params must be a TendonActuatedPlanarPCSParams instance.")
-        super().__init__(params, structure=structure, **kwargs)
+        params.validate()
+        super().__init__(params.body, structure=structure, **kwargs)
+        self.params = params
 
-        if segment_actuation_selector is None:
-            segment_actuation_selector = jnp.ones(self.num_segments, dtype=bool)
-
-        self.segment_indices_to_actuate = jnp.array(
-            [i for i, act in enumerate(segment_actuation_selector) if act]
+        if active_tendon_routing_basis is None:
+            active_tendon_routing_basis = {
+                "d_s": act.linear_routing,
+                "dd_s_ds": act.linear_routing_arc_length_derivative,
+            }
+        self.active_d_s, self.active_dd_s_ds = self._set_tendon_routing_basis(
+            active_tendon_routing_basis
+        )
+        self.active_tendon_routing = self._set_active_tendon_routing(
+            params.active_tendon_routing
         )
 
-        self.num_actuators = int(jnp.sum(segment_actuation_selector)) * self.d.shape[1]
+        if passive_tendon_routing_basis is None:
+            passive_tendon_routing_basis = {
+                "d_s": act.linear_routing,
+                "dd_s_ds": act.linear_routing_arc_length_derivative,
+            }
+        self.passive_d_s, self.passive_dd_s_ds = self._set_tendon_routing_basis(
+            passive_tendon_routing_basis
+        )
+        self.passive_tendon_routing = self._set_passive_tendon_routing(
+            params.passive_tendon_routing
+        )
+        self._set_passive_tendon(params.passive_tendon)
 
-        self._set_params(params)
+    def _set_tendon_routing_basis(
+        self, tendon_routing_basis: dict[str, Callable]
+    ) -> tuple[Callable, Callable]:
+        """Store tendon routing and arc-length derivative callables."""
+        return tendon_routing_basis["d_s"], tendon_routing_basis["dd_s_ds"]
 
-    def _set_params(self, params: TendonActuatedPlanarPCSParams):
+    @staticmethod
+    def _planar_component_from_routing_value(value: Array, name: str) -> Array:
         """
-        Set the parameters of the tendon-driven planar PCS.
+        Extract the scalar planar tendon offset from one routing-basis value.
 
-        Args:
-            params (Dict[str, Array]): Dictionary containing the parameters of the robot.
-                Dictionary containing the robot parameters:
-                - "th0": (optional) float
-                    Initial orientation angle [rad]
-                    Default is 90 degrees (1.57 radians).
-                - "L": List/Array of num_segments floats
-                    Length of each segment [m]
-                - "r": List/Array of num_segments floats
-                    Radius of each segment [m]
-                - "rho": List/Array of num_segments floats
-                    Density of each segment [kg/m^3]
-                - "g": List/Array of 2 floats [gx, gy]
-                    Gravitational acceleration vector [m/s^2]
-                - "E": List/Array of num_segments floats
-                    Elastic modulus of each segment [Pa]
-                - "G": List/Array of num_segments floats
-                    Shear modulus of each segment [Pa]
-                - "D": List/Array of (num_segments x num_segments) floats
-                    Damping matrix of each segment [Pa*s]
-                - "d": List/Array of num_segments floats
-                    Distance of the tendons from the segment's backbone [m]
+        Accepted shapes are scalar, ``(1,)``, and PCS/GVS-compatible ``(3,)``.
+        Shape ``(2,)`` is rejected because its coordinate convention is
+        ambiguous.
         """
-        super()._set_params(params)
-
-        # Distance of the tendons from the segment's backbone
-        d = jnp.asarray(params.tendon_distance, dtype=jnp.float64)
-        if d.ndim != 2 or d.shape[0] != self.num_segments:
+        value = jnp.asarray(value)
+        if value.ndim == 0:
+            return value
+        if value.shape[-1] == 1:
+            return value[..., 0]
+        if value.shape[-1] == 3:
+            return value[..., 1]
+        if value.shape[-1] == 2:
             raise ValueError(
-                "tendon_distance must have shape "
-                f"({self.num_segments}, num_tendons_per_segment), got {d.shape}."
+                f"{name} returned shape (..., 2), which is ambiguous for planar "
+                "routing. Return a scalar, shape (1,), or PCS/GVS-compatible "
+                "shape (3,) with zero z."
             )
-        self.d = d
+        raise ValueError(
+            f"{name} must return a scalar, shape (1,), or shape (3,), got "
+            f"shape {value.shape}."
+        )
+
+    @staticmethod
+    def _planar_z_magnitude_from_routing_value(value: Array, name: str) -> Array:
+        """Return ``abs(z)`` for PCS/GVS-compatible planar routing samples."""
+        value = jnp.asarray(value)
+        if value.ndim == 0 or value.shape[-1] == 1:
+            return jnp.asarray(0.0, dtype=value.dtype)
+        if value.shape[-1] == 3:
+            return jnp.abs(value[..., 2])
+        if value.shape[-1] == 2:
+            raise ValueError(
+                f"{name} returned shape (..., 2), which is ambiguous for planar "
+                "routing. Return a scalar, shape (1,), or PCS/GVS-compatible "
+                "shape (3,) with zero z."
+            )
+        raise ValueError(
+            f"{name} must return a scalar, shape (1,), or shape (3,), got "
+            f"shape {value.shape}."
+        )
+
+    def _validate_planar_routing_basis(
+        self,
+        tendon_routing_params: BaseTendonRoutingParams,
+        d_s: Callable,
+        dd_s_ds: Callable,
+        name: str,
+    ) -> None:
+        """Validate planar routing shape, zero out-of-plane routing, and body fit."""
+        if tendon_routing_params.num_tendons == 0:
+            return
+
+        sample_s = jnp.linspace(0.0, self.L_cum[-1], 75)
+
+        def radius_at_s(s: Array) -> Array:
+            idx = jnp.sum(self.L_cum <= s) - 1
+            idx = jnp.clip(idx, 0, self.num_segments - 1)
+            return self.r[idx]
+
+        def sample_tendon(
+            tendon_routing_params_k: BaseTendonRoutingParams, s: Array
+        ) -> tuple[Array, Array, Array]:
+            d_value = d_s(tendon_routing_params_k, s)
+            dd_value = dd_s_ds(tendon_routing_params_k, s)
+            d = self._planar_component_from_routing_value(d_value, f"{name}.d_s")
+            z = self._planar_z_magnitude_from_routing_value(d_value, f"{name}.d_s")
+            dz = self._planar_z_magnitude_from_routing_value(
+                dd_value, f"{name}.dd_s_ds"
+            )
+            return jnp.abs(d), z, dz
+
+        d_abs, z_abs, dz_abs = vmap(
+            vmap(sample_tendon, in_axes=(None, 0), out_axes=0),
+            in_axes=(0, None),
+            out_axes=0,
+        )(tendon_routing_params, sample_s)
+        r_body = vmap(radius_at_s)(sample_s)
+
+        if bool(jnp.any(z_abs > 1e-12)) or bool(jnp.any(dz_abs > 1e-12)):
+            raise ValueError(
+                f"{name} returned nonzero z routing or z derivative, which is "
+                "invalid for TendonActuatedPlanarPCS."
+            )
+        if bool(jnp.any(d_abs > r_body[None, :])):
+            raise UserWarning(f"{name} tendon(s) exit the robot body.")
+
+    def _set_active_tendon_routing(
+        self, active_tendon_routing: BaseTendonRoutingParams
+    ) -> BaseTendonRoutingParams:
+        """Store and validate active tendon routing parameters."""
+        if not isinstance(active_tendon_routing, BaseTendonRoutingParams):
+            raise TypeError(
+                "active_tendon_routing must be a BaseTendonRoutingParams instance."
+            )
+        active_tendon_routing.validate()
+        self.num_actuators = active_tendon_routing.num_tendons
+        active_tendon_routing.validate_attachment_segments(
+            self.num_segments, "active_tendon_routing"
+        )
+        self._validate_planar_routing_basis(
+            active_tendon_routing,
+            self.active_d_s,
+            self.active_dd_s_ds,
+            "active_tendon_routing",
+        )
+        return active_tendon_routing
+
+    def _set_passive_tendon_routing(
+        self, passive_tendon_routing: BaseTendonRoutingParams
+    ) -> BaseTendonRoutingParams:
+        """Store and validate passive tendon routing parameters."""
+        if not isinstance(passive_tendon_routing, BaseTendonRoutingParams):
+            raise TypeError(
+                "passive_tendon_routing must be a BaseTendonRoutingParams instance."
+            )
+        passive_tendon_routing.validate()
+        self.n_p = passive_tendon_routing.num_tendons
+        passive_tendon_routing.validate_attachment_segments(
+            self.num_segments, "passive_tendon_routing"
+        )
+        self._validate_planar_routing_basis(
+            passive_tendon_routing,
+            self.passive_d_s,
+            self.passive_dd_s_ds,
+            "passive_tendon_routing",
+        )
+        return passive_tendon_routing
+
+    def _set_passive_tendon(self, passive_tendon: PassiveTendonParams) -> None:
+        """Store per-passive-tendon stiffness, damping, and rest-length offsets."""
+        if not isinstance(passive_tendon, PassiveTendonParams):
+            raise TypeError("passive_tendon must be a PassiveTendonParams instance.")
+        passive_tendon.validate()
+        if passive_tendon.num_tendons != self.n_p:
+            raise ValueError(
+                "passive_tendon length must match passive_tendon_routing length; "
+                f"got {passive_tendon.num_tendons} and {self.n_p}."
+            )
+        self.K_pt = jnp.diag(jnp.asarray(passive_tendon.stiffness))
+        self.D_pt = jnp.diag(jnp.asarray(passive_tendon.damping))
+        self.l_pt0 = jnp.asarray(passive_tendon.rest_length_offset)
 
     def with_params(
         self, params: TendonActuatedPlanarPCSParams
@@ -138,166 +274,302 @@ class TendonActuatedPlanarPCS(PlanarPCS):
         """Return an updated copy with a full typed parameter object."""
         if not isinstance(params, TendonActuatedPlanarPCSParams):
             raise TypeError("params must be a TendonActuatedPlanarPCSParams instance.")
-        d = jnp.asarray(params.tendon_distance, dtype=jnp.float64)
-        if d.shape != self.d.shape:
+        params.validate()
+        if type(params.active_tendon_routing) is not type(
+            self.params.active_tendon_routing
+        ):
             raise ValueError(
-                "tendon_distance shape changes the actuation layout; construct a new TendonActuatedPlanarPCS."
+                "Changing active_tendon_routing type requires reconstruction."
             )
-        updated_self = self._with_planar_pcs_params(params)
-        return eqx.tree_at(lambda model: model.d, updated_self, d)
+        if type(params.passive_tendon_routing) is not type(
+            self.params.passive_tendon_routing
+        ):
+            raise ValueError(
+                "Changing passive_tendon_routing type requires reconstruction."
+            )
+        if (
+            params.active_tendon_routing.num_tendons
+            != self.params.active_tendon_routing.num_tendons
+        ):
+            raise ValueError(
+                "Changing the number of active tendons requires reconstruction."
+            )
+        if (
+            params.passive_tendon_routing.num_tendons
+            != self.params.passive_tendon_routing.num_tendons
+        ):
+            raise ValueError(
+                "Changing the number of passive tendons requires reconstruction."
+            )
+        self.params.active_tendon_routing.assert_same_attachment_segments(
+            params.active_tendon_routing, "active_tendon_routing"
+        )
+        self.params.passive_tendon_routing.assert_same_attachment_segments(
+            params.passive_tendon_routing, "passive_tendon_routing"
+        )
 
-    def update_params(self, **updates: Array) -> "TendonActuatedPlanarPCS":
+        updated_self = self._with_planar_pcs_params(params.body, stored_params=params)
+        updated_self._validate_planar_routing_basis(
+            params.active_tendon_routing,
+            self.active_d_s,
+            self.active_dd_s_ds,
+            "active_tendon_routing",
+        )
+        updated_self._validate_planar_routing_basis(
+            params.passive_tendon_routing,
+            self.passive_d_s,
+            self.passive_dd_s_ds,
+            "passive_tendon_routing",
+        )
+        return eqx.tree_at(
+            lambda model: (
+                model.params,
+                model.active_tendon_routing,
+                model.passive_tendon_routing,
+                model.K_pt,
+                model.D_pt,
+                model.l_pt0,
+            ),
+            updated_self,
+            (
+                params,
+                params.active_tendon_routing,
+                params.passive_tendon_routing,
+                jnp.diag(jnp.asarray(params.passive_tendon.stiffness)),
+                jnp.diag(jnp.asarray(params.passive_tendon.damping)),
+                jnp.asarray(params.passive_tendon.rest_length_offset),
+            ),
+        )
+
+    def update_params(self, **updates: Any) -> "TendonActuatedPlanarPCS":
         """Return an updated copy with selected typed parameter fields replaced."""
         return self.with_params(self.params.replace(**updates))
 
     @eqx.filter_jit
-    def actuation_matrix(self, q: Array) -> Array:
-        """
-        Compute the actuation matrix of the robot.
-
-        Args:
-            q (Array): generalized coordinates of shape (num_active_strains,).
-
-        Returns:
-            A (Array): Actuation matrix of shape (num_active_strains, num_actuators)
-        """
-        xi = self.strain(q)
-
-        segment_indices = jnp.arange(self.num_segments)
-
-        def compute_actuation_matrix_for_segment(
-            segment_idx: int,
-            d_sm: Array,
-        ) -> Array:
-            """
-            Compute the actuation matrix for a single segment.
-            We assume that each segment is actuated by num_segment_tendons that are routed at a distance of d from the segment's backbone,
-            respectively, and attached to the segment's distal end. We assume that the motor is located at the base of the robot and that the
-            tendons are routed through all proximal segments.
-            The positive control inputs u1 and u2 are the tensions (i.e., forces) applied by the two tendons.
-            At a straight configuration with a positive d1, a positive u1 and zero u2 should cause the bend negatively (to the right) and contract its length.
-
-            Args:
-                segment_idx: index of the segment
-                d_sm: distance of the tendons from the segment's backbone (shape: (num_segment_tendons,))
-
-            Returns:
-                A_sm: actuation matrix of shape (n_xi, num_segment_tendons)
-            """
-
-            def compute_A_d(d_k: Array) -> Array:
-                """
-                Compute the actuation matrix for a single actuator/tendon with respect to the soft robot's strains.
-                Args:
-                    d_k: distance of the k-th tendon from the centerline as array of shape ()
-                Returns:
-                    A_d: actuation matrix of shape (n_xi, ) where n_xi is the number of strains
-                """
-
-                def compute_A_d_wrt_xi_i(i: Array, L_i: Array, xi_i: Array) -> Array:
-                    """
-                    Compute the actuation matrix for a single actuator with respect to the strains of a single segment.
-                    Args:
-                        i: index of the segment
-                        L_i: length of the segment
-                        xi_i: strains for the segment
-
-                    Returns:
-                        A_d_segment: actuation matrix for the segment of shape (3, 3)
-                    """
-                    kappa_i = xi_i[0]  # bending strain
-                    axial_i = xi_i[1]  # axial strain
-                    shear_i = xi_i[2]  # shear strain
-
-                    square_root_term = jnp.sqrt(
-                        shear_i**2 + (axial_i + d_k * kappa_i) ** 2
-                    )
-
-                    A_d_wrt_xi_i = jnp.array(
-                        [
-                            L_i
-                            * d_k
-                            * (d_k * kappa_i + axial_i)
-                            / square_root_term,  # actuation on the bending
-                            L_i
-                            * (d_k * kappa_i + axial_i)
-                            / square_root_term,  # actuation on the axial strain
-                            L_i
-                            * shear_i
-                            / square_root_term,  # actuation on the shear strain
-                        ]
-                    )
-
-                    A_d_segment = jnp.where(
-                        i * jnp.ones((3,)) <= segment_idx * jnp.ones((3,)),
-                        A_d_wrt_xi_i,
-                        jnp.zeros_like(A_d_wrt_xi_i),
-                    )
-
-                    return A_d_segment
-
-                A_d = vmap(compute_A_d_wrt_xi_i)(
-                    segment_indices, self.L, xi.reshape(-1, 3)
-                ).reshape(-1)
-
-                return A_d
-
-            A_sm = vmap(compute_A_d, in_axes=0, out_axes=-1)(d_sm)
-
-            return A_sm
-
-        # compute the actuation matrix for all segments
-
-        # (num_segments, n_xi, num_segment_tendons)
-        A = vmap(compute_actuation_matrix_for_segment, in_axes=(0, 0), out_axes=0)(
-            segment_indices, self.d
+    def _local_tendon_basis_single(
+        self,
+        i: Array,
+        xi_i: Array,
+        s: Array,
+        tendon_routing_params_k: BaseTendonRoutingParams,
+        d_s_fn: Callable,
+        dd_s_ds_fn: Callable,
+        attachment_segment_idx: Array,
+    ) -> Array:
+        """Return the local planar actuation basis for one tendon at ``s``."""
+        is_tendon_active = attachment_segment_idx >= i
+        d = self._planar_component_from_routing_value(
+            d_s_fn(tendon_routing_params_k, s), "d_s"
+        )
+        dd_ds = self._planar_component_from_routing_value(
+            dd_s_ds_fn(tendon_routing_params_k, s), "dd_s_ds"
         )
 
-        # deactivate the actuation for some segments
-        # (num_actuated_segments, n_xi, num_segment_tendons)
-        A = A[self.segment_indices_to_actuate]
-
-        # reshape the actuation matrix to have shape (n_xi, n_act)
-        A = jnp.concatenate(A, axis=1)  # concatenate along the second axis
-
-        # project onto the active strain basis to match the generalized coordinates
-        A = self.B_xi.T @ A
-
-        return A
+        kappa = xi_i[0]
+        axial = xi_i[1] + d * kappa
+        shear = xi_i[2] + dd_ds
+        norm = jnp.sqrt(axial**2 + shear**2)
+        basis = jnp.array([d * axial / norm, axial / norm, shear / norm])
+        return is_tendon_active * basis
 
     @eqx.filter_jit
-    def tendon_length(self, q: Array) -> Array:
-        """
-        Compute the cumulative tendon length for each actuator.
+    def actuation_matrix(self, q: Array) -> Array:
+        """Return the active tendon actuation matrix."""
+        return self._actuation_matrix(
+            q, self.active_tendon_routing, self.active_d_s, self.active_dd_s_ds
+        )
 
-        Each tendon is assumed to be routed along the backbone and attached at the distal
-        end of the corresponding actuated segment. The tendon length is obtained by
-        integrating the local stretch along every traversed segment, which depends on
-        shear and axial strains and on the tendon offset d.
+    @eqx.filter_jit
+    def jacobian_passive_tendon(self, q: Array) -> Array:
+        """Return the passive tendon length Jacobian in active coordinates."""
+        return self._actuation_matrix(
+            q,
+            self.passive_tendon_routing,
+            self.passive_d_s,
+            self.passive_dd_s_ds,
+        ).T
 
-        Args:
-            q (Array): generalized coordinates of shape (num_active_strains,).
+    @eqx.filter_jit
+    def _actuation_matrix(
+        self,
+        q: Array,
+        tendon_routing_params: BaseTendonRoutingParams,
+        d_s: Callable,
+        dd_s_ds: Callable,
+    ) -> Array:
+        """Compute the generalized tendon actuation matrix by quadrature."""
+        xi = self.strain(q).reshape((self.num_segments, 3))
+        num_tendons = tendon_routing_params.num_tendons
+        if num_tendons == 0:
+            return jnp.zeros((self.num_dofs, 0), dtype=q.dtype)
 
-        Returns:
-            l (Array): tendon lengths of shape (num_actuators,).
-        """
+        def A_segment_i(i: Array) -> Array:
+            xi_i = xi[i]
 
-        xi = self.strain(q).reshape(self.num_segments, 3)
-        kappa = xi[:, 0:1]
-        axial = xi[:, 1:2]
-        shear = xi[:, 2:3]  # ensure 2D for broadcasting
+            def A_point_j(j: Array) -> Array:
+                Xs_j = Xs_scaled[j]
+                Ws_j = Ws_scaled[j]
+                Phi_a_j = vmap(
+                    self._local_tendon_basis_single,
+                    in_axes=(None, None, None, 0, None, None, 0),
+                    out_axes=-1,
+                )(
+                    i,
+                    xi_i,
+                    Xs_j,
+                    tendon_routing_params,
+                    d_s,
+                    dd_s_ds,
+                    tendon_routing_params.attachment_segment_index_array,
+                )
+                return Ws_j * Phi_a_j
 
-        d = self.d
-        if d.ndim == 1:
-            d = d[:, None]
+            Xs_scaled, Ws_scaled = scale_gaussian_quadrature(
+                self.integration_points,
+                self.integration_weights,
+                self.L_cum[i],
+                self.L_cum[i + 1],
+            )
+            return vmap(A_point_j)(jnp.arange(self.num_integration_points))
 
-        local_extension = axial + d * kappa
-        segment_lengths = self.L[:, None] * jnp.sqrt(shear**2 + local_extension**2)
+        A_blocks = vmap(A_segment_i)(jnp.arange(self.num_segments))
+        A = jnp.sum(A_blocks, axis=1).reshape((3 * self.num_segments, num_tendons))
+        return self.B_xi.T @ A
 
-        cumulative_lengths = jnp.cumsum(segment_lengths, axis=0)
-        tendon_lengths = cumulative_lengths[self.segment_indices_to_actuate]
+    @eqx.filter_jit
+    def active_tendon_length(self, q: Array) -> Array:
+        """Return active tendon lengths."""
+        return self._tendon_length(
+            q, self.active_tendon_routing, self.active_d_s, self.active_dd_s_ds
+        )
 
-        return tendon_lengths.reshape(-1)
+    @eqx.filter_jit
+    def passive_tendon_length(self, q: Array) -> Array:
+        """Return passive tendon lengths."""
+        return self._tendon_length(
+            q,
+            self.passive_tendon_routing,
+            self.passive_d_s,
+            self.passive_dd_s_ds,
+        )
+
+    tendon_length = active_tendon_length
+    actuated_coordinates = active_tendon_length
+
+    @eqx.filter_jit
+    def _tendon_length(
+        self,
+        q: Array,
+        tendon_routing_params: BaseTendonRoutingParams,
+        d_s: Callable,
+        dd_s_ds: Callable,
+    ) -> Array:
+        """Compute tendon lengths by integrating local planar length density."""
+        xi = self.strain(q).reshape((self.num_segments, 3))
+        num_tendons = tendon_routing_params.num_tendons
+        if num_tendons == 0:
+            return jnp.zeros((0,), dtype=q.dtype)
+
+        def length_density_segment_i(i: Array) -> Array:
+            xi_i = xi[i]
+
+            def length_density_point_j(j: Array) -> Array:
+                Xs_j = Xs_scaled[j]
+                Ws_j = Ws_scaled[j]
+
+                def length_density_tendon_k(
+                    tendon_routing_params_k: BaseTendonRoutingParams,
+                    attachment_segment_idx: Array,
+                ) -> Array:
+                    is_tendon_active = attachment_segment_idx >= i
+                    d = self._planar_component_from_routing_value(
+                        d_s(tendon_routing_params_k, Xs_j), "d_s"
+                    )
+                    dd_ds = self._planar_component_from_routing_value(
+                        dd_s_ds(tendon_routing_params_k, Xs_j), "dd_s_ds"
+                    )
+                    axial = xi_i[1] + d * xi_i[0]
+                    shear = xi_i[2] + dd_ds
+                    return is_tendon_active * jnp.sqrt(axial**2 + shear**2)
+
+                dl_ds_j = vmap(length_density_tendon_k)(
+                    tendon_routing_params,
+                    tendon_routing_params.attachment_segment_index_array,
+                )
+                return Ws_j * dl_ds_j
+
+            Xs_scaled, Ws_scaled = scale_gaussian_quadrature(
+                self.integration_points,
+                self.integration_weights,
+                self.L_cum[i],
+                self.L_cum[i + 1],
+            )
+            return vmap(length_density_point_j)(
+                jnp.arange(self.num_integration_points)
+            )
+
+        dl_ds_blocks = vmap(length_density_segment_i)(jnp.arange(self.num_segments))
+        return jnp.sum(dl_ds_blocks, axis=(0, 1))
+
+    @eqx.filter_jit
+    def forward_kinematics_active_tendons(self, q: Array, s: Array) -> Array:
+        """Return active tendon Cartesian points at arc length ``s``."""
+        return self._forward_kinematics_tendons(
+            q, s, self.active_tendon_routing, self.active_d_s
+        )
+
+    @eqx.filter_jit
+    def forward_kinematics_passive_tendons(self, q: Array, s: Array) -> Array:
+        """Return passive tendon Cartesian points at arc length ``s``."""
+        return self._forward_kinematics_tendons(
+            q, s, self.passive_tendon_routing, self.passive_d_s
+        )
+
+    @eqx.filter_jit
+    def forward_kinematics_tendons(self, q: Array, s: Array) -> Array:
+        """Return active and passive tendon Cartesian points at arc length ``s``."""
+        active_pos = self.forward_kinematics_active_tendons(q, s)
+        passive_pos = self.forward_kinematics_passive_tendons(q, s)
+        if active_pos.size == 0:
+            return passive_pos
+        if passive_pos.size == 0:
+            return active_pos
+        return jnp.concatenate([active_pos, passive_pos], axis=0)
+
+    @eqx.filter_jit
+    def _forward_kinematics_tendons(
+        self,
+        q: Array,
+        s: Array,
+        tendon_routing_params: BaseTendonRoutingParams,
+        d_s: Callable,
+    ) -> Array:
+        """Compute Cartesian tendon positions for one routing family."""
+        if tendon_routing_params.num_tendons == 0:
+            return jnp.zeros((0, 2), dtype=q.dtype)
+
+        def forward_kinematics_tendon_k(
+            tendon_routing_params_k: BaseTendonRoutingParams,
+            attachment_segment_idx: Array,
+            q: Array,
+            s: Array,
+        ) -> Array:
+            attachment_s = self.L_cum[attachment_segment_idx + 1]
+            s_val = jnp.clip(s, 0.0, attachment_s)
+            pose = self.forward_kinematics(q, s_val)
+            theta = pose[0]
+            normal = jnp.array([-jnp.sin(theta), jnp.cos(theta)])
+            d = self._planar_component_from_routing_value(
+                d_s(tendon_routing_params_k, s_val), "d_s"
+            )
+            return pose[1:3] + d * normal
+
+        return vmap(forward_kinematics_tendon_k, in_axes=(0, 0, None, None))(
+            tendon_routing_params,
+            tendon_routing_params.attachment_segment_index_array,
+            q,
+            s,
+        )
 
     def actuator_visual_layers(
         self,
@@ -306,30 +578,52 @@ class TendonActuatedPlanarPCS(PlanarPCS):
         *,
         actuator_inputs: Array | None = None,
     ) -> tuple[ActuatorVisualLayer, ...]:
-        """Return renderer-facing actuator geometry for planar routed tendons."""
+        """Return renderer-facing actuator geometry for active/passive tendons."""
         del actuator_inputs
-        num_tendons_per_segment = self.d.shape[1]
-        attachment_indices = jnp.repeat(
-            self.segment_indices_to_actuate, num_tendons_per_segment
-        )
-        distances = self.d[self.segment_indices_to_actuate].reshape(-1)
+        layers: list[ActuatorVisualLayer] = []
+        if self.active_tendon_routing.num_tendons > 0:
+            active_points = vmap(
+                lambda s: self.forward_kinematics_active_tendons(q, s)
+            )(s_points)
+            layers.append(
+                ActuatorVisualLayer(
+                    name="active_tendons",
+                    kind="tendon",
+                    points=active_points.transpose(1, 0, 2),
+                )
+            )
+        if self.passive_tendon_routing.num_tendons > 0:
+            passive_points = vmap(
+                lambda s: self.forward_kinematics_passive_tendons(q, s)
+            )(s_points)
+            layers.append(
+                ActuatorVisualLayer(
+                    name="passive_tendons",
+                    kind="tendon",
+                    points=passive_points.transpose(1, 0, 2),
+                )
+            )
+        return tuple(layers)
 
-        def tendon_path(segment_idx: Array, distance: Array) -> Array:
-            attachment_s = self.L_cum[segment_idx + 1]
+    @eqx.filter_jit
+    def elastic_force(self, q: Array) -> Array:
+        """Return body elastic force plus passive tendon spring force."""
+        tau_el = super().elastic_force(q)
+        J_pt = self.jacobian_passive_tendon(q)
+        l_pt = self.passive_tendon_length(q)
+        return tau_el + J_pt.T @ self.K_pt @ (l_pt - self.l_pt0)
 
-            def tendon_point(s: Array) -> Array:
-                pose = self.forward_kinematics(q, jnp.clip(s, 0.0, attachment_s))
-                theta = pose[0]
-                normal = jnp.array([-jnp.sin(theta), jnp.cos(theta)])
-                return pose[1:3] + distance * normal
+    @eqx.filter_jit
+    def damping_matrix(self, q: Array) -> Array:
+        """Return body damping plus passive tendon damping."""
+        D = super().damping_matrix(q)
+        J_pt = self.jacobian_passive_tendon(q)
+        return D + J_pt.T @ self.D_pt @ J_pt
 
-            return vmap(tendon_point)(s_points)
-
-        points = vmap(tendon_path)(attachment_indices, distances)
-        return (
-            ActuatorVisualLayer(
-                name="active_tendons",
-                kind="tendon",
-                points=points,
-            ),
-        )
+    @eqx.filter_jit
+    def _elastic_energy(self, q: Array) -> Array:
+        """Return body elastic energy plus passive tendon spring energy."""
+        U_K = super()._elastic_energy(q)
+        l_pt = self.passive_tendon_length(q)
+        delta_l = l_pt - self.l_pt0
+        return U_K + 0.5 * delta_l.T @ self.K_pt @ delta_l

--- a/tests/system_param_builders.py
+++ b/tests/system_param_builders.py
@@ -227,19 +227,21 @@ def tendon_actuated_pcs_params(
 
 
 def tendon_actuated_planar_pcs_params(
-    *, body: PlanarPCSParams, tendon_distance: Array
+    *,
+    body: PlanarPCSParams,
+    active_tendon_routing: BaseTendonRoutingParams,
+    passive_tendon_routing: BaseTendonRoutingParams | None = None,
+    passive_tendon: PassiveTendonParams | None = None,
 ) -> TendonActuatedPlanarPCSParams:
+    if passive_tendon_routing is None:
+        passive_tendon_routing = LinearTendonRoutingParams.empty()
+    if passive_tendon is None:
+        passive_tendon = PassiveTendonParams.empty()
     return TendonActuatedPlanarPCSParams(
-        length=body.length,
-        radius=body.radius,
-        density=body.density,
-        young_modulus=body.young_modulus,
-        shear_modulus=body.shear_modulus,
-        damping_matrix=body.damping_matrix,
-        gravity=body.gravity,
-        base_pose=body.base_pose,
-        reference_strain=body.reference_strain,
-        tendon_distance=jnp.asarray(tendon_distance),
+        body=body,
+        active_tendon_routing=active_tendon_routing,
+        passive_tendon_routing=passive_tendon_routing,
+        passive_tendon=passive_tendon,
     )
 
 

--- a/tests/systems/test_system_lengths.py
+++ b/tests/systems/test_system_lengths.py
@@ -142,6 +142,19 @@ def _tendon_routing(num_segments):
     )
 
 
+def _planar_tendon_routing(num_segments):
+    offsets = 0.02 * jnp.ones((num_segments, 2), dtype=jnp.float64).at[:, 1].set(-1.0)
+    return linear_tendon_routing(
+        y_intercept=offsets.reshape(-1),
+        z_intercept=jnp.zeros((2 * num_segments,), dtype=jnp.float64),
+        y_slope=jnp.zeros((2 * num_segments,), dtype=jnp.float64),
+        z_slope=jnp.zeros((2 * num_segments,), dtype=jnp.float64),
+        attachment_segment_index=jnp.repeat(
+            jnp.arange(num_segments, dtype=jnp.int32), 2
+        ),
+    )
+
+
 def _pressure_planar_robot():
     body = _planar_pcs_params([0.08, 0.12])
     params = PressureActuatedPlanarPCSParams(
@@ -216,8 +229,7 @@ def _planar_hsa_robot():
         TendonActuatedPlanarPCS(
             params=tendon_actuated_planar_pcs_params(
                 body=_planar_pcs_params([0.08, 0.12, 0.2]),
-                tendon_distance=0.02
-                * jnp.ones((3, 2), dtype=jnp.float64).at[:, 1].set(-1.0),
+                active_tendon_routing=_planar_tendon_routing(3),
             )
         ),
         _pressure_planar_robot(),

--- a/tests/systems/test_tendon_actuated_planar_pcs.py
+++ b/tests/systems/test_tendon_actuated_planar_pcs.py
@@ -1,45 +1,200 @@
 # ruff: noqa: E402
+import equinox as eqx
 import jax
+import pytest
 
 jax.config.update("jax_enable_x64", True)
 
+from jax import Array
 from jax import numpy as jnp
 from numpy.testing import assert_allclose
 from system_param_builders import (
+    linear_tendon_routing,
+    passive_tendon_params,
     planar_base_pose,
     planar_pcs_params,
     tendon_actuated_planar_pcs_params,
 )
 
-from soromox.systems import TendonActuatedPlanarPCS
+from soromox.systems import (
+    BaseTendonRoutingParams,
+    PassiveTendonParams,
+    PlanarPCSStructure,
+    TendonActuatedPlanarPCS,
+)
 from soromox.utils.tolerance import Tolerance
 
 
-def _build_planar_robot(num_segments: int = 3) -> TendonActuatedPlanarPCS:
-    rho = 1070.0 * jnp.ones((num_segments,))
-    segment_lengths = 1e-1 * jnp.ones((num_segments,))
+class PlanarRoutingParams(BaseTendonRoutingParams):
+    offset: Array
+    slope: Array
+    attachment_segment_index: tuple[int, ...] = eqx.field(static=True)
+
+    @property
+    def num_tendons(self) -> int:
+        return int(self.offset.shape[0])
+
+    @property
+    def attachment_segment_indices(self) -> tuple[int, ...]:
+        return self.attachment_segment_index
+
+    def validate(self) -> None:
+        if self.slope.shape != self.offset.shape:
+            raise ValueError("slope must match offset shape.")
+        if len(self.attachment_segment_index) != self.num_tendons:
+            raise ValueError("attachment_segment_index must match num_tendons.")
+
+
+def scalar_planar_routing(params: PlanarRoutingParams, s: Array) -> Array:
+    return params.offset + params.slope * s
+
+
+def scalar_planar_routing_derivative(params: PlanarRoutingParams, s: Array) -> Array:
+    return params.slope + jnp.zeros_like(s)
+
+
+def vector1_planar_routing(params: PlanarRoutingParams, s: Array) -> Array:
+    return jnp.array([params.offset + params.slope * s])
+
+
+def vector1_planar_routing_derivative(params: PlanarRoutingParams, s: Array) -> Array:
+    return jnp.array([params.slope + jnp.zeros_like(s)])
+
+
+def ambiguous_planar_routing(params: PlanarRoutingParams, s: Array) -> Array:
+    d = params.offset + params.slope * s
+    return jnp.array([0.0, d])
+
+
+def ambiguous_planar_routing_derivative(params: PlanarRoutingParams, s: Array) -> Array:
+    d = params.slope + jnp.zeros_like(s)
+    return jnp.array([0.0, d])
+
+
+def _body_params(num_segments: int):
+    rho = 1070.0 * jnp.ones((num_segments,), dtype=jnp.float64)
+    segment_lengths = 1e-1 * jnp.ones((num_segments,), dtype=jnp.float64)
     damping_matrix = 1e-3 * jnp.diag(
         (
-            jnp.repeat(jnp.array([[1e0, 1e3, 1e3]]), num_segments, axis=0)
+            jnp.repeat(jnp.array([[1e0, 1e3, 1e3]], dtype=jnp.float64), num_segments, axis=0)
             * segment_lengths[:, None]
         ).flatten()
     )
-    body = planar_pcs_params(
+    return planar_pcs_params(
         base_pose=planar_base_pose(jnp.pi / 2),
         length=segment_lengths,
-        radius=2e-2 * jnp.ones((num_segments,)),
+        radius=2e-2 * jnp.ones((num_segments,), dtype=jnp.float64),
         density=rho,
-        gravity=jnp.array([0.0, 9.81]),
-        young_modulus=5e3 * jnp.ones((num_segments,)),
-        shear_modulus=1e3 * jnp.ones((num_segments,)),
+        gravity=jnp.array([0.0, 9.81], dtype=jnp.float64),
+        young_modulus=5e3 * jnp.ones((num_segments,), dtype=jnp.float64),
+        shear_modulus=1e3 * jnp.ones((num_segments,), dtype=jnp.float64),
         damping_matrix=damping_matrix,
     )
-    params = tendon_actuated_planar_pcs_params(
-        body=body,
-        tendon_distance=2e-2 * jnp.array([[1.0, -1.0]]).repeat(num_segments, axis=0),
+
+
+def _constant_distance_matrix(num_segments: int) -> Array:
+    return 2e-2 * jnp.array([[1.0, -1.0]], dtype=jnp.float64).repeat(
+        num_segments, axis=0
     )
 
-    return TendonActuatedPlanarPCS(params=params)
+
+def _constant_distance_routing(distance_matrix: Array):
+    num_segments, num_tendons_per_segment = distance_matrix.shape
+    return linear_tendon_routing(
+        y_intercept=distance_matrix.reshape(-1),
+        y_slope=jnp.zeros((num_segments * num_tendons_per_segment,), dtype=jnp.float64),
+        z_intercept=jnp.zeros(
+            (num_segments * num_tendons_per_segment,), dtype=jnp.float64
+        ),
+        z_slope=jnp.zeros((num_segments * num_tendons_per_segment,), dtype=jnp.float64),
+        attachment_segment_index=jnp.repeat(
+            jnp.arange(num_segments, dtype=jnp.int32), num_tendons_per_segment
+        ),
+    )
+
+
+def _build_planar_robot(
+    num_segments: int = 3,
+    *,
+    active_tendon_routing=None,
+    active_tendon_routing_basis=None,
+    passive_tendon_routing=None,
+    passive_tendon: PassiveTendonParams | None = None,
+) -> TendonActuatedPlanarPCS:
+    body = _body_params(num_segments)
+    if active_tendon_routing is None:
+        active_tendon_routing = _constant_distance_routing(
+            _constant_distance_matrix(num_segments)
+        )
+    params = tendon_actuated_planar_pcs_params(
+        body=body,
+        active_tendon_routing=active_tendon_routing,
+        passive_tendon_routing=passive_tendon_routing,
+        passive_tendon=passive_tendon,
+    )
+    return TendonActuatedPlanarPCS(
+        params=params,
+        structure=PlanarPCSStructure(num_gauss_points=4),
+        active_tendon_routing_basis=active_tendon_routing_basis,
+    )
+
+
+def _closed_form_constant_tendon_length(
+    robot: TendonActuatedPlanarPCS, q: Array, distance_matrix: Array
+) -> Array:
+    xi = robot.strain(q).reshape(robot.num_segments, 3)
+    kappa = xi[:, 0:1]
+    axial = xi[:, 1:2]
+    shear = xi[:, 2:3]
+    local_extension = axial + distance_matrix * kappa
+    segment_lengths = robot.L[:, None] * jnp.sqrt(shear**2 + local_extension**2)
+    return jnp.cumsum(segment_lengths, axis=0).reshape(-1)
+
+
+def _closed_form_constant_actuation_matrix(
+    robot: TendonActuatedPlanarPCS, q: Array, distance_matrix: Array
+) -> Array:
+    xi = robot.strain(q).reshape(robot.num_segments, 3)
+    columns = []
+    for attachment_idx in range(robot.num_segments):
+        for d in distance_matrix[attachment_idx]:
+            segment_blocks = []
+            for segment_idx in range(robot.num_segments):
+                kappa, axial_strain, shear_strain = xi[segment_idx]
+                axial = axial_strain + d * kappa
+                norm = jnp.sqrt(axial**2 + shear_strain**2)
+                local_basis = robot.L[segment_idx] * jnp.array(
+                    [d * axial / norm, axial / norm, shear_strain / norm]
+                )
+                segment_blocks.append(
+                    jnp.where(
+                        segment_idx <= attachment_idx,
+                        local_basis,
+                        jnp.zeros_like(local_basis),
+                    )
+                )
+            columns.append(jnp.concatenate(segment_blocks))
+    return robot.B_xi.T @ jnp.stack(columns, axis=1)
+
+
+def test_constant_distance_routing_matches_previous_closed_form():
+    num_segments = 3
+    distance_matrix = _constant_distance_matrix(num_segments)
+    robot = _build_planar_robot(num_segments=num_segments)
+    q = jnp.linspace(-0.05, 0.05, robot.num_active_strains, dtype=jnp.float64)
+
+    assert_allclose(
+        robot.active_tendon_length(q),
+        _closed_form_constant_tendon_length(robot, q, distance_matrix),
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
+    assert_allclose(
+        robot.actuation_matrix(q),
+        _closed_form_constant_actuation_matrix(robot, q, distance_matrix),
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
 
 
 def test_tendon_length_gradient_matches_actuation_matrix():
@@ -55,6 +210,183 @@ def test_tendon_length_gradient_matches_actuation_matrix():
     assert_allclose(
         jac_lengths,
         A.T,
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
+
+
+def test_variable_linear_routing_length_gradient_matches_actuation_matrix():
+    num_segments = 2
+    routing = linear_tendon_routing(
+        y_intercept=jnp.array([0.004, -0.005], dtype=jnp.float64),
+        y_slope=jnp.array([0.01, -0.008], dtype=jnp.float64),
+        z_intercept=jnp.zeros((2,), dtype=jnp.float64),
+        z_slope=jnp.zeros((2,), dtype=jnp.float64),
+        attachment_segment_index=jnp.array([1, 1], dtype=jnp.int32),
+    )
+    robot = _build_planar_robot(num_segments, active_tendon_routing=routing)
+    q = jnp.linspace(-0.03, 0.04, robot.num_active_strains, dtype=jnp.float64)
+
+    assert_allclose(
+        jax.jacrev(robot.active_tendon_length)(q),
+        robot.actuation_matrix(q).T,
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("basis", "expected_lengths_close"),
+    [
+        (
+            {
+                "d_s": scalar_planar_routing,
+                "dd_s_ds": scalar_planar_routing_derivative,
+            },
+            True,
+        ),
+        (
+            {
+                "d_s": vector1_planar_routing,
+                "dd_s_ds": vector1_planar_routing_derivative,
+            },
+            True,
+        ),
+    ],
+)
+def test_planar_custom_routing_accepts_scalar_and_single_entry_returns(
+    basis, expected_lengths_close
+):
+    del expected_lengths_close
+    routing = PlanarRoutingParams(
+        offset=jnp.array([0.006, -0.004], dtype=jnp.float64),
+        slope=jnp.array([0.004, -0.003], dtype=jnp.float64),
+        attachment_segment_index=(1, 1),
+    )
+    robot = _build_planar_robot(
+        2,
+        active_tendon_routing=routing,
+        active_tendon_routing_basis=basis,
+    )
+    q = jnp.linspace(-0.02, 0.03, robot.num_active_strains, dtype=jnp.float64)
+
+    assert robot.active_tendon_length(q).shape == (2,)
+    assert_allclose(
+        jax.jacrev(robot.active_tendon_length)(q),
+        robot.actuation_matrix(q).T,
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
+
+
+def test_planar_routing_rejects_ambiguous_two_entry_returns():
+    routing = PlanarRoutingParams(
+        offset=jnp.array([0.006], dtype=jnp.float64),
+        slope=jnp.array([0.0], dtype=jnp.float64),
+        attachment_segment_index=(0,),
+    )
+    with pytest.raises(ValueError, match="ambiguous"):
+        _build_planar_robot(
+            1,
+            active_tendon_routing=routing,
+            active_tendon_routing_basis={
+                "d_s": ambiguous_planar_routing,
+                "dd_s_ds": ambiguous_planar_routing_derivative,
+            },
+        )
+
+
+def test_planar_routing_rejects_nonzero_z_component():
+    routing = linear_tendon_routing(
+        y_intercept=jnp.array([0.006], dtype=jnp.float64),
+        y_slope=jnp.array([0.0], dtype=jnp.float64),
+        z_intercept=jnp.array([0.001], dtype=jnp.float64),
+        z_slope=jnp.array([0.0], dtype=jnp.float64),
+        attachment_segment_index=jnp.array([0], dtype=jnp.int32),
+    )
+    with pytest.raises(ValueError, match="nonzero z"):
+        _build_planar_robot(1, active_tendon_routing=routing)
+
+
+def test_empty_passive_tendons_preserve_shapes():
+    robot = _build_planar_robot(num_segments=2)
+    q = jnp.zeros((robot.num_active_strains,), dtype=jnp.float64)
+
+    assert robot.passive_tendon_length(q).shape == (0,)
+    assert robot.jacobian_passive_tendon(q).shape == (0, robot.num_active_strains)
+
+
+def test_passive_tendon_length_gradient_matches_jacobian():
+    passive_routing = linear_tendon_routing(
+        y_intercept=jnp.array([0.005, -0.006], dtype=jnp.float64),
+        y_slope=jnp.array([0.002, -0.001], dtype=jnp.float64),
+        z_intercept=jnp.zeros((2,), dtype=jnp.float64),
+        z_slope=jnp.zeros((2,), dtype=jnp.float64),
+        attachment_segment_index=jnp.array([1, 1], dtype=jnp.int32),
+    )
+    passive_phys = passive_tendon_params(
+        stiffness=jnp.array([40.0, 60.0], dtype=jnp.float64),
+        damping=jnp.array([0.4, 0.7], dtype=jnp.float64),
+        rest_length_offset=jnp.array([0.001, -0.002], dtype=jnp.float64),
+    )
+    robot = _build_planar_robot(
+        2,
+        passive_tendon_routing=passive_routing,
+        passive_tendon=passive_phys,
+    )
+    q = jnp.linspace(-0.02, 0.025, robot.num_active_strains, dtype=jnp.float64)
+
+    assert_allclose(
+        jax.jacrev(robot.passive_tendon_length)(q),
+        robot.jacobian_passive_tendon(q),
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
+
+
+def test_passive_tendons_contribute_to_dynamics_terms():
+    passive_routing = linear_tendon_routing(
+        y_intercept=jnp.array([0.005], dtype=jnp.float64),
+        y_slope=jnp.array([0.001], dtype=jnp.float64),
+        z_intercept=jnp.array([0.0], dtype=jnp.float64),
+        z_slope=jnp.array([0.0], dtype=jnp.float64),
+        attachment_segment_index=jnp.array([1], dtype=jnp.int32),
+    )
+    passive_phys = passive_tendon_params(
+        stiffness=jnp.array([50.0], dtype=jnp.float64),
+        damping=jnp.array([0.6], dtype=jnp.float64),
+        rest_length_offset=jnp.array([-0.001], dtype=jnp.float64),
+    )
+    robot_passive = _build_planar_robot(
+        2,
+        passive_tendon_routing=passive_routing,
+        passive_tendon=passive_phys,
+    )
+    robot_body = _build_planar_robot(2)
+    q = jnp.linspace(-0.02, 0.025, robot_passive.num_active_strains, dtype=jnp.float64)
+
+    J_pt = robot_passive.jacobian_passive_tendon(q)
+    l_pt = robot_passive.passive_tendon_length(q)
+    expected_elastic = J_pt.T @ robot_passive.K_pt @ (l_pt - robot_passive.l_pt0)
+    expected_damping = J_pt.T @ robot_passive.D_pt @ J_pt
+    delta_l = l_pt - robot_passive.l_pt0
+    expected_energy = 0.5 * delta_l.T @ robot_passive.K_pt @ delta_l
+
+    assert_allclose(
+        robot_passive.elastic_force(q) - robot_body.elastic_force(q),
+        expected_elastic,
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
+    assert_allclose(
+        robot_passive.damping_matrix(q) - robot_body.damping_matrix(q),
+        expected_damping,
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
+    assert_allclose(
+        robot_passive.elastic_energy(q) - robot_body.elastic_energy(q),
+        expected_energy,
         rtol=Tolerance.rtol(),
         atol=Tolerance.atol(),
     )

--- a/tests/systems/test_tendon_actuated_planar_pcs.py
+++ b/tests/systems/test_tendon_actuated_planar_pcs.py
@@ -76,7 +76,9 @@ def _body_params(num_segments: int):
     segment_lengths = 1e-1 * jnp.ones((num_segments,), dtype=jnp.float64)
     damping_matrix = 1e-3 * jnp.diag(
         (
-            jnp.repeat(jnp.array([[1e0, 1e3, 1e3]], dtype=jnp.float64), num_segments, axis=0)
+            jnp.repeat(
+                jnp.array([[1e0, 1e3, 1e3]], dtype=jnp.float64), num_segments, axis=0
+            )
             * segment_lengths[:, None]
         ).flatten()
     )
@@ -177,7 +179,7 @@ def _closed_form_constant_actuation_matrix(
     return robot.B_xi.T @ jnp.stack(columns, axis=1)
 
 
-def test_constant_distance_routing_matches_previous_closed_form():
+def test_constant_distance_routing_matches_closed_form():
     num_segments = 3
     distance_matrix = _constant_distance_matrix(num_segments)
     robot = _build_planar_robot(num_segments=num_segments)

--- a/tests/systems/test_typed_params_api.py
+++ b/tests/systems/test_typed_params_api.py
@@ -12,6 +12,7 @@ from system_param_builders import (
     planar_pcs_params,
     spatial_base_pose,
     tendon_actuated_pcs_params,
+    tendon_actuated_planar_pcs_params,
 )
 
 from soromox.actuation.tendon_actuation import (
@@ -26,6 +27,7 @@ from soromox.systems import (
     Pendulum,
     PendulumParams,
     TendonActuatedPCS,
+    TendonActuatedPlanarPCS,
 )
 
 jax.config.update("jax_enable_x64", True)
@@ -53,6 +55,20 @@ def _pcs_params(num_segments: int = 2):
         shear_modulus=1e5 * jnp.ones((num_segments,), dtype=jnp.float64),
         gravity=jnp.array([0.0, 0.0, -9.81], dtype=jnp.float64),
         damping_matrix=jnp.eye(6 * num_segments, dtype=jnp.float64),
+    )
+
+
+def _planar_pcs_params(num_segments: int = 2):
+    segment_lengths = 0.1 * jnp.ones((num_segments,), dtype=jnp.float64)
+    return planar_pcs_params(
+        length=segment_lengths,
+        radius=0.02 * jnp.ones((num_segments,), dtype=jnp.float64),
+        density=1000.0 * jnp.ones((num_segments,), dtype=jnp.float64),
+        young_modulus=1e6 * jnp.ones((num_segments,), dtype=jnp.float64),
+        shear_modulus=1e5 * jnp.ones((num_segments,), dtype=jnp.float64),
+        gravity=jnp.array([0.0, -9.81], dtype=jnp.float64),
+        damping_matrix=jnp.eye(3 * num_segments, dtype=jnp.float64),
+        base_pose=planar_base_pose(),
     )
 
 
@@ -222,6 +238,40 @@ def test_tendon_system_accepts_base_routing_subclasses():
         robot.num_dofs,
         1,
     )
+
+
+def test_planar_tendon_params_use_body_wrapper_and_reject_topology_changes():
+    body = _planar_pcs_params(num_segments=2)
+    routing = linear_tendon_routing(
+        y_intercept=jnp.array([0.005], dtype=jnp.float64),
+        y_slope=jnp.array([0.0], dtype=jnp.float64),
+        z_intercept=jnp.array([0.0], dtype=jnp.float64),
+        z_slope=jnp.array([0.0], dtype=jnp.float64),
+        attachment_segment_index=jnp.array([1], dtype=jnp.int32),
+    )
+    robot = TendonActuatedPlanarPCS(
+        params=tendon_actuated_planar_pcs_params(
+            body=body,
+            active_tendon_routing=routing,
+        )
+    )
+
+    updated_body = body.replace(radius=0.9 * body.radius)
+    updated_robot = robot.with_params(robot.params.replace(body=updated_body))
+    assert_allclose(updated_robot.r, 0.9 * robot.r)
+    assert robot.params.body is body
+
+    changed_attachment = linear_tendon_routing(
+        y_intercept=routing.y_intercept,
+        y_slope=routing.y_slope,
+        z_intercept=routing.z_intercept,
+        z_slope=routing.z_slope,
+        attachment_segment_index=jnp.array([0], dtype=jnp.int32),
+    )
+    with pytest.raises(ValueError, match="topology"):
+        robot.with_params(
+            robot.params.replace(active_tendon_routing=changed_attachment)
+        )
 
 
 def test_same_shape_param_updates_do_not_retrace_under_filter_jit():


### PR DESCRIPTION
## Summary

- Migrates `TendonActuatedPlanarPCS` to the routed tendon API used by PCS/GVS systems.
- Replaces the old planar-only `tendon_distance`/`segment_actuation_selector` interface with `body`, `active_tendon_routing`, optional passive routing, and routing basis callables.
- Adds planar route-shape normalization for scalar, `(1,)`, and PCS/GVS-compatible `(3,)` returns, with explicit rejection of ambiguous `(2,)` and nonzero `z` routes.
- Updates tests, examples, and docs for the new API.

## Validation

- `uv run pytest tests/systems/test_tendon_actuated_planar_pcs.py`
- `uv run pytest tests/systems/test_system_lengths.py tests/systems/test_typed_params_api.py`
- `uv run pytest tests/systems/test_tendon_actuated_pcs.py tests/systems/test_tendon_actuated_gvs.py`
- `uv run ruff check src/soromox/systems/pcs/tendon_actuated_planar_pcs.py src/soromox/systems/pcs/params.py tests/systems/test_tendon_actuated_planar_pcs.py tests/systems/test_typed_params_api.py tests/systems/test_system_lengths.py examples/simulation/pcs/simulate_tendon_actuated_planar_pcs.py examples/control/actuation_space/setpoint_regulation_comparison.py examples/optimization/control_gain_optimization_with_synergistic.py examples/optimization/control_gain_optimization_with_collocated.py`