### PR TITLE
Render swept backbones in material frames

### DIFF
--- a/examples/simulation/articulated/simulate_articulated_soft_robot.py
+++ b/examples/simulation/articulated/simulate_articulated_soft_robot.py
@@ -233,7 +233,6 @@ def render_robot(
             renderer = ViserRenderer(
                 robot,
                 num_points=80,
-                backbone_style="discrete",
             )
             renderer.render_sequence(
                 ts,

--- a/examples/simulation/gvs/simulate_gvs.py
+++ b/examples/simulation/gvs/simulate_gvs.py
@@ -219,7 +219,7 @@ if __name__ == "__main__":
             ]
         )
     )
-    viser_renderer = ViserRenderer(robot, num_points=50, backbone_style="discrete")
+    viser_renderer = ViserRenderer(robot, num_points=50)
     viser_renderer.render_sequence(
         ts=ts,
         q_ts=q_ts_overlay,

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -213,7 +213,6 @@ if __name__ == "__main__":
         viser_renderer = ViserRenderer(
             robot,
             num_points=50,
-            backbone_style="discrete",
         )
         viser_renderer.render_sequence(
             ts=ts,

--- a/examples/simulation/pcs/simulate_pcs.py
+++ b/examples/simulation/pcs/simulate_pcs.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     # ViserRenderer provides interactive 3D visualization in the browser
     # with GUI controls for playback, speed, and looping.
     # Plotly plots are automatically added to the GUI at the end of the sidebar
-    viser_renderer = ViserRenderer(robot, num_points=50, backbone_style="discrete")
+    viser_renderer = ViserRenderer(robot, num_points=50)
 
     # Create custom strain plots for PCS
     # Reshape to (T, num_segments, 6)

--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -242,7 +242,7 @@ if __name__ == "__main__":
     # ViserRenderer provides interactive 3D visualization in the browser
     # with GUI controls for playback, speed, and looping.
     # Plotly plots are automatically added to the GUI at the end of the sidebar
-    viser_renderer = ViserRenderer(robot, num_points=50, backbone_style="discrete")
+    viser_renderer = ViserRenderer(robot, num_points=50)
 
     # Create custom strain plots for Tendon-Actuated PCS
     # Reshape to (T, num_segments, 6)

--- a/src/soromox/rendering/base.py
+++ b/src/soromox/rendering/base.py
@@ -272,17 +272,17 @@ class BaseSoftRobotRenderer(ABC):
         Returns:
             Array of shape (num_points, 3) for 3D or (num_points, 2) for 2D
         """
-        s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
-        if hasattr(self.robot, "forward_kinematics_batched"):
-            poses = self.robot.forward_kinematics_batched(q, s_ps)
-        else:
-            # Fallback to vmap over single-point FK
-            poses = jax.vmap(lambda s: self.robot.forward_kinematics(q, s))(s_ps)
-
-        # extract positions
+        poses = self.compute_backbone_poses(q)
         curve = self._extract_positions(poses)  # (num_points, dim)
 
         return curve
+
+    def compute_backbone_poses(self, q: Array) -> Array:
+        """Compute full FK poses at the configured backbone sample points."""
+        s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
+        if hasattr(self.robot, "forward_kinematics_batched"):
+            return self.robot.forward_kinematics_batched(q, s_ps)
+        return jax.vmap(lambda s: self.robot.forward_kinematics(q, s))(s_ps)
 
     def compute_actuator_visual_layers(
         self,
@@ -313,9 +313,7 @@ class BaseSoftRobotRenderer(ABC):
                 num_robots=int(points.shape[0]),
                 target_dim=int(points.shape[-1]),
             )
-            offset_layers.append(
-                layer.with_points(points + offsets[:, None, None, :])
-            )
+            offset_layers.append(layer.with_points(points + offsets[:, None, None, :]))
         return tuple(offset_layers)
 
     def _offset_trajectory_actuator_layers(
@@ -540,8 +538,7 @@ class BaseSoftRobotRenderer(ABC):
             return self._offset_trajectory_actuator_layers(layers, base_offsets)
 
         if not (
-            self._has_batched_actuator_visual_layers
-            or self._has_actuator_visual_layers
+            self._has_batched_actuator_visual_layers or self._has_actuator_visual_layers
         ):
             return ()
 
@@ -655,6 +652,11 @@ class BaseSoftRobotRenderer(ABC):
         if poses.ndim == 3 and poses.shape[-2:] == (4, 4):
             # SE(3): extract translation from 4x4 matrices
             return poses[:, :3, 3]
+        elif poses.ndim == 3 and poses.shape[-2:] == (3, 3):
+            # Homogeneous SE(2): extract x, y and pad with z=0
+            xy = poses[:, :2, 2]
+            z = jnp.zeros((poses.shape[0], 1), dtype=poses.dtype)
+            return jnp.concatenate([xy, z], axis=1)
         elif poses.ndim == 2 and poses.shape[-1] == 3:
             # SE(2): extract x, y from [theta, x, y] and pad with z=0
             xy = poses[:, 1:3]  # Extract x, y (skip theta at index 0)
@@ -665,6 +667,36 @@ class BaseSoftRobotRenderer(ABC):
                 f"Unsupported pose format: expected SE(2) (N, 3) or SE(3) (N, 4, 4), "
                 f"got shape {poses.shape}"
             )
+
+    def _extract_material_frames_3d(self, poses: Array) -> Array:
+        """Extract 3D material-frame rotations from SE(2) or SE(3) poses."""
+        poses = jnp.asarray(poses)
+        if poses.ndim == 3 and poses.shape[-2:] == (4, 4):
+            return poses[:, :3, :3]
+        if poses.ndim == 3 and poses.shape[-2:] == (3, 3):
+            rotations = poses[:, :2, :2]
+            frames = jnp.zeros((poses.shape[0], 3, 3), dtype=poses.dtype)
+            frames = frames.at[:, :2, :2].set(rotations)
+            return frames.at[:, 2, 2].set(1.0)
+        if poses.ndim == 2 and poses.shape[-1] == 3:
+            theta = poses[:, 0]
+            cos_theta = jnp.cos(theta)
+            sin_theta = jnp.sin(theta)
+            zeros = jnp.zeros_like(theta)
+            ones = jnp.ones_like(theta)
+            return jnp.stack(
+                [
+                    jnp.stack([cos_theta, -sin_theta, zeros], axis=1),
+                    jnp.stack([sin_theta, cos_theta, zeros], axis=1),
+                    jnp.stack([zeros, zeros, ones], axis=1),
+                ],
+                axis=1,
+            )
+        raise ValueError(
+            "Unsupported pose format for material-frame extraction: expected "
+            "SE(2) (N, 3) or (N, 3, 3), or SE(3) (N, 4, 4), "
+            f"got shape {poses.shape}"
+        )
 
     @abstractmethod
     def render_frame(self, q: Array) -> np.ndarray:
@@ -1034,3 +1066,27 @@ class BaseSoftRobotRenderer(ABC):
 
         # Add base offsets: (N, num_points, dim) + (N, 1, dim)
         return curves + offsets[:, None, :]
+
+    def compute_backbone_curves_and_frames_batched(
+        self, q_batch: Array, base_offsets: Array
+    ) -> tuple[Array, Array]:
+        """Compute 3D backbone positions and material frames for multiple robots.
+
+        The frame columns are the local material-frame axes in world coordinates.
+        Positional base offsets translate the curves without rotating the frames.
+        """
+        q_batch = jnp.asarray(q_batch)
+        if q_batch.ndim != 2:
+            raise ValueError(
+                f"q_batch must have shape (N, DOF), got {q_batch.shape} with ndim={q_batch.ndim}"
+            )
+
+        poses = jax.vmap(self.compute_backbone_poses)(q_batch)
+        curves = jax.vmap(self._extract_positions_3d)(poses)
+        frames = jax.vmap(self._extract_material_frames_3d)(poses)
+        offsets = self._normalize_base_offsets(
+            base_offsets,
+            num_robots=int(q_batch.shape[0]),
+            target_dim=3,
+        )
+        return curves + offsets[:, None, :], frames

--- a/src/soromox/rendering/open3d_renderer.py
+++ b/src/soromox/rendering/open3d_renderer.py
@@ -136,6 +136,8 @@ class CachedMesh:
     scale_base: np.ndarray
     dynamic_length: bool
     rotate_to_axis: bool
+    swept_ring_offsets: np.ndarray | None = None
+    cap_end: bool = False
 
 
 def _unit_mesh_from_o3d(mesh: o3d.geometry.TriangleMesh) -> UnitMesh:
@@ -351,6 +353,106 @@ def _make_elliptical_cylinder_between(
     return mesh
 
 
+def _primitive_rotation_from_material_frame(frame: np.ndarray) -> np.ndarray:
+    """Map a +Z-axis primitive into the robot's +X backbone convention."""
+    frame = np.asarray(frame, dtype=np.float64)
+    return frame[:, [1, 2, 0]]
+
+
+def _cross_section_ring_offsets(
+    geom_tag: int, params: np.ndarray, resolution: int
+) -> np.ndarray:
+    """Return cross-section offsets in material-frame coordinates."""
+    params = np.asarray(params, dtype=np.float64).reshape(-1)
+    eps = 1e-6
+    if geom_tag == CrossSectionGeometry.RECTANGULAR:
+        width = max(float(params[0]) if params.size else 0.0, eps)
+        height = max(float(params[1]) if params.size > 1 else 0.0, eps)
+        return np.array(
+            [
+                [0.0, -0.5 * width, -0.5 * height],
+                [0.0, 0.5 * width, -0.5 * height],
+                [0.0, 0.5 * width, 0.5 * height],
+                [0.0, -0.5 * width, 0.5 * height],
+            ],
+            dtype=np.float64,
+        )
+
+    angles = np.linspace(0.0, 2.0 * np.pi, int(resolution), endpoint=False)
+    if geom_tag == CrossSectionGeometry.CIRCULAR:
+        a_val = b_val = max(float(params[0]) if params.size else 0.0, eps)
+    else:
+        a_val = max(float(params[0]) if params.size else 0.0, eps)
+        b_val = max(float(params[1]) if params.size > 1 else 0.0, eps)
+    return np.stack(
+        [
+            np.zeros_like(angles),
+            a_val * np.cos(angles),
+            b_val * np.sin(angles),
+        ],
+        axis=1,
+    )
+
+
+def _swept_segment_vertices(
+    p0: np.ndarray,
+    p1: np.ndarray,
+    frame0: np.ndarray,
+    frame1: np.ndarray,
+    ring_offsets: np.ndarray,
+    *,
+    cap_end: bool = False,
+) -> np.ndarray:
+    """Place both cross-section rings using their sampled material frames."""
+    ring0 = np.asarray(p0) + ring_offsets @ np.asarray(frame0).T
+    ring1 = np.asarray(p1) + ring_offsets @ np.asarray(frame1).T
+    vertices = [ring0, ring1]
+    if cap_end:
+        vertices.append(np.asarray(p1, dtype=np.float64).reshape(1, 3))
+    return np.concatenate(vertices, axis=0)
+
+
+def _swept_segment_faces(ring_size: int, *, cap_end: bool = False) -> np.ndarray:
+    faces: list[tuple[int, int, int]] = []
+    for idx in range(int(ring_size)):
+        nxt = (idx + 1) % int(ring_size)
+        faces.append((idx, nxt, int(ring_size) + idx))
+        faces.append((nxt, int(ring_size) + nxt, int(ring_size) + idx))
+    if cap_end:
+        center_idx = 2 * int(ring_size)
+        for idx in range(int(ring_size)):
+            nxt = (idx + 1) % int(ring_size)
+            faces.append((center_idx, int(ring_size) + idx, int(ring_size) + nxt))
+    return np.asarray(faces, dtype=np.int32)
+
+
+def _make_swept_cross_section_segment(
+    p0: np.ndarray,
+    p1: np.ndarray,
+    frame0: np.ndarray,
+    frame1: np.ndarray,
+    geom_tag: int,
+    params: np.ndarray,
+    color: tuple[float, float, float],
+    resolution: int,
+    apply_color: bool = True,
+    cap_end: bool = False,
+) -> o3d.geometry.TriangleMesh:
+    """Create a body segment by connecting FK-oriented cross-section rings."""
+    offsets = _cross_section_ring_offsets(geom_tag, params, resolution)
+    mesh = o3d.geometry.TriangleMesh()
+    mesh.vertices = o3d.utility.Vector3dVector(
+        _swept_segment_vertices(p0, p1, frame0, frame1, offsets, cap_end=cap_end)
+    )
+    mesh.triangles = o3d.utility.Vector3iVector(
+        _swept_segment_faces(offsets.shape[0], cap_end=cap_end)
+    )
+    mesh.compute_vertex_normals()
+    if apply_color:
+        mesh.paint_uniform_color(np.asarray(color, dtype=np.float64))
+    return mesh
+
+
 def _make_target_sphere(
     center_xyz: np.ndarray,
     radius: float = 0.01,
@@ -406,6 +508,7 @@ class DynamicSpheres:
 @dataclass
 class SceneData:
     curves: np.ndarray  # (N, T, P, 3)
+    material_frames: np.ndarray  # (N, T, P, 3, 3)
     q_ts: np.ndarray  # (N, T, DOF)
     ts: np.ndarray  # (T,)
     layout: SegmentLayout
@@ -467,7 +570,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         num_points: int = 80,
         background_color: tuple[float, float, float] = (1.0, 1.0, 1.0),
         color_config: RendererColorConfig | None = None,
-        backbone_style: str = "discrete",
+        backbone_style: str = "swept",
         recompute_normals: bool = True,
         tube_resolution: int = 20,
         sphere_resolution: int = 32,
@@ -487,7 +590,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             num_points: Number of points for backbone discretization
             background_color: RGB background color (0-1 range)
             color_config: Shared renderer color configuration
-            backbone_style: "discrete" or "swept"
+            backbone_style: "swept" (material-frame surface) or "discrete" (markers)
             recompute_normals: Whether to recompute vertex normals per segment update
             tube_resolution: Radial resolution for tube segments
             sphere_resolution: Resolution for backbone spheres
@@ -650,6 +753,27 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             norms = np.linalg.norm(normals, axis=1, keepdims=True)
             normals = np.where(norms > 1e-9, normals / norms, normals)
             cached.mesh.vertex_normals = o3d.utility.Vector3dVector(normals)
+
+    @staticmethod
+    def _apply_swept_cached_mesh(
+        cached: CachedMesh,
+        p0: np.ndarray,
+        p1: np.ndarray,
+        frame0: np.ndarray,
+        frame1: np.ndarray,
+    ) -> None:
+        if cached.swept_ring_offsets is None:
+            raise ValueError("Swept mesh is missing cross-section ring offsets.")
+        vertices = _swept_segment_vertices(
+            p0,
+            p1,
+            frame0,
+            frame1,
+            cached.swept_ring_offsets,
+            cap_end=cached.cap_end,
+        )
+        cached.mesh.vertices = o3d.utility.Vector3dVector(vertices)
+        cached.mesh.compute_vertex_normals()
 
     def _frame_intervals_from_ts(self, ts: Array, playback_speed: float) -> np.ndarray:
         """Compute per-frame wall-clock intervals from timestamps, scaled by playback speed."""
@@ -816,20 +940,20 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             if mode == "swept":
                 return "box", np.array([width, height, 1.0]), True, True
             depth = max(width, height)
-            return "box", np.array([width, height, depth]), False, False
+            return "box", np.array([width, height, depth]), False, True
         if geom_tag == CrossSectionGeometry.ELLIPTICAL:
             a_val = max(float(params[0]) if params.size else 0.0, eps)
             b_val = max(float(params[1]) if params.size > 1 else 0.0, eps)
             if mode == "swept":
                 return "elliptical_cylinder", np.array([a_val, b_val, 1.0]), True, True
             rz = max(a_val, b_val)
-            return "ellipsoid", np.array([a_val, b_val, rz]), False, False
+            return "ellipsoid", np.array([a_val, b_val, rz]), False, True
         a_val = max(float(params[0]) if params.size else 0.0, eps)
         b_val = max(float(params[1]) if params.size > 1 else 0.0, eps)
         if mode == "swept":
             return "elliptical_cylinder", np.array([a_val, b_val, 1.0]), True, True
         rz = max(a_val, b_val)
-        return "ellipsoid", np.array([a_val, b_val, rz]), False, False
+        return "ellipsoid", np.array([a_val, b_val, rz]), False, True
 
     def _prepare_scene_data(
         self,
@@ -884,14 +1008,21 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             allow_extra_rows=uses_configured_offsets,
         )
 
-        # Backbone curves (T, N, P, 3) -> (N, T, P, 3)
+        # Backbone curves and material frames, time-first then robot-first.
         q_ts_time_first = q_ts_arr.transpose(1, 0, 2)
 
-        def _compute_curves_for_timestep(q_batch: jax.Array) -> jax.Array:
-            return self.compute_backbone_curves_batched(q_batch, offsets)
+        def _compute_geometry_for_timestep(
+            q_batch: jax.Array,
+        ) -> tuple[jax.Array, jax.Array]:
+            return self.compute_backbone_curves_and_frames_batched(q_batch, offsets)
 
-        all_curves_time_first = jax.vmap(_compute_curves_for_timestep)(q_ts_time_first)
+        all_curves_time_first, all_frames_time_first = jax.vmap(
+            _compute_geometry_for_timestep
+        )(q_ts_time_first)
         curves = np.array(all_curves_time_first.transpose(1, 0, 2, 3), dtype=np.float64)
+        material_frames = np.array(
+            all_frames_time_first.transpose(1, 0, 2, 3, 4), dtype=np.float64
+        )
 
         layout = self._compute_segment_layout(curves.shape[2])
         resolved_colors = self.resolve_backbone_colors(
@@ -918,6 +1049,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
 
         return SceneData(
             curves=curves,
+            material_frames=material_frames,
             q_ts=q_ts_np,
             ts=ts_np,
             layout=layout,
@@ -956,10 +1088,11 @@ class Open3DRenderer(BaseSoftRobotRenderer):
 
         for robot_idx in range(scene_data.num_robots):
             curve = scene_data.curves[robot_idx, frame_idx]
+            material_frames = scene_data.material_frames[robot_idx, frame_idx]
             q_frame = scene_data.q_ts[robot_idx, frame_idx]
             sections, max_radius = self._cross_sections_for_points(q_frame, s_ps)
             base_color_rgba = ensure_rgba(np.asarray(cfg.base_plate_color))[0]
-            base_axis = self._base_tangent_axis(dim=3)
+            base_axis = material_frames[0, :, 0]
             base_mesh = _make_base_plate(
                 curve[0] - 0.5 * self.base_plate_thickness * base_axis,
                 radius=float(self.base_plate_radius_scale * max_radius),
@@ -979,59 +1112,23 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                     edge_end = min(c1, curve.shape[0] - 1)
                     for p in range(c0, edge_end):
                         geom_type, params = sections[p]
-                        if geom_type == CrossSectionGeometry.CIRCULAR:
-                            radius = float(params[0]) if params.size else 0.0
-                            radius = max(radius, 1e-6)
-                            cyl = _make_cylinder_between(
-                                curve[p],
-                                curve[p + 1],
-                                radius=radius,
-                                color=raw_color_rgb,
-                                resolution=self.tube_resolution,
-                                apply_color=False,
-                            )
-                            scene.add_geometry(
-                                f"tube_{robot_idx}_{s}_{p}",
-                                cyl,
-                                mat_for(raw_color_rgba),
-                            )
-                        elif geom_type == CrossSectionGeometry.RECTANGULAR:
-                            if params.size < 2:
-                                continue
-                            width = max(float(params[0]), 1e-6)
-                            height = max(float(params[1]), 1e-6)
-                            box = _make_box_between(
-                                curve[p],
-                                curve[p + 1],
-                                width=width,
-                                height=height,
-                                color=raw_color_rgb,
-                                apply_color=False,
-                            )
-                            scene.add_geometry(
-                                f"box_{robot_idx}_{s}_{p}",
-                                box,
-                                mat_for(raw_color_rgba),
-                            )
-                        else:
-                            if params.size < 2:
-                                continue
-                            a_val = max(float(params[0]), 1e-6)
-                            b_val = max(float(params[1]), 1e-6)
-                            cyl = _make_elliptical_cylinder_between(
-                                curve[p],
-                                curve[p + 1],
-                                a=a_val,
-                                b=b_val,
-                                color=raw_color_rgb,
-                                resolution=self.tube_resolution,
-                                apply_color=False,
-                            )
-                            scene.add_geometry(
-                                f"ell_{robot_idx}_{s}_{p}",
-                                cyl,
-                                mat_for(raw_color_rgba),
-                            )
+                        body = _make_swept_cross_section_segment(
+                            curve[p],
+                            curve[p + 1],
+                            material_frames[p],
+                            material_frames[p + 1],
+                            geom_type,
+                            params,
+                            raw_color_rgb,
+                            self.tube_resolution,
+                            apply_color=False,
+                            cap_end=p == curve.shape[0] - 2,
+                        )
+                        scene.add_geometry(
+                            f"body_{robot_idx}_{s}_{p}",
+                            body,
+                            mat_for(raw_color_rgba),
+                        )
                 else:
                     for p in range(c0, c1):
                         geom_type, params = sections[p]
@@ -1066,6 +1163,12 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                                 apply_color=False,
                                 apply_translation=True,
                             )
+                            box.rotate(
+                                _primitive_rotation_from_material_frame(
+                                    material_frames[p]
+                                ),
+                                center=curve[p],
+                            )
                             scene.add_geometry(
                                 f"box_{robot_idx}_{s}_{p}",
                                 box,
@@ -1085,6 +1188,12 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                                 apply_color=False,
                                 apply_translation=True,
                             )
+                            ell.rotate(
+                                _primitive_rotation_from_material_frame(
+                                    material_frames[p]
+                                ),
+                                center=curve[p],
+                            )
                             scene.add_geometry(
                                 f"ell_{robot_idx}_{s}_{p}",
                                 ell,
@@ -1100,7 +1209,9 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                 robot_actuators = np.asarray(layer.points)[robot_idx, frame_idx]
                 for actuator_idx in range(robot_actuators.shape[0]):
                     color = tuple(colors[robot_idx, frame_idx, actuator_idx, :3])
-                    ls = _make_polyline_lineset(robot_actuators[actuator_idx], color=color)
+                    ls = _make_polyline_lineset(
+                        robot_actuators[actuator_idx], color=color
+                    )
                     mat_line = o3d.visualization.MaterialRecord()
                     mat_line.shader = "unlitLine"
                     mat_line.line_width = layer.line_width or self.actuator_line_width
@@ -1526,6 +1637,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         self,
         vis,
         curve0: np.ndarray,
+        material_frames0: np.ndarray,
         sections: list[tuple[int, np.ndarray]],
         max_radius: float,
         layout: SegmentLayout,
@@ -1534,7 +1646,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
     ) -> tuple[object, list[list[CachedMesh]]]:
         """Add base and backbone meshes for one robot; return handles."""
         base_color = self._blend_with_background(base_plate_color)
-        base_axis = self._base_tangent_axis(dim=3)
+        base_axis = material_frames0[0, :, 0]
         base_mesh = _make_base_plate(
             curve0[0] - 0.5 * self.base_plate_thickness * base_axis,
             radius=float(self.base_plate_radius_scale * max_radius),
@@ -1554,26 +1666,34 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                 edge_end = min(c1, curve0.shape[0] - 1)
                 for p in range(c0, edge_end):
                     geom_tag, params = sections[p]
-                    unit_key, scale_base, dynamic_length, rotate_to_axis = (
-                        self._primitive_from_section(geom_tag, params)
+                    ring_offsets = _cross_section_ring_offsets(
+                        geom_tag, params, self.tube_resolution
                     )
-                    unit = self._unit_meshes[unit_key]
-                    mesh = self._instantiate_mesh(unit, seg_color)
+                    cap_end = p == curve0.shape[0] - 2
+                    vertices = _swept_segment_vertices(
+                        curve0[p],
+                        curve0[p + 1],
+                        material_frames0[p],
+                        material_frames0[p + 1],
+                        ring_offsets,
+                        cap_end=cap_end,
+                    )
+                    faces = _swept_segment_faces(ring_offsets.shape[0], cap_end=cap_end)
+                    mesh = o3d.geometry.TriangleMesh()
+                    mesh.vertices = o3d.utility.Vector3dVector(vertices)
+                    mesh.triangles = o3d.utility.Vector3iVector(faces)
+                    mesh.compute_vertex_normals()
+                    mesh.paint_uniform_color(np.asarray(seg_color, dtype=np.float64))
                     cached = CachedMesh(
                         mesh=mesh,
-                        base_vertices=unit.vertices,
-                        base_normals=unit.normals,
-                        scale_base=scale_base,
-                        dynamic_length=dynamic_length,
-                        rotate_to_axis=rotate_to_axis,
+                        base_vertices=vertices,
+                        base_normals=None,
+                        scale_base=np.ones(3),
+                        dynamic_length=False,
+                        rotate_to_axis=False,
+                        swept_ring_offsets=ring_offsets,
+                        cap_end=cap_end,
                     )
-                    p0 = curve0[p]
-                    p1 = curve0[p + 1]
-                    axis = p1 - p0
-                    length = float(np.linalg.norm(axis))
-                    R = _axis_alignment_rotation(axis)
-                    mid = (p0 + p1) / 2.0
-                    self._apply_cached_mesh(cached, mid, R, length)
                     seg_meshes.append(cached)
                     vis.add_geometry(mesh)
             else:
@@ -1592,7 +1712,10 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                         dynamic_length=dynamic_length,
                         rotate_to_axis=rotate_to_axis,
                     )
-                    self._apply_cached_mesh(cached, curve0[p], None, None)
+                    rotation = _primitive_rotation_from_material_frame(
+                        material_frames0[p]
+                    )
+                    self._apply_cached_mesh(cached, curve0[p], rotation, None)
                     seg_meshes.append(cached)
                     vis.add_geometry(mesh)
             meshes_groups.append(seg_meshes)
@@ -1602,12 +1725,13 @@ class Open3DRenderer(BaseSoftRobotRenderer):
         self,
         vis,
         curve: np.ndarray,
+        material_frames: np.ndarray,
         base_mesh,
         meshes_groups: list[list[CachedMesh]],
         layout: SegmentLayout,
     ) -> None:
         """Translate base and backbone geometry to a new curve position."""
-        base_axis = self._base_tangent_axis(dim=3)
+        base_axis = material_frames[0, :, 0]
         base_center = curve[0] - 0.5 * self.base_plate_thickness * base_axis
         delta = base_center - _mesh_center(base_mesh)
         base_mesh.translate(delta, relative=True)
@@ -1618,23 +1742,25 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             seg_meshes = meshes_groups[s]
             if self._backbone_mode == "swept" and c1 - c0 >= 1:
                 edge_end = min(c1, curve.shape[0] - 1)
-                # Cylinders need full re-orientation + centering, not just translation
                 for i_local, p in enumerate(range(c0, edge_end)):
                     if i_local >= len(seg_meshes):
                         break
                     cached = seg_meshes[i_local]
-                    p0 = curve[p]
-                    p1 = curve[p + 1]
-                    axis = p1 - p0
-                    length = float(np.linalg.norm(axis))
-                    R = _axis_alignment_rotation(axis)
-                    mid = (p0 + p1) / 2.0
-                    self._apply_cached_mesh(cached, mid, R, length)
+                    self._apply_swept_cached_mesh(
+                        cached,
+                        curve[p],
+                        curve[p + 1],
+                        material_frames[p],
+                        material_frames[p + 1],
+                    )
                     vis.update_geometry(cached.mesh)
             else:
                 for i_local, p in enumerate(range(c0, min(c1, c0 + len(seg_meshes)))):
                     cached = seg_meshes[i_local]
-                    self._apply_cached_mesh(cached, curve[p], None, None)
+                    rotation = _primitive_rotation_from_material_frame(
+                        material_frames[p]
+                    )
+                    self._apply_cached_mesh(cached, curve[p], rotation, None)
                     vis.update_geometry(cached.mesh)
 
     def _build_scene(
@@ -1663,11 +1789,13 @@ class Open3DRenderer(BaseSoftRobotRenderer):
 
         for robot_idx in range(scene_data.num_robots):
             curve0 = scene_data.curves[robot_idx, frame_idx]
+            material_frames0 = scene_data.material_frames[robot_idx, frame_idx]
             q0 = scene_data.q_ts[robot_idx, frame_idx]
             sections, max_radius = self._cross_sections_for_points(q0, s_ps)
             base_mesh, groups = self._build_robot_geometry(
                 vis,
                 curve0,
+                material_frames0,
                 sections,
                 max_radius,
                 layout,
@@ -1755,9 +1883,11 @@ class Open3DRenderer(BaseSoftRobotRenderer):
 
         for robot_idx in range(scene_data.num_robots):
             curve = scene_data.curves[robot_idx, frame_idx]
+            material_frames = scene_data.material_frames[robot_idx, frame_idx]
             self._update_robot_geometry(
                 vis,
                 curve,
+                material_frames,
                 handles.base_meshes[robot_idx],
                 handles.backbone_meshes[robot_idx],
                 layout,

--- a/src/soromox/rendering/umarm/viser_renderer.py
+++ b/src/soromox/rendering/umarm/viser_renderer.py
@@ -222,6 +222,7 @@ class UMArmViserRenderer(ViserRenderer):
         curves: np.ndarray,
         point_colors: np.ndarray,
         *,
+        material_frames: np.ndarray,
         base_plate_color: tuple[float, float, float],
     ) -> None:
         """Build a UMArm-specific rigid visual model instead of a soft tube."""
@@ -231,7 +232,10 @@ class UMArmViserRenderer(ViserRenderer):
             or self._current_geometry_q is None
         ):
             super()._build_robot_geometry(
-                curves, point_colors, base_plate_color=base_plate_color
+                curves,
+                point_colors,
+                material_frames=material_frames,
+                base_plate_color=base_plate_color,
             )
             return
 
@@ -436,8 +440,11 @@ class UMArmViserRenderer(ViserRenderer):
         self._scene_handles.num_robots = num_robots
         self._scene_handles.num_backbone_points = curves.shape[1]
 
-    def _update_robot_geometry(self, curves: np.ndarray) -> None:
+    def _update_robot_geometry(
+        self, curves: np.ndarray, material_frames: np.ndarray
+    ) -> None:
         """Update the UMArm rigid visual model without rebuilding scene objects."""
+        del material_frames
         if (
             self._scene_handles is None
             or self._current_geometry_q is None
@@ -702,9 +709,11 @@ class UMArmLiveModeController(LiveModeController):
             target_dim=3,
         )
 
-        curves = np.asarray(
-            self._renderer.compute_backbone_curves_batched(q, base_offsets)
+        curves, material_frames = (
+            self._renderer.compute_backbone_curves_and_frames_batched(q, base_offsets)
         )
+        curves = np.asarray(curves)
+        material_frames = np.asarray(material_frames)
 
         if (
             self._resolved_colors is None
@@ -721,11 +730,12 @@ class UMArmLiveModeController(LiveModeController):
             and scene_handles.num_backbone_points == curves.shape[1]
         )
         if can_update:
-            self._renderer._update_robot_geometry(curves)
+            self._renderer._update_robot_geometry(curves, material_frames)
         else:
             self._renderer._build_robot_geometry(
                 curves,
                 self._resolved_colors.per_robot_point_rgba,
+                material_frames=material_frames,
                 base_plate_color=self._renderer.color_config.base_plate_color,
             )
         if self._renderer._has_actuator_visuals:

--- a/src/soromox/rendering/viser_renderer.py
+++ b/src/soromox/rendering/viser_renderer.py
@@ -163,28 +163,6 @@ def _direction_to_quaternion(
     return (float(w), float(xyz[0]), float(xyz[1]), float(xyz[2]))
 
 
-def _fallback_material_frames(curve: np.ndarray) -> np.ndarray:
-    """Construct tangent frames only for legacy private-method callers."""
-    curve = np.asarray(curve, dtype=np.float64)
-    tangents = np.gradient(curve, axis=0)
-    frames = np.empty((curve.shape[0], 3, 3), dtype=np.float64)
-    previous_x = np.array([1.0, 0.0, 0.0], dtype=np.float64)
-    for idx, tangent in enumerate(tangents):
-        norm = np.linalg.norm(tangent)
-        x_axis = tangent / norm if norm > 1e-9 else previous_x
-        reference = (
-            np.array([0.0, 0.0, 1.0])
-            if abs(x_axis[2]) < 0.9
-            else np.array([0.0, 1.0, 0.0])
-        )
-        y_axis = np.cross(reference, x_axis)
-        y_axis /= np.linalg.norm(y_axis)
-        z_axis = np.cross(x_axis, y_axis)
-        frames[idx] = np.column_stack((x_axis, y_axis, z_axis))
-        previous_x = x_axis
-    return frames
-
-
 def _oriented_tube_segment_mesh(
     p0: np.ndarray,
     p1: np.ndarray,
@@ -498,7 +476,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         curves: np.ndarray,
         point_colors: np.ndarray,
         *,
-        material_frames: np.ndarray | None = None,
+        material_frames: np.ndarray,
         base_plate_color: tuple[float, float, float],
     ) -> None:
         """Build robot backbone geometry in the scene.
@@ -519,11 +497,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         for robot_idx in range(num_robots):
             curve = curves[robot_idx]  # (num_points, 3)
-            robot_frames = (
-                material_frames[robot_idx]
-                if material_frames is not None
-                else _fallback_material_frames(curve)
-            )
+            robot_frames = material_frames[robot_idx]
 
             # Create backbone geometry
             robot_points = []
@@ -795,7 +769,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
     def _update_robot_geometry(
         self,
         curves: np.ndarray,
-        material_frames: np.ndarray | None = None,
+        material_frames: np.ndarray,
     ) -> None:
         """Atomically update all robot geometry for one animation frame."""
         if self._scene_handles is None or self._server is None:
@@ -807,11 +781,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
             for robot_idx in range(num_robots):
                 curve = curves[robot_idx]  # (num_points, 3)
-                robot_frames = (
-                    material_frames[robot_idx]
-                    if material_frames is not None
-                    else _fallback_material_frames(curve)
-                )
+                robot_frames = material_frames[robot_idx]
                 if robot_idx < len(self._scene_handles.base_plates):
                     base_handle = self._scene_handles.base_plates[robot_idx]
                     base_pos, base_wxyz = self._base_plate_pose(curve[0])

--- a/src/soromox/rendering/viser_renderer.py
+++ b/src/soromox/rendering/viser_renderer.py
@@ -163,6 +163,68 @@ def _direction_to_quaternion(
     return (float(w), float(xyz[0]), float(xyz[1]), float(xyz[2]))
 
 
+def _fallback_material_frames(curve: np.ndarray) -> np.ndarray:
+    """Construct tangent frames only for legacy private-method callers."""
+    curve = np.asarray(curve, dtype=np.float64)
+    tangents = np.gradient(curve, axis=0)
+    frames = np.empty((curve.shape[0], 3, 3), dtype=np.float64)
+    previous_x = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    for idx, tangent in enumerate(tangents):
+        norm = np.linalg.norm(tangent)
+        x_axis = tangent / norm if norm > 1e-9 else previous_x
+        reference = (
+            np.array([0.0, 0.0, 1.0])
+            if abs(x_axis[2]) < 0.9
+            else np.array([0.0, 1.0, 0.0])
+        )
+        y_axis = np.cross(reference, x_axis)
+        y_axis /= np.linalg.norm(y_axis)
+        z_axis = np.cross(x_axis, y_axis)
+        frames[idx] = np.column_stack((x_axis, y_axis, z_axis))
+        previous_x = x_axis
+    return frames
+
+
+def _oriented_tube_segment_mesh(
+    p0: np.ndarray,
+    p1: np.ndarray,
+    frame0: np.ndarray,
+    frame1: np.ndarray,
+    radius: float,
+    sections: int,
+    *,
+    cap_end: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return a tube segment whose endpoint rings use the FK material frames."""
+    angles = np.linspace(0.0, 2.0 * np.pi, int(sections), endpoint=False)
+    local_offsets = np.stack(
+        [
+            np.zeros_like(angles),
+            float(radius) * np.cos(angles),
+            float(radius) * np.sin(angles),
+        ],
+        axis=1,
+    )
+    ring0 = np.asarray(p0) + local_offsets @ np.asarray(frame0).T
+    ring1 = np.asarray(p1) + local_offsets @ np.asarray(frame1).T
+    vertex_groups = [ring0, ring1]
+    if cap_end:
+        vertex_groups.append(np.asarray(p1, dtype=np.float64).reshape(1, 3))
+    vertices = np.concatenate(vertex_groups, axis=0).astype(np.float32)
+
+    faces: list[tuple[int, int, int]] = []
+    for idx in range(int(sections)):
+        nxt = (idx + 1) % int(sections)
+        faces.append((idx, nxt, int(sections) + idx))
+        faces.append((nxt, int(sections) + nxt, int(sections) + idx))
+    if cap_end:
+        center_idx = 2 * int(sections)
+        for idx in range(int(sections)):
+            nxt = (idx + 1) % int(sections)
+            faces.append((center_idx, int(sections) + idx, int(sections) + nxt))
+    return vertices, np.asarray(faces, dtype=np.uint32)
+
+
 # =============================================================================
 # ViserRenderer
 # =============================================================================
@@ -200,7 +262,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         color_config: RendererColorConfig | None = None,
         host: str = "0.0.0.0",
         port: int = 8080,
-        backbone_style: Literal["discrete", "swept"] = "discrete",
+        backbone_style: Literal["discrete", "swept"] = "swept",
         sphere_resolution: int = 3,
         cylinder_sections: int = 48,
         grid_spacing: tuple[float, float] = (0.5, 0.5),
@@ -240,7 +302,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
             color_config: Shared renderer color configuration
             host: Server bind address (0.0.0.0 for all interfaces)
             port: Server port number
-            backbone_style: "discrete" (spheres) or "swept" (cylinders)
+            backbone_style: "swept" (material-frame surface) or "discrete" (spheres)
             sphere_resolution: Icosphere subdivision level (1=low, 2=medium, 3=good, 4=high)
             cylinder_sections: Number of cylinder cross-section segments (higher=smoother)
             grid_spacing: (x, y) spacing for multi-robot grid layout
@@ -436,6 +498,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         curves: np.ndarray,
         point_colors: np.ndarray,
         *,
+        material_frames: np.ndarray | None = None,
         base_plate_color: tuple[float, float, float],
     ) -> None:
         """Build robot backbone geometry in the scene.
@@ -456,6 +519,11 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         for robot_idx in range(num_robots):
             curve = curves[robot_idx]  # (num_points, 3)
+            robot_frames = (
+                material_frames[robot_idx]
+                if material_frames is not None
+                else _fallback_material_frames(curve)
+            )
 
             # Create backbone geometry
             robot_points = []
@@ -488,55 +556,27 @@ class ViserRenderer(BaseSoftRobotRenderer):
                     color_rgba = point_colors[robot_idx, pt_idx]
                     color, opacity = _rgba_to_viser_color_and_opacity(color_rgba)
 
-                    # Compute cylinder parameters
-                    direction = p1 - p0
-                    length = float(np.linalg.norm(direction))
-                    if length < 1e-9:
-                        continue
-
-                    center = (p0 + p1) / 2.0
-                    # Compute quaternion for orientation (Z-aligned cylinder rotated to direction)
-                    wxyz = _direction_to_quaternion(direction)
-
-                    # Create Z-aligned cylinder mesh, apply rotation via handle
-                    cylinder_mesh = self._make_cylinder_trimesh(
-                        length=length,
-                        radius=self._robot_radius,
-                        color=color_rgba[:3],
-                        direction=None,  # Keep Z-aligned for efficient updates
+                    vertices, faces = _oriented_tube_segment_mesh(
+                        p0,
+                        p1,
+                        robot_frames[pt_idx],
+                        robot_frames[pt_idx + 1],
+                        self._robot_radius,
+                        self._cylinder_sections,
+                        cap_end=pt_idx == num_points - 2,
                     )
                     handle = self._server.scene.add_mesh_simple(
                         name=f"/robots/robot_{robot_idx}/backbone/seg_{pt_idx}",
-                        vertices=cylinder_mesh.vertices,
-                        faces=cylinder_mesh.faces,
+                        vertices=vertices,
+                        faces=faces,
                         color=color,
                         opacity=opacity,
                         wireframe=self._wireframe,
                         material=self._material,
                         flat_shading=self._flat_shading,
                         cast_shadow=self._backbone_cast_shadow,
-                        position=tuple(center),
-                        wxyz=wxyz,
                     )
                     robot_points.append(handle)
-
-                # Add sphere at tip
-                tip_pos = curve[-1]
-                color_rgba = point_colors[robot_idx, -1]
-                color, opacity = _rgba_to_viser_color_and_opacity(color_rgba)
-                handle = self._server.scene.add_icosphere(
-                    name=f"/robots/robot_{robot_idx}/backbone/tip",
-                    radius=self._robot_radius,
-                    color=color,
-                    opacity=opacity,
-                    subdivisions=self._sphere_resolution,
-                    position=tuple(tip_pos),
-                    material=self._material,
-                    flat_shading=self._flat_shading,
-                    wireframe=self._wireframe,
-                    cast_shadow=self._backbone_cast_shadow,
-                )
-                robot_points.append(handle)
 
             self._scene_handles.backbone_points.append(robot_points)
 
@@ -635,9 +675,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
                     num_segments = len(curve) - 1
                     if num_segments <= 0:
                         continue
-                    points = np.stack(
-                        [curve[:-1], curve[1:]], axis=1
-                    )
+                    points = np.stack([curve[:-1], curve[1:]], axis=1)
                     color = _rgb_to_viser_color(
                         layer_colors[robot_idx, actuator_idx, :3]
                     )
@@ -757,63 +795,52 @@ class ViserRenderer(BaseSoftRobotRenderer):
     def _update_robot_geometry(
         self,
         curves: np.ndarray,
+        material_frames: np.ndarray | None = None,
     ) -> None:
-        """Update existing robot geometry positions (and orientations for swept mode).
-
-        This is more efficient than rebuilding geometry each frame:
-        - Discrete mode: Only updates sphere positions
-        - Swept mode: Updates cylinder positions and orientations via handle properties
-
-        Args:
-            curves: Backbone curves of shape (num_robots, num_points, 3)
-        """
-        if self._scene_handles is None:
+        """Atomically update all robot geometry for one animation frame."""
+        if self._scene_handles is None or self._server is None:
             return
 
-        num_robots = min(len(curves), len(self._scene_handles.backbone_points))
-        num_points = curves.shape[1]
+        with self._server.atomic():
+            num_robots = min(len(curves), len(self._scene_handles.backbone_points))
+            num_points = curves.shape[1]
 
-        for robot_idx in range(num_robots):
-            curve = curves[robot_idx]  # (num_points, 3)
-            if robot_idx < len(self._scene_handles.base_plates):
-                base_handle = self._scene_handles.base_plates[robot_idx]
-                base_pos, base_wxyz = self._base_plate_pose(curve[0])
-                base_handle.position = tuple(base_pos)
-                base_handle.wxyz = base_wxyz
+            for robot_idx in range(num_robots):
+                curve = curves[robot_idx]  # (num_points, 3)
+                robot_frames = (
+                    material_frames[robot_idx]
+                    if material_frames is not None
+                    else _fallback_material_frames(curve)
+                )
+                if robot_idx < len(self._scene_handles.base_plates):
+                    base_handle = self._scene_handles.base_plates[robot_idx]
+                    base_pos, base_wxyz = self._base_plate_pose(curve[0])
+                    base_handle.position = tuple(base_pos)
+                    base_handle.wxyz = base_wxyz
 
-            robot_points = self._scene_handles.backbone_points[robot_idx]
+                robot_points = self._scene_handles.backbone_points[robot_idx]
 
-            if self._backbone_style == "discrete":
-                # Update sphere positions only
-                for pt_idx, handle in enumerate(robot_points):
-                    if pt_idx < len(curve):
-                        handle.position = tuple(curve[pt_idx])
-            else:
-                # Swept style: update cylinder positions and orientations
-                # robot_points contains (num_points - 1) cylinders + 1 tip sphere
-                num_segments = num_points - 1
-                for seg_idx in range(min(len(robot_points) - 1, num_segments)):
-                    handle = robot_points[seg_idx]
-                    p0 = curve[seg_idx]
-                    p1 = curve[seg_idx + 1]
+                if self._backbone_style == "discrete":
+                    for pt_idx, handle in enumerate(robot_points):
+                        if pt_idx < len(curve):
+                            handle.position = tuple(curve[pt_idx])
+                else:
+                    num_segments = num_points - 1
+                    for seg_idx in range(min(len(robot_points), num_segments)):
+                        handle = robot_points[seg_idx]
+                        p0 = curve[seg_idx]
+                        p1 = curve[seg_idx + 1]
 
-                    # Compute new center and orientation
-                    direction = p1 - p0
-                    length = float(np.linalg.norm(direction))
-                    if length < 1e-9:
-                        continue
-
-                    center = (p0 + p1) / 2.0
-                    wxyz = _direction_to_quaternion(direction)
-
-                    # Update handle properties (no mesh recreation!)
-                    handle.position = tuple(center)
-                    handle.wxyz = wxyz
-
-                # Update tip sphere position (last element in robot_points)
-                if len(robot_points) > 0:
-                    tip_handle = robot_points[-1]
-                    tip_handle.position = tuple(curve[-1])
+                        vertices, _ = _oriented_tube_segment_mesh(
+                            p0,
+                            p1,
+                            robot_frames[seg_idx],
+                            robot_frames[seg_idx + 1],
+                            self._robot_radius,
+                            self._cylinder_sections,
+                            cap_end=seg_idx == num_segments - 1,
+                        )
+                        handle.vertices = vertices
 
     def _build_static_spheres(
         self,
@@ -918,7 +945,9 @@ class ViserRenderer(BaseSoftRobotRenderer):
         # Use a Viser-specific auto-distance. CameraConfig's default distance
         # factor is tuned for backends with an additional zoom control, while
         # Viser uses the camera position as a true perspective eye point.
-        config = camera_config or CameraConfig(fov=self._camera_fov, distance_factor=1.0)
+        config = camera_config or CameraConfig(
+            fov=self._camera_fov, distance_factor=1.0
+        )
 
         # Compute bounding box of all curves
         all_points = curves.reshape(-1, 3)
@@ -1056,8 +1085,11 @@ class ViserRenderer(BaseSoftRobotRenderer):
             allow_extra_rows=uses_configured_offsets,
         )
 
-        # Compute backbone curves
-        curves = np.asarray(self.compute_backbone_curves_batched(q, base_offsets))
+        curves, material_frames = self.compute_backbone_curves_and_frames_batched(
+            q, base_offsets
+        )
+        curves = np.asarray(curves)
+        material_frames = np.asarray(material_frames)
 
         cfg = color_config or self.color_config
         resolved_colors = self.resolve_backbone_colors(num_robots, color_config=cfg)
@@ -1067,6 +1099,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         self._build_robot_geometry(
             curves,
             resolved_colors.per_robot_point_rgba,
+            material_frames=material_frames,
             base_plate_color=cfg.base_plate_color,
         )
 
@@ -1167,8 +1200,11 @@ class ViserRenderer(BaseSoftRobotRenderer):
             allow_extra_rows=uses_configured_offsets,
         )
 
-        # Compute backbone curves
-        curves = np.asarray(self.compute_backbone_curves_batched(q, base_offsets))
+        curves, material_frames = self.compute_backbone_curves_and_frames_batched(
+            q, base_offsets
+        )
+        curves = np.asarray(curves)
+        material_frames = np.asarray(material_frames)
 
         cfg = color_config or self.color_config
         resolved_colors = self.resolve_backbone_colors(num_robots, color_config=cfg)
@@ -1178,6 +1214,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         self._build_robot_geometry(
             curves,
             resolved_colors.per_robot_point_rgba,
+            material_frames=material_frames,
             base_plate_color=cfg.base_plate_color,
         )
 
@@ -1326,9 +1363,11 @@ class ViserRenderer(BaseSoftRobotRenderer):
         resolved_colors = self.resolve_backbone_colors(num_robots, color_config=cfg)
 
         # Precompute backbone curves for the first frame used to build geometry.
-        curves_0 = np.asarray(
-            self.compute_backbone_curves_batched(q_ts[:, 0, :], base_offsets)
+        curves_0, material_frames_0 = self.compute_backbone_curves_and_frames_batched(
+            q_ts[:, 0, :], base_offsets
         )
+        curves_0 = np.asarray(curves_0)
+        material_frames_0 = np.asarray(material_frames_0)
 
         # Fit the initial camera to the full animated trajectory, matching
         # Open3DRenderer.render_sequence and avoiding under-framing on motion.
@@ -1347,6 +1386,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         self._build_robot_geometry(
             curves_0,
             resolved_colors.per_robot_point_rgba,
+            material_frames=material_frames_0,
             base_plate_color=cfg.base_plate_color,
         )
 
@@ -1438,7 +1478,9 @@ class ViserRenderer(BaseSoftRobotRenderer):
                     actuator_fig = self.create_actuator_position_plot(
                         ts, q_ts_for_plots, self.robot, robot_name=robot_name
                     )
-                    self.add_gui_plotly("Actuator Coordinates", actuator_fig, aspect=2.0)
+                    self.add_gui_plotly(
+                        "Actuator Coordinates", actuator_fig, aspect=2.0
+                    )
 
                 # Add custom plots
                 if custom_plots:
@@ -1547,8 +1589,11 @@ class ViserRenderer(BaseSoftRobotRenderer):
         q_frame = q_ts[:, frame_idx, :]  # (num_robots, DOF)
         num_robots = q_frame.shape[0]
 
-        # Compute new curves
-        curves = np.asarray(self.compute_backbone_curves_batched(q_frame, base_offsets))
+        curves, material_frames = self.compute_backbone_curves_and_frames_batched(
+            q_frame, base_offsets
+        )
+        curves = np.asarray(curves)
+        material_frames = np.asarray(material_frames)
 
         # Check if we can use efficient updates (geometry already built with same config)
         can_update = (
@@ -1560,11 +1605,14 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         if can_update:
             # Efficient update: only modify position/orientation properties
-            self._update_robot_geometry(curves)
+            self._update_robot_geometry(curves, material_frames)
         else:
             # Full rebuild needed (first frame or configuration changed)
             self._build_robot_geometry(
-                curves, point_colors, base_plate_color=base_plate_color
+                curves,
+                point_colors,
+                material_frames=material_frames,
+                base_plate_color=base_plate_color,
             )
 
         if render_actuators and self._has_actuator_visuals:
@@ -2135,10 +2183,11 @@ class LiveModeController:
             target_dim=3,
         )
 
-        # Compute curves
-        curves = np.asarray(
-            self._renderer.compute_backbone_curves_batched(q, base_offsets)
+        curves, material_frames = (
+            self._renderer.compute_backbone_curves_and_frames_batched(q, base_offsets)
         )
+        curves = np.asarray(curves)
+        material_frames = np.asarray(material_frames)
 
         if (
             self._resolved_colors is None
@@ -2158,11 +2207,12 @@ class LiveModeController:
 
         if can_update:
             # Efficient update: only modify position/orientation properties
-            self._renderer._update_robot_geometry(curves)
+            self._renderer._update_robot_geometry(curves, material_frames)
         else:
             # Full rebuild needed (first frame or configuration changed)
             self._renderer._build_robot_geometry(
                 curves,
                 self._resolved_colors.per_robot_point_rgba,
+                material_frames=material_frames,
                 base_plate_color=self._renderer.color_config.base_plate_color,
             )

--- a/tests/rendering/test_base_renderer.py
+++ b/tests/rendering/test_base_renderer.py
@@ -610,11 +610,13 @@ def test_viser_discrete_backbone_spheres_use_robot_radius():
     renderer._server = server
     renderer._scene_handles = SceneHandles()
     curves = np.array([[[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]]])
+    material_frames = np.broadcast_to(np.eye(3), (1, 2, 3, 3)).copy()
     point_colors = np.ones((1, 2, 4), dtype=np.float64)
 
     renderer._build_robot_geometry(
         curves,
         point_colors,
+        material_frames=material_frames,
         base_plate_color=(0.15, 0.15, 0.15),
     )
 

--- a/tests/rendering/test_base_renderer.py
+++ b/tests/rendering/test_base_renderer.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -117,7 +119,9 @@ class DummyBatchedActuatedSpatialRobot(DummySpatialRobot):
         self.single_calls += 1
         raise AssertionError("single actuator hook should not be used")
 
-    def actuator_visual_layers_batched(self, q_batch, s_points, *, actuator_inputs=None):
+    def actuator_visual_layers_batched(
+        self, q_batch, s_points, *, actuator_inputs=None
+    ):
         self.batched_calls += 1
         num_robots = int(q_batch.shape[0])
         base_paths = jnp.stack(
@@ -316,6 +320,7 @@ class FakeViserScene:
         self.line_segments = []
         self.icospheres = []
         self.trimeshes = []
+        self.simple_meshes = []
 
     def add_line_segments(self, *, name, points, colors, line_width):
         handle = FakeViserLineHandle(
@@ -337,10 +342,21 @@ class FakeViserScene:
         self.trimeshes.append(handle)
         return handle
 
+    def add_mesh_simple(self, **kwargs):
+        handle = FakeViserGeometryHandle(**kwargs)
+        self.simple_meshes.append(handle)
+        return handle
+
 
 class FakeViserActuatorServer:
     def __init__(self):
         self.scene = FakeViserScene()
+        self.atomic_calls = 0
+
+    @contextmanager
+    def atomic(self):
+        self.atomic_calls += 1
+        yield
 
 
 class FakeViserGuiHandle:
@@ -420,12 +436,22 @@ def test_renderer_exposes_base_pose_transform_and_axis():
     )
 
 
+def test_backbone_geometry_sampling_preserves_fk_material_frames():
+    robot = DummySpatialRobot(jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]))
+    renderer = DummyRenderer(robot)
+
+    curves, frames = renderer.compute_backbone_curves_and_frames_batched(
+        jnp.zeros((1, 0)), jnp.array([[1.0, 2.0, 3.0]])
+    )
+
+    assert_allclose(curves[0, 0], jnp.array([1.0, 2.0, 3.0]), atol=1e-7)
+    assert_allclose(frames[0, 0], robot.base_transform[:3, :3], atol=1e-7)
+
+
 def test_camera_auto_position_rotates_default_offset_by_base_pose():
     config = CameraConfig(distance_factor=2.0, position_offset=(1.0, 0.0, 0.0))
     center = np.array([10.0, 20.0, 30.0])
-    base_transform = poses.planar_pose_to_transform(
-        jnp.array([jnp.pi / 2, 1.0, 2.0])
-    )
+    base_transform = poses.planar_pose_to_transform(jnp.array([jnp.pi / 2, 1.0, 2.0]))
 
     camera_pos, look_at = config.compute_auto_position(
         center,
@@ -444,9 +470,7 @@ def test_camera_explicit_position_remains_world_space_with_base_pose():
         position_offset=(1.0, 0.0, 0.0),
     )
     center = np.array([10.0, 20.0, 30.0])
-    base_transform = poses.planar_pose_to_transform(
-        jnp.array([jnp.pi / 2, 1.0, 2.0])
-    )
+    base_transform = poses.planar_pose_to_transform(jnp.array([jnp.pi / 2, 1.0, 2.0]))
 
     camera_pos, look_at = config.compute_auto_position(
         center,
@@ -507,7 +531,9 @@ def test_open3d_interactive_camera_front_points_from_eye_to_target():
         vis,
         ctrl,
         scene_data,
-        camera_config=CameraConfig(distance_factor=1.0, position_offset=(1.0, 0.0, 0.0)),
+        camera_config=CameraConfig(
+            distance_factor=1.0, position_offset=(1.0, 0.0, 0.0)
+        ),
     )
 
     assert_allclose(ctrl.front, np.array([1.0, 0.0, 0.0]), atol=1e-12)
@@ -565,7 +591,9 @@ def test_viser_camera_accepts_full_trajectory_curves_for_bounds():
 
     renderer._setup_camera(
         curves,
-        camera_config=CameraConfig(distance_factor=1.0, position_offset=(1.0, 0.0, 0.0)),
+        camera_config=CameraConfig(
+            distance_factor=1.0, position_offset=(1.0, 0.0, 0.0)
+        ),
     )
 
     assert_allclose(client.camera.look_at, np.array([1.0, 0.5, 0.0]), atol=1e-12)
@@ -597,6 +625,86 @@ def test_viser_discrete_backbone_spheres_use_robot_radius():
     )
 
 
+def test_viser_defaults_to_swept_backbone():
+    pytest.importorskip("viser")
+    from soromox.rendering.viser_renderer import ViserRenderer
+
+    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    renderer = ViserRenderer(robot, auto_start=False)
+
+    assert renderer._backbone_style == "swept"
+
+
+def test_open3d_defaults_to_swept_backbone():
+    pytest.importorskip("open3d")
+    from soromox.rendering.open3d_renderer import Open3DRenderer
+
+    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    renderer = Open3DRenderer(robot)
+
+    assert renderer._backbone_mode == "swept"
+
+
+def test_viser_swept_backbone_uses_material_frame_rings():
+    pytest.importorskip("viser")
+    from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
+
+    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    renderer = ViserRenderer(
+        robot, auto_start=False, backbone_style="swept", cylinder_sections=8
+    )
+    server = FakeViserActuatorServer()
+    renderer._server = server
+    renderer._scene_handles = SceneHandles()
+    curves = np.array([[[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]]])
+    material_frames = np.broadcast_to(np.eye(3), (1, 2, 3, 3)).copy()
+
+    renderer._build_robot_geometry(
+        curves,
+        np.ones((1, 2, 4), dtype=np.float64),
+        material_frames=material_frames,
+        base_plate_color=(0.15, 0.15, 0.15),
+    )
+
+    first_ring = server.scene.simple_meshes[0].vertices[:8]
+    assert_allclose(first_ring[:, 0], 0.0, atol=1e-7)
+    assert np.ptp(first_ring[:, 1]) > renderer._robot_radius
+
+
+def test_viser_swept_body_owns_closed_tip_and_updates_atomically():
+    pytest.importorskip("viser")
+    from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
+
+    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    renderer = ViserRenderer(
+        robot, auto_start=False, backbone_style="swept", cylinder_sections=8
+    )
+    server = FakeViserActuatorServer()
+    renderer._server = server
+    renderer._scene_handles = SceneHandles()
+    frames = np.broadcast_to(np.eye(3), (1, 2, 3, 3)).copy()
+    colors = np.ones((1, 2, 4), dtype=np.float64)
+    initial_curve = np.array([[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]])
+    updated_curve = np.array([[[0.0, 0.0, 0.0], [1.0, 1.0, 0.0]]])
+
+    renderer._build_robot_geometry(
+        initial_curve,
+        colors,
+        material_frames=frames,
+        base_plate_color=(0.15, 0.15, 0.15),
+    )
+    renderer._update_robot_geometry(updated_curve, frames)
+
+    tip_mesh = server.scene.simple_meshes[0]
+    body_tip_ring = tip_mesh.vertices[8:16]
+    cap_triangles = tip_mesh.faces[-8:]
+    assert server.atomic_calls == 1
+    assert_allclose(body_tip_ring.mean(axis=0), updated_curve[0, -1], atol=1e-7)
+    assert_allclose(tip_mesh.vertices[-1], updated_curve[0, -1], atol=1e-7)
+    assert np.all(cap_triangles[:, 0] == 16)
+    assert server.scene.icospheres == []
+
+
 def test_viser_default_camera_uses_backend_specific_distance():
     pytest.importorskip("viser")
     from soromox.rendering.viser_renderer import ViserRenderer
@@ -621,9 +729,7 @@ def test_viser_actuator_geometry_updates_existing_line_handles():
     pytest.importorskip("viser")
     from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
 
-    robot = DummyActuatedSpatialRobot(
-        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-    )
+    robot = DummyActuatedSpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
     renderer._server = FakeViserActuatorServer()
     renderer._scene_handles = SceneHandles()
@@ -716,9 +822,7 @@ def test_renderer_rejects_extra_explicit_base_offsets_by_default():
 
 
 def test_renderer_computes_actuator_visual_layers_single_and_batched():
-    robot = DummyActuatedSpatialRobot(
-        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-    )
+    robot = DummyActuatedSpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
     renderer = DummyRenderer(robot, num_points=5)
 
     single = renderer.compute_actuator_visual_layers(jnp.array([]))
@@ -770,9 +874,7 @@ def test_renderer_uses_batched_actuator_visual_fast_path():
 
 
 def test_renderer_computes_trajectory_actuator_visual_layers():
-    robot = DummyActuatedSpatialRobot(
-        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-    )
+    robot = DummyActuatedSpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
     renderer = DummyRenderer(robot, num_points=4)
 
     layers = renderer.compute_actuator_visual_layers_trajectory(
@@ -811,9 +913,7 @@ def test_renderer_uses_trajectory_actuator_visual_fast_path():
 
 
 def test_matplotlib_actuator_overlay_changes_rendered_frame():
-    robot = DummyActuatedSpatialRobot(
-        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-    )
+    robot = DummyActuatedSpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
     renderer = MatplotlibRenderer(robot, width=240, height=180, num_points=8)
 
     without_actuators = renderer.render_frame(jnp.array([]), render_actuators=False)

--- a/tests/rendering/test_open3d_material_frames.py
+++ b/tests/rendering/test_open3d_material_frames.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+pytest.importorskip("open3d")
+
+from soromox.rendering.open3d_renderer import (  # noqa: E402
+    _cross_section_ring_offsets,
+    _make_swept_cross_section_segment,
+    _swept_segment_vertices,
+)
+from soromox.systems.soft_robot import CrossSectionGeometry  # noqa: E402
+
+
+def test_swept_cylinder_rings_follow_material_frame_not_curve_chord():
+    p0 = np.array([0.0, 0.0, 0.0])
+    p1 = np.array([0.0, 1.0, 0.0])
+    frame = np.eye(3)
+
+    mesh = _make_swept_cross_section_segment(
+        p0,
+        p1,
+        frame,
+        frame,
+        CrossSectionGeometry.CIRCULAR,
+        np.array([0.2]),
+        (1.0, 0.0, 0.0),
+        resolution=8,
+    )
+
+    first_ring = np.asarray(mesh.vertices)[:8]
+    assert_allclose(first_ring[:, 0], 0.0, atol=1e-12)
+    assert np.ptp(first_ring[:, 1]) > 0.39
+
+
+def test_swept_segment_applies_each_endpoint_material_frame():
+    offsets = _cross_section_ring_offsets(
+        CrossSectionGeometry.RECTANGULAR, np.array([0.4, 0.2]), resolution=8
+    )
+    frame0 = np.eye(3)
+    frame1 = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, -1.0],
+            [0.0, 1.0, 0.0],
+        ]
+    )
+    p0 = np.zeros(3)
+    p1 = np.array([1.0, 0.0, 0.0])
+
+    vertices = _swept_segment_vertices(p0, p1, frame0, frame1, offsets)
+
+    assert_allclose(vertices[:4], p0 + offsets @ frame0.T, atol=1e-12)
+    assert_allclose(vertices[4:], p1 + offsets @ frame1.T, atol=1e-12)
+
+
+def test_swept_segment_terminal_cap_closes_tip_with_outward_faces():
+    p0 = np.zeros(3)
+    p1 = np.array([1.0, 0.0, 0.0])
+    frame = np.eye(3)
+
+    mesh = _make_swept_cross_section_segment(
+        p0,
+        p1,
+        frame,
+        frame,
+        CrossSectionGeometry.CIRCULAR,
+        np.array([0.2]),
+        (1.0, 0.0, 0.0),
+        resolution=8,
+        cap_end=True,
+    )
+
+    vertices = np.asarray(mesh.vertices)
+    triangles = np.asarray(mesh.triangles)
+    cap_triangles = triangles[-8:]
+    assert_allclose(vertices[-1], p1, atol=1e-12)
+    assert np.all(cap_triangles[:, 0] == 16)
+    first_cap = vertices[cap_triangles[0]]
+    normal = np.cross(first_cap[1] - first_cap[0], first_cap[2] - first_cap[0])
+    assert np.dot(normal, frame[:, 0]) > 0.0


### PR DESCRIPTION
## Summary

- preserve full forward-kinematics material frames alongside sampled backbone positions
- construct Viser and Open3D swept surfaces from endpoint cross-section rings rather than centerline chord alignment
- support material-frame orientation for circular, elliptical, and rectangular Open3D cross-sections
- close the terminal swept segment with an outward-facing cap in both renderers
- update Viser meshes atomically and remove the independently updated swept-mode tip sphere
- make `backbone_style="swept"` the default for both Open3DRenderer and ViserRenderer while retaining explicit `discrete` mode
- update generic GVS, PCS, I-SUPPORT, and articulated simulation examples to exercise the swept default
- require FK material frames in generic Viser geometry paths and propagate them through the specialized UMArm renderer

## Root cause

The renderers reduced forward-kinematics poses to positions, then oriented each body primitive from the chord between neighboring backbone samples. This discarded the robot's local material-frame rotation, producing incorrect surfaces under shear and twist. The first ring-based implementation also left Open3D's terminal ring open and used a separate Viser tip sphere, which could visually lag behind mesh updates.

## Implementation

A shared batched helper now returns both 3D backbone curves and FK material frames, applying base offsets only to positions. Each swept segment connects cross-section rings transformed by the material frames at both endpoints. Open3D uses this geometry in offscreen and interactive cached paths; non-circular discrete markers also inherit the local frame. Final segments own their cap topology, including during animation updates.

Viser geometry construction and updates now require material frames explicitly. The tangent-derived fallback was removed so missing frame propagation fails at the call site instead of silently reintroducing the original orientation bug. UMArm's custom rigid renderer accepts the same private API and its live controller propagates sampled frames.

## Compatibility

Callers that require the prior marker visualization can continue to pass `backbone_style="discrete"` explicitly. Deliberately lightweight or planar examples retain that override.

## Validation

- `uv run ruff check` on all changed renderer, example, and rendering-test files
- `uv run pytest -q tests/rendering tests/systems/test_mckibben_umarm.py` (`43 passed`)
- `git diff --check`