### PR TITLE
Standardize soft robot mounting and gravity defaults

### DIFF
--- a/docs/api/systems/articulated/articulated-soft-robot.md
+++ b/docs/api/systems/articulated/articulated-soft-robot.md
@@ -36,7 +36,6 @@ params = ArticulatedSoftRobotParams(
         jnp.diag(jnp.array([0.02, 0.03, 0.04])),
         jnp.diag(jnp.array([0.01, 0.02, 0.03])),
     ]),
-    gravity=jnp.array([0.0, 0.0, -9.81]),
     joint_stiffness=jnp.diag(jnp.array([0.5, 0.3])),
     joint_damping=jnp.diag(jnp.array([0.02, 0.01])),
     joint_rest_configuration=jnp.zeros(2),

--- a/docs/api/systems/gvs/gvs.md
+++ b/docs/api/systems/gvs/gvs.md
@@ -38,8 +38,6 @@ segment = GVSSegment(
 
 robot = GVS.from_segments(
     [segment],
-    gravity=jnp.array([0.0, 0.0, -9.81]),
-    base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     max_dof=4,
 )
 q = jnp.zeros(robot.num_dofs)

--- a/docs/api/systems/gvs/tendon-actuated-gvs.md
+++ b/docs/api/systems/gvs/tendon-actuated-gvs.md
@@ -39,8 +39,6 @@ active_tendon_routing = LinearTendonRoutingParams(
 
 robot = TendonActuatedGVS.from_segments(
     [segment],
-    gravity=jnp.array([0.0, 0.0, -9.81]),
-    base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     max_dof=4,
     active_tendon_routing=active_tendon_routing,
 )

--- a/docs/api/systems/pcs/isupport.md
+++ b/docs/api/systems/pcs/isupport.md
@@ -41,11 +41,9 @@ import jax.numpy as jnp
 from soromox.systems import ISupport, ISupportParams, ISupportStructure
 
 params = ISupportParams(
-    base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     length=jnp.array([0.18]),
     radius=jnp.array([0.03]),
     density=jnp.array([1104.0]),
-    gravity=jnp.array([0.0, 0.0, -9.81]),
     young_modulus=jnp.array([1.6464e6]),
     shear_modulus=jnp.array([0.5488e6]),
     damping_matrix=1e-3 * jnp.eye(6),

--- a/docs/api/systems/pcs/tendon-actuated-pcs.md
+++ b/docs/api/systems/pcs/tendon-actuated-pcs.md
@@ -31,8 +31,6 @@ body_params = PCSParams(
     young_modulus=jnp.array([1e6, 1e6]),
     shear_modulus=jnp.array([1e5, 1e5]),
     damping_matrix=jnp.eye(12),
-    gravity=jnp.array([0.0, 0.0, -9.81]),
-    base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     reference_strain=jnp.tile(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), 2),
 )
 

--- a/docs/api/systems/pcs/tendon-actuated-planar-pcs.md
+++ b/docs/api/systems/pcs/tendon-actuated-planar-pcs.md
@@ -19,11 +19,9 @@ from soromox.systems import (
 
 num_segments = 2
 body = PlanarPCSParams(
-    base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
     length=0.1 * jnp.ones((num_segments,)),
     radius=0.02 * jnp.ones((num_segments,)),
     density=1070.0 * jnp.ones((num_segments,)),
-    gravity=jnp.array([0.0, 9.81]),
     young_modulus=5e3 * jnp.ones((num_segments,)),
     shear_modulus=1e3 * jnp.ones((num_segments,)),
     damping_matrix=jnp.eye(3 * num_segments),

--- a/docs/api/systems/pendulum/pendulum.md
+++ b/docs/api/systems/pendulum/pendulum.md
@@ -20,7 +20,6 @@ params = PendulumParams(
     moment_inertia=jnp.array([0.1, 0.05]),
     length=jnp.array([0.5, 0.3]),
     center_of_mass_length=jnp.array([0.25, 0.15]),
-    gravity=jnp.array([0.0, -9.81]),
     joint_stiffness=jnp.zeros((2, 2)),
     joint_damping=jnp.zeros((2, 2)),
     joint_rest_configuration=jnp.zeros(2),

--- a/docs/api/systems/pendulum/tendon-actuated-pendulum.md
+++ b/docs/api/systems/pendulum/tendon-actuated-pendulum.md
@@ -86,7 +86,6 @@ body_params = PendulumParams(
     moment_inertia=jnp.array([3.0, 2.0]),
     length=jnp.array([2.0, 1.0]),
     center_of_mass_length=jnp.array([1.0, 0.5]),
-    gravity=jnp.array([0.0, -9.81]),
     joint_stiffness=jnp.diag(jnp.array([1.5, 2.0])),
     joint_damping=jnp.zeros((2, 2)),
     joint_rest_configuration=jnp.zeros(2),

--- a/docs/api/utilities/parameters.md
+++ b/docs/api/utilities/parameters.md
@@ -69,6 +69,71 @@ or `(num_links,)`.
 | `reference_strain` | Reference strain vector |
 | `joint_rest_configuration` | Joint coordinates where elastic joint force is zero |
 
+## World Frame, Mounting, and Gravity Defaults
+
+Soft-robot parameter objects use an upright mounting and Earth gravity when
+`base_pose` or `gravity` is omitted. Vertical is world y for planar systems and
+world z for spatial systems. Gravity is always expressed in the inertial/world
+frame; changing the base mounting does not rotate the gravity vector.
+
+| Mounting constructor | Planar backbone | Spatial backbone | Default gravity |
+|----------------------|-----------------|------------------|-----------------|
+| `horizontal` | +x | +x | negative vertical |
+| `upright` | +y | +z | negative vertical |
+| `hanging` | -y | -z | negative vertical |
+
+The exact default values are:
+
+- Planar upright pose: `[pi / 2, 0, 0]`; gravity: `[0, -9.81]` m/s².
+- Spatial upright pose: `[sqrt(0.5), 0, -sqrt(0.5), 0, 0, 0, 0]`;
+  gravity: `[0, 0, -9.81]` m/s².
+- Planar poses use `[theta, x, y]`. Spatial poses use scalar-first Hamilton
+  quaternions in `[qw, qx, qy, qz, x, y, z]` order.
+
+Omitting both fields selects the defaults:
+
+```python
+params = PlanarPCSParams(
+    length=length,
+    radius=radius,
+    density=density,
+    young_modulus=young_modulus,
+    shear_modulus=shear_modulus,
+    damping_matrix=damping_matrix,
+    reference_strain=reference_strain,
+)
+```
+
+Use the inherited mounting constructors to make another common mounting
+explicit. `base_position` translates the mounting without changing its
+orientation:
+
+```python
+horizontal = PlanarPCSParams.horizontal(**planar_params)
+upright = PlanarPCSParams.upright(
+    **planar_params, base_position=jnp.array([0.2, 0.1])
+)
+hanging = PCSParams.hanging(
+    **spatial_params, base_position=jnp.array([0.0, 0.0, 0.5])
+)
+```
+
+Pass an explicit vector for custom or zero gravity. Pass an explicit
+`base_pose` through the ordinary constructor for arbitrary orientations:
+
+```python
+zero_gravity = PCSParams(..., gravity=jnp.zeros(3))
+custom = PlanarPCSParams(
+    ...,
+    gravity=jnp.array([1.0, -9.7]),
+    base_pose=jnp.array([0.3, 0.2, 0.1]),
+)
+```
+
+Calling `replace(base_pose=None)` or `replace(gravity=None)` restores the
+dimension-appropriate default. The former identity fallback is available as
+`.horizontal(...)` or by passing an explicit identity pose.
+
 ## Tendon Parameters
 
 Continuum tendon routing uses `LinearTendonRoutingParams`. It is a batched
@@ -120,31 +185,19 @@ choices that affect compilation.
 import jax.numpy as jnp
 from soromox.systems import PCS, PCSParams, PCSStructure
 
-params = PCSParams(
+params = PCSParams.upright(
     length=jnp.array([0.1, 0.1]),
     radius=jnp.array([0.01, 0.01]),
     density=jnp.array([1000.0, 1000.0]),
     young_modulus=jnp.array([1e6, 1e6]),
     shear_modulus=jnp.array([1e5, 1e5]),
     damping_matrix=jnp.eye(12),
-    gravity=jnp.array([0.0, 0.0, -9.81]),
-    base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     reference_strain=jnp.tile(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), 2),
 )
 
 robot = PCS(params=params, structure=PCSStructure(num_gauss_points=5))
 updated_robot = robot.update_params(length=jnp.array([0.12, 0.1]))
 ```
-
-`base_pose` convention:
-
-- Planar systems use shape `(3,)`: `[theta, x, y]`, where `theta` is a
-  right-handed angle in radians about the out-of-plane z-axis.
-- Spatial systems use shape `(7,)`: `[qw, qx, qy, qz, x, y, z]`.
-- Spatial quaternions are scalar-first Hamilton quaternions, normalized before
-  use, and must have nonzero finite norm.
-- Zero base rotation means the undeformed soft-robot backbone is aligned with
-  the positive base-frame x-axis.
 
 ## API Reference
 

--- a/docs/development/extending.md
+++ b/docs/development/extending.md
@@ -89,6 +89,27 @@ class SoftRobot(DynamicalSystem):
         ...
 ```
 
+#### Soft-Robot Parameter Classes
+
+Parameter classes derived from `BaseSoftRobotParams` declare their world-frame
+dimensionality explicitly:
+
+```python
+from typing import ClassVar
+from soromox.systems import BaseSoftRobotParams
+
+class MyPlanarParams(BaseSoftRobotParams):
+    is_planar: ClassVar[bool] = True
+    # Additional numeric fields...
+```
+
+Use `False` for SE(3) systems. This mirrors the `SoftRobot.is_planar` property
+and lets the base class materialize
+the upright pose and negative-vertical Earth gravity when those keyword inputs
+are omitted, and provides inherited `.horizontal(...)`, `.upright(...)`, and
+`.hanging(...)` constructors. Do not infer the convention from an input array
+shape. Explicit `base_pose` and `gravity` values continue to override defaults.
+
 ### Step-by-Step: Implementing a New System
 
 #### 1. Choose Your Base Class
@@ -1053,9 +1074,7 @@ params = PlanarPCSParams(
     young_modulus=jnp.array([1e6, 1e6, 1e6]),
     shear_modulus=jnp.array([1e5, 1e5, 1e5]),
     damping_matrix=jnp.eye(9),
-    gravity=jnp.array([0.0, -9.81]),
     reference_strain=jnp.tile(jnp.array([0.0, 1.0, 0.0]), 3),
-    base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
 )
 robot = PlanarPCS(params=params)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,11 +118,9 @@ Get up and running in minutes:
         radius=0.02 * jnp.ones((num_segments,)),
         density=1070.0 * jnp.ones((num_segments,)),
         reference_strain=jnp.tile(jnp.array([0.0, 1.0, 0.0]), num_segments),
-        gravity=jnp.array([0.0, 9.81]),
         young_modulus=2e3 * jnp.ones((num_segments,)),
         shear_modulus=1e3 * jnp.ones((num_segments,)),
         damping_matrix=1e-3 * jnp.eye(3 * num_segments),
-        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
     )
     robot = PlanarPCS(params=params)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -179,9 +179,7 @@ Test your installation with this quick verification script:
         young_modulus=jnp.array([1e6]),
         shear_modulus=jnp.array([1e5]),
         damping_matrix=jnp.eye(3),
-        gravity=jnp.array([0.0, -9.81]),
         reference_strain=jnp.array([0.0, 1.0, 0.0]),
-        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
     )
     robot = PlanarPCS(params=params)
     robot.forward_kinematics(jnp.zeros(robot.num_dofs), s=0.1)
@@ -203,9 +201,7 @@ Test your installation with this quick verification script:
         young_modulus=jnp.array([1e6, 1e6]),
         shear_modulus=jnp.array([1e5, 1e5]),
         damping_matrix=jnp.eye(6),
-        gravity=jnp.array([0.0, -9.81]),
         reference_strain=jnp.tile(jnp.array([0.0, 1.0, 0.0]), 2),
-        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
     )
     robot = PlanarPCS(params=params)
 

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -392,7 +392,6 @@ params = params.replace(
     center_of_mass_position=center_of_mass_positions,
     mass=masses,
     center_of_mass_inertia=center_of_mass_inertia,
-    gravity=jnp.array([0.0, 0.0, -9.81]),
     joint_stiffness=jnp.diag(joint_stiffness),
     joint_damping=jnp.diag(joint_damping),
 )

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -184,12 +184,14 @@ Each robot system expects a typed Equinox PyTree params object. Numeric fields a
 JAX arrays, so same-shape updates can flow through `jit`, `grad`, and `vmap`
 without changing the compiled structure.
 
-`base_pose` follows the dimensionality of the robot. Planar robots expect
-`[theta, x, y]`, where `theta` is a right-handed angle in radians about the
-out-of-plane z-axis. Spatial robots expect `[qw, qx, qy, qz, x, y, z]`, using
-scalar-first Hamilton quaternions. Zero base rotation means the undeformed
-backbone is aligned with the positive base-frame x-axis. Spatial quaternions
-must have nonzero finite norm and are normalized before transform construction.
+When omitted, `base_pose` mounts the robot upright (+y planar, +z spatial) and
+`gravity` uses Earth gravity in the negative vertical world direction. Gravity
+is an inertial-frame vector and is not rotated with the base. Use the inherited
+`.horizontal(...)`, `.upright(...)`, and `.hanging(...)` parameter constructors
+for the three standard mountings. Explicit arrays remain available for custom
+poses, gravity directions, and zero-gravity models. See
+[Parameters](../api/utilities/parameters.md#world-frame-mounting-and-gravity-defaults)
+for exact vectors and quaternions.
 
 ```python title="Parameter Structure"
 params = PCSParams(
@@ -197,11 +199,9 @@ params = PCSParams(
     radius=radii,
     density=densities,
     reference_strain=reference_strain,
-    gravity=gravity,
     young_modulus=young_modulus,
     shear_modulus=shear_modulus,
     damping_matrix=damping_matrix,
-    base_pose=base_pose,
 )
 robot = PCS(params=params)
 robot = robot.update_params(length=new_lengths)
@@ -262,11 +262,9 @@ Ready for something more advanced? Let's simulate a soft continuum robot:
         radius=0.02 * jnp.ones((num_segments,)),
         density=1070.0 * jnp.ones((num_segments,)),
         reference_strain=jnp.tile(jnp.array([0.0, 1.0, 0.0]), num_segments),
-        gravity=jnp.array([0.0, 9.81]),
         young_modulus=2e3 * jnp.ones((num_segments,)),
         shear_modulus=1e3 * jnp.ones((num_segments,)),
         damping_matrix=damping_matrix,
-        base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
     )
     # Note: Damping helps stabilize simulations and represents material dissipation.
     # For static analysis, you can omit this or set to zero.

--- a/src/soromox/systems/__init__.py
+++ b/src/soromox/systems/__init__.py
@@ -19,6 +19,7 @@ from soromox.systems.gvs.structures import (
 from soromox.systems.hsa.params import PlanarHSAParams
 from soromox.systems.hsa.structures import PlanarHSAStructure
 from soromox.systems.params import (
+    DEFAULT_GRAVITY_MAGNITUDE,
     BaseArticulatedSoftRobotParams,
     BaseContinuumSoftRobotParams,
     BaseSoftRobotParams,
@@ -72,6 +73,7 @@ from .pendulum import Pendulum, TendonActuatedPendulum
 
 __all__ = [
     # base classes
+    "DEFAULT_GRAVITY_MAGNITUDE",
     "DynamicalSystem",
     "EnvironmentState",
     "SoftRobot",

--- a/src/soromox/systems/articulated/params.py
+++ b/src/soromox/systems/articulated/params.py
@@ -1,6 +1,7 @@
 __all__ = ["ArticulatedSoftRobotParams", "McKibbenActuatedUMArmParams"]
 
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
 from jax import Array
@@ -18,8 +19,12 @@ class ArticulatedSoftRobotParams(BaseArticulatedSoftRobotParams):
     Per-joint screw axes and transforms define the dynamic link geometry used by
     the articulated model. The number of joints is fixed by array shapes.
     ``base_pose`` uses scalar-first quaternion SE(3) coordinates
-    ``[qw, qx, qy, qz, x, y, z]`` with nonzero finite quaternion norm.
+    ``[qw, qx, qy, qz, x, y, z]`` with nonzero finite quaternion norm. Omitting
+    ``base_pose`` and ``gravity`` selects upright mounting and negative-z Earth
+    gravity.
     """
+
+    is_planar: ClassVar[bool] = False
 
     joint_screw: Array
     parent_to_joint_transform: Array
@@ -37,18 +42,16 @@ class ArticulatedSoftRobotParams(BaseArticulatedSoftRobotParams):
         center_of_mass_position: Array,
         mass: Array,
         center_of_mass_inertia: Array,
-        gravity: Array,
+        gravity: Array | None = None,
         joint_stiffness: Array,
         joint_damping: Array,
         joint_rest_configuration: Array,
         radius: Array,
         base_pose: Array | None = None,
     ) -> None:
-        """Create articulated parameters with a default spatial identity base."""
-        if base_pose is None:
-            base_pose = jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-        self.base_pose = jnp.asarray(base_pose)
-        self.gravity = jnp.asarray(gravity)
+        """Create articulated parameters with default upright mounting and gravity."""
+        self.base_pose = self._resolve_base_pose(base_pose)
+        self.gravity = self._resolve_gravity(gravity)
         self.mass = jnp.asarray(mass)
         self.joint_stiffness = jnp.asarray(joint_stiffness)
         self.joint_damping = jnp.asarray(joint_damping)
@@ -112,7 +115,7 @@ class McKibbenActuatedUMArmParams(ArticulatedSoftRobotParams):
         center_of_mass_position: Array,
         mass: Array,
         center_of_mass_inertia: Array,
-        gravity: Array,
+        gravity: Array | None = None,
         joint_stiffness: Array,
         joint_damping: Array,
         joint_rest_configuration: Array,

--- a/src/soromox/systems/gvs/construction.py
+++ b/src/soromox/systems/gvs/construction.py
@@ -18,7 +18,7 @@ from soromox.systems.gvs.structures import (
 def params_and_structure_from_segments(
     segments: list[GVSSegment] | tuple[GVSSegment, ...],
     *,
-    gravity: Array,
+    gravity: Array | None = None,
     base_pose: Array | None = None,
     max_dof: int | None = None,
     max_num_gauss_points: int | None = None,
@@ -29,9 +29,6 @@ def params_and_structure_from_segments(
         raise ValueError("GVS requires at least one segment.")
     input_segments = tuple(segments)
     n_segments = len(input_segments)
-    if base_pose is None:
-        base_pose = jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-
     dofs_joint = [
         Joint.DICT_JOINT_TYPE_DOF[segment.joint.type] for segment in input_segments
     ]
@@ -90,8 +87,8 @@ def params_and_structure_from_segments(
             semi_minor_initial=jnp.asarray([link.b_i for link in links]),
             semi_minor_final=jnp.asarray([link.b_f for link in links]),
         ),
-        gravity=jnp.asarray(gravity),
-        base_pose=jnp.asarray(base_pose),
+        gravity=gravity,
+        base_pose=base_pose,
         reference_strain=jnp.asarray(
             [segment.basis.xi_ref for segment in input_segments]
         ),

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -229,7 +229,7 @@ class GVS(SoftRobot):
     def params_from_segments(
         segments: list[GVSSegment] | tuple[GVSSegment, ...],
         *,
-        gravity: Array,
+        gravity: Array | None = None,
         base_pose: Array | None = None,
         max_dof: int | None = None,
         max_num_gauss_points: int | None = None,
@@ -243,6 +243,8 @@ class GVS(SoftRobot):
         family, basis family, quadrature count, and cross-section family remain
         static in ``GVSStructure``. Numeric link, joint, and reference-strain
         values are copied into ``GVSParams``.
+        Omitted ``base_pose`` and ``gravity`` use the standard upright spatial
+        mounting and negative-z Earth gravity.
         """
         return params_and_structure_from_segments(
             segments,
@@ -258,14 +260,18 @@ class GVS(SoftRobot):
         cls,
         segments: list[GVSSegment] | tuple[GVSSegment, ...],
         *,
-        gravity: Array,
+        gravity: Array | None = None,
         base_pose: Array | None = None,
         max_dof: int | None = None,
         max_num_gauss_points: int | None = None,
         scale_rotational_basis_by_length: bool = False,
         **kwargs: Any,
     ) -> "GVS":
-        """Construct a GVS model directly from user-facing segment specs."""
+        """Construct a GVS model directly from user-facing segment specs.
+
+        Omitted ``base_pose`` and ``gravity`` use the standard upright spatial
+        mounting and negative-z Earth gravity.
+        """
         params, structure = cls.params_from_segments(
             segments,
             gravity=gravity,

--- a/src/soromox/systems/gvs/params.py
+++ b/src/soromox/systems/gvs/params.py
@@ -1,5 +1,7 @@
 __all__ = ["GVSLinkParams", "GVSParams", "TendonActuatedGVSParams"]
 
+from typing import ClassVar
+
 import equinox as eqx
 from jax import Array
 from jax import numpy as jnp
@@ -81,8 +83,12 @@ class GVSParams(BaseSoftRobotParams):
     than link geometry or material properties. ``joint_stiffness`` has shape
     ``(num_segments, max_dof, max_dof)`` and is padded to the static GVS layout.
     ``base_pose`` uses scalar-first quaternion SE(3) coordinates
-    ``[qw, qx, qy, qz, x, y, z]`` with nonzero finite quaternion norm.
+    ``[qw, qx, qy, qz, x, y, z]`` with nonzero finite quaternion norm. Omitting
+    ``base_pose`` and ``gravity`` selects upright spatial mounting and
+    negative-z Earth gravity.
     """
+
+    is_planar: ClassVar[bool] = False
 
     link: GVSLinkParams
     reference_strain: Array

--- a/src/soromox/systems/gvs/tendon_actuated_gvs.py
+++ b/src/soromox/systems/gvs/tendon_actuated_gvs.py
@@ -197,7 +197,7 @@ class TendonActuatedGVS(GVS):
         cls,
         segments: list[GVSSegment] | tuple[GVSSegment, ...],
         *,
-        gravity: Array,
+        gravity: Array | None = None,
         active_tendon_routing: BaseTendonRoutingParams,
         passive_tendon_routing: BaseTendonRoutingParams | None = None,
         passive_tendon: PassiveTendonParams | None = None,
@@ -209,7 +209,11 @@ class TendonActuatedGVS(GVS):
         passive_tendon_routing_basis: dict[str, Callable] | None = None,
         **kwargs: Any,
     ) -> "TendonActuatedGVS":
-        """Construct a tendon-actuated GVS model from segment and tendon specs."""
+        """Construct a tendon-actuated GVS model from segment and tendon specs.
+
+        Omitted ``base_pose`` and ``gravity`` use the standard upright spatial
+        mounting and negative-z Earth gravity.
+        """
         body, structure = GVS.params_from_segments(
             segments,
             gravity=gravity,

--- a/src/soromox/systems/hsa/params.py
+++ b/src/soromox/systems/hsa/params.py
@@ -1,7 +1,8 @@
 __all__ = ["PlanarHSAParams"]
 
-from dataclasses import fields
+from dataclasses import MISSING, fields
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
 from jax import Array
@@ -19,8 +20,12 @@ class PlanarHSAParams(BaseSoftRobotParams):
     hysteresis coefficients used by the symbolic HSA expressions. ``base_pose``
     stores the planar pose ``[theta, x, y]`` with shape ``(3,)``. ``theta`` is
     a right-handed angle in radians about the out-of-plane z-axis, and
-    ``x``/``y`` are direct translations in the parent frame.
+    ``x``/``y`` are direct translations in the parent frame. Omitting
+    ``base_pose`` and ``gravity`` selects upright mounting and negative-y Earth
+    gravity.
     """
+
+    is_planar: ClassVar[bool] = True
 
     length: Array
     proximal_cap_length: Array
@@ -37,7 +42,6 @@ class PlanarHSAParams(BaseSoftRobotParams):
     rod_density: Array
     platform_density: Array
     end_cap_density: Array
-    gravity: Array
     nominal_bending_stiffness: Array
     nominal_shear_stiffness: Array
     nominal_axial_stiffness: Array
@@ -64,7 +68,12 @@ class PlanarHSAParams(BaseSoftRobotParams):
         """Load planar HSA parameters from an explicit ``.npz`` file path."""
         with np.load(path) as data:
             field_names = [field.name for field in fields(cls)]
-            missing = sorted(name for name in field_names if name not in data)
+            required_names = {
+                field.name
+                for field in fields(cls)
+                if field.default is MISSING and field.default_factory is MISSING
+            }
+            missing = sorted(name for name in required_names if name not in data)
             if missing:
                 missing_names = ", ".join(missing)
                 raise KeyError(
@@ -75,6 +84,7 @@ class PlanarHSAParams(BaseSoftRobotParams):
                 **{
                     field_name: jnp.asarray(data[field_name])
                     for field_name in field_names
+                    if field_name in data
                 }
             )
 

--- a/src/soromox/systems/params.py
+++ b/src/soromox/systems/params.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "DEFAULT_GRAVITY_MAGNITUDE",
     "BaseSystemParams",
     "BaseSoftRobotParams",
     "BaseContinuumSoftRobotParams",
@@ -11,12 +12,14 @@ __all__ = [
 ]
 
 from dataclasses import fields
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 import equinox as eqx
 from jax import Array
 from jax import numpy as jnp
 from jax.errors import ConcretizationTypeError, TracerBoolConversionError
+
+DEFAULT_GRAVITY_MAGNITUDE = 9.81
 
 
 def _validate_finite_array(
@@ -127,6 +130,7 @@ class BaseSystemParams(eqx.Module):
 
         updated = self
         for name, value in updates.items():
+            value = self._normalize_replacement(name, value)
             updated = eqx.tree_at(
                 lambda params, field_name=name: getattr(params, field_name),
                 updated,
@@ -135,6 +139,10 @@ class BaseSystemParams(eqx.Module):
             )
         updated.validate()
         return updated
+
+    def _normalize_replacement(self, name: str, value: Any) -> Any:
+        """Normalize a field replacement before rebuilding the PyTree."""
+        return value
 
     def validate(self) -> None:
         """Validate parameter consistency."""
@@ -148,17 +156,127 @@ class BaseSystemParams(eqx.Module):
 class BaseSoftRobotParams(BaseSystemParams):
     """Common dynamic parameters for soft robot systems.
 
-    ``base_pose`` and ``gravity`` are JAX arrays in the dimensional convention
-    of the concrete model. Planar robots use ``base_pose = [theta, x, y]`` with
-    2D gravity, where ``theta`` is a right-handed angle in radians about the
-    out-of-plane z-axis. Spatial robots use
+    ``base_pose`` and ``gravity`` are optional keyword-only constructor inputs.
+    When omitted, the robot points upright and standard Earth gravity acts in
+    the negative vertical world direction. Planar robots use
+    ``base_pose = [theta, x, y]`` with 2D gravity, where ``theta`` is a
+    right-handed angle in radians about the out-of-plane z-axis. Spatial robots use
     ``base_pose = [qw, qx, qy, qz, x, y, z]`` with 3D gravity. Spatial
     quaternions are scalar-first Hamilton quaternions, normalized before
-    transform construction, and must have nonzero finite norm.
+    transform construction, and must have nonzero finite norm. Use
+    :meth:`horizontal`, :meth:`upright`, or :meth:`hanging` for explicit common
+    mounting configurations.
     """
 
-    base_pose: Array
-    gravity: Array
+    is_planar: ClassVar[bool | None] = None
+
+    base_pose: Array | None = eqx.field(default=None, kw_only=True)
+    gravity: Array | None = eqx.field(default=None, kw_only=True)
+
+    def __check_init__(self) -> None:
+        object.__setattr__(self, "base_pose", self._resolve_base_pose(self.base_pose))
+        object.__setattr__(self, "gravity", self._resolve_gravity(self.gravity))
+
+    @classmethod
+    def _require_planarity(cls) -> bool:
+        if cls.is_planar is None:
+            raise TypeError(
+                f"{cls.__name__} must declare is_planar as True or False."
+            )
+        return cls.is_planar
+
+    @classmethod
+    def _mounting_base_pose(
+        cls,
+        mounting: Literal["horizontal", "upright", "hanging"],
+        base_position: Array | None = None,
+    ) -> Array:
+        is_planar = cls._require_planarity()
+        position_dimension = 2 if is_planar else 3
+        if base_position is None:
+            position = jnp.zeros(position_dimension)
+        else:
+            position = _validate_finite_array(
+                "base_position", base_position, (position_dimension,)
+            )
+            position = jnp.asarray(position)
+
+        if is_planar:
+            angles = {
+                "horizontal": 0.0,
+                "upright": jnp.pi / 2,
+                "hanging": -jnp.pi / 2,
+            }
+            return jnp.concatenate([jnp.asarray([angles[mounting]]), position])
+
+        sqrt_half = jnp.sqrt(jnp.asarray(0.5))
+        quaternions = {
+            "horizontal": jnp.asarray([1.0, 0.0, 0.0, 0.0]),
+            "upright": jnp.asarray([sqrt_half, 0.0, -sqrt_half, 0.0]),
+            "hanging": jnp.asarray([sqrt_half, 0.0, sqrt_half, 0.0]),
+        }
+        return jnp.concatenate([quaternions[mounting], position])
+
+    @classmethod
+    def _default_gravity(cls) -> Array:
+        if cls._require_planarity():
+            return jnp.asarray([0.0, -DEFAULT_GRAVITY_MAGNITUDE])
+        return jnp.asarray([0.0, 0.0, -DEFAULT_GRAVITY_MAGNITUDE])
+
+    @classmethod
+    def _resolve_base_pose(cls, base_pose: Array | None) -> Array:
+        if base_pose is None:
+            return cls._mounting_base_pose("upright")
+        return jnp.asarray(base_pose)
+
+    @classmethod
+    def _resolve_gravity(cls, gravity: Array | None) -> Array:
+        if gravity is None:
+            return cls._default_gravity()
+        return jnp.asarray(gravity)
+
+    @classmethod
+    def _from_mounting(
+        cls,
+        mounting: Literal["horizontal", "upright", "hanging"],
+        *,
+        base_position: Array | None = None,
+        **kwargs: Any,
+    ) -> "BaseSoftRobotParams":
+        if "base_pose" in kwargs:
+            raise TypeError(
+                f"{cls.__name__}.{mounting}() does not accept base_pose; "
+                "use base_position or the ordinary constructor instead."
+            )
+        return cls(base_pose=cls._mounting_base_pose(mounting, base_position), **kwargs)
+
+    @classmethod
+    def horizontal(
+        cls, *, base_position: Array | None = None, **kwargs: Any
+    ) -> "BaseSoftRobotParams":
+        """Construct parameters with the backbone pointing along world +x."""
+        return cls._from_mounting("horizontal", base_position=base_position, **kwargs)
+
+    @classmethod
+    def upright(
+        cls, *, base_position: Array | None = None, **kwargs: Any
+    ) -> "BaseSoftRobotParams":
+        """Construct parameters pointing along world +y (planar) or +z (spatial)."""
+        return cls._from_mounting("upright", base_position=base_position, **kwargs)
+
+    @classmethod
+    def hanging(
+        cls, *, base_position: Array | None = None, **kwargs: Any
+    ) -> "BaseSoftRobotParams":
+        """Construct parameters pointing along world -y (planar) or -z (spatial)."""
+        return cls._from_mounting("hanging", base_position=base_position, **kwargs)
+
+    def _normalize_replacement(self, name: str, value: Any) -> Any:
+        if name == "base_pose":
+            return type(self)._resolve_base_pose(value)
+        if name == "gravity":
+            return type(self)._resolve_gravity(value)
+        return value
 
 
 class BaseContinuumSoftRobotParams(BaseSoftRobotParams):

--- a/src/soromox/systems/pcs/params.py
+++ b/src/soromox/systems/pcs/params.py
@@ -7,6 +7,8 @@ __all__ = [
     "ISupportParams",
 ]
 
+from typing import ClassVar
+
 import equinox as eqx
 import jax.numpy as jnp
 from jax import Array
@@ -57,7 +59,11 @@ class PCSParams(BaseContinuumSoftRobotParams):
     ``base_pose`` is the scalar-first quaternion SE(3) base pose vector
     ``[qw, qx, qy, qz, x, y, z]`` used to initialize the base transform. The
     quaternion is normalized before use and must have nonzero finite norm.
+    Omitting ``base_pose`` and ``gravity`` selects upright spatial mounting and
+    negative-z Earth gravity.
     """
+
+    is_planar: ClassVar[bool] = False
 
     radius: Array
     young_modulus: Array
@@ -82,8 +88,11 @@ class PlanarPCSParams(BaseContinuumSoftRobotParams):
     segments. ``base_pose`` stores the planar pose ``[theta, x, y]`` with shape
     ``(3,)``. ``theta`` is a right-handed angle in radians about the
     out-of-plane z-axis, and ``x``/``y`` are direct translations in the parent
-    frame.
+    frame. Omitting ``base_pose`` and ``gravity`` selects upright planar
+    mounting and negative-y Earth gravity.
     """
+
+    is_planar: ClassVar[bool] = True
 
     radius: Array
     young_modulus: Array

--- a/src/soromox/systems/pendulum/params.py
+++ b/src/soromox/systems/pendulum/params.py
@@ -1,5 +1,7 @@
 __all__ = ["PendulumParams", "TendonActuatedPendulumParams"]
 
+from typing import ClassVar
+
 import jax.numpy as jnp
 from jax import Array
 
@@ -19,8 +21,12 @@ class PendulumParams(BaseArticulatedSoftRobotParams):
     generalized-coordinate matrices inherited from the articulated base class.
     ``base_pose`` stores the planar pose ``[theta, x, y]`` with shape ``(3,)``.
     ``theta`` is a right-handed angle in radians about the out-of-plane z-axis,
-    and ``x``/``y`` are direct translations in the parent frame.
+    and ``x``/``y`` are direct translations in the parent frame. Omitting
+    ``base_pose`` and ``gravity`` selects upright mounting and negative-y Earth
+    gravity.
     """
+
+    is_planar: ClassVar[bool] = True
 
     moment_inertia: Array
     length: Array

--- a/src/soromox/systems/pendulum/pendulum.py
+++ b/src/soromox/systems/pendulum/pendulum.py
@@ -217,6 +217,7 @@ class Pendulum(SoftRobot):
         for name in shape_locked_fields:
             if (
                 name in updates
+                and updates[name] is not None
                 and jnp.asarray(updates[name]).shape != getattr(self.params, name).shape
             ):
                 raise ValueError(

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -55,8 +55,9 @@ class SoftRobot(DynamicalSystem):
             scalar-first Hamilton quaternions, normalized before use, and
             represent the base-frame orientation; translations are inserted
             directly. Configured spatial quaternions must have nonzero finite
-            norm. In the standard zero-rotation base pose, the soft robot
-            backbone is aligned with the positive base-frame x-axis.
+            norm. When omitted, the base pose is upright: the backbone points
+            along world +y for planar robots and world +z for spatial robots.
+            In an explicit zero-rotation pose, the backbone is aligned with +x.
         num_gauss_points (int | Array | None): Requested nonzero
             Gauss-Legendre quadrature point count. May be scalar for systems
             with a uniform grid or an array for systems with per-segment grids.
@@ -102,9 +103,8 @@ class SoftRobot(DynamicalSystem):
                 expect shape ``(7,)`` with ``[qw, qx, qy, qz, x, y, z]``.
                 Spatial quaternions are scalar-first Hamilton quaternions,
                 normalized before use, and must have nonzero finite norm. If
-                omitted, the zero-rotation base pose is used in the appropriate
-                dimension. With zero base rotation, the soft robot backbone is
-                aligned with the positive base-frame x-axis.
+                omitted, the upright pose is used: the backbone points along
+                world +y for planar robots and world +z for spatial robots.
             **kwargs: Additional keyword arguments (unused, kept for API compatibility).
         """
         # Note: We don't call super().__init__() here because Equinox modules
@@ -112,10 +112,12 @@ class SoftRobot(DynamicalSystem):
         # parent __init__ calls. Child classes must set num_dofs and num_actuators.
         if base_pose is None:
             if self.is_planar:
-                base_pose = jnp.zeros(3, dtype=jnp.float64)
+                base_pose = jnp.array([jnp.pi / 2, 0.0, 0.0], dtype=jnp.float64)
             else:
+                sqrt_half = jnp.sqrt(jnp.asarray(0.5, dtype=jnp.float64))
                 base_pose = jnp.array(
-                    [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=jnp.float64
+                    [sqrt_half, 0.0, -sqrt_half, 0.0, 0.0, 0.0, 0.0],
+                    dtype=jnp.float64,
                 )
         if self.is_planar:
             validate_planar_base_pose("base_pose", base_pose)

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -138,6 +138,37 @@ def test_params_from_segments_stores_resolved_max_dof():
         GVS(params=oversized, structure=structure)
 
 
+def test_params_from_segments_uses_spatial_environment_defaults():
+    segment = GVSSegment(
+        link=LinkSpec(
+            cross_section_geometry=CrossSectionGeometry.CIRCULAR,
+            E=1e6,
+            nu=0.45,
+            rho=1000.0,
+            eta=0.0,
+            L=0.2,
+            r_i=0.02,
+            r_f=0.02,
+        ),
+        joint=JointSpec(type="fixed"),
+        basis=StrainBasisSpec(
+            type="monomial",
+            active=[1, 1, 1, 1, 1, 1],
+            orders=[0, 0, 0, 0, 0, 0],
+            xi_ref=[0, 0, 0, 1, 0, 0],
+        ),
+        num_gauss_points=5,
+    )
+
+    params, _ = GVS.params_from_segments([segment])
+
+    assert_allclose(
+        params.base_pose,
+        jnp.array([jnp.sqrt(0.5), 0.0, -jnp.sqrt(0.5), 0.0, 0.0, 0.0, 0.0]),
+    )
+    assert_allclose(params.gravity, jnp.array([0.0, 0.0, -9.81]))
+
+
 def build_varied_basis_gvs(num_segments: int = 3) -> GVS:
     """
     Initialize a GVS robot with a configurable number of segments, mixing joint families and

--- a/tests/systems/test_planar_hsa.py
+++ b/tests/systems/test_planar_hsa.py
@@ -85,6 +85,22 @@ def test_planar_hsa_exposes_phi_max():
     assert jnp.allclose(robot.phi_max, typed_params.phi_max)
 
 
+def test_planar_hsa_npz_uses_environment_defaults_when_fields_are_absent(tmp_path):
+    with np.load(HSA_PARAMS_PATH) as data:
+        values = {
+            name: data[name]
+            for name in data.files
+            if name not in {"base_pose", "gravity"}
+        }
+    path = tmp_path / "hsa_without_environment.npz"
+    np.savez(path, **values)
+
+    params = PlanarHSAParams.from_npz(path)
+
+    assert jnp.allclose(params.base_pose, jnp.array([jnp.pi / 2, 0.0, 0.0]))
+    assert jnp.allclose(params.gravity, jnp.array([0.0, -9.81]))
+
+
 def test_jacobian_virtual_backbone(seed: int = 0):
     """
     Test that the symbolic Jacobian matches the autograd Jacobian of forward kinematics.

--- a/tests/systems/test_typed_params_api.py
+++ b/tests/systems/test_typed_params_api.py
@@ -1,9 +1,12 @@
+from dataclasses import fields
+
 import equinox as eqx
 import jax
 import pytest
 from jax import numpy as jnp
 from numpy.testing import assert_allclose
 from system_param_builders import (
+    articulated_params,
     linear_tendon_routing,
     passive_tendon_params,
     pcs_params,
@@ -26,9 +29,11 @@ from soromox.systems import (
     PCSParams,
     Pendulum,
     PendulumParams,
+    PlanarPCSParams,
     TendonActuatedPCS,
     TendonActuatedPlanarPCS,
 )
+from soromox.utils.geometry import poses
 
 jax.config.update("jax_enable_x64", True)
 
@@ -70,6 +75,144 @@ def _planar_pcs_params(num_segments: int = 2):
         damping_matrix=jnp.eye(3 * num_segments, dtype=jnp.float64),
         base_pose=planar_base_pose(),
     )
+
+
+def _constructor_kwargs_without_environment(params):
+    return {
+        field.name: getattr(params, field.name)
+        for field in fields(params)
+        if field.name not in {"base_pose", "gravity"}
+    }
+
+
+def _articulated_params():
+    return articulated_params(
+        joint_screw=jnp.array([[0.0, 0.0, 1.0, 0.0, 0.0, 0.0]]),
+        tip_position=jnp.array([[0.5, 0.0, 0.0]]),
+        center_of_mass_position=jnp.array([[0.25, 0.0, 0.0]]),
+        mass=jnp.array([1.0]),
+        center_of_mass_inertia=jnp.eye(3)[None, :, :],
+        gravity=jnp.zeros(3),
+    )
+
+
+@pytest.mark.parametrize(
+    ("params_type", "source", "expected_pose", "expected_gravity"),
+    [
+        (
+            PlanarPCSParams,
+            _planar_pcs_params,
+            jnp.array([jnp.pi / 2, 0.0, 0.0]),
+            jnp.array([0.0, -9.81]),
+        ),
+        (
+            PendulumParams,
+            _pendulum_params,
+            jnp.array([jnp.pi / 2, 0.0, 0.0]),
+            jnp.array([0.0, -9.81]),
+        ),
+        (
+            PCSParams,
+            _pcs_params,
+            jnp.array([jnp.sqrt(0.5), 0.0, -jnp.sqrt(0.5), 0.0, 0.0, 0.0, 0.0]),
+            jnp.array([0.0, 0.0, -9.81]),
+        ),
+        (
+            ArticulatedSoftRobotParams,
+            _articulated_params,
+            jnp.array([jnp.sqrt(0.5), 0.0, -jnp.sqrt(0.5), 0.0, 0.0, 0.0, 0.0]),
+            jnp.array([0.0, 0.0, -9.81]),
+        ),
+    ],
+)
+def test_soft_robot_params_materialize_upright_environment_defaults(
+    params_type, source, expected_pose, expected_gravity
+):
+    params = params_type(**_constructor_kwargs_without_environment(source()))
+
+    assert_allclose(params.base_pose, expected_pose)
+    assert_allclose(params.gravity, expected_gravity)
+
+
+@pytest.mark.parametrize(
+    ("mounting", "expected_direction"),
+    [
+        ("horizontal", jnp.array([1.0, 0.0])),
+        ("upright", jnp.array([0.0, 1.0])),
+        ("hanging", jnp.array([0.0, -1.0])),
+    ],
+)
+def test_planar_mounting_constructors_map_local_x_to_world_direction(
+    mounting, expected_direction
+):
+    params = getattr(PlanarPCSParams, mounting)(
+        **_constructor_kwargs_without_environment(_planar_pcs_params()),
+        base_position=jnp.array([1.0, 2.0]),
+    )
+    transform = poses.planar_pose_to_transform(params.base_pose)
+
+    assert_allclose(
+        transform[:2, :2] @ jnp.array([1.0, 0.0]),
+        expected_direction,
+        atol=1e-12,
+    )
+    assert_allclose(params.base_pose[1:], jnp.array([1.0, 2.0]))
+    assert_allclose(params.gravity, jnp.array([0.0, -9.81]))
+
+
+@pytest.mark.parametrize(
+    ("mounting", "expected_direction"),
+    [
+        ("horizontal", jnp.array([1.0, 0.0, 0.0])),
+        ("upright", jnp.array([0.0, 0.0, 1.0])),
+        ("hanging", jnp.array([0.0, 0.0, -1.0])),
+    ],
+)
+def test_spatial_mounting_constructors_map_local_x_to_world_direction(
+    mounting, expected_direction
+):
+    params = getattr(PCSParams, mounting)(
+        **_constructor_kwargs_without_environment(_pcs_params()),
+        base_position=jnp.array([1.0, 2.0, 3.0]),
+    )
+    transform = poses.quaternion_pose_to_transform(params.base_pose)
+
+    assert_allclose(
+        transform[:3, :3] @ jnp.array([1.0, 0.0, 0.0]),
+        expected_direction,
+        atol=1e-12,
+    )
+    assert_allclose(params.base_pose[4:], jnp.array([1.0, 2.0, 3.0]))
+    assert_allclose(params.gravity, jnp.array([0.0, 0.0, -9.81]))
+
+
+def test_environment_defaults_can_be_overridden_and_restored():
+    custom_pose = jnp.array([0.25, 1.0, 2.0])
+    custom_gravity = jnp.array([1.0, -2.0])
+    params = PlanarPCSParams(
+        **_constructor_kwargs_without_environment(_planar_pcs_params()),
+        base_pose=custom_pose,
+        gravity=custom_gravity,
+    )
+    assert_allclose(params.base_pose, custom_pose)
+    assert_allclose(params.gravity, custom_gravity)
+
+    restored = params.replace(base_pose=None, gravity=None)
+    assert_allclose(restored.base_pose, jnp.array([jnp.pi / 2, 0.0, 0.0]))
+    assert_allclose(restored.gravity, jnp.array([0.0, -9.81]))
+
+    robot = Pendulum(params=_pendulum_params())
+    updated_robot = robot.update_params(base_pose=None, gravity=None)
+    assert_allclose(updated_robot.params.base_pose, jnp.array([jnp.pi / 2, 0.0, 0.0]))
+    assert_allclose(updated_robot.params.gravity, jnp.array([0.0, -9.81]))
+
+
+def test_named_mounting_rejects_competing_base_pose():
+    with pytest.raises(TypeError, match="does not accept base_pose"):
+        PlanarPCSParams.upright(
+            **_constructor_kwargs_without_environment(_planar_pcs_params()),
+            base_pose=jnp.zeros(3),
+        )
 
 
 class QuadraticTendonRoutingParams(BaseTendonRoutingParams):


### PR DESCRIPTION
## Motivation

SoRoMoX previously mixed two conventions:

- the low-level fallback base pose was the identity pose, so an undeformed robot pointed along world +x;
- examples typically modeled gravity along negative y (planar) or negative z (spatial), and repeatedly supplied an upright pose manually.

That made the most common physical setup verbose and left the package with inconsistent examples, including planar snippets with opposite gravity signs. This PR makes the default setup explicit and symmetric: planar robots point along +y, spatial robots point along +z, and gravity points along the corresponding negative vertical world axis.

## Implementation

- Make `base_pose` and `gravity` optional keyword-only inputs on `BaseSoftRobotParams`.
- Mirror `SoftRobot.is_planar` with an `is_planar` class flag on parameter families so defaults never depend on guessing array shapes.
- Materialize these defaults during parameter construction:
  - planar pose `[pi / 2, 0, 0]`, gravity `[0, -9.81]`;
  - spatial pose `[sqrt(0.5), 0, -sqrt(0.5), 0, 0, 0, 0]`, gravity `[0, 0, -9.81]`.
- Add inherited `.horizontal(...)`, `.upright(...)`, and `.hanging(...)` constructors, with optional `base_position`.
- Let `replace(base_pose=None)` and `replace(gravity=None)` restore defaults, including robot-level `update_params` paths.
- Apply the same behavior to articulated constructors, GVS segment builders, the `SoftRobot` fallback, and HSA NPZ loading.
- Export `DEFAULT_GRAVITY_MAGNITUDE = 9.81`.
- Update the user guide, installation examples, system API pages, parameter reference, and extension guide with the world-frame convention and migration guidance.

## User API

The common upright Earth-gravity setup no longer needs explicit environment arrays:

```python
params = PlanarPCSParams(
    length=length,
    radius=radius,
    density=density,
    young_modulus=young_modulus,
    shear_modulus=shear_modulus,
    damping_matrix=damping_matrix,
    reference_strain=reference_strain,
)
```

Common mountings can be selected explicitly:

```python
horizontal = PlanarPCSParams.horizontal(**physical_params)
upright = PlanarPCSParams.upright(
    **physical_params,
    base_position=jnp.array([0.2, 0.1]),
)
hanging = PCSParams.hanging(
    **spatial_physical_params,
    base_position=jnp.array([0.0, 0.0, 0.5]),
)
```

Custom and zero-gravity configurations remain explicit:

```python
custom = PlanarPCSParams(
    **physical_params,
    base_pose=jnp.array([0.3, 0.2, 0.1]),
    gravity=jnp.array([1.0, -9.7]),
)
zero_gravity = PCSParams(**spatial_physical_params, gravity=jnp.zeros(3))
```

Users who need the previous identity orientation can call `.horizontal(...)` or pass an explicit identity pose.

## Validation

- Focused mounting/default tests: 27 passed.
- Systems regression coverage: 161 tests passed before a sandbox-only Viser process-probe failure; the Viser smoke test passed outside the sandbox, and the remaining 389 systems tests passed.
- `ruff check`: passed.
- `git diff --check`: passed.
- `mkdocs build --strict`: passed.
