### PR TITLE
Generalize I-SUPPORT rigid and pneumatic segment layouts

### DIFF
--- a/docs/api/systems/pcs/isupport.md
+++ b/docs/api/systems/pcs/isupport.md
@@ -29,10 +29,10 @@ renderer = ISupportViserRenderer(
 renderer.show(q)
 ```
 
-`ISupportVisualConfig` exposes the interface and spacer dimensions, chamber
-ellipticity, bellows pitch and amplitude, mesh resolution, colors, and spacer
-opacity. When an `ISupport` topology omits a rigid connector, the renderer adds
-a thin visual-only interface plate without changing the robot kinematics.
+`ISupportVisualConfig` exposes spacer thickness, chamber ellipticity, bellows
+pitch and amplitude, mesh resolution, colors, and spacer opacity. Rigid
+segments and pneumatic-section spacers use their modeled radii; no visual-only
+connector slots are added.
 
 ## Model Quick Start
 
@@ -41,19 +41,28 @@ import jax.numpy as jnp
 from soromox.systems import ISupport, ISupportParams, ISupportStructure
 
 params = ISupportParams(
-    length=jnp.array([0.18]),
-    radius=jnp.array([35.6e-3]),
-    density=jnp.array([1104.0]),
-    young_modulus=jnp.array([1.6464e6]),
-    shear_modulus=jnp.array([0.5488e6]),
+    # Physical order: rigid base, pneumatic section, rigid tip.
+    length=jnp.array([0.01, 0.18, 0.01]),
+    radius=jnp.array([0.03, 35.6e-3, 0.025]),
+    density=jnp.array([1210.0, 1104.0, 1210.0]),
+    young_modulus=jnp.array([2.0e9, 1.6464e6, 2.0e9]),
+    shear_modulus=jnp.array([0.8e9, 0.5488e6, 0.8e9]),
     material_damping_coefficient=1.96e3,
-    reference_strain=jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
+    reference_strain=jnp.tile(
+        jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), 3
+    ),
     chamber_inner_radius=jnp.array([6.39e-3]),
     chamber_outer_radius=jnp.array([7.79e-3]),
     chamber_distance=jnp.array([20e-3]),
     chamber_azimuth_angles=(2.0 * jnp.pi * jnp.arange(3) / 3)[None, :],
 )
-robot = ISupport(params, structure=ISupportStructure(num_gauss_points=3))
+robot = ISupport(
+    params,
+    structure=ISupportStructure(
+        num_gauss_points=3,
+        rigid_segment_selector=(True, False, True),
+    ),
+)
 
 q = jnp.zeros(robot.num_dofs)
 

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -26,7 +26,16 @@ if __name__ == "__main__":
         2 * (1 + poisson_ratio)
     )  # Shear modulus from elastic modulus and poisson ratio
 
-    pneumatic_segment_lengths = jnp.array([190e-3, 180e-3])
+    # Physical layout: base interface, pneumatic section, middle interface,
+    # pneumatic section, tip interface.
+    rigid_segment_selector = (True, False, True, False, True)
+    physical_segment_lengths = jnp.array([41e-3, 190e-3, 27e-3, 180e-3, 6e-3])
+    # Alessi et al. (2023) report a 30 mm circular cross-section radius for
+    # the complete arm, including its pneumatic sections and terminal plates.
+    physical_segment_radii = 30e-3 * jnp.ones((len(rigid_segment_selector),))
+    # The compiled reference model stores 1210 kg/m^3 for every rigid
+    # interface and 1104 kg/m^3 for each pneumatic section.
+    physical_segment_densities = jnp.array([1210.0, 1104.0, 1210.0, 1104.0, 1210.0])
     # Topology: how many PCS segments approximate each pneumatic segment.
     pcs_segment_counts = (2, 3)
     # Parameters: metric PCS segment lengths, flattened by pneumatic segment.
@@ -34,11 +43,6 @@ if __name__ == "__main__":
     # Set this to None to divide each pneumatic segment equally according to
     # pcs_segment_counts.
     pcs_segment_lengths = jnp.array([95e-3, 95e-3, 60e-3, 60e-3, 60e-3])
-    # Topology: base, interface, and tip connector slots are present.
-    rigid_connector_selector = (True, True, True)
-    # Parameters: base connector, interface connector, and tip connector lengths.
-    rigid_connector_lengths = jnp.array([41e-3, 27e-3, 6e-3])
-
     # Previous explicit damping used gamma_t = 806e-3 and gamma_r = 1.0e-3:
     # D_i = L_i * diag([gamma_r, gamma_r, gamma_r, gamma_t, gamma_t, gamma_t]).
     # The material damping coefficient below is the least-squares scalar c for
@@ -48,15 +52,17 @@ if __name__ == "__main__":
     material_damping_coefficient = 1.96e3
     params = ISupportParams(
         base_pose=jnp.array([0.5, 0.5, 0.5, -0.5, 0.0, 0.0, 0.0]),
-        length=pneumatic_segment_lengths,
-        radius=35.6 * 1e-3 * jnp.ones((num_pneumatic_segments,)),
-        density=1104 * jnp.ones((num_pneumatic_segments,)),
+        length=physical_segment_lengths,
+        radius=physical_segment_radii,
+        density=physical_segment_densities,
         gravity=jnp.array([0.0, 0.0, -9.81]),
-        young_modulus=E * jnp.ones((num_pneumatic_segments,)),
-        shear_modulus=G * jnp.ones((num_pneumatic_segments,)),
-        material_damping_coefficient=material_damping_coefficient,
+        young_modulus=E * jnp.ones((len(rigid_segment_selector),)),
+        shear_modulus=G * jnp.ones((len(rigid_segment_selector),)),
+        material_damping_coefficient=material_damping_coefficient
+        * jnp.ones((len(rigid_segment_selector),)),
         reference_strain=jnp.tile(
-            jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), num_pneumatic_segments
+            jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
+            len(rigid_segment_selector),
         ),
         chamber_inner_radius=6.39 * 1e-3 * jnp.ones((num_pneumatic_segments,)),
         chamber_outer_radius=7.79 * 1e-3 * jnp.ones((num_pneumatic_segments,)),
@@ -68,7 +74,6 @@ if __name__ == "__main__":
             (num_pneumatic_segments, 1),
         ),
         pcs_segment_lengths=pcs_segment_lengths,
-        rigid_connector_lengths=rigid_connector_lengths,
     )
 
     # ======================================================
@@ -78,7 +83,7 @@ if __name__ == "__main__":
         params=params,
         structure=ISupportStructure(
             pcs_segment_counts=pcs_segment_counts,
-            rigid_connector_selector=rigid_connector_selector,
+            rigid_segment_selector=rigid_segment_selector,
         ),
     )
 

--- a/src/soromox/rendering/isupport/viser_renderer.py
+++ b/src/soromox/rendering/isupport/viser_renderer.py
@@ -26,9 +26,7 @@ __all__ = ["ISupportVisualConfig", "ISupportViserRenderer"]
 class ISupportVisualConfig:
     """Physical and stylistic defaults for :class:`ISupportViserRenderer`."""
 
-    interface_radius: float = 0.030
     interface_color: tuple[float, float, float] = (0.08, 0.20, 0.72)
-    fallback_interface_thickness: float = 0.005
     chamber_color: tuple[float, float, float] = (0.94, 0.91, 0.72)
     chamber_aspect_ratio: float = 21.72 / 13.03
     bellows_pitch: float = 0.010
@@ -36,18 +34,14 @@ class ISupportVisualConfig:
     chamber_sections: int = 20
     samples_per_fold: int = 4
     spacers_per_segment: int = 6
-    spacer_radius: float = 0.030
     spacer_thickness: float = 0.0015
     spacer_color: tuple[float, float, float] = (0.72, 0.82, 0.88)
     spacer_opacity: float = 0.35
 
     def __post_init__(self) -> None:
         positive_fields = (
-            "interface_radius",
-            "fallback_interface_thickness",
             "chamber_aspect_ratio",
             "bellows_pitch",
-            "spacer_radius",
             "spacer_thickness",
         )
         for name in positive_fields:
@@ -76,6 +70,7 @@ class ISupportVisualConfig:
 @dataclass(frozen=True)
 class _PneumaticVisualSpec:
     pneumatic_idx: int
+    radius: float
     s_start: float
     s_end: float
     ring_slice: slice
@@ -90,6 +85,7 @@ class _InterfaceVisualSpec:
     modeled: bool
     sample_indices: tuple[int, ...]
     thickness: float
+    radius: float
 
 
 @dataclass
@@ -170,7 +166,6 @@ class ISupportViserRenderer(ViserRenderer):
         rigid_selector = np.asarray(self.robot.pcs_segment_is_rigid, dtype=bool)
         sample_s: list[float] = []
         pneumatic_specs: list[_PneumaticVisualSpec] = []
-        pneumatic_bounds: list[tuple[float, float]] = []
 
         for pneumatic_idx in range(self.robot.num_pneumatic_segments):
             pcs_indices = np.flatnonzero(
@@ -210,6 +205,7 @@ class ISupportViserRenderer(ViserRenderer):
             pneumatic_specs.append(
                 _PneumaticVisualSpec(
                     pneumatic_idx=pneumatic_idx,
+                    radius=float(self.robot.r[pcs_indices[0]]),
                     s_start=s_start,
                     s_end=s_end,
                     ring_slice=ring_slice,
@@ -218,66 +214,33 @@ class ISupportViserRenderer(ViserRenderer):
                     faces=_tube_faces(num_rings, self.visual_config.chamber_sections),
                 )
             )
-            pneumatic_bounds.append((s_start, s_end))
 
-        rigid_indices = iter(np.flatnonzero(rigid_selector).tolist())
+        rigid_indices = np.flatnonzero(rigid_selector).tolist()
+        rigid_physical_indices = [
+            i
+            for i, is_rigid in enumerate(self.robot.structure.rigid_segment_selector)
+            if is_rigid
+        ]
+        if len(rigid_indices) != len(rigid_physical_indices):
+            raise ValueError("Rigid segment topology does not match the PCS layout.")
         interface_specs: list[_InterfaceVisualSpec] = []
-        connector_selector = self.robot.structure.rigid_connector_selector
-        if connector_selector is None:
-            connector_selector = tuple(
-                False for _ in range(self.robot.num_pneumatic_segments + 1)
+        for physical_idx, pcs_idx in zip(rigid_physical_indices, rigid_indices):
+            start_idx = len(sample_s)
+            sample_s.extend(
+                [
+                    float(cumulative_lengths[pcs_idx]),
+                    float(cumulative_lengths[pcs_idx + 1]),
+                ]
             )
-
-        for slot_idx, modeled in enumerate(connector_selector):
-            if modeled:
-                try:
-                    pcs_idx = next(rigid_indices)
-                except StopIteration as exc:
-                    raise ValueError(
-                        "Rigid connector topology does not match the PCS layout."
-                    ) from exc
-                start_idx = len(sample_s)
-                sample_s.extend(
-                    [
-                        float(cumulative_lengths[pcs_idx]),
-                        float(cumulative_lengths[pcs_idx + 1]),
-                    ]
+            interface_specs.append(
+                _InterfaceVisualSpec(
+                    slot_idx=physical_idx,
+                    modeled=True,
+                    sample_indices=(start_idx, start_idx + 1),
+                    thickness=float(lengths[pcs_idx]),
+                    radius=float(self.robot.r[pcs_idx]),
                 )
-                interface_specs.append(
-                    _InterfaceVisualSpec(
-                        slot_idx=slot_idx,
-                        modeled=True,
-                        sample_indices=(start_idx, start_idx + 1),
-                        thickness=float(lengths[pcs_idx]),
-                    )
-                )
-            else:
-                if slot_idx == 0:
-                    boundary = pneumatic_bounds[0][0]
-                elif slot_idx == self.robot.num_pneumatic_segments:
-                    boundary = pneumatic_bounds[-1][1]
-                else:
-                    boundary = 0.5 * (
-                        pneumatic_bounds[slot_idx - 1][1]
-                        + pneumatic_bounds[slot_idx][0]
-                    )
-                sample_idx = len(sample_s)
-                sample_s.append(float(boundary))
-                interface_specs.append(
-                    _InterfaceVisualSpec(
-                        slot_idx=slot_idx,
-                        modeled=False,
-                        sample_indices=(sample_idx,),
-                        thickness=self.visual_config.fallback_interface_thickness,
-                    )
-                )
-
-        try:
-            next(rigid_indices)
-        except StopIteration:
-            pass
-        else:
-            raise ValueError("PCS layout contains an unmatched rigid connector.")
+            )
 
         return (
             tuple(pneumatic_specs),
@@ -493,7 +456,7 @@ class ISupportViserRenderer(ViserRenderer):
                             f"/robots/robot_{robot_idx}/isupport/spacers/"
                             f"segment_{spec.pneumatic_idx}/spacer_{spacer_idx}"
                         ),
-                        radius=cfg.spacer_radius,
+                        radius=spec.radius,
                         thickness=cfg.spacer_thickness,
                         color=cfg.spacer_color,
                         opacity=cfg.spacer_opacity,
@@ -510,7 +473,7 @@ class ISupportViserRenderer(ViserRenderer):
                         f"/robots/robot_{robot_idx}/isupport/interfaces/"
                         f"interface_{spec.slot_idx}"
                     ),
-                    radius=cfg.interface_radius,
+                    radius=spec.radius,
                     thickness=spec.thickness,
                     color=cfg.interface_color,
                     opacity=None,

--- a/src/soromox/systems/pcs/isupport.py
+++ b/src/soromox/systems/pcs/isupport.py
@@ -18,7 +18,7 @@ def _with_default_chamber_azimuth_angles(params: ISupportParams) -> ISupportPara
     """Resolve the canonical three-chamber layout when no angles are supplied."""
     if params.chamber_azimuth_angles is not None:
         return params
-    num_pneumatic_segments = int(params.length.shape[0])
+    num_pneumatic_segments = int(params.chamber_inner_radius.shape[0])
     canonical_angles = 2.0 * jnp.pi * jnp.arange(3, dtype=jnp.float64) / 3.0
     return params.replace(
         chamber_azimuth_angles=jnp.tile(
@@ -31,19 +31,31 @@ def _straight_reference_strain(dtype: jnp.dtype) -> Array:
     return jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0], dtype=dtype)
 
 
-def _connector_source_index(connector_index: int, num_pneumatic_segments: int) -> int:
-    if connector_index <= 0:
-        return 0
-    if connector_index >= num_pneumatic_segments:
-        return num_pneumatic_segments - 1
-    return connector_index - 1
-
-
 def _normalize_structure_for_params(
     params: ISupportParams,
     structure: ISupportStructure,
 ) -> ISupportStructure:
-    num_pneumatic_segments = int(params.length.shape[0])
+    num_physical_segments = int(params.length.shape[0])
+
+    rigid_segment_selector = structure.rigid_segment_selector
+    if rigid_segment_selector is None:
+        rigid_segment_selector = tuple(i % 2 == 0 for i in range(num_physical_segments))
+    if len(rigid_segment_selector) != num_physical_segments:
+        raise ValueError(
+            "rigid_segment_selector must contain one entry per physical segment; "
+            f"expected {num_physical_segments}, got {len(rigid_segment_selector)}."
+        )
+    num_pneumatic_segments = sum(not is_rigid for is_rigid in rigid_segment_selector)
+    if num_pneumatic_segments < 1:
+        raise ValueError(
+            "rigid_segment_selector must contain at least one pneumatic segment."
+        )
+    num_chamber_segments = int(params.chamber_inner_radius.shape[0])
+    if num_chamber_segments != num_pneumatic_segments:
+        raise ValueError(
+            "Chamber parameter arrays must contain one entry per pneumatic segment; "
+            f"expected {num_pneumatic_segments}, got {num_chamber_segments}."
+        )
 
     pcs_segment_counts = structure.pcs_segment_counts
     if pcs_segment_counts is None:
@@ -58,24 +70,10 @@ def _normalize_structure_for_params(
     if any(count < 1 for count in pcs_segment_counts):
         raise ValueError("pcs_segment_counts entries must be positive integers.")
 
-    rigid_connector_selector = structure.rigid_connector_selector
-    num_rigid_connectors = num_pneumatic_segments + 1
-    if rigid_connector_selector is None:
-        rigid_connector_selector = tuple(False for _ in range(num_rigid_connectors))
-    elif len(rigid_connector_selector) == 1 and num_rigid_connectors > 1:
-        rigid_connector_selector = rigid_connector_selector * num_rigid_connectors
-    if len(rigid_connector_selector) != num_rigid_connectors:
-        raise ValueError(
-            "rigid_connector_selector must contain one more entry than there are "
-            "pneumatic segments; "
-            f"expected {num_rigid_connectors}, "
-            f"got {len(rigid_connector_selector)}."
-        )
-
     return ISupportStructure(
         num_gauss_points=structure.num_gauss_points,
         pcs_segment_counts=pcs_segment_counts,
-        rigid_connector_selector=rigid_connector_selector,
+        rigid_segment_selector=rigid_segment_selector,
         strain_selector=structure.strain_selector,
         scale_rotational_basis_by_length=structure.scale_rotational_basis_by_length,
     )
@@ -84,12 +82,20 @@ def _normalize_structure_for_params(
 def _resolve_pcs_segment_lengths(
     params: ISupportParams,
     pcs_segment_counts: tuple[int, ...],
+    rigid_segment_selector: tuple[bool, ...],
 ) -> tuple[Array, ...]:
-    pneumatic_lengths = jnp.asarray(params.length, dtype=jnp.float64)
+    physical_lengths = jnp.asarray(params.length, dtype=jnp.float64)
+    pneumatic_physical_indices = [
+        i for i, is_rigid in enumerate(rigid_segment_selector) if not is_rigid
+    ]
 
     if params.pcs_segment_lengths is None:
         return tuple(
-            jnp.full((count,), pneumatic_lengths[i] / count, dtype=jnp.float64)
+            jnp.full(
+                (count,),
+                physical_lengths[pneumatic_physical_indices[i]] / count,
+                dtype=jnp.float64,
+            )
             for i, count in enumerate(pcs_segment_counts)
         )
 
@@ -102,7 +108,7 @@ def _resolve_pcs_segment_lengths(
     expected_num_pcs_segments = sum(pcs_segment_counts)
     if pcs_segment_lengths.shape != (expected_num_pcs_segments,):
         raise ValueError(
-            "pcs_segment_lengths must contain one length per soft PCS segment; "
+            "pcs_segment_lengths must contain one length per pneumatic PCS segment; "
             f"expected {expected_num_pcs_segments}, got {pcs_segment_lengths.shape[0]}."
         )
     if not bool(jnp.all(pcs_segment_lengths > 0.0)):
@@ -114,7 +120,7 @@ def _resolve_pcs_segment_lengths(
         stop = start + count
         child_lengths = pcs_segment_lengths[start:stop]
         child_length_sum = float(jnp.sum(child_lengths))
-        pneumatic_length = float(pneumatic_lengths[i])
+        pneumatic_length = float(physical_lengths[pneumatic_physical_indices[i]])
         if not math.isclose(
             child_length_sum,
             pneumatic_length,
@@ -132,45 +138,6 @@ def _resolve_pcs_segment_lengths(
     return tuple(segment_lengths_by_pneumatic_segment)
 
 
-def _resolve_rigid_connector_lengths(
-    params: ISupportParams,
-    rigid_connector_selector: tuple[bool, ...],
-) -> Array:
-    num_rigid_connectors = len(rigid_connector_selector)
-    if params.rigid_connector_lengths is None:
-        rigid_connector_lengths = jnp.zeros((num_rigid_connectors,), dtype=jnp.float64)
-    else:
-        rigid_connector_lengths = jnp.asarray(
-            params.rigid_connector_lengths, dtype=jnp.float64
-        )
-    if rigid_connector_lengths.shape != (num_rigid_connectors,):
-        raise ValueError(
-            "rigid_connector_lengths must contain one entry per canonical "
-            "connector slot; "
-            f"expected {num_rigid_connectors}, got {rigid_connector_lengths.shape}."
-        )
-    if not bool(jnp.all(rigid_connector_lengths >= 0.0)):
-        raise ValueError("rigid_connector_lengths entries must be nonnegative.")
-
-    for connector_index, is_selected in enumerate(rigid_connector_selector):
-        connector_length = float(rigid_connector_lengths[connector_index])
-        if is_selected:
-            if connector_length <= 0.0:
-                raise ValueError(
-                    "Selected rigid connectors must have positive lengths; "
-                    f"rigid_connector_lengths[{connector_index}] is "
-                    f"{connector_length}."
-                )
-        elif not math.isclose(connector_length, 0.0, rel_tol=1e-9, abs_tol=1e-12):
-            raise ValueError(
-                "rigid_connector_lengths contains a nonzero length for an "
-                "unselected connector; set "
-                f"rigid_connector_selector[{connector_index}] to True or set "
-                f"rigid_connector_lengths[{connector_index}] to zero."
-            )
-    return rigid_connector_lengths
-
-
 def _expand_isupport_layout(
     params: ISupportParams,
     structure: ISupportStructure,
@@ -179,33 +146,40 @@ def _expand_isupport_layout(
     params.validate()
     structure = _normalize_structure_for_params(params, structure)
 
-    num_pneumatic_segments = int(params.length.shape[0])
-    pneumatic_lengths = jnp.asarray(params.length, dtype=jnp.float64)
+    num_physical_segments = int(params.length.shape[0])
+    physical_lengths = jnp.asarray(params.length, dtype=jnp.float64)
     pcs_segment_lengths = _resolve_pcs_segment_lengths(
-        params, structure.pcs_segment_counts
-    )
-    rigid_connector_lengths = _resolve_rigid_connector_lengths(
-        params, structure.rigid_connector_selector
+        params, structure.pcs_segment_counts, structure.rigid_segment_selector
     )
     radius = jnp.asarray(params.radius, dtype=jnp.float64)
     density = jnp.asarray(params.density, dtype=jnp.float64)
     young_modulus = jnp.asarray(params.young_modulus, dtype=jnp.float64)
     shear_modulus = jnp.asarray(params.shear_modulus, dtype=jnp.float64)
     reference_strain = jnp.asarray(params.reference_strain, dtype=jnp.float64).reshape(
-        num_pneumatic_segments, 6
+        num_physical_segments, 6
     )
+    straight_reference_strain = _straight_reference_strain(reference_strain.dtype)
+    for physical_index, is_rigid in enumerate(structure.rigid_segment_selector):
+        if is_rigid and not bool(
+            jnp.allclose(reference_strain[physical_index], straight_reference_strain)
+        ):
+            raise ValueError(
+                "Rigid segment reference_strain entries must equal "
+                "[0, 0, 0, 1, 0, 0]; "
+                f"physical segment {physical_index} does not."
+            )
     has_damping_matrix = params.damping_matrix is not None
     if has_damping_matrix:
         damping_matrix = jnp.asarray(params.damping_matrix, dtype=jnp.float64)
         damping_blocks = jnp.stack(
             [
                 damping_matrix[6 * i : 6 * (i + 1), 6 * i : 6 * (i + 1)]
-                for i in range(num_pneumatic_segments)
+                for i in range(num_physical_segments)
             ]
         )
         if not bool(jnp.allclose(damping_matrix, blk_diag(damping_blocks))):
             raise ValueError(
-                "ISupport damping_matrix must be block diagonal by pneumatic segment "
+                "ISupport damping_matrix must be block diagonal by physical segment "
                 "before expansion into PCS segments."
             )
     else:
@@ -216,7 +190,7 @@ def _expand_isupport_layout(
         )
         if material_damping_coefficient.ndim == 0:
             material_damping_coefficient = jnp.full(
-                (num_pneumatic_segments,),
+                (num_physical_segments,),
                 material_damping_coefficient,
                 dtype=jnp.float64,
             )
@@ -248,7 +222,7 @@ def _expand_isupport_layout(
         *,
         length: Array,
         source_index: int,
-        pneumatic_index: int,
+        pneumatic_index: int | None,
         is_rigid: bool,
     ) -> None:
         expanded_lengths.append(jnp.asarray(length, dtype=jnp.float64))
@@ -256,59 +230,55 @@ def _expand_isupport_layout(
         expanded_density.append(density[source_index])
         expanded_young_modulus.append(young_modulus[source_index])
         expanded_shear_modulus.append(shear_modulus[source_index])
-        expanded_chamber_inner_radius.append(r_chamber_in[source_index])
-        expanded_chamber_outer_radius.append(r_chamber_out[source_index])
-        expanded_chamber_distance.append(d_chamber[source_index])
-        expanded_chamber_azimuth_angles.append(chamber_azimuth_angles[source_index])
+        chamber_index = 0 if pneumatic_index is None else pneumatic_index
+        expanded_chamber_inner_radius.append(r_chamber_in[chamber_index])
+        expanded_chamber_outer_radius.append(r_chamber_out[chamber_index])
+        expanded_chamber_distance.append(d_chamber[chamber_index])
+        expanded_chamber_azimuth_angles.append(chamber_azimuth_angles[chamber_index])
 
         if is_rigid:
-            expanded_reference_strain.append(
-                _straight_reference_strain(reference_strain.dtype)
-            )
+            expanded_reference_strain.append(reference_strain[source_index])
             if has_damping_matrix:
-                expanded_damping_blocks.append(
-                    jnp.zeros((6, 6), dtype=damping_matrix.dtype)
-                )
+                expanded_damping_blocks.append(damping_blocks[source_index])
             else:
                 expanded_material_damping_coefficient.append(
-                    jnp.asarray(0.0, dtype=material_damping_coefficient.dtype)
+                    material_damping_coefficient[source_index]
                 )
             default_strain_selector.append(jnp.zeros((6,), dtype=bool))
             pcs_segment_to_pneumatic_segment.append(_RIGID_CONNECTOR_PARENT)
         else:
-            length_scale = length / pneumatic_lengths[pneumatic_index]
-            expanded_reference_strain.append(reference_strain[pneumatic_index])
+            length_scale = length / physical_lengths[source_index]
+            expanded_reference_strain.append(reference_strain[source_index])
             if has_damping_matrix:
                 expanded_damping_blocks.append(
-                    damping_blocks[pneumatic_index] * length_scale
+                    damping_blocks[source_index] * length_scale
                 )
             else:
                 expanded_material_damping_coefficient.append(
-                    material_damping_coefficient[pneumatic_index]
+                    material_damping_coefficient[source_index]
                 )
             default_strain_selector.append(jnp.ones((6,), dtype=bool))
             pcs_segment_to_pneumatic_segment.append(pneumatic_index)
         pcs_segment_is_rigid.append(is_rigid)
 
-    for connector_index in range(num_pneumatic_segments + 1):
-        if structure.rigid_connector_selector[connector_index]:
+    pneumatic_index = 0
+    for physical_index, is_rigid in enumerate(structure.rigid_segment_selector):
+        if is_rigid:
             append_segment(
-                length=rigid_connector_lengths[connector_index],
-                source_index=_connector_source_index(
-                    connector_index, num_pneumatic_segments
-                ),
-                pneumatic_index=_RIGID_CONNECTOR_PARENT,
+                length=physical_lengths[physical_index],
+                source_index=physical_index,
+                pneumatic_index=None,
                 is_rigid=True,
             )
-
-        if connector_index < num_pneumatic_segments:
-            for segment_length in pcs_segment_lengths[connector_index]:
+        else:
+            for segment_length in pcs_segment_lengths[pneumatic_index]:
                 append_segment(
                     length=segment_length,
-                    source_index=connector_index,
-                    pneumatic_index=connector_index,
+                    source_index=physical_index,
+                    pneumatic_index=pneumatic_index,
                     is_rigid=False,
                 )
+            pneumatic_index += 1
 
     strain_selector = jnp.concatenate(default_strain_selector)
     if structure.strain_selector is not None:
@@ -445,9 +415,9 @@ class ISupport(PCS):
 
         Args:
             params: Dynamic I-SUPPORT parameters.
-            structure: Static I-SUPPORT layout. If omitted, each pneumatic
-                segment is represented by one PCS segment and no rigid
-                connectors are inserted.
+            structure: Static I-SUPPORT layout. If omitted, physical segments
+                alternate rigid and pneumatic from index zero, and each
+                pneumatic segment is represented by one PCS segment.
             **kwargs: Additional keyword arguments.
         """
         if not isinstance(params, ISupportParams):
@@ -466,12 +436,17 @@ class ISupport(PCS):
             pcs_segment_to_pneumatic_segment,
             pcs_segment_is_rigid,
         ) = _expand_isupport_layout(params, structure)
+        # Geometry-dependent caches are constructed by PCS.__init__, so expose
+        # the expanded type mask before delegating to it.
+        self.pcs_segment_is_rigid = pcs_segment_is_rigid
         super().__init__(pcs_params, structure=pcs_structure, **kwargs)
 
         self.params = params
         self.pcs_params = pcs_params
         self.structure = normalized_structure
-        self.num_pneumatic_segments = int(params.length.shape[0])
+        self.num_pneumatic_segments = sum(
+            not is_rigid for is_rigid in normalized_structure.rigid_segment_selector
+        )
         self.num_pcs_segments = self.num_segments
         self.pcs_segment_to_pneumatic_segment = pcs_segment_to_pneumatic_segment
         self.pcs_segment_is_rigid = pcs_segment_is_rigid
@@ -698,11 +673,11 @@ class ISupport(PCS):
         Returns:
             A_i (Array): local cross-sectional area of the i-th segment as array of shape ()
         """
-        A_one_actuator_i = self._local_actuator_cross_sectional_area(i)
-        # we assume that the cross-section only consists of the actuators
-        A_i = self.num_chambers_per_segment * A_one_actuator_i
-
-        return A_i
+        pneumatic_area = (
+            self.num_chambers_per_segment * self._local_actuator_cross_sectional_area(i)
+        )
+        rigid_area = super()._local_cross_sectional_area(i)
+        return jnp.where(self.pcs_segment_is_rigid[i], rigid_area, pneumatic_area)
 
     def _local_actuator_second_moment_of_area(
         self, i: Array, varphi_chamber: Array
@@ -759,17 +734,14 @@ class ISupport(PCS):
             I_i (Array): local second moment of area of the i-th segment as array of shape (3, )
         """
 
-        # compute the polar angles of the actuators
+        # Compute the pneumatic-section moments from its actuator annuli.
         varphi_actuators_i = self.chamber_azimuth_angles[i]
-        # compute the second moment of area of each actuator
         I_actuators_i = vmap(
             lambda varphi: self._local_actuator_second_moment_of_area(i, varphi)
         )(varphi_actuators_i)
-
-        # the second moment of area is assumed to be the sum across all actuators
-        I_i = jnp.sum(I_actuators_i, axis=0)
-
-        return I_i
+        pneumatic_moments = jnp.sum(I_actuators_i, axis=0)
+        rigid_moments = super()._local_second_moment_of_area(i)
+        return jnp.where(self.pcs_segment_is_rigid[i], rigid_moments, pneumatic_moments)
 
     @eqx.filter_jit
     def actuation_matrix(self, q: Array) -> Array:

--- a/src/soromox/systems/pcs/params.py
+++ b/src/soromox/systems/pcs/params.py
@@ -239,9 +239,10 @@ class PressureActuatedPlanarPCSParams(PlanarPCSParams):
 class ISupportParams(PCSParams):
     """Dynamic parameters for the I-SUPPORT spatial pneumatic PCS model.
 
-    The leading axis indexes physical pneumatic segments. ``ISupport`` expands
-    these fields into the internal PCS segment layout using ``ISupportStructure``.
-    Chamber fields describe per-pneumatic-segment chamber geometry. Chamber
+    The leading axis of the standard PCS body fields indexes every physical
+    rigid or pneumatic segment in robot order. ``ISupport`` expands these fields
+    into the internal PCS layout using ``ISupportStructure``. Chamber fields
+    index only pneumatic segments, in their order of appearance. Chamber
     azimuth is right-handed about local +X, measured from +Y toward +Z; array
     index ``j`` is pressure channel ``j``. If ``chamber_azimuth_angles`` is
     omitted, ``ISupport`` uses 0, 120, and 240 degrees for every pneumatic
@@ -256,10 +257,7 @@ class ISupportParams(PCSParams):
     assigned to each pneumatic segment must sum to the corresponding
     ``length`` entry when the model is constructed.
 
-    ``rigid_connector_lengths`` optionally stores connector lengths in the
-    canonical I-SUPPORT order: base connector, interfaces between pneumatic
-    segments, and tip connector. ``ISupportStructure.rigid_connector_selector``
-    determines which connector slots are part of the fixed model topology.
+    Segment types are defined by ``ISupportStructure.rigid_segment_selector``.
     """
 
     chamber_inner_radius: Array
@@ -267,21 +265,34 @@ class ISupportParams(PCSParams):
     chamber_distance: Array
     chamber_azimuth_angles: Array | None = None
     pcs_segment_lengths: Array | None = None
-    rigid_connector_lengths: Array | None = None
 
     def validate(self) -> None:
         super().validate()
-        n_segments = self.length.shape[0]
+        chamber_inner_radius = jnp.asarray(self.chamber_inner_radius)
+        if chamber_inner_radius.ndim != 1:
+            raise ValueError(
+                "chamber_inner_radius must be one-dimensional with shape "
+                "(num_pneumatic_segments,)."
+            )
+        n_pneumatic_segments = chamber_inner_radius.shape[0]
+        if n_pneumatic_segments < 1:
+            raise ValueError(
+                "ISupportParams must describe at least one pneumatic segment"
+            )
         for name in (
             "chamber_inner_radius",
             "chamber_outer_radius",
             "chamber_distance",
         ):
-            _require_shape(name, getattr(self, name), (n_segments,))
+            _require_shape(name, getattr(self, name), (n_pneumatic_segments,))
 
         if self.chamber_azimuth_angles is not None:
             angles = jnp.asarray(self.chamber_azimuth_angles)
-            if angles.ndim != 2 or angles.shape[0] != n_segments or angles.shape[1] < 1:
+            if (
+                angles.ndim != 2
+                or angles.shape[0] != n_pneumatic_segments
+                or angles.shape[1] < 1
+            ):
                 raise ValueError(
                     "chamber_azimuth_angles must have shape "
                     "(num_pneumatic_segments, num_chambers_per_segment) with at "
@@ -309,11 +320,3 @@ class ISupportParams(PCSParams):
                     "pcs_segment_lengths must be one-dimensional with shape "
                     "(num_pcs_segments,)."
                 )
-
-        if self.rigid_connector_lengths is not None:
-            rigid_connector_lengths = jnp.asarray(self.rigid_connector_lengths)
-            _require_shape(
-                "rigid_connector_lengths",
-                rigid_connector_lengths,
-                (n_segments + 1,),
-            )

--- a/src/soromox/systems/pcs/structures.py
+++ b/src/soromox/systems/pcs/structures.py
@@ -34,10 +34,13 @@ def _pcs_segment_counts(
     return _int_tuple(value, name="pcs_segment_counts")
 
 
-def _rigid_connector_selector(value: Any) -> tuple[bool, ...] | None:
+def _rigid_segment_selector(value: Any) -> tuple[bool, ...] | None:
     if value is None:
         return None
-    return _bool_tuple(value, name="rigid_connector_selector")
+    value = _tolist(value)
+    if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
+        raise TypeError("rigid_segment_selector must be a boolean sequence.")
+    return tuple(bool(entry) for entry in value)
 
 
 class PCSStructure(eqx.Module):
@@ -60,30 +63,20 @@ class ISupportStructure(PCSStructure):
     """Static I-SUPPORT PCS layout.
 
     ``pcs_segment_counts`` defines how many constant-strain PCS segments are
-    used for each physical pneumatic segment. A scalar count applies the same
-    count to every pneumatic segment. The actual PCS segment lengths live in
-    ``ISupportParams.pcs_segment_lengths``.
+    used for each physical pneumatic segment, in pneumatic-segment order. A
+    scalar count applies the same count to every pneumatic segment. Child
+    lengths live in ``ISupportParams.pcs_segment_lengths``.
 
-    ``rigid_connector_selector`` has one entry more than the number of
-    pneumatic segments, with ``True`` marking a rigid connector PCS segment in
-    the fixed physical sequence:
-
-    ``rigid_connector[0]``,
-    ``pneumatic_segment[0]``,
-    ``rigid_connector[1]``,
-    ...,
-    ``pneumatic_segment[n - 1]``,
-    ``rigid_connector[n]``.
-
-    A scalar connector selector applies to all connector slots. The actual
-    connector lengths live in ``ISupportParams.rigid_connector_lengths``. If
-    ``strain_selector`` is provided, it is interpreted on the expanded PCS
-    segment layout; rigid connector strains are always deactivated.
+    ``rigid_segment_selector`` has one entry per physical segment in
+    ``ISupportParams``. ``True`` marks a rigid segment and ``False`` a pneumatic
+    segment. When omitted, segment types alternate from a rigid segment at index
+    zero. If ``strain_selector`` is provided, it is interpreted on the expanded
+    PCS layout; rigid-segment strains are always deactivated.
     """
 
     pcs_segment_counts: tuple[int, ...] | None = eqx.field(
         static=True, default=None, converter=_pcs_segment_counts
     )
-    rigid_connector_selector: tuple[bool, ...] | None = eqx.field(
-        static=True, default=None, converter=_rigid_connector_selector
+    rigid_segment_selector: tuple[bool, ...] | None = eqx.field(
+        static=True, default=None, converter=_rigid_segment_selector
     )

--- a/tests/rendering/test_isupport_viser_renderer.py
+++ b/tests/rendering/test_isupport_viser_renderer.py
@@ -52,17 +52,30 @@ class _FakeServer:
 
 
 def _make_robot(*, connectors: bool = True) -> ISupport:
-    lengths = jnp.array([0.10, 0.12])
+    if connectors:
+        lengths = jnp.array([0.01, 0.10, 0.02, 0.12, 0.03])
+        rigid_segment_selector = (True, False, True, False, True)
+        radii = jnp.array([0.025, 0.03, 0.026, 0.035, 0.027])
+        densities = jnp.array([1200.0, 1000.0, 1250.0, 1000.0, 1300.0])
+    else:
+        lengths = jnp.array([0.10, 0.12])
+        rigid_segment_selector = (False, False)
+        radii = jnp.array([0.03, 0.03])
+        densities = jnp.array([1000.0, 1000.0])
+    num_physical_segments = len(rigid_segment_selector)
     params = ISupportParams(
         base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
         length=lengths,
-        radius=jnp.array([0.03, 0.03]),
-        density=jnp.array([1000.0, 1000.0]),
+        radius=radii,
+        density=densities,
         gravity=jnp.array([0.0, 0.0, -9.81]),
-        young_modulus=jnp.array([2.0e3, 2.0e3]),
-        shear_modulus=jnp.array([1.0e3, 1.0e3]),
-        damping_matrix=1.0e-3 * jnp.eye(12),
-        reference_strain=jnp.tile(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), 2),
+        young_modulus=2.0e3 * jnp.ones((num_physical_segments,)),
+        shear_modulus=1.0e3 * jnp.ones((num_physical_segments,)),
+        damping_matrix=1.0e-3 * jnp.eye(6 * num_physical_segments),
+        reference_strain=jnp.tile(
+            jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
+            num_physical_segments,
+        ),
         chamber_inner_radius=jnp.array([0.005, 0.005]),
         chamber_outer_radius=jnp.array([0.00779, 0.00779]),
         chamber_distance=jnp.array([0.020, 0.020]),
@@ -70,16 +83,13 @@ def _make_robot(*, connectors: bool = True) -> ISupport:
             [2 * jnp.pi * jnp.arange(3) / 3, 0.15 + 2 * jnp.pi * jnp.arange(3) / 3]
         ),
         pcs_segment_lengths=jnp.array([0.04, 0.06, 0.12]),
-        rigid_connector_lengths=(
-            jnp.array([0.01, 0.02, 0.03]) if connectors else jnp.zeros((3,))
-        ),
     )
     return ISupport(
         params=params,
         structure=ISupportStructure(
             num_gauss_points=1,
             pcs_segment_counts=(2, 1),
-            rigid_connector_selector=(connectors, connectors, connectors),
+            rigid_segment_selector=rigid_segment_selector,
         ),
     )
 
@@ -111,7 +121,6 @@ def _curves_and_frames(renderer, q, offsets=None):
         ({"chamber_sections": 5}, "chamber_sections"),
         ({"samples_per_fold": 1}, "samples_per_fold"),
         ({"spacer_opacity": 1.1}, "spacer_opacity"),
-        ({"interface_radius": 0.0}, "interface_radius"),
     ],
 )
 def test_visual_config_validation(updates, message):
@@ -151,8 +160,14 @@ def test_layout_tracks_split_pneumatic_segments_and_connectors():
         [(0.01, 0.11), (0.13, 0.25)],
         atol=1e-12,
     )
+    assert [spec.radius for spec in renderer._pneumatic_specs] == pytest.approx(
+        [0.03, 0.035]
+    )
     assert [spec.thickness for spec in renderer._interface_specs] == pytest.approx(
         [0.01, 0.02, 0.03]
+    )
+    assert [spec.radius for spec in renderer._interface_specs] == pytest.approx(
+        [0.025, 0.026, 0.027]
     )
     assert all(spec.modeled for spec in renderer._interface_specs)
 
@@ -164,18 +179,9 @@ def test_layout_tracks_split_pneumatic_segments_and_connectors():
     )
 
 
-def test_layout_adds_visual_only_interfaces_without_connectors():
-    config = ISupportVisualConfig(fallback_interface_thickness=0.004)
-    renderer = _renderer(
-        _make_robot(connectors=False),
-        visual_config=config,
-    )
-
-    assert len(renderer._interface_specs) == 3
-    assert not any(spec.modeled for spec in renderer._interface_specs)
-    assert [spec.thickness for spec in renderer._interface_specs] == pytest.approx(
-        [0.004, 0.004, 0.004]
-    )
+def test_layout_has_no_visual_only_interfaces_without_rigid_segments():
+    renderer = _renderer(_make_robot(connectors=False))
+    assert renderer._interface_specs == ()
 
 
 def test_chambers_follow_model_angles_ellipse_and_bellows():

--- a/tests/systems/test_pressure_actuated_pcs_models.py
+++ b/tests/systems/test_pressure_actuated_pcs_models.py
@@ -58,6 +58,13 @@ def make_isupport_params(num_segments=1):
     )
 
 
+def make_pneumatic_isupport_structure(num_segments=1, **kwargs):
+    return ISupportStructure(
+        rigid_segment_selector=(False,) * num_segments,
+        **kwargs,
+    )
+
+
 def expected_isupport_segment_actuation(params, segment_idx, num_chambers=3):
     chamber_area = jnp.pi * params.chamber_inner_radius[segment_idx] ** 2
     chamber_distance = params.chamber_distance[segment_idx]
@@ -171,7 +178,10 @@ def test_pressure_planar_pcs_validates_chamber_parameters():
 
 def test_isupport_geometry_helpers_and_actuation_matrix_shape():
     params = make_isupport_params()
-    robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(num_gauss_points=1),
+    )
 
     expected_angles = jnp.array([0.0, 2.0 * jnp.pi / 3.0, 4.0 * jnp.pi / 3.0])
     expected_centroid = jnp.array([0.0, params.chamber_distance[0], 0.0])
@@ -203,7 +213,10 @@ def test_isupport_chamber_azimuth_cardinals_and_symmetry_validation():
         chamber_azimuth_angles=cardinal_angles,
         chamber_distance=jnp.array([0.01]),
     )
-    robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(num_gauss_points=1),
+    )
     assert jnp.allclose(
         robot.local_chamber_offsets(jnp.array(0)),
         jnp.array(
@@ -222,7 +235,9 @@ def test_isupport_chamber_azimuth_cardinals_and_symmetry_validation():
     )
     unsorted.validate()
     assert jnp.allclose(
-        ISupport(unsorted).chamber_azimuths(0),
+        ISupport(
+            unsorted, structure=make_pneumatic_isupport_structure()
+        ).chamber_azimuths(0),
         unsorted.chamber_azimuth_angles[0],
     )
 
@@ -234,7 +249,10 @@ def test_isupport_chamber_azimuth_cardinals_and_symmetry_validation():
 
 def test_isupport_defaults_to_canonical_three_chamber_azimuths():
     params = make_isupport_params(num_segments=2).replace(chamber_azimuth_angles=None)
-    robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(2, num_gauss_points=1),
+    )
     expected = jnp.tile(
         jnp.array([0.0, 2.0 * jnp.pi / 3.0, 4.0 * jnp.pi / 3.0]),
         (2, 1),
@@ -247,7 +265,10 @@ def test_isupport_defaults_to_canonical_three_chamber_azimuths():
 
 def test_isupport_actuation_matrix_matches_per_segment_chamber_model():
     params = make_isupport_params()
-    robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(num_gauss_points=1),
+    )
 
     actuation_matrix = robot.actuation_matrix(jnp.zeros((robot.num_dofs,)))
 
@@ -270,7 +291,10 @@ def test_isupport_actuation_matrix_assembles_segments_block_diagonal():
             ]
         ),
     )
-    robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(2, num_gauss_points=1),
+    )
 
     actuation_matrix = robot.actuation_matrix(jnp.zeros((robot.num_dofs,)))
     num_chambers = robot.num_chambers_per_segment
@@ -306,11 +330,13 @@ def test_isupport_actuation_matrix_projects_to_active_strains():
         dtype=bool,
     )
     full_robot = ISupport(
-        params=params, structure=ISupportStructure(num_gauss_points=1)
+        params=params,
+        structure=make_pneumatic_isupport_structure(2, num_gauss_points=1),
     )
     reduced_robot = ISupport(
         params=params,
-        structure=ISupportStructure(
+        structure=make_pneumatic_isupport_structure(
+            2,
             num_gauss_points=1,
             strain_selector=strain_selector,
         ),
@@ -334,204 +360,203 @@ def test_isupport_actuation_matrix_projects_to_active_strains():
     )
 
 
-@pytest.mark.parametrize(
-    ("pcs_segment_counts", "rigid_connector_selector"),
-    [
-        ([2, 2], [False, False, False]),
-        ((2, 2), (False, False, False)),
-        (jnp.array([2, 2]), jnp.array([False, False, False])),
-    ],
-)
-def test_isupport_structure_accepts_sequence_inputs(
-    pcs_segment_counts, rigid_connector_selector
-):
-    params = make_isupport_params(num_segments=2).replace(
-        pcs_segment_lengths=jnp.array([0.04, 0.06, 0.025, 0.075])
-    )
-    structure = ISupportStructure(
-        num_gauss_points=1,
-        pcs_segment_counts=pcs_segment_counts,
-        rigid_connector_selector=rigid_connector_selector,
-    )
-    robot = ISupport(params=params, structure=structure)
-
-    assert robot.structure.pcs_segment_counts == (2, 2)
-    assert robot.structure.rigid_connector_selector == (False, False, False)
-    assert robot.num_pneumatic_segments == 2
-    assert robot.num_pcs_segments == 4
-    assert jnp.allclose(robot.L, jnp.array([0.04, 0.06, 0.025, 0.075]))
-    assert jnp.allclose(
-        robot.pcs_segment_to_pneumatic_segment,
-        jnp.array([0, 0, 1, 1], dtype=jnp.int32),
+def make_mixed_isupport_params():
+    angles = 2.0 * jnp.pi * jnp.arange(3) / 3
+    return make_isupport_params(num_segments=5).replace(
+        length=jnp.array([0.01, 0.10, 0.02, 0.20, 0.03]),
+        radius=jnp.array([0.011, 0.020, 0.012, 0.025, 0.013]),
+        density=jnp.array([1200.0, 1000.0, 1300.0, 1050.0, 1400.0]),
+        young_modulus=jnp.array([2e9, 2e3, 2e9, 3e3, 2e9]),
+        shear_modulus=jnp.array([8e8, 1e3, 8e8, 1.5e3, 8e8]),
+        damping_matrix=1e-3 * jnp.eye(30),
+        chamber_inner_radius=jnp.array([0.002, 0.003]),
+        chamber_outer_radius=jnp.array([0.004, 0.005]),
+        chamber_distance=jnp.array([0.01, 0.015]),
+        chamber_azimuth_angles=jnp.stack([angles, 0.2 + angles]),
+        pcs_segment_lengths=jnp.array([0.04, 0.06, 0.20]),
     )
 
 
-def test_isupport_structure_accepts_scalar_topology_inputs():
-    params = make_isupport_params(num_segments=2).replace(
-        pcs_segment_lengths=jnp.array([0.05, 0.05, 0.05, 0.05])
-    )
-    robot = ISupport(
-        params=params,
-        structure=ISupportStructure(
-            num_gauss_points=1,
-            pcs_segment_counts=2,
-            rigid_connector_selector=False,
+@pytest.mark.parametrize("num_segments", [4, 5])
+def test_isupport_defaults_to_alternating_physical_segment_types(num_segments):
+    params = make_isupport_params(num_segments=num_segments).replace(
+        chamber_inner_radius=jnp.array([0.002, 0.003]),
+        chamber_outer_radius=jnp.array([0.004, 0.005]),
+        chamber_distance=jnp.array([0.01, 0.015]),
+        chamber_azimuth_angles=jnp.tile(
+            2.0 * jnp.pi * jnp.arange(3)[None, :] / 3, (2, 1)
         ),
     )
+    robot = ISupport(params, structure=ISupportStructure(num_gauss_points=1))
 
-    assert robot.structure.pcs_segment_counts == (2, 2)
-    assert robot.structure.rigid_connector_selector == (False, False, False)
-    assert jnp.allclose(robot.L, jnp.array([0.05, 0.05, 0.05, 0.05]))
-
-
-def test_isupport_structure_validates_split_sums_and_connector_count():
-    params = make_isupport_params(num_segments=2)
-
-    with pytest.raises(ValueError, match="sum"):
-        ISupport(
-            params=params.replace(pcs_segment_lengths=jnp.array([0.04, 0.05, 0.1])),
-            structure=ISupportStructure(
-                num_gauss_points=1,
-                pcs_segment_counts=(2, 1),
-            ),
-        )
-
-    with pytest.raises(ValueError, match="pcs_segment_counts"):
-        ISupport(
-            params=params,
-            structure=ISupportStructure(
-                num_gauss_points=1,
-                pcs_segment_counts=(2, 2, 1),
-            ),
-        )
-
-    with pytest.raises(ValueError, match="rigid_connector_selector"):
-        ISupport(
-            params=params,
-            structure=ISupportStructure(
-                num_gauss_points=1,
-                rigid_connector_selector=[False, False],
-            ),
-        )
-
-    with pytest.raises(ValueError, match="unselected connector"):
-        ISupport(
-            params=params.replace(rigid_connector_lengths=jnp.array([0.01, 0.0, 0.0])),
-            structure=ISupportStructure(num_gauss_points=1),
-        )
-
-    with pytest.raises(ValueError, match="Selected rigid connectors"):
-        ISupport(
-            params=params,
-            structure=ISupportStructure(
-                num_gauss_points=1,
-                rigid_connector_selector=[True, False, False],
-            ),
-        )
-
-
-def test_isupport_rigid_connectors_expand_in_documented_sequence():
-    params = make_isupport_params(num_segments=2).replace(
-        length=jnp.array([0.1, 0.2]),
-        pcs_segment_lengths=jnp.array([0.04, 0.06, 0.2]),
-        rigid_connector_lengths=jnp.array([0.01, 0.02, 0.03]),
+    assert robot.structure.rigid_segment_selector == tuple(
+        i % 2 == 0 for i in range(num_segments)
     )
+    assert robot.num_pneumatic_segments == 2
+
+
+def test_isupport_expands_arbitrary_physical_layout_and_pneumatic_subdivision():
+    params = make_mixed_isupport_params()
     robot = ISupport(
-        params=params,
+        params,
         structure=ISupportStructure(
             num_gauss_points=1,
             pcs_segment_counts=(2, 1),
-            rigid_connector_selector=(True, True, True),
+            rigid_segment_selector=(True, False, True, False, True),
         ),
     )
 
     assert jnp.allclose(robot.L, jnp.array([0.01, 0.04, 0.06, 0.02, 0.2, 0.03]))
+    assert jnp.allclose(robot.r, jnp.array([0.011, 0.020, 0.020, 0.012, 0.025, 0.013]))
     assert jnp.allclose(
-        robot.pcs_segment_to_pneumatic_segment,
-        jnp.array([-1, 0, 0, -1, 1, -1], dtype=jnp.int32),
+        robot.rho, jnp.array([1200.0, 1000.0, 1000.0, 1300.0, 1050.0, 1400.0])
     )
-    assert jnp.allclose(
+    assert jnp.array_equal(
+        robot.pcs_segment_to_pneumatic_segment, jnp.array([-1, 0, 0, -1, 1, -1])
+    )
+    assert jnp.array_equal(
         robot.pcs_segment_is_rigid,
-        jnp.array([True, False, False, True, False, True], dtype=bool),
+        jnp.array([True, False, False, True, False, True]),
     )
     assert robot.num_dofs == 18
 
-    xi_ref = robot.xi_ref.reshape(robot.num_pcs_segments, 6)
-    straight = jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
-    assert jnp.allclose(xi_ref[0], straight)
-    assert jnp.allclose(xi_ref[3], straight)
-    assert jnp.allclose(xi_ref[5], straight)
 
-
-def test_isupport_actuation_groups_pressures_by_pneumatic_segment_after_split():
-    params = make_isupport_params(num_segments=2).replace(
-        length=jnp.array([0.1, 0.2]),
+def test_isupport_supports_adjacent_and_endpoint_pneumatic_segments():
+    params = make_isupport_params(num_segments=4).replace(
         chamber_inner_radius=jnp.array([0.002, 0.003]),
+        chamber_outer_radius=jnp.array([0.004, 0.005]),
         chamber_distance=jnp.array([0.01, 0.015]),
-        chamber_azimuth_angles=jnp.stack(
-            [2 * jnp.pi * jnp.arange(3) / 3, 0.2 + 2 * jnp.pi * jnp.arange(3) / 3]
+        chamber_azimuth_angles=jnp.tile(
+            2.0 * jnp.pi * jnp.arange(3)[None, :] / 3, (2, 1)
         ),
-        pcs_segment_lengths=jnp.array([0.04, 0.06, 0.2]),
-        rigid_connector_lengths=jnp.array([0.01, 0.02, 0.03]),
     )
     robot = ISupport(
-        params=params,
+        params,
         structure=ISupportStructure(
             num_gauss_points=1,
-            pcs_segment_counts=(2, 1),
-            rigid_connector_selector=(True, True, True),
+            rigid_segment_selector=(False, True, True, False),
         ),
     )
 
+    assert jnp.array_equal(
+        robot.pcs_segment_to_pneumatic_segment, jnp.array([0, -1, -1, 1])
+    )
+    assert robot.num_dofs == 12
+
+
+def test_isupport_rigid_geometry_uses_filled_cylinders():
+    robot = ISupport(
+        make_mixed_isupport_params(),
+        structure=ISupportStructure(
+            num_gauss_points=1,
+            pcs_segment_counts=(2, 1),
+            rigid_segment_selector=(True, False, True, False, True),
+        ),
+    )
+    radius = robot.r[0]
+    assert jnp.allclose(
+        robot._local_cross_sectional_area(jnp.array(0)), jnp.pi * radius**2
+    )
+    assert jnp.allclose(
+        robot._local_second_moment_of_area(jnp.array(0)),
+        jnp.array(
+            [jnp.pi * radius**4 / 2, jnp.pi * radius**4 / 4, jnp.pi * radius**4 / 4]
+        ),
+    )
+    expected_pneumatic_area = 3 * jnp.pi * (0.004**2 - 0.002**2)
+    assert jnp.allclose(
+        robot._local_cross_sectional_area(jnp.array(1)), expected_pneumatic_area
+    )
+
+
+def test_isupport_preserves_rigid_material_damping_properties():
+    params = make_mixed_isupport_params().replace(
+        damping_matrix=None,
+        material_damping_coefficient=jnp.array([10.0, 20.0, 30.0, 40.0, 50.0]),
+    )
+    robot = ISupport(
+        params,
+        structure=ISupportStructure(
+            num_gauss_points=1,
+            pcs_segment_counts=(2, 1),
+            rigid_segment_selector=(True, False, True, False, True),
+        ),
+    )
+
+    assert jnp.allclose(
+        robot.pcs_params.material_damping_coefficient,
+        jnp.array([10.0, 20.0, 20.0, 30.0, 40.0, 50.0]),
+    )
+    rigid_area = jnp.pi * params.radius[0] ** 2
+    expected_axial_damping = params.length[0] * 10.0 * 3.0 * rigid_area
+    assert jnp.allclose(robot.D_full[3, 3], expected_axial_damping)
+    assert jnp.allclose(robot.D_active, robot.B_xi.T @ robot.D_full @ robot.B_xi)
+
+
+def test_isupport_actuation_groups_pressures_after_generalized_expansion():
+    params = make_mixed_isupport_params()
+    robot = ISupport(
+        params,
+        structure=ISupportStructure(
+            num_gauss_points=1,
+            pcs_segment_counts=(2, 1),
+            rigid_segment_selector=(True, False, True, False, True),
+        ),
+    )
     actuation_matrix = robot.actuation_matrix(jnp.zeros((robot.num_dofs,)))
     num_chambers = robot.num_chambers_per_segment
-    expected_segment_0 = expected_isupport_segment_actuation(params, 0, num_chambers)
-    expected_segment_1 = expected_isupport_segment_actuation(params, 1, num_chambers)
-
-    assert robot.num_actuators == 2 * num_chambers
-    assert actuation_matrix.shape == (18, robot.num_actuators)
-    assert jnp.allclose(actuation_matrix[:6, :num_chambers], expected_segment_0)
-    assert jnp.allclose(actuation_matrix[6:12, :num_chambers], expected_segment_0)
-    assert jnp.allclose(actuation_matrix[12:, num_chambers:], expected_segment_1)
-    assert jnp.allclose(actuation_matrix[:12, num_chambers:], 0.0)
-    assert jnp.allclose(actuation_matrix[12:, :num_chambers], 0.0)
-
-
-def test_isupport_update_params_and_validation():
-    params = make_isupport_params()
-    robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
-
-    updated_angles = 0.25 + 2 * jnp.pi * jnp.arange(3)[None, :] / 3
-    updated = robot.update_params(chamber_azimuth_angles=updated_angles)
-    assert jnp.allclose(updated.chamber_azimuth_angles, updated_angles)
-    assert jnp.allclose(robot.chamber_azimuth_angles, params.chamber_azimuth_angles)
-
-    with pytest.raises(ValueError, match="chamber_inner_radius"):
-        robot.update_params(chamber_inner_radius=jnp.array([0.001, 0.002]))
-
-    split_params = make_isupport_params(num_segments=2).replace(
-        length=jnp.array([0.1, 0.2]),
-        pcs_segment_lengths=jnp.array([0.04, 0.06, 0.2]),
-        rigid_connector_lengths=jnp.array([0.01, 0.02, 0.03]),
-    )
-    split_robot = ISupport(
-        params=split_params,
-        structure=ISupportStructure(
-            num_gauss_points=1,
-            pcs_segment_counts=(2, 1),
-            rigid_connector_selector=(True, True, True),
-        ),
-    )
-
-    updated_split = split_robot.update_params(
-        length=jnp.array([0.12, 0.2]),
-        pcs_segment_lengths=jnp.array([0.05, 0.07, 0.2]),
-        rigid_connector_lengths=jnp.array([0.015, 0.025, 0.035]),
-    )
-
-    assert updated_split.structure.pcs_segment_counts == (2, 1)
-    assert updated_split.structure.rigid_connector_selector == (True, True, True)
+    assert actuation_matrix.shape == (18, 2 * num_chambers)
     assert jnp.allclose(
-        updated_split.L,
-        jnp.array([0.015, 0.05, 0.07, 0.025, 0.2, 0.035]),
+        actuation_matrix[:6, :num_chambers],
+        expected_isupport_segment_actuation(params, 0, num_chambers),
+    )
+    assert jnp.allclose(
+        actuation_matrix[6:12, :num_chambers], actuation_matrix[:6, :num_chambers]
+    )
+    assert jnp.allclose(
+        actuation_matrix[12:, num_chambers:],
+        expected_isupport_segment_actuation(params, 1, num_chambers),
+    )
+
+
+def test_isupport_layout_validation_and_updates():
+    params = make_mixed_isupport_params()
+    structure = ISupportStructure(
+        num_gauss_points=1,
+        pcs_segment_counts=(2, 1),
+        rigid_segment_selector=(True, False, True, False, True),
+    )
+    robot = ISupport(params, structure=structure)
+
+    with pytest.raises(TypeError, match="boolean sequence"):
+        ISupportStructure(rigid_segment_selector=False)
+    with pytest.raises(ValueError, match="one entry per physical segment"):
+        ISupport(params, structure=ISupportStructure(rigid_segment_selector=(False,)))
+    with pytest.raises(ValueError, match="at least one pneumatic"):
+        ISupport(
+            params, structure=ISupportStructure(rigid_segment_selector=(True,) * 5)
+        )
+    with pytest.raises(ValueError, match="one entry per pneumatic segment"):
+        ISupport(
+            params,
+            structure=ISupportStructure(rigid_segment_selector=(False,) * 5),
+        )
+    with pytest.raises(ValueError, match="sum"):
+        ISupport(
+            params.replace(pcs_segment_lengths=jnp.array([0.03, 0.06, 0.20])),
+            structure=structure,
+        )
+    bad_reference = params.reference_strain.at[0].set(0.1)
+    with pytest.raises(ValueError, match="Rigid segment reference_strain"):
+        ISupport(params.replace(reference_strain=bad_reference), structure=structure)
+
+    updated = robot.update_params(
+        length=jnp.array([0.015, 0.12, 0.025, 0.20, 0.035]),
+        pcs_segment_lengths=jnp.array([0.05, 0.07, 0.20]),
+        radius=jnp.array([0.015, 0.020, 0.016, 0.025, 0.017]),
+    )
+    assert updated.structure.rigid_segment_selector == structure.rigid_segment_selector
+    assert jnp.allclose(updated.L, jnp.array([0.015, 0.05, 0.07, 0.025, 0.20, 0.035]))
+    assert jnp.allclose(
+        updated.r[jnp.array([0, 3, 5])], jnp.array([0.015, 0.016, 0.017])
     )

--- a/tests/systems/test_system_lengths.py
+++ b/tests/systems/test_system_lengths.py
@@ -181,7 +181,12 @@ def _isupport_robot():
             2 * jnp.pi * jnp.arange(3, dtype=jnp.float64) / 3, (2, 1)
         ),
     )
-    return ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
+    return ISupport(
+        params=params,
+        structure=ISupportStructure(
+            num_gauss_points=1, rigid_segment_selector=(False, False)
+        ),
+    )
 
 
 def _planar_hsa_robot():

--- a/tests/systems/test_typed_params_api.py
+++ b/tests/systems/test_typed_params_api.py
@@ -517,7 +517,12 @@ def test_isupport_inherits_material_damping_path():
             None, :
         ],
     )
-    robot = ISupport(params=params, structure=ISupportStructure(num_gauss_points=1))
+    robot = ISupport(
+        params=params,
+        structure=ISupportStructure(
+            num_gauss_points=1, rigid_segment_selector=(False,)
+        ),
+    )
 
     I_i = robot._local_second_moment_of_area(jnp.array(0))
     A_i = robot._local_cross_sectional_area(jnp.array(0))


### PR DESCRIPTION
## Motivation

The I-SUPPORT model previously treated rigid interfaces as optional slots around a sequence of pneumatic segments. That representation assumed a fixed connector/pneumatic alternation, prevented adjacent segments of the same type, and forced rigid lengths into a separate `rigid_connector_lengths` field. It also meant that rigid radius, density, material fields, geometry, and rendering were not consistently described by the model's ordinary per-segment parameters.

This PR makes the physical robot layout explicit. Every modeled segment now occupies one entry in the standard PCS body arrays, while pneumatic-only chamber and subdivision data remain indexed by pneumatic segment order.

## What changed

- Replace `rigid_connector_selector` with `rigid_segment_selector`.
  - It contains one boolean per physical segment.
  - `True` means rigid and `False` means pneumatic.
  - When omitted, the selector defaults to `[rigid, pneumatic, rigid, pneumatic, ...]`.
  - Arbitrary layouts are supported, including adjacent rigid or pneumatic segments and layouts beginning or ending with either type.
- Remove `rigid_connector_lengths` and the canonical connector-slot abstraction.
- Index `length`, `radius`, `density`, elastic moduli, material damping, reference strain, and custom damping matrices by physical segment.
- Keep chamber geometry, `pcs_segment_counts`, pressure inputs, and subdivision groups indexed only by pneumatic segments in their order of appearance.
- Validate selector dimensions, body and chamber array shapes, at least one pneumatic segment, subdivision sums, and straight rigid reference strains.
- Expand pneumatic physical segments into their child PCS segments while preserving explicitly supplied rigid properties and pressure-group ordering.
- Use filled-cylinder geometry for rigid segments:
  - `A = pi r^2`
  - `Ixx = pi r^4 / 2`
  - `Iyy = Izz = pi r^4 / 4`
- Continue using the actuator-annulus and parallel-axis geometry for pneumatic segments.
- Update the specialized Viser renderer to traverse the generalized physical layout and render every rigid segment with its own modeled radius, including the final rigid segment.
- Update the simulation example with physical-layout arrays and values recovered from the compiled reference model: 1210 kg/m^3 for rigid interfaces and 1104 kg/m^3 for pneumatic segments.
- Standardize documentation and comments on the term “pneumatic segment”.

## New interface

All standard PCS body fields describe physical segments in base-to-tip order:

```python
import jax.numpy as jnp

from soromox.systems import ISupport, ISupportParams, ISupportStructure

# Physical layout:
# rigid base -> pneumatic -> rigid interface -> pneumatic -> rigid tip
rigid_segment_selector = (True, False, True, False, True)

params = ISupportParams(
    length=jnp.array([0.041, 0.190, 0.027, 0.180, 0.006]),
    radius=jnp.array([0.030, 0.030, 0.030, 0.030, 0.030]),
    density=jnp.array([1210.0, 1104.0, 1210.0, 1104.0, 1210.0]),
    young_modulus=jnp.array([1.6464e6] * 5),
    shear_modulus=jnp.array([0.5488e6] * 5),
    material_damping_coefficient=jnp.array([1.96e3] * 5),
    reference_strain=jnp.tile(
        jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]), 5
    ),
    # Pneumatic-segment order only: the first and second False entries above.
    chamber_inner_radius=jnp.array([6.39e-3, 6.39e-3]),
    chamber_outer_radius=jnp.array([7.79e-3, 7.79e-3]),
    chamber_distance=jnp.array([20e-3, 20e-3]),
    chamber_azimuth_angles=jnp.tile(
        2.0 * jnp.pi * jnp.arange(3) / 3, (2, 1)
    ),
    # Flattened child lengths, grouped by pneumatic segment.
    pcs_segment_lengths=jnp.array([0.095, 0.095, 0.060, 0.060, 0.060]),
)

robot = ISupport(
    params,
    structure=ISupportStructure(
        rigid_segment_selector=rigid_segment_selector,
        pcs_segment_counts=(2, 3),
    ),
)
```

A non-alternating layout uses the same API:

```python
# pneumatic -> pneumatic -> rigid -> rigid -> pneumatic
structure = ISupportStructure(
    rigid_segment_selector=(False, False, True, True, False),
    pcs_segment_counts=(1, 2, 1),
)
```

If `rigid_segment_selector` is omitted, a five-segment parameter set derives `(True, False, True, False, True)`; a four-segment set derives `(True, False, True, False)`.

## Migration guide

This is intentionally a breaking change with no compatibility aliases.

1. Merge the old pneumatic lengths and `rigid_connector_lengths` into one physical-order `length` array.
2. Replace `rigid_connector_selector` with a same-length `rigid_segment_selector`.
3. Expand every standard body field from pneumatic-only entries to one value per physical segment:
   - `radius`
   - `density`
   - `young_modulus`
   - `shear_modulus`
   - material damping
   - `reference_strain`
4. Expand `reference_strain` to `6 * num_physical_segments` entries. Rigid segments must use `[0, 0, 0, 1, 0, 0]`.
5. If supplying a custom `damping_matrix`, migrate it to physical-segment strain coordinates with shape `(6N, 6N)`.
6. Leave chamber arrays, `pcs_segment_counts`, pressure vectors, and `pcs_segment_lengths` grouped by pneumatic segments only, in the order of the `False` selector entries.
7. Reconstruct `ISupport` when segment types change; the selector is structural/static.

Before:

```python
params = ISupportParams(
    length=jnp.array([0.190, 0.180]),          # pneumatic only
    radius=jnp.array([0.030, 0.030]),
    density=jnp.array([1104.0, 1104.0]),
    rigid_connector_lengths=jnp.array([0.041, 0.027, 0.006]),
    # ...
)
structure = ISupportStructure(
    rigid_connector_selector=(True, True, True),
    pcs_segment_counts=(2, 3),
)
```

After:

```python
params = ISupportParams(
    length=jnp.array([0.041, 0.190, 0.027, 0.180, 0.006]),
    radius=jnp.array([0.030, 0.030, 0.030, 0.030, 0.030]),
    density=jnp.array([1210.0, 1104.0, 1210.0, 1104.0, 1210.0]),
    # Supply all other standard body fields in the same physical order.
    # Chamber and subdivision fields still have two pneumatic groups.
    # ...
)
structure = ISupportStructure(
    rigid_segment_selector=(True, False, True, False, True),
    pcs_segment_counts=(2, 3),
)
```

## Validation

- Full test suite: 1093 passed.
- Post-parameter-update targeted I-SUPPORT system, length, and renderer tests: 45 passed.
- Ruff formatting and lint checks pass for the updated simulation example.
