### PR TITLE
updated outer radius

### DIFF
--- a/src/soromox/systems/pcs/isupport.py
+++ b/src/soromox/systems/pcs/isupport.py
@@ -363,7 +363,8 @@ class ISupport(PCS):
 
         def _actuation_matrix_one_chamber(i: Array, varphi: Array) -> Array:
             # Area of one pneumatic chamber
-            A_one_chamber = jnp.pi * self.r_chamber_in[i] ** 2
+            # A_one_chamber = jnp.pi * self.r_chamber_in[i] ** 2
+            A_one_chamber = jnp.pi * self.r_chamber_out[i] ** 2
 
             # force contribution of the chamber
             force_contrib = jnp.array(


### PR DESCRIPTION
The model presented in the [paper](https://ieeexplore.ieee.org/abstract/document/10098800) uses this area only to scale the pressure values into force (Newtons). However, when pressure is applied to the chambers, they unroll (as shown [here](https://link.springer.com/article/10.1007/s40964-020-00158-y?utm_source=researchgate.net&utm_medium=article)), causing the effective pressure to act over the entire annular area, which is approximated by the outer circle rather than the inner one.