### PR TITLE
Add IK tests for inactive strain segments

### DIFF
--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -386,6 +386,51 @@ def test_inverse_kinematics_with_deactivated_strains(num_segments: int):
         assert_allclose(q_recovered, q, rtol=RTOL, atol=ATOL)
 
 
+@pytest.mark.parametrize(
+    "strain_selector",
+    [
+        jnp.array(
+            [
+                False,
+                False,
+                True,
+                True,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                True,
+                False,
+                True,
+                False,
+                False,
+            ],
+            dtype=bool,
+        ),
+        jnp.zeros((12,), dtype=bool),
+    ],
+    ids=["segment-specific-inactive-strains", "all-strains-inactive"],
+)
+def test_inverse_kinematics_with_inactive_strain_segments(strain_selector: Array):
+    num_segments = int(strain_selector.size // 6)
+    model, _ = make_pcs(num_segments=num_segments, strain_selector=strain_selector)
+
+    q = random_q(model, jax.random.PRNGKey(789), scale=0.05)
+    g_tips = segment_tip_transforms(model, q)
+    q_recovered = model.inverse_kinematics(g_tips)
+
+    assert q_recovered.shape == q.shape
+    assert_allclose(q_recovered, q, rtol=RTOL, atol=ATOL)
+    assert_allclose(
+        segment_tip_transforms(model, q_recovered), g_tips, rtol=RTOL, atol=ATOL
+    )
+
+
 @pytest.mark.parametrize("num_segments", [1, 2])
 def test_J_local_tips_matches_pointwise_evaluation(num_segments: int):
     model, _ = make_pcs(num_segments=num_segments, total_length=PCS_TOTAL_LENGTH)

--- a/tests/systems/test_planar_pcs.py
+++ b/tests/systems/test_planar_pcs.py
@@ -659,6 +659,44 @@ def test_inverse_kinematics_strain_selector_edge_cases():
     )
 
 
+@pytest.mark.parametrize(
+    "strain_selector",
+    [
+        jnp.array(
+            [
+                True,
+                True,
+                False,
+                False,
+                False,
+                False,
+                True,
+                False,
+                True,
+            ],
+            dtype=bool,
+        ),
+        jnp.zeros((6,), dtype=bool),
+    ],
+    ids=["segment-specific-inactive-strains", "all-strains-inactive"],
+)
+def test_inverse_kinematics_with_inactive_strain_segments(strain_selector: Array):
+    num_segments = int(strain_selector.size // 3)
+    model, _ = make_planar_pcs(
+        num_segments=num_segments, th0=0.0, strain_selector=strain_selector
+    )
+
+    q = random_q(model, key=jax.random.PRNGKey(333), scale=0.08)
+    chi_tips = segment_tip_poses(model, q)
+    q_recovered = model.inverse_kinematics(chi_tips)
+
+    assert q_recovered.shape == q.shape
+    assert_allclose(q_recovered, q, rtol=RTOL, atol=ATOL)
+    assert_allclose(
+        segment_tip_poses(model, q_recovered), chi_tips, rtol=RTOL, atol=ATOL
+    )
+
+
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
 def test_J_local_tips_matches_pointwise_evaluation(num_segments):
     model, _ = make_planar_pcs(num_segments=num_segments)


### PR DESCRIPTION
## Summary

Adds inverse kinematics coverage for `PCS` and `PlanarPCS` when strain selectors deactivate segment-specific strain components, including fully inactive segments and all-inactive strain selectors.

## Why

Existing IK tests covered reduced strain selectors, but did not explicitly exercise the case where a segment contributes no active generalized coordinates. These tests document that IK still consumes segment tip poses, returns only active coordinates, and round-trips model-consistent measurements.

## Validation

- `uv run pytest tests/systems/test_pcs.py tests/systems/test_planar_pcs.py`