### PR TITLE
Adopt explicit I-SUPPORT chamber azimuths

### DIFF
--- a/docs/api/systems/pcs/isupport.md
+++ b/docs/api/systems/pcs/isupport.md
@@ -51,7 +51,7 @@ params = ISupportParams(
     chamber_inner_radius=jnp.array([0.00639]),
     chamber_outer_radius=jnp.array([0.00779]),
     chamber_distance=jnp.array([0.020]),
-    chamber_angle_offset=jnp.array([0.0]),
+    chamber_azimuth_angles=(2.0 * jnp.pi * jnp.arange(3) / 3)[None, :],
 )
 robot = ISupport(params, structure=ISupportStructure(num_gauss_points=3))
 
@@ -65,6 +65,22 @@ g_tip = robot.forward_kinematics(q, s=jnp.sum(robot.L))
 ### Chamber Configuration
 
 The I-Support robot uses 3 pneumatic chambers per segment, arranged radially at 120-degree intervals. This configuration enables:
+
+`chamber_azimuth_angles` has shape
+`(num_pneumatic_segments, num_chambers_per_segment)`. Azimuth is a
+right-handed rotation about local `+X`, measured in radians from local `+Y`
+toward local `+Z`, so a chamber center is
+`[0, d*cos(phi), d*sin(phi)]`. Entry `j` is pressure channel `j`; the model
+does not sort or generate angles. Each row may be rotated, wrapped, and listed
+in any channel order, but its wrapped circular gaps must be uniformly
+`2*pi/num_chambers_per_segment` (within `rtol=1e-6`, `atol=1e-8`). Asymmetric
+layouts are currently rejected because the passive cross-section model assumes
+rotational symmetry.
+
+If `chamber_azimuth_angles` is omitted, `ISupport` supplies the canonical
+three-chamber layout `[0, 2*pi/3, 4*pi/3]`, or `[0°, 120°, 240°]`, for every
+pneumatic segment. Pass an explicit array whenever physical pressure-channel
+order differs from that default.
 
 - Bending in any direction
 - Extension/compression along the backbone

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -75,7 +75,12 @@ if __name__ == "__main__":
         chamber_inner_radius=6.39 * 1e-3 * jnp.ones((num_pneumatic_segments,)),
         chamber_outer_radius=7.79 * 1e-3 * jnp.ones((num_pneumatic_segments,)),
         chamber_distance=20 * 1e-3 * jnp.ones((num_pneumatic_segments,)),
-        chamber_angle_offset=jnp.zeros((num_pneumatic_segments,)),
+        # Explicit [0, 2*pi/3, 4*pi/3] = [0, 120, 240] degrees for each
+        # pneumatic segment. Array index is the corresponding pressure channel.
+        chamber_azimuth_angles=jnp.tile(
+            2.0 * jnp.pi * jnp.arange(3) / 3,
+            (num_pneumatic_segments, 1),
+        ),
         pcs_segment_lengths=pcs_segment_lengths,
         rigid_connector_lengths=rigid_connector_lengths,
     )

--- a/src/soromox/rendering/isupport/viser_renderer.py
+++ b/src/soromox/rendering/isupport/viser_renderer.py
@@ -307,19 +307,15 @@ class ISupportViserRenderer(ViserRenderer):
         segment_poses = poses[spec.ring_slice]
         rotations = segment_poses[:, :3, :3]
         centerline = segment_poses[:, :3, 3]
-        material_y = rotations[:, :, 1]
-        material_z = rotations[:, :, 2]
-
         pneumatic_idx = spec.pneumatic_idx
-        angle = float(self.robot.params.chamber_angle_offset[pneumatic_idx]) + (
-            2.0 * np.pi * chamber_idx / self.robot.num_chambers_per_segment
+        local_offset = np.asarray(
+            self.robot.local_chamber_offsets(pneumatic_idx)[chamber_idx]
         )
-        radial = np.sin(angle) * material_y + np.cos(angle) * material_z
-        tangential = np.cos(angle) * material_y - np.sin(angle) * material_z
-        chamber_centers = (
-            centerline
-            + float(self.robot.params.chamber_distance[pneumatic_idx]) * radial
-        )
+        radial_local = local_offset / np.linalg.norm(local_offset)
+        tangential_local = np.cross(np.array([1.0, 0.0, 0.0]), radial_local)
+        radial = rotations @ radial_local
+        tangential = rotations @ tangential_local
+        chamber_centers = centerline + rotations @ local_offset
 
         equivalent_radius = float(self.robot.params.chamber_outer_radius[pneumatic_idx])
         aspect_scale = np.sqrt(self.visual_config.chamber_aspect_ratio)

--- a/src/soromox/systems/pcs/isupport.py
+++ b/src/soromox/systems/pcs/isupport.py
@@ -14,6 +14,19 @@ from .pcs import PCS
 _RIGID_CONNECTOR_PARENT = -1
 
 
+def _with_default_chamber_azimuth_angles(params: ISupportParams) -> ISupportParams:
+    """Resolve the canonical three-chamber layout when no angles are supplied."""
+    if params.chamber_azimuth_angles is not None:
+        return params
+    num_pneumatic_segments = int(params.length.shape[0])
+    canonical_angles = 2.0 * jnp.pi * jnp.arange(3, dtype=jnp.float64) / 3.0
+    return params.replace(
+        chamber_azimuth_angles=jnp.tile(
+            canonical_angles[None, :], (num_pneumatic_segments, 1)
+        )
+    )
+
+
 def _straight_reference_strain(dtype: jnp.dtype) -> Array:
     return jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0], dtype=dtype)
 
@@ -162,6 +175,7 @@ def _expand_isupport_layout(
     params: ISupportParams,
     structure: ISupportStructure,
 ) -> tuple[ISupportParams, PCSStructure, ISupportStructure, Array, Array]:
+    params = _with_default_chamber_azimuth_angles(params)
     params.validate()
     structure = _normalize_structure_for_params(params, structure)
 
@@ -196,7 +210,9 @@ def _expand_isupport_layout(
     r_chamber_in = jnp.asarray(params.chamber_inner_radius, dtype=jnp.float64)
     r_chamber_out = jnp.asarray(params.chamber_outer_radius, dtype=jnp.float64)
     d_chamber = jnp.asarray(params.chamber_distance, dtype=jnp.float64)
-    varphi_chamber_off = jnp.asarray(params.chamber_angle_offset, dtype=jnp.float64)
+    chamber_azimuth_angles = jnp.asarray(
+        params.chamber_azimuth_angles, dtype=jnp.float64
+    )
 
     expanded_lengths: list[float] = []
     expanded_radius: list[Array] = []
@@ -208,7 +224,7 @@ def _expand_isupport_layout(
     expanded_chamber_inner_radius: list[Array] = []
     expanded_chamber_outer_radius: list[Array] = []
     expanded_chamber_distance: list[Array] = []
-    expanded_chamber_angle_offset: list[Array] = []
+    expanded_chamber_azimuth_angles: list[Array] = []
     default_strain_selector: list[Array] = []
     pcs_segment_to_pneumatic_segment: list[int] = []
     pcs_segment_is_rigid: list[bool] = []
@@ -228,7 +244,7 @@ def _expand_isupport_layout(
         expanded_chamber_inner_radius.append(r_chamber_in[source_index])
         expanded_chamber_outer_radius.append(r_chamber_out[source_index])
         expanded_chamber_distance.append(d_chamber[source_index])
-        expanded_chamber_angle_offset.append(varphi_chamber_off[source_index])
+        expanded_chamber_azimuth_angles.append(chamber_azimuth_angles[source_index])
 
         if is_rigid:
             expanded_reference_strain.append(
@@ -298,7 +314,7 @@ def _expand_isupport_layout(
         chamber_inner_radius=jnp.stack(expanded_chamber_inner_radius),
         chamber_outer_radius=jnp.stack(expanded_chamber_outer_radius),
         chamber_distance=jnp.stack(expanded_chamber_distance),
-        chamber_angle_offset=jnp.stack(expanded_chamber_angle_offset),
+        chamber_azimuth_angles=jnp.stack(expanded_chamber_azimuth_angles),
     )
     pcs_structure = PCSStructure(
         num_gauss_points=structure.num_gauss_points,
@@ -344,8 +360,8 @@ class ISupport(PCS):
             cached as ``r_chamber_out``.
         chamber_distance: Radial distance of the center of the actuators from
             the centerline of the backbone [m], cached as ``d_chamber``.
-        chamber_angle_offset: Angular offset of the first actuator from the
-            local segment frame [rad], cached as ``varphi_chamber_off``.
+        chamber_azimuth_angles: Explicit chamber azimuths [rad], right-handed
+            about local +X from +Y toward +Z. The second axis is pressure-channel order.
 
     References:
         Arleo, L., Stano, G., Percoco, G., & Cianchetti, M. (2021). I-support soft
@@ -372,7 +388,8 @@ class ISupport(PCS):
         Array  # outer radius of each segment's chamber, shape (num_segments,)
     )
     d_chamber: Array  # radial distance of the center of the chambers from the centerline of the backbone, shape (num_segments,)
-    varphi_chamber_off: Array  # angular offset of the first actuator from the local
+    # Expanded per-PCS-segment copy of the resolved channel layout.
+    chamber_azimuth_angles: Array
 
     num_chambers_per_segment: int = eqx.field(
         static=True, default=3
@@ -386,7 +403,6 @@ class ISupport(PCS):
         self,
         params: ISupportParams,
         structure: ISupportStructure | None = None,
-        num_chambers_per_segment: int = 3,
         **kwargs: Any,
     ):
         """
@@ -397,18 +413,17 @@ class ISupport(PCS):
             structure: Static I-SUPPORT layout. If omitted, each pneumatic
                 segment is represented by one PCS segment and no rigid
                 connectors are inserted.
-            num_chambers_per_segment:
-                Number of pneumatic chambers per segment. Defaults to 3.
             **kwargs: Additional keyword arguments.
         """
         if not isinstance(params, ISupportParams):
             raise TypeError("params must be an ISupportParams instance.")
+        params = _with_default_chamber_azimuth_angles(params)
         if structure is None:
             structure = ISupportStructure()
         if not isinstance(structure, ISupportStructure):
             raise TypeError("structure must be an ISupportStructure instance.")
 
-        self.num_chambers_per_segment = num_chambers_per_segment
+        self.num_chambers_per_segment = int(params.chamber_azimuth_angles.shape[1])
         (
             pcs_params,
             pcs_structure,
@@ -470,9 +485,9 @@ class ISupport(PCS):
                 - ``chamber_distance``: Array of shape ``(num_segments,)``.
                     Radial distance of the center of the chambers from the
                     centerline of the backbone [m].
-                - ``chamber_angle_offset``: Array of shape
-                    ``(num_segments,)``. Angular offset of the first actuator
-                    from the local z-axis [rad].
+                - ``chamber_azimuth_angles``: Array of shape
+                    ``(num_segments, num_chambers_per_segment)``. Right-handed
+                    azimuth about local +X, from local +Y toward local +Z [rad].
         """
         super()._set_params(params)
 
@@ -501,13 +516,18 @@ class ISupport(PCS):
             )
         self.d_chamber = d_chamber
 
-        varphi_chamber_off = jnp.asarray(params.chamber_angle_offset, dtype=jnp.float64)
-        if varphi_chamber_off.shape != (self.num_segments,):
+        chamber_azimuth_angles = jnp.asarray(
+            params.chamber_azimuth_angles, dtype=jnp.float64
+        )
+        if chamber_azimuth_angles.shape != (
+            self.num_segments,
+            self.num_chambers_per_segment,
+        ):
             raise ValueError(
-                "chamber_angle_offset must have shape "
-                f"({self.num_segments},), got {varphi_chamber_off.shape}."
+                "chamber_azimuth_angles must have shape "
+                f"({self.num_segments}, {self.num_chambers_per_segment}), got {chamber_azimuth_angles.shape}."
             )
-        self.varphi_chamber_off = varphi_chamber_off
+        self.chamber_azimuth_angles = chamber_azimuth_angles
 
     def _current_body_params(self) -> ISupportParams:
         """Return the expanded PCS params used by inherited PCS update helpers."""
@@ -517,6 +537,7 @@ class ISupport(PCS):
         """Return an updated copy with a full pneumatic-segment parameter object."""
         if not isinstance(params, ISupportParams):
             raise TypeError("params must be an ISupportParams instance.")
+        params = _with_default_chamber_azimuth_angles(params)
         (
             pcs_params,
             _,
@@ -528,7 +549,7 @@ class ISupport(PCS):
             jnp.asarray(pcs_params.chamber_inner_radius, dtype=jnp.float64),
             jnp.asarray(pcs_params.chamber_outer_radius, dtype=jnp.float64),
             jnp.asarray(pcs_params.chamber_distance, dtype=jnp.float64),
-            jnp.asarray(pcs_params.chamber_angle_offset, dtype=jnp.float64),
+            jnp.asarray(pcs_params.chamber_azimuth_angles, dtype=jnp.float64),
         )
         updated_self = self._with_pcs_params(pcs_params, stored_params=params)
         updated_self = eqx.tree_at(
@@ -537,7 +558,7 @@ class ISupport(PCS):
                 model.r_chamber_in,
                 model.r_chamber_out,
                 model.d_chamber,
-                model.varphi_chamber_off,
+                model.chamber_azimuth_angles,
             ),
             updated_self,
             (pcs_params, *chamber_arrays),
@@ -549,20 +570,42 @@ class ISupport(PCS):
         return self.with_params(self.params.replace(**updates))
 
     @eqx.filter_jit
-    def _local_actuator_polar_angles(self, i: Array) -> Array:
-        """
-        Compute the polar angles of the chambers in the i-th segment.
+    def chamber_azimuths(self, pneumatic_segment_idx: Array) -> Array:
+        """Return one azimuth per chamber in pressure-channel order.
+
+        This concise accessor name is distinct from the parameter field
+        ``chamber_azimuth_angles``. The returned array has shape
+        ``(num_chambers_per_segment,)`` and is not sorted or normalized.
 
         Args:
-            i (Array): index of the segment as array of shape ()
+            pneumatic_segment_idx: Index of the physical pneumatic segment.
 
         Returns:
-            varphi_chambers_i (Array): polar angles of the i-th pneumatic chamber as Array of shape (num_chambers_per_segment, )
+            Chamber azimuth angles in radians, indexed exactly like the
+            segment's pressure inputs.
         """
-        varphi_chambers_i = self.varphi_chamber_off[i] + jnp.linspace(
-            0, 2 * jnp.pi, self.num_chambers_per_segment, endpoint=False
+        return self.params.chamber_azimuth_angles[pneumatic_segment_idx]
+
+    @eqx.filter_jit
+    def local_chamber_offsets(self, pneumatic_segment_idx: Array) -> Array:
+        """Return vectors from the local backbone centerline to chamber centers.
+
+        The result has shape ``(num_chambers_per_segment, 3)`` and follows
+        pressure-channel order. Each row is expressed in the pneumatic
+        segment's local frame as ``[0, d*cos(phi), d*sin(phi)]``; it is an
+        offset vector, not an absolute chamber-center position.
+
+        Args:
+            pneumatic_segment_idx: Index of the physical pneumatic segment.
+
+        Returns:
+            Local chamber-center offset vectors in meters.
+        """
+        phi = self.chamber_azimuths(pneumatic_segment_idx)
+        distance = self.params.chamber_distance[pneumatic_segment_idx]
+        return distance * jnp.stack(
+            [jnp.zeros_like(phi), jnp.cos(phi), jnp.sin(phi)], axis=-1
         )
-        return varphi_chambers_i
 
     @eqx.filter_jit
     def _local_actuator_centroid(self, i: Array, varphi_angle: Array) -> Array:
@@ -579,8 +622,8 @@ class ISupport(PCS):
         centroid_actuator = jnp.array(
             [
                 0.0,  # the actuator centroid is on the cross-section
-                self.d_chamber[i] * jnp.sin(varphi_angle),  # up along local y-axis
-                self.d_chamber[i] * jnp.cos(varphi_angle),  # right along local z-axis
+                self.d_chamber[i] * jnp.cos(varphi_angle),
+                self.d_chamber[i] * jnp.sin(varphi_angle),
             ]
         )
         return centroid_actuator
@@ -677,7 +720,7 @@ class ISupport(PCS):
         """
 
         # compute the polar angles of the actuators
-        varphi_actuators_i = self._local_actuator_polar_angles(i)
+        varphi_actuators_i = self.chamber_azimuth_angles[i]
         # compute the second moment of area of each actuator
         I_actuators_i = vmap(
             lambda varphi: self._local_actuator_second_moment_of_area(i, varphi)
@@ -698,14 +741,7 @@ class ISupport(PCS):
         segment is split into multiple PCS segments, the same pressure columns
         are applied to each child PCS segment. Rigid connector PCS segments do
         not contribute to the actuation matrix.
-        Furthermore, we consider the following geometrical arrangement:
-            - The 1st chamber with pressure p1 is located at the
-              chamber_angle_offset value for its segment.
-            - The 2nd chamber with pressure p2 is located at
-              chamber_angle_offset + 1 * 2 * jnp.pi / self.num_chambers_per_segment.
-            - The 3rd chamber with pressure p3 is located at
-              chamber_angle_offset + 2 * 2 * jnp.pi / self.num_chambers_per_segment.
-            - etc.
+        Chamber columns follow ``chamber_azimuth_angles`` without reordering.
 
         Args:
             q (Array): generalized coordinates of shape (num_active_strains,).
@@ -727,7 +763,7 @@ class ISupport(PCS):
             centroid_chamber = self._local_actuator_centroid(i, varphi)
 
             # compute the contribution of the chamber on the (rotational) backbone torque
-            torque_contrib = -jnp.cross(centroid_chamber, force_contrib)
+            torque_contrib = jnp.cross(centroid_chamber, force_contrib)
 
             A_single_chamber = jnp.concatenate(
                 [
@@ -746,7 +782,7 @@ class ISupport(PCS):
 
         def _actuation_matrix_pcs_segment_i(i: Array) -> Array:
             # compute the local polar chamber angles
-            varphi_chambers = self._local_actuator_polar_angles(i)
+            varphi_chambers = self.chamber_azimuth_angles[i]
 
             # build the actuation matrix
             A_columns_i = vmap(lambda varphi: _actuation_matrix_one_chamber(i, varphi))(

--- a/src/soromox/systems/pcs/params.py
+++ b/src/soromox/systems/pcs/params.py
@@ -201,8 +201,11 @@ class ISupportParams(PCSParams):
 
     The leading axis indexes physical pneumatic segments. ``ISupport`` expands
     these fields into the internal PCS segment layout using ``ISupportStructure``.
-    Chamber fields describe per-pneumatic-segment chamber geometry and angular
-    offsets. ``damping_matrix`` is expressed in flattened pneumatic-segment
+    Chamber fields describe per-pneumatic-segment chamber geometry. Chamber
+    azimuth is right-handed about local +X, measured from +Y toward +Z; array
+    index ``j`` is pressure channel ``j``. If ``chamber_azimuth_angles`` is
+    omitted, ``ISupport`` uses 0, 120, and 240 degrees for every pneumatic
+    segment. ``damping_matrix`` is expressed in flattened pneumatic-segment
     strain coordinates and must be block diagonal by pneumatic segment when the
     model is constructed.
 
@@ -221,7 +224,7 @@ class ISupportParams(PCSParams):
     chamber_inner_radius: Array
     chamber_outer_radius: Array
     chamber_distance: Array
-    chamber_angle_offset: Array
+    chamber_azimuth_angles: Array | None = None
     pcs_segment_lengths: Array | None = None
     rigid_connector_lengths: Array | None = None
 
@@ -232,9 +235,31 @@ class ISupportParams(PCSParams):
             "chamber_inner_radius",
             "chamber_outer_radius",
             "chamber_distance",
-            "chamber_angle_offset",
         ):
             _require_shape(name, getattr(self, name), (n_segments,))
+
+        if self.chamber_azimuth_angles is not None:
+            angles = jnp.asarray(self.chamber_azimuth_angles)
+            if angles.ndim != 2 or angles.shape[0] != n_segments or angles.shape[1] < 1:
+                raise ValueError(
+                    "chamber_azimuth_angles must have shape "
+                    "(num_pneumatic_segments, num_chambers_per_segment) with at "
+                    "least one chamber per segment"
+                )
+            if not bool(jnp.all(jnp.isfinite(angles))):
+                raise ValueError("chamber_azimuth_angles entries must be finite")
+            wrapped = jnp.mod(angles, 2.0 * jnp.pi)
+            ordered = jnp.sort(wrapped, axis=-1)
+            closed = jnp.concatenate(
+                [ordered, ordered[..., :1] + 2.0 * jnp.pi], axis=-1
+            )
+            gaps = jnp.diff(closed, axis=-1)
+            expected_gap = 2.0 * jnp.pi / angles.shape[-1]
+            if not bool(jnp.allclose(gaps, expected_gap, rtol=1e-6, atol=1e-8)):
+                raise ValueError(
+                    "chamber_azimuth_angles must be uniformly distributed around "
+                    "the full circle for every pneumatic segment"
+                )
 
         if self.pcs_segment_lengths is not None:
             pcs_segment_lengths = jnp.asarray(self.pcs_segment_lengths)

--- a/tests/rendering/test_isupport_viser_renderer.py
+++ b/tests/rendering/test_isupport_viser_renderer.py
@@ -66,7 +66,9 @@ def _make_robot(*, connectors: bool = True) -> ISupport:
         chamber_inner_radius=jnp.array([0.005, 0.005]),
         chamber_outer_radius=jnp.array([0.00779, 0.00779]),
         chamber_distance=jnp.array([0.020, 0.020]),
-        chamber_angle_offset=jnp.array([0.0, 0.15]),
+        chamber_azimuth_angles=jnp.stack(
+            [2 * jnp.pi * jnp.arange(3) / 3, 0.15 + 2 * jnp.pi * jnp.arange(3) / 3]
+        ),
         pcs_segment_lengths=jnp.array([0.04, 0.06, 0.12]),
         rigid_connector_lengths=(
             jnp.array([0.01, 0.02, 0.03]) if connectors else jnp.zeros((3,))
@@ -198,8 +200,11 @@ def test_chambers_follow_model_angles_ellipse_and_bellows():
     vertices = renderer._chamber_vertices(poses, spec, 0)
     first_ring = vertices[:sections]
     center = first_ring.mean(axis=0)
-    radial = poses[spec.ring_slice.start, :3, 2]
-    tangential = poses[spec.ring_slice.start, :3, 1]
+    rotation = poses[spec.ring_slice.start, :3, :3]
+    local_offset = np.asarray(renderer.robot.local_chamber_offsets(0)[0])
+    radial_local = local_offset / np.linalg.norm(local_offset)
+    radial = rotation @ radial_local
+    tangential = rotation @ np.cross(np.array([1.0, 0.0, 0.0]), radial_local)
     radial_extent = np.max(np.abs((first_ring - center) @ radial))
     tangential_extent = np.max(np.abs((first_ring - center) @ tangential))
     assert radial_extent / tangential_extent == pytest.approx(

--- a/tests/systems/test_pressure_actuated_pcs_models.py
+++ b/tests/systems/test_pressure_actuated_pcs_models.py
@@ -38,6 +38,7 @@ def make_pressure_planar_params():
 
 
 def make_isupport_params(num_segments=1):
+    angles = 2.0 * jnp.pi * jnp.arange(3) / 3
     return ISupportParams(
         base_pose=spatial_base_pose(),
         length=jnp.full((num_segments,), 0.1),
@@ -53,24 +54,22 @@ def make_isupport_params(num_segments=1):
         chamber_inner_radius=jnp.full((num_segments,), 0.002),
         chamber_outer_radius=jnp.full((num_segments,), 0.004),
         chamber_distance=jnp.full((num_segments,), 0.01),
-        chamber_angle_offset=jnp.zeros((num_segments,)),
+        chamber_azimuth_angles=jnp.tile(angles, (num_segments, 1)),
     )
 
 
 def expected_isupport_segment_actuation(params, segment_idx, num_chambers=3):
     chamber_area = jnp.pi * params.chamber_inner_radius[segment_idx] ** 2
     chamber_distance = params.chamber_distance[segment_idx]
-    chamber_angles = params.chamber_angle_offset[segment_idx] + jnp.linspace(
-        0.0, 2.0 * jnp.pi, num_chambers, endpoint=False
-    )
+    chamber_angles = params.chamber_azimuth_angles[segment_idx]
     expected_columns = []
     for angle in chamber_angles:
         expected_columns.append(
             jnp.array(
                 [
                     0.0,
-                    -chamber_distance * jnp.cos(angle) * chamber_area,
                     chamber_distance * jnp.sin(angle) * chamber_area,
+                    -chamber_distance * jnp.cos(angle) * chamber_area,
                     chamber_area,
                     0.0,
                     0.0,
@@ -175,14 +174,12 @@ def test_isupport_geometry_helpers_and_actuation_matrix_shape():
     robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
 
     expected_angles = jnp.array([0.0, 2.0 * jnp.pi / 3.0, 4.0 * jnp.pi / 3.0])
-    expected_centroid = jnp.array([0.0, 0.0, params.chamber_distance[0]])
+    expected_centroid = jnp.array([0.0, params.chamber_distance[0], 0.0])
     expected_area = jnp.pi * (
         params.chamber_outer_radius[0] ** 2 - params.chamber_inner_radius[0] ** 2
     )
 
-    assert jnp.allclose(
-        robot._local_actuator_polar_angles(jnp.array(0)), expected_angles
-    )
+    assert jnp.allclose(robot.chamber_azimuths(jnp.array(0)), expected_angles)
     assert jnp.allclose(
         robot._local_actuator_centroid(jnp.array(0), jnp.array(0.0)),
         expected_centroid,
@@ -198,6 +195,54 @@ def test_isupport_geometry_helpers_and_actuation_matrix_shape():
     actuation_matrix = robot.actuation_matrix(jnp.zeros((6,)))
     assert actuation_matrix.shape == (6, 3)
     assert not jnp.isnan(actuation_matrix).any()
+
+
+def test_isupport_chamber_azimuth_cardinals_and_symmetry_validation():
+    cardinal_angles = jnp.array([[0.0, jnp.pi / 2, jnp.pi, 3 * jnp.pi / 2]])
+    params = make_isupport_params().replace(
+        chamber_azimuth_angles=cardinal_angles,
+        chamber_distance=jnp.array([0.01]),
+    )
+    robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
+    assert jnp.allclose(
+        robot.local_chamber_offsets(jnp.array(0)),
+        jnp.array(
+            [
+                [0.0, 0.01, 0.0],
+                [0.0, 0.0, 0.01],
+                [0.0, -0.01, 0.0],
+                [0.0, 0.0, -0.01],
+            ]
+        ),
+        atol=1e-12,
+    )
+
+    unsorted = params.replace(
+        chamber_azimuth_angles=cardinal_angles[:, jnp.array([2, 0, 3, 1])]
+    )
+    unsorted.validate()
+    assert jnp.allclose(
+        ISupport(unsorted).chamber_azimuths(0),
+        unsorted.chamber_azimuth_angles[0],
+    )
+
+    with pytest.raises(ValueError, match="uniformly distributed"):
+        params.replace(
+            chamber_azimuth_angles=jnp.array([[0.0, 0.5, jnp.pi, 3 * jnp.pi / 2]])
+        ).validate()
+
+
+def test_isupport_defaults_to_canonical_three_chamber_azimuths():
+    params = make_isupport_params(num_segments=2).replace(chamber_azimuth_angles=None)
+    robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
+    expected = jnp.tile(
+        jnp.array([0.0, 2.0 * jnp.pi / 3.0, 4.0 * jnp.pi / 3.0]),
+        (2, 1),
+    )
+
+    assert robot.num_chambers_per_segment == 3
+    assert jnp.allclose(robot.params.chamber_azimuth_angles, expected)
+    assert jnp.allclose(robot.pcs_params.chamber_azimuth_angles, expected)
 
 
 def test_isupport_actuation_matrix_matches_per_segment_chamber_model():
@@ -218,7 +263,12 @@ def test_isupport_actuation_matrix_assembles_segments_block_diagonal():
     params = make_isupport_params(num_segments=2).replace(
         chamber_inner_radius=jnp.array([0.002, 0.003]),
         chamber_distance=jnp.array([0.01, 0.015]),
-        chamber_angle_offset=jnp.array([0.0, 0.2]),
+        chamber_azimuth_angles=jnp.stack(
+            [
+                2 * jnp.pi * jnp.arange(3) / 3,
+                (0.2 + 2 * jnp.pi * jnp.arange(3) / 3)[jnp.array([2, 0, 1])],
+            ]
+        ),
     )
     robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
 
@@ -418,7 +468,9 @@ def test_isupport_actuation_groups_pressures_by_pneumatic_segment_after_split():
         length=jnp.array([0.1, 0.2]),
         chamber_inner_radius=jnp.array([0.002, 0.003]),
         chamber_distance=jnp.array([0.01, 0.015]),
-        chamber_angle_offset=jnp.array([0.0, 0.2]),
+        chamber_azimuth_angles=jnp.stack(
+            [2 * jnp.pi * jnp.arange(3) / 3, 0.2 + 2 * jnp.pi * jnp.arange(3) / 3]
+        ),
         pcs_segment_lengths=jnp.array([0.04, 0.06, 0.2]),
         rigid_connector_lengths=jnp.array([0.01, 0.02, 0.03]),
     )
@@ -449,9 +501,10 @@ def test_isupport_update_params_and_validation():
     params = make_isupport_params()
     robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
 
-    updated = robot.update_params(chamber_angle_offset=jnp.array([0.25]))
-    assert jnp.allclose(updated.varphi_chamber_off, jnp.array([0.25]))
-    assert jnp.allclose(robot.varphi_chamber_off, params.chamber_angle_offset)
+    updated_angles = 0.25 + 2 * jnp.pi * jnp.arange(3)[None, :] / 3
+    updated = robot.update_params(chamber_azimuth_angles=updated_angles)
+    assert jnp.allclose(updated.chamber_azimuth_angles, updated_angles)
+    assert jnp.allclose(robot.chamber_azimuth_angles, params.chamber_azimuth_angles)
 
     with pytest.raises(ValueError, match="chamber_inner_radius"):
         robot.update_params(chamber_inner_radius=jnp.array([0.001, 0.002]))

--- a/tests/systems/test_system_lengths.py
+++ b/tests/systems/test_system_lengths.py
@@ -177,7 +177,9 @@ def _isupport_robot():
         chamber_inner_radius=jnp.array([0.002, 0.002], dtype=jnp.float64),
         chamber_outer_radius=jnp.array([0.004, 0.004], dtype=jnp.float64),
         chamber_distance=jnp.array([0.01, 0.01], dtype=jnp.float64),
-        chamber_angle_offset=jnp.array([0.0, 0.0], dtype=jnp.float64),
+        chamber_azimuth_angles=jnp.tile(
+            2 * jnp.pi * jnp.arange(3, dtype=jnp.float64) / 3, (2, 1)
+        ),
     )
     return ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
 


### PR DESCRIPTION
## Summary

- replace the implicit chamber-angle offset with explicit per-channel chamber azimuth arrays
- adopt the right-handed local +X convention from local +Y toward local +Z
- share chamber geometry between the PCS actuation model and specialized Viser renderer
- validate rotational symmetry while preserving pressure-channel order
- provide a canonical default layout of 0°, 120°, and 240°
- update examples, API documentation, and regression tests

## Why

The previous geometry used a non-right-handed azimuth convention and duplicated its trigonometry across the model and renderer. It also inferred chamber positions from one offset, obscuring the mapping between physical chambers and pressure inputs. This change makes the model the single geometry source of truth and gives each pressure channel an explicit azimuth.

## Impact

`chamber_angle_offset` is replaced by `chamber_azimuth_angles`. Existing configurations can omit the new field to receive the canonical three-chamber layout, or pass an explicit `(num_pneumatic_segments, num_chambers_per_segment)` array when channel order differs.

## Validation

- `uv run ruff check` on affected Python files
- focused I-SUPPORT system, renderer, and length tests: 46 passed
- `git diff --check`