### PR TITLE
Add I-SUPPORT chamber pressure visualization

### DIFF
--- a/docs/api/systems/pcs/isupport.md
+++ b/docs/api/systems/pcs/isupport.md
@@ -34,6 +34,42 @@ ellipticity, bellows pitch and amplitude, mesh resolution, colors, and spacer
 opacity. When an `ISupport` topology omits a rigid connector, the renderer adds
 a thin visual-only interface plate without changing the robot kinematics.
 
+Pass chamber pressures in pascals to color each chamber with the sequential
+Matplotlib `Blues` colormap. The default scale spans 0–300 kPa and omits the
+palest 15% of the colormap so unpressurized chambers remain visible. Values
+outside the configured scale are clamped. Pressure channels use segment-major
+order: all chamber azimuth indices of the first pneumatic segment, followed by
+those of the second segment, and so on.
+
+The `pressure_range` configuration is expressed in pascals, matching the
+model and pressure input API. Conversion to kPa happens only for sidebar and
+label presentation.
+
+```python
+pressures = jnp.array([2.0e4, 0.0, 0.0])
+renderer.show(q, pressures=pressures)
+```
+
+Interactive views color the chambers whenever pressures are supplied. Pressure
+text starts hidden and can be enabled with the **Show pressure labels** sidebar
+checkbox. Labels use one-based model terminology and display values in kPa, for
+example `Segment 1 · Chamber 1` and `20.0 kPa`. A captured frame has no
+interactive sidebar, so `render_frame(q, pressures=pressures)` includes both
+the colors and labels automatically. Omitting `pressures` retains the original
+uniform chamber appearance and renders no pressure text.
+
+For trajectories, `pressures` may be a constant `(num_actuators,)` vector, a
+`(T, num_actuators)` time series, or a batched
+`(N, T, num_actuators)` time series:
+
+```python
+renderer.render_sequence(ts, q_ts, pressures=pressure_ts)
+```
+
+The live controller accepts synchronized updates through
+`push_state_with_pressures(q, pressures)`, a separate `pressure_callback`, or a
+state callback that returns `(q, pressures)`.
+
 ## Model Quick Start
 
 ```python

--- a/docs/api/systems/pcs/isupport.md
+++ b/docs/api/systems/pcs/isupport.md
@@ -36,7 +36,8 @@ a thin visual-only interface plate without changing the robot kinematics.
 
 Pass chamber pressures in pascals to color each chamber with the sequential
 Matplotlib `Blues` colormap. The default scale spans 0–300 kPa and omits the
-palest 15% of the colormap so unpressurized chambers remain visible. Values
+palest 50% of the colormap so unpressurized chambers remain visibly distinct
+from the white scene background. Values
 outside the configured scale are clamped. Pressure channels use segment-major
 order: all chamber azimuth indices of the first pneumatic segment, followed by
 those of the second segment, and so on.

--- a/docs/api/systems/pcs/isupport.md
+++ b/docs/api/systems/pcs/isupport.md
@@ -36,8 +36,7 @@ a thin visual-only interface plate without changing the robot kinematics.
 
 Pass chamber pressures in pascals to color each chamber with the sequential
 Matplotlib `Blues` colormap. The default scale spans 0–300 kPa and omits the
-palest 50% of the colormap so unpressurized chambers remain visibly distinct
-from the white scene background. Values
+palest 15% of the colormap so unpressurized chambers remain visible. Values
 outside the configured scale are clamped. Pressure channels use segment-major
 order: all chamber azimuth indices of the first pneumatic segment, followed by
 those of the second segment, and so on.

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -13,7 +13,11 @@ import jax.numpy as jnp
 import matplotlib.pyplot as plt
 
 jax.config.update("jax_enable_x64", True)  # double precision
-from soromox.rendering import ISupportViserRenderer, MatplotlibRenderer
+from soromox.rendering import (
+    ISupportViserRenderer,
+    ISupportVisualConfig,
+    MatplotlibRenderer,
+)
 from soromox.systems import ISupport, ISupportParams, ISupportStructure, SystemState
 
 if __name__ == "__main__":
@@ -204,10 +208,12 @@ if __name__ == "__main__":
         viser_renderer = ISupportViserRenderer(
             robot,
             num_points=50,
+            visual_config=ISupportVisualConfig(pressure_range=(0.0, float(jnp.max(u)))),
         )
         viser_renderer.render_sequence(
             ts=ts,
             q_ts=q_ts,
+            pressures=u,
             playback_speed=1.0,
             autoplay=True,
             loop=True,

--- a/src/soromox/rendering/isupport/viser_renderer.py
+++ b/src/soromox/rendering/isupport/viser_renderer.py
@@ -49,7 +49,7 @@ class ISupportVisualConfig:
     spacer_opacity: float = 0.35
     pressure_colormap: str = "Blues"
     pressure_range: tuple[float, float] = (0.0, 3.0e5)
-    pressure_colormap_start: float = 0.50
+    pressure_colormap_start: float = 0.15
     pressure_label_offset: float = 0.012
 
     def __post_init__(self) -> None:
@@ -176,6 +176,7 @@ class ISupportViserRenderer(ViserRenderer):
         self._pressure_frame_idx = 0
         self._show_pressure_labels = False
         self._force_pressure_labels = False
+        self._current_world_poses: np.ndarray | None = None
         self._robot_visual_handles: list[_ISupportRobotHandles] = []
         (
             self._pneumatic_specs,
@@ -514,7 +515,11 @@ class ISupportViserRenderer(ViserRenderer):
         robot_idx: int,
         poses: np.ndarray,
     ) -> list[Any]:
-        if self._server is None or self._current_pressures is None:
+        if (
+            self._server is None
+            or self._current_pressures is None
+            or not (self._force_pressure_labels or self._show_pressure_labels)
+        ):
             return []
         labels: list[Any] = []
         for spec in self._pneumatic_specs:
@@ -551,7 +556,8 @@ class ISupportViserRenderer(ViserRenderer):
                     handle.visible = False
                 continue
 
-            if not robot_handles.pressure_label_handles:
+            labels_enabled = self._force_pressure_labels or self._show_pressure_labels
+            if labels_enabled and not robot_handles.pressure_label_handles:
                 robot_handles.pressure_label_handles = self._add_pressure_labels(
                     robot_idx, poses
                 )
@@ -563,29 +569,43 @@ class ISupportViserRenderer(ViserRenderer):
                     pressure = float(pressures[flat_chamber_idx])
                     chamber_handle = robot_handles.chamber_handles[flat_chamber_idx]
                     chamber_handle.color = self._pressure_color(pressure)
-                    label_handle = robot_handles.pressure_label_handles[
-                        flat_chamber_idx
-                    ]
-                    value_text = (
-                        f"{pressure / 1.0e3:.1f} kPa" if np.isfinite(pressure) else "--"
-                    )
-                    label_handle.text = (
-                        f"Segment {spec.pneumatic_idx + 1} · "
-                        f"Chamber {chamber_idx + 1}\n{value_text}"
-                    )
-                    label_handle.position = self._pressure_label_position(
-                        poses, spec, chamber_idx
-                    )
-                    label_handle.visible = (
-                        self._force_pressure_labels or self._show_pressure_labels
-                    )
+                    if labels_enabled:
+                        label_handle = robot_handles.pressure_label_handles[
+                            flat_chamber_idx
+                        ]
+                        value_text = (
+                            f"{pressure / 1.0e3:.1f} kPa"
+                            if np.isfinite(pressure)
+                            else "--"
+                        )
+                        label_handle.text = (
+                            f"Segment {spec.pneumatic_idx + 1} · "
+                            f"Chamber {chamber_idx + 1}\n{value_text}"
+                        )
+                        label_handle.position = self._pressure_label_position(
+                            poses, spec, chamber_idx
+                        )
+                        label_handle.visible = True
                     flat_chamber_idx += 1
+
+    def _remove_pressure_labels(self) -> None:
+        for robot_handles in self._robot_visual_handles:
+            for handle in robot_handles.pressure_label_handles:
+                if hasattr(handle, "remove"):
+                    handle.remove()
+            robot_handles.pressure_label_handles = []
 
     def _set_pressure_labels_visible(self, visible: bool) -> None:
         self._show_pressure_labels = bool(visible)
-        for robot_handles in self._robot_visual_handles:
-            for handle in robot_handles.pressure_label_handles:
-                handle.visible = self._show_pressure_labels
+        if not self._show_pressure_labels:
+            self._remove_pressure_labels()
+            return
+        if self._current_pressures is None or self._current_world_poses is None:
+            return
+        if self._server is None:
+            return
+        with self._server.atomic():
+            self._apply_pressure_visuals(self._current_world_poses)
 
     def _pressure_colorbar_image(self) -> np.ndarray:
         cfg = self.visual_config
@@ -726,10 +746,7 @@ class ISupportViserRenderer(ViserRenderer):
     def _remove_robot_geometry(self) -> None:
         if self._scene_handles is None:
             return
-        for robot_handles in self._robot_visual_handles:
-            for handle in robot_handles.pressure_label_handles:
-                if hasattr(handle, "remove"):
-                    handle.remove()
+        self._remove_pressure_labels()
         for robot_handles in self._scene_handles.backbone_points:
             for handle in robot_handles:
                 if hasattr(handle, "remove"):
@@ -766,6 +783,7 @@ class ISupportViserRenderer(ViserRenderer):
         self._remove_robot_geometry()
         q = self._as_batch(self._current_geometry_q)
         world_poses = self._sample_world_poses(q, curves)
+        self._current_world_poses = world_poses
         cfg = self.visual_config
 
         for robot_idx in range(q.shape[0]):
@@ -858,6 +876,7 @@ class ISupportViserRenderer(ViserRenderer):
 
         q = self._as_batch(self._current_geometry_q)
         world_poses = self._sample_world_poses(q, curves)
+        self._current_world_poses = world_poses
         with self._server.atomic():
             for robot_idx, robot_handles in enumerate(self._robot_visual_handles):
                 poses = world_poses[robot_idx]

--- a/src/soromox/rendering/isupport/viser_renderer.py
+++ b/src/soromox/rendering/isupport/viser_renderer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -10,6 +11,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
+from matplotlib import colormaps
 
 from soromox.rendering.color_config import validate_rgb
 from soromox.rendering.viser_renderer import (
@@ -40,6 +42,10 @@ class ISupportVisualConfig:
     spacer_thickness: float = 0.0015
     spacer_color: tuple[float, float, float] = (0.72, 0.82, 0.88)
     spacer_opacity: float = 0.35
+    pressure_colormap: str = "Blues"
+    pressure_range: tuple[float, float] = (0.0, 3.0e5)
+    pressure_colormap_start: float = 0.15
+    pressure_label_offset: float = 0.012
 
     def __post_init__(self) -> None:
         positive_fields = (
@@ -68,6 +74,26 @@ class ISupportVisualConfig:
             0.0 <= self.spacer_opacity <= 1.0
         ):
             raise ValueError("spacer_opacity must be finite and in [0, 1].")
+        pressure_range = np.asarray(self.pressure_range, dtype=np.float64)
+        if pressure_range.shape != (2,) or not np.all(np.isfinite(pressure_range)):
+            raise ValueError("pressure_range must contain two finite values.")
+        if pressure_range[1] <= pressure_range[0]:
+            raise ValueError("pressure_range maximum must exceed its minimum.")
+        if not np.isfinite(self.pressure_colormap_start) or not (
+            0.0 <= self.pressure_colormap_start < 1.0
+        ):
+            raise ValueError("pressure_colormap_start must be finite and in [0, 1).")
+        if (
+            not np.isfinite(self.pressure_label_offset)
+            or self.pressure_label_offset < 0
+        ):
+            raise ValueError("pressure_label_offset must be finite and nonnegative.")
+        try:
+            colormaps.get_cmap(self.pressure_colormap)
+        except ValueError as exc:
+            raise ValueError(
+                f"Unknown Matplotlib colormap {self.pressure_colormap!r}."
+            ) from exc
         validate_rgb(self.interface_color, name="interface_color")
         validate_rgb(self.chamber_color, name="chamber_color")
         validate_rgb(self.spacer_color, name="spacer_color")
@@ -97,6 +123,7 @@ class _ISupportRobotHandles:
     chamber_handles: list[Any]
     interface_handles: list[Any]
     spacer_handles: list[Any]
+    pressure_label_handles: list[Any]
 
 
 def _tube_faces(num_rings: int, sections: int) -> np.ndarray:
@@ -139,6 +166,11 @@ class ISupportViserRenderer(ViserRenderer):
         super().__init__(robot, *args, **kwargs)
         self.visual_config = resolved_visual_config
         self._current_geometry_q: Array | None = None
+        self._current_pressures: np.ndarray | None = None
+        self._pressure_ts: np.ndarray | None = None
+        self._pressure_frame_idx = 0
+        self._show_pressure_labels = False
+        self._force_pressure_labels = False
         self._robot_visual_handles: list[_ISupportRobotHandles] = []
         (
             self._pneumatic_specs,
@@ -152,8 +184,69 @@ class ISupportViserRenderer(ViserRenderer):
         return q_array[None, :] if q_array.ndim == 1 else q_array
 
     @staticmethod
-    def _color_tuple(color: tuple[float, float, float]) -> tuple[int, int, int]:
+    def _color_tuple(
+        color: tuple[float, float, float] | np.ndarray,
+    ) -> tuple[int, int, int]:
         return tuple(np.asarray(np.clip(color, 0.0, 1.0) * 255.0, dtype=np.uint8))
+
+    def _pressure_color(self, pressure_pa: float) -> tuple[int, int, int]:
+        if not np.isfinite(pressure_pa):
+            return (145, 145, 145)
+        pressure_min, pressure_max = self.visual_config.pressure_range
+        normalized = np.clip(
+            (pressure_pa - pressure_min) / (pressure_max - pressure_min),
+            0.0,
+            1.0,
+        )
+        sample = (
+            self.visual_config.pressure_colormap_start
+            + (1.0 - self.visual_config.pressure_colormap_start) * normalized
+        )
+        rgb = np.asarray(
+            colormaps.get_cmap(self.visual_config.pressure_colormap)(float(sample))[:3]
+        )
+        return tuple(int(round(255.0 * component)) for component in rgb)
+
+    def _static_pressures(
+        self, pressures: Array | np.ndarray | None, *, num_robots: int
+    ) -> np.ndarray | None:
+        if pressures is None:
+            return None
+        values = np.asarray(pressures, dtype=np.float64)
+        expected = self.robot.num_actuators
+        if values.shape == (expected,):
+            return np.broadcast_to(values, (num_robots, expected)).copy()
+        if values.shape == (num_robots, expected):
+            return values.copy()
+        raise ValueError(
+            "pressures must have shape (num_actuators,) or "
+            f"(num_robots, num_actuators); got {values.shape}."
+        )
+
+    def _sequence_pressures(
+        self,
+        pressures: Array | np.ndarray | None,
+        *,
+        num_robots: int,
+        num_frames: int,
+    ) -> np.ndarray | None:
+        if pressures is None:
+            return None
+        values = np.asarray(pressures, dtype=np.float64)
+        expected = self.robot.num_actuators
+        if values.shape == (expected,):
+            return np.broadcast_to(values, (num_robots, num_frames, expected)).copy()
+        if values.shape == (num_frames, expected):
+            return np.broadcast_to(
+                values[None, ...], (num_robots, num_frames, expected)
+            ).copy()
+        if values.shape == (num_robots, num_frames, expected):
+            return values.copy()
+        raise ValueError(
+            "sequence pressures must have shape (num_actuators,), "
+            "(T, num_actuators), or (N, T, num_actuators); "
+            f"got {values.shape}."
+        )
 
     def _build_visual_layout(
         self,
@@ -391,38 +484,224 @@ class ISupportViserRenderer(ViserRenderer):
             cast_shadow=self._backbone_cast_shadow,
         )
 
-    def render_frame(self, q: Array, **kwargs) -> np.ndarray:
-        """Render and capture one I-SUPPORT configuration."""
+    def _pressure_label_position(
+        self,
+        poses: np.ndarray,
+        spec: _PneumaticVisualSpec,
+        chamber_idx: int,
+    ) -> np.ndarray:
+        ring_poses = poses[spec.ring_slice]
+        pose = ring_poses[len(ring_poses) // 2]
+        local_offset = np.asarray(
+            self.robot.local_chamber_offsets(spec.pneumatic_idx)[chamber_idx],
+            dtype=np.float64,
+        )
+        offset_norm = float(np.linalg.norm(local_offset))
+        radial_world = pose[:3, :3] @ (local_offset / offset_norm)
+        outer_radius = float(self.robot.params.chamber_outer_radius[spec.pneumatic_idx])
+        label_radius = (
+            offset_norm + outer_radius + self.visual_config.pressure_label_offset
+        )
+        return pose[:3, 3] + label_radius * radial_world
+
+    def _add_pressure_labels(
+        self,
+        robot_idx: int,
+        poses: np.ndarray,
+    ) -> list[Any]:
+        if self._server is None or self._current_pressures is None:
+            return []
+        labels: list[Any] = []
+        for spec in self._pneumatic_specs:
+            for chamber_idx in range(self.robot.num_chambers_per_segment):
+                labels.append(
+                    self._server.scene.add_label(
+                        name=(
+                            f"/robots/robot_{robot_idx}/isupport/pressure_labels/"
+                            f"segment_{spec.pneumatic_idx}/chamber_{chamber_idx}"
+                        ),
+                        text="",
+                        position=self._pressure_label_position(
+                            poses, spec, chamber_idx
+                        ),
+                        anchor="center-center",
+                        depth_test=False,
+                        font_screen_scale=0.8,
+                        visible=(
+                            self._force_pressure_labels or self._show_pressure_labels
+                        ),
+                    )
+                )
+        return labels
+
+    def _apply_pressure_visuals(self, world_poses: np.ndarray) -> None:
+        cfg = self.visual_config
+        for robot_idx, (robot_handles, poses) in enumerate(
+            zip(self._robot_visual_handles, world_poses, strict=True)
+        ):
+            if self._current_pressures is None:
+                for handle in robot_handles.chamber_handles:
+                    handle.color = self._color_tuple(cfg.chamber_color)
+                for handle in robot_handles.pressure_label_handles:
+                    handle.visible = False
+                continue
+
+            if not robot_handles.pressure_label_handles:
+                robot_handles.pressure_label_handles = self._add_pressure_labels(
+                    robot_idx, poses
+                )
+
+            pressures = self._current_pressures[robot_idx]
+            flat_chamber_idx = 0
+            for spec in self._pneumatic_specs:
+                for chamber_idx in range(self.robot.num_chambers_per_segment):
+                    pressure = float(pressures[flat_chamber_idx])
+                    chamber_handle = robot_handles.chamber_handles[flat_chamber_idx]
+                    chamber_handle.color = self._pressure_color(pressure)
+                    label_handle = robot_handles.pressure_label_handles[
+                        flat_chamber_idx
+                    ]
+                    value_text = (
+                        f"{pressure / 1.0e3:.1f} kPa" if np.isfinite(pressure) else "--"
+                    )
+                    label_handle.text = (
+                        f"Segment {spec.pneumatic_idx + 1} · "
+                        f"Chamber {chamber_idx + 1}\n{value_text}"
+                    )
+                    label_handle.position = self._pressure_label_position(
+                        poses, spec, chamber_idx
+                    )
+                    label_handle.visible = (
+                        self._force_pressure_labels or self._show_pressure_labels
+                    )
+                    flat_chamber_idx += 1
+
+    def _set_pressure_labels_visible(self, visible: bool) -> None:
+        self._show_pressure_labels = bool(visible)
+        for robot_handles in self._robot_visual_handles:
+            for handle in robot_handles.pressure_label_handles:
+                handle.visible = self._show_pressure_labels
+
+    def _setup_pressure_gui(self) -> None:
+        if self._server is None:
+            return
+        cfg = self.visual_config
+        existing = self._gui_handles.get("show_pressure_labels")
+        if existing is not None:
+            existing.value = self._show_pressure_labels
+            return
+        with self._server.gui.add_folder("I-SUPPORT"):
+            checkbox = self._server.gui.add_checkbox(
+                "Show pressure labels",
+                initial_value=self._show_pressure_labels,
+            )
+            self._gui_handles["show_pressure_labels"] = checkbox
+            self._server.gui.add_text(
+                "Pressure scale",
+                initial_value=(
+                    f"{cfg.pressure_range[0] / 1.0e3:g}–"
+                    f"{cfg.pressure_range[1] / 1.0e3:g} kPa · "
+                    f"{cfg.pressure_colormap}"
+                ),
+                disabled=True,
+            )
+
+        @checkbox.on_update
+        def _(event):
+            self._set_pressure_labels_visible(event.target.value)
+
+    def render_frame(
+        self,
+        q: Array,
+        *,
+        pressures: Array | np.ndarray | None = None,
+        **kwargs,
+    ) -> np.ndarray:
+        """Render one I-SUPPORT configuration, optionally with pressure labels."""
         self._current_geometry_q = self._as_batch(q)
+        self._current_pressures = self._static_pressures(
+            pressures, num_robots=int(self._current_geometry_q.shape[0])
+        )
+        self._pressure_ts = None
+        self._force_pressure_labels = pressures is not None
         return super().render_frame(q, **kwargs)
 
-    def show(self, q: Array, **kwargs) -> None:
-        """Display one I-SUPPORT configuration interactively."""
+    def show(
+        self,
+        q: Array,
+        *,
+        pressures: Array | np.ndarray | None = None,
+        **kwargs,
+    ) -> None:
+        """Display one I-SUPPORT configuration with optional chamber pressures."""
         self._current_geometry_q = self._as_batch(q)
+        self._current_pressures = self._static_pressures(
+            pressures, num_robots=int(self._current_geometry_q.shape[0])
+        )
+        self._pressure_ts = None
+        self._force_pressure_labels = False
+        self._set_pressure_labels_visible(False)
+        if self._server is None:
+            self.start()
+        self._setup_pressure_gui()
         super().show(q, **kwargs)
 
-    def render_sequence(self, ts: Array, q_ts: Array, **kwargs) -> None:
-        """Render an I-SUPPORT trajectory."""
+    def render_sequence(
+        self,
+        ts: Array,
+        q_ts: Array,
+        *,
+        pressures: Array | np.ndarray | None = None,
+        **kwargs,
+    ) -> None:
+        """Render an I-SUPPORT trajectory with optional chamber pressures."""
         q_array = jnp.asarray(q_ts)
         if q_array.ndim == 2:
             self._current_geometry_q = q_array[0][None, :]
+            num_robots, num_frames = 1, int(q_array.shape[0])
         elif q_array.ndim == 3:
             self._current_geometry_q = q_array[:, 0, :]
+            num_robots, num_frames = int(q_array.shape[0]), int(q_array.shape[1])
         else:
             raise ValueError(
                 f"q_ts must have shape (T, DOF) or (N, T, DOF), got {q_array.shape}."
             )
+        self._pressure_ts = self._sequence_pressures(
+            pressures,
+            num_robots=num_robots,
+            num_frames=num_frames,
+        )
+        self._pressure_frame_idx = 0
+        self._current_pressures = (
+            None if self._pressure_ts is None else self._pressure_ts[:, 0, :]
+        )
+        self._force_pressure_labels = False
+        self._set_pressure_labels_visible(False)
         super().render_sequence(ts, q_ts, **kwargs)
 
     def _update_frame(self, frame_idx: int, *args, **kwargs) -> None:
+        self._pressure_frame_idx = int(frame_idx)
+        self._current_pressures = (
+            None
+            if self._pressure_ts is None
+            else self._pressure_ts[:, self._pressure_frame_idx, :]
+        )
         if args:
             q_ts = jnp.asarray(args[0])
             self._current_geometry_q = q_ts[:, frame_idx, :]
         super()._update_frame(frame_idx, *args, **kwargs)
 
+    def _setup_playback_gui(self, on_frame_seek=None) -> None:
+        super()._setup_playback_gui(on_frame_seek=on_frame_seek)
+        self._setup_pressure_gui()
+
     def _remove_robot_geometry(self) -> None:
         if self._scene_handles is None:
             return
+        for robot_handles in self._robot_visual_handles:
+            for handle in robot_handles.pressure_label_handles:
+                if hasattr(handle, "remove"):
+                    handle.remove()
         for robot_handles in self._scene_handles.backbone_points:
             for handle in robot_handles:
                 if hasattr(handle, "remove"):
@@ -526,9 +805,11 @@ class ISupportViserRenderer(ViserRenderer):
                     chamber_handles=chamber_handles,
                     interface_handles=interface_handles,
                     spacer_handles=spacer_handles,
+                    pressure_label_handles=self._add_pressure_labels(robot_idx, poses),
                 )
             )
 
+        self._apply_pressure_visuals(world_poses)
         self._scene_handles.geometry_initialized = True
         self._scene_handles.num_robots = int(q.shape[0])
         self._scene_handles.num_backbone_points = curves.shape[1]
@@ -573,16 +854,24 @@ class ISupportViserRenderer(ViserRenderer):
                     position, wxyz = self._interface_pose(poses, spec)
                     handle.position = tuple(position)
                     handle.wxyz = wxyz
+            self._apply_pressure_visuals(world_poses)
 
     def start_live_mode(
         self,
-        callback: Callable[[float], np.ndarray] | None = None,
+        callback: Callable[[float], np.ndarray | tuple[np.ndarray, np.ndarray]]
+        | None = None,
         dt: float = 0.033,
+        pressure_callback: Callable[[float], np.ndarray] | None = None,
     ) -> ISupportLiveModeController:
-        """Start live mode while retaining the active I-SUPPORT configuration."""
+        """Start live mode with optional synchronized chamber pressures."""
         if self._server is None:
             self.start()
-        controller = ISupportLiveModeController(self, callback, dt)
+        self._pressure_ts = None
+        self._current_pressures = None
+        self._force_pressure_labels = False
+        self._set_pressure_labels_visible(False)
+        self._setup_pressure_gui()
+        controller = ISupportLiveModeController(self, callback, dt, pressure_callback)
         controller.start()
         return controller
 
@@ -593,11 +882,49 @@ class ISupportLiveModeController(LiveModeController):
     def __init__(
         self,
         renderer: ISupportViserRenderer,
-        callback: Callable[[float], np.ndarray] | None = None,
+        callback: Callable[[float], np.ndarray | tuple[np.ndarray, np.ndarray]]
+        | None = None,
         dt: float = 0.033,
+        pressure_callback: Callable[[float], np.ndarray] | None = None,
     ) -> None:
         super().__init__(renderer, callback, dt)
         self._renderer: ISupportViserRenderer = renderer
+        self._pressure_callback = pressure_callback
+
+    def push_state_with_pressures(self, q: np.ndarray, pressures: np.ndarray) -> None:
+        """Push a configuration and matching chamber pressures."""
+        q_batch = self._renderer._as_batch(q)
+        self._renderer._current_pressures = self._renderer._static_pressures(
+            pressures, num_robots=int(q_batch.shape[0])
+        )
+        self.push_state(q)
+
+    def _callback_loop(self) -> None:
+        while self._running:
+            t = time.time() - self._start_time
+            if self._callback is not None:
+                try:
+                    callback_result = self._callback(t)
+                    if isinstance(callback_result, tuple):
+                        q, pressures = callback_result
+                    else:
+                        q = callback_result
+                        pressures = (
+                            None
+                            if self._pressure_callback is None
+                            else self._pressure_callback(t)
+                        )
+                    if pressures is not None:
+                        q_batch = self._renderer._as_batch(q)
+                        self._renderer._current_pressures = (
+                            self._renderer._static_pressures(
+                                pressures, num_robots=int(q_batch.shape[0])
+                            )
+                        )
+                    self._process_state(q)
+                except Exception as exc:
+                    print(f"[ISupportViserRenderer] Callback error: {exc}")
+            time.sleep(self._dt)
 
     def _process_state(self, q: np.ndarray) -> None:
         self._renderer._current_geometry_q = self._renderer._as_batch(q)

--- a/src/soromox/rendering/isupport/viser_renderer.py
+++ b/src/soromox/rendering/isupport/viser_renderer.py
@@ -44,7 +44,7 @@ class ISupportVisualConfig:
     spacer_opacity: float = 0.35
     pressure_colormap: str = "Blues"
     pressure_range: tuple[float, float] = (0.0, 3.0e5)
-    pressure_colormap_start: float = 0.15
+    pressure_colormap_start: float = 0.50
     pressure_label_offset: float = 0.012
 
     def __post_init__(self) -> None:

--- a/src/soromox/rendering/isupport/viser_renderer.py
+++ b/src/soromox/rendering/isupport/viser_renderer.py
@@ -12,6 +12,11 @@ import jax.numpy as jnp
 import numpy as np
 from jax import Array
 from matplotlib import colormaps
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.colorbar import ColorbarBase
+from matplotlib.colors import LinearSegmentedColormap, Normalize
+from matplotlib.figure import Figure
+from matplotlib.ticker import FixedLocator, FuncFormatter
 
 from soromox.rendering.color_config import validate_rgb
 from soromox.rendering.viser_renderer import (
@@ -582,10 +587,38 @@ class ISupportViserRenderer(ViserRenderer):
             for handle in robot_handles.pressure_label_handles:
                 handle.visible = self._show_pressure_labels
 
+    def _pressure_colorbar_image(self) -> np.ndarray:
+        cfg = self.visual_config
+        base_colormap = colormaps.get_cmap(cfg.pressure_colormap)
+        samples = np.linspace(cfg.pressure_colormap_start, 1.0, 256)
+        pressure_colormap = LinearSegmentedColormap.from_list(
+            "isupport_pressure", base_colormap(samples)
+        )
+
+        figure = Figure(figsize=(3.0, 0.65), dpi=120)
+        figure.patch.set_alpha(0.0)
+        canvas = FigureCanvasAgg(figure)
+        axes = figure.add_axes((0.08, 0.48, 0.84, 0.28))
+        colorbar = ColorbarBase(
+            axes,
+            cmap=pressure_colormap,
+            norm=Normalize(*cfg.pressure_range),
+            orientation="horizontal",
+        )
+        colorbar.ax.xaxis.set_major_formatter(
+            FuncFormatter(lambda value, _: f"{value / 1.0e3:g}")
+        )
+        colorbar.ax.xaxis.set_major_locator(
+            FixedLocator(np.linspace(*cfg.pressure_range, 5))
+        )
+        colorbar.ax.tick_params(labelsize=8, length=2, pad=1)
+        colorbar.set_label("Pressure [kPa]", fontsize=8, labelpad=2)
+        canvas.draw()
+        return np.asarray(canvas.buffer_rgba()).copy()
+
     def _setup_pressure_gui(self) -> None:
         if self._server is None:
             return
-        cfg = self.visual_config
         existing = self._gui_handles.get("show_pressure_labels")
         if existing is not None:
             existing.value = self._show_pressure_labels
@@ -596,14 +629,9 @@ class ISupportViserRenderer(ViserRenderer):
                 initial_value=self._show_pressure_labels,
             )
             self._gui_handles["show_pressure_labels"] = checkbox
-            self._server.gui.add_text(
-                "Pressure scale",
-                initial_value=(
-                    f"{cfg.pressure_range[0] / 1.0e3:g}–"
-                    f"{cfg.pressure_range[1] / 1.0e3:g} kPa · "
-                    f"{cfg.pressure_colormap}"
-                ),
-                disabled=True,
+            self._gui_handles["pressure_colorbar"] = self._server.gui.add_image(
+                self._pressure_colorbar_image(),
+                format="png",
             )
 
         @checkbox.on_update

--- a/tests/rendering/test_isupport_viser_renderer.py
+++ b/tests/rendering/test_isupport_viser_renderer.py
@@ -57,6 +57,9 @@ class _FakeGuiHandle(_FakeHandle):
 
 
 class _FakeGui:
+    def __init__(self):
+        self.images = []
+
     @contextmanager
     def add_folder(self, _name):
         yield
@@ -66,6 +69,11 @@ class _FakeGui:
 
     def add_text(self, _name, *, initial_value, disabled):
         return _FakeGuiHandle(value=initial_value, disabled=disabled)
+
+    def add_image(self, image, *, format):
+        handle = _FakeGuiHandle(image=image, format=format)
+        self.images.append(handle)
+        return handle
 
 
 class _FakeServer:
@@ -360,7 +368,11 @@ def test_pressure_labels_and_colors_update_in_place():
 
     renderer._setup_pressure_gui()
     checkbox = renderer._gui_handles["show_pressure_labels"]
+    colorbar = renderer._gui_handles["pressure_colorbar"]
     assert checkbox.value is False
+    assert colorbar.format == "png"
+    assert colorbar.image.ndim == 3
+    assert colorbar.image.shape[-1] == 4
     checkbox.update(True)
     assert all(label.visible for label in labels)
     assert robot_handles.chamber_handles[0].color == pressure_color

--- a/tests/rendering/test_isupport_viser_renderer.py
+++ b/tests/rendering/test_isupport_viser_renderer.py
@@ -264,10 +264,15 @@ def test_pressure_colormap_clamps_and_handles_missing_values():
     )
     expected_mid = tuple(
         int(round(255.0 * component))
-        for component in cmap(config.pressure_colormap_start + 0.85 * 0.5)[:3]
+        for component in cmap(
+            config.pressure_colormap_start
+            + (1.0 - config.pressure_colormap_start) * 0.5
+        )[:3]
     )
     expected_high = tuple(int(round(255.0 * component)) for component in cmap(1.0)[:3])
 
+    assert config.pressure_colormap_start == pytest.approx(0.50)
+    assert max(expected_low) < 220
     assert renderer._pressure_color(-1.0e5) == expected_low
     assert renderer._pressure_color(0.0) == expected_low
     assert renderer._pressure_color(1.5e5) == expected_mid

--- a/tests/rendering/test_isupport_viser_renderer.py
+++ b/tests/rendering/test_isupport_viser_renderer.py
@@ -33,16 +33,45 @@ class _FakeHandle:
 class _FakeScene:
     def __init__(self):
         self.simple_meshes = []
+        self.labels = []
 
     def add_mesh_simple(self, **kwargs):
         handle = _FakeHandle(**kwargs)
         self.simple_meshes.append(handle)
         return handle
 
+    def add_label(self, **kwargs):
+        handle = _FakeHandle(**kwargs)
+        self.labels.append(handle)
+        return handle
+
+
+class _FakeGuiHandle(_FakeHandle):
+    def on_update(self, callback):
+        self.update_callback = callback
+        return callback
+
+    def update(self, value):
+        self.value = value
+        self.update_callback(type("Event", (), {"target": self})())
+
+
+class _FakeGui:
+    @contextmanager
+    def add_folder(self, _name):
+        yield
+
+    def add_checkbox(self, _name, *, initial_value):
+        return _FakeGuiHandle(value=initial_value)
+
+    def add_text(self, _name, *, initial_value, disabled):
+        return _FakeGuiHandle(value=initial_value, disabled=disabled)
+
 
 class _FakeServer:
     def __init__(self):
         self.scene = _FakeScene()
+        self.gui = _FakeGui()
         self.atomic_calls = 0
 
     @contextmanager
@@ -112,6 +141,10 @@ def _curves_and_frames(renderer, q, offsets=None):
         ({"samples_per_fold": 1}, "samples_per_fold"),
         ({"spacer_opacity": 1.1}, "spacer_opacity"),
         ({"interface_radius": 0.0}, "interface_radius"),
+        ({"pressure_range": (1.0, 1.0)}, "pressure_range"),
+        ({"pressure_colormap_start": 1.0}, "pressure_colormap_start"),
+        ({"pressure_label_offset": -0.01}, "pressure_label_offset"),
+        ({"pressure_colormap": "not-a-colormap"}, "colormap"),
     ],
 )
 def test_visual_config_validation(updates, message):
@@ -218,6 +251,48 @@ def test_chambers_follow_model_angles_ellipse_and_bellows():
     assert bulge_radius > 1.2 * waist_radius
 
 
+def test_pressure_colormap_clamps_and_handles_missing_values():
+    renderer = _renderer(_make_robot(connectors=True))
+    config = renderer.visual_config
+
+    from matplotlib import colormaps
+
+    cmap = colormaps[config.pressure_colormap]
+    expected_low = tuple(
+        int(round(255.0 * component))
+        for component in cmap(config.pressure_colormap_start)[:3]
+    )
+    expected_mid = tuple(
+        int(round(255.0 * component))
+        for component in cmap(config.pressure_colormap_start + 0.85 * 0.5)[:3]
+    )
+    expected_high = tuple(int(round(255.0 * component)) for component in cmap(1.0)[:3])
+
+    assert renderer._pressure_color(-1.0e5) == expected_low
+    assert renderer._pressure_color(0.0) == expected_low
+    assert renderer._pressure_color(1.5e5) == expected_mid
+    assert renderer._pressure_color(3.0e5) == expected_high
+    assert renderer._pressure_color(5.0e5) == expected_high
+    assert renderer._pressure_color(np.nan) == (145, 145, 145)
+
+
+def test_pressure_shape_normalization():
+    renderer = _renderer(_make_robot(connectors=True))
+    pressures = np.arange(renderer.robot.num_actuators, dtype=float)
+
+    static = renderer._static_pressures(pressures, num_robots=2)
+    assert static.shape == (2, renderer.robot.num_actuators)
+    assert_allclose(static[0], pressures)
+    sequence = renderer._sequence_pressures(pressures, num_robots=2, num_frames=4)
+    assert sequence.shape == (2, 4, renderer.robot.num_actuators)
+    assert_allclose(sequence[1, 3], pressures)
+
+    with pytest.raises(ValueError, match="pressures must have shape"):
+        renderer._static_pressures(np.zeros((2, 2, 2)), num_robots=2)
+    with pytest.raises(ValueError, match="sequence pressures"):
+        renderer._sequence_pressures(np.zeros((2, 2)), num_robots=2, num_frames=4)
+
+
 def test_build_and_update_preserve_custom_handle_identity():
     renderer = _renderer(_make_robot(connectors=True))
     renderer._server = _FakeServer()
@@ -249,6 +324,94 @@ def test_build_and_update_preserve_custom_handle_identity():
     assert renderer._robot_visual_handles[0].chamber_handles[0] is first_handle
     assert renderer._server.atomic_calls == 1
     assert not np.allclose(first_handle.vertices, first_vertices)
+
+
+def test_pressure_labels_and_colors_update_in_place():
+    renderer = _renderer(_make_robot(connectors=True))
+    renderer._server = _FakeServer()
+    renderer._scene_handles = SceneHandles()
+    q = jnp.zeros((renderer.robot.num_dofs,))
+    curves, frames = _curves_and_frames(renderer, q)
+    renderer._current_geometry_q = q[None, :]
+    renderer._current_pressures = np.array([[2.0e4, 1.5e5, 3.0e5, np.nan, 0.0, 4.0e5]])
+
+    renderer._build_robot_geometry(
+        curves,
+        np.ones((1, renderer.num_points, 4)),
+        material_frames=frames,
+        base_plate_color=(0.1, 0.1, 0.1),
+    )
+
+    robot_handles = renderer._robot_visual_handles[0]
+    labels = robot_handles.pressure_label_handles
+    assert len(labels) == 6
+    assert labels[0].text == "Segment 1 · Chamber 1\n20.0 kPa"
+    assert labels[3].text == "Segment 2 · Chamber 1\n--"
+    assert not any(label.visible for label in labels)
+    assert robot_handles.chamber_handles[3].color == (145, 145, 145)
+    pressure_color = robot_handles.chamber_handles[0].color
+    first_label = labels[0]
+    first_position = np.asarray(first_label.position)
+
+    renderer._setup_pressure_gui()
+    checkbox = renderer._gui_handles["show_pressure_labels"]
+    assert checkbox.value is False
+    checkbox.update(True)
+    assert all(label.visible for label in labels)
+    assert robot_handles.chamber_handles[0].color == pressure_color
+
+    q_next = q.at[1].set(2.0)
+    curves_next, frames_next = _curves_and_frames(renderer, q_next)
+    renderer._current_geometry_q = q_next[None, :]
+    renderer._update_robot_geometry(curves_next, frames_next)
+
+    assert renderer._robot_visual_handles[0].pressure_label_handles[0] is first_label
+    assert not np.allclose(first_label.position, first_position)
+    assert first_label.visible
+
+
+def test_geometry_without_pressures_uses_default_chamber_style():
+    renderer = _renderer(_make_robot(connectors=True))
+    renderer._server = _FakeServer()
+    renderer._scene_handles = SceneHandles()
+    q = jnp.zeros((renderer.robot.num_dofs,))
+    curves, frames = _curves_and_frames(renderer, q)
+    renderer._current_geometry_q = q[None, :]
+
+    renderer._build_robot_geometry(
+        curves,
+        np.ones((1, renderer.num_points, 4)),
+        material_frames=frames,
+        base_plate_color=(0.1, 0.1, 0.1),
+    )
+
+    robot_handles = renderer._robot_visual_handles[0]
+    assert robot_handles.pressure_label_handles == []
+    assert robot_handles.chamber_handles[0].color == renderer._color_tuple(
+        renderer.visual_config.chamber_color
+    )
+
+
+def test_render_frame_forces_labels_only_when_pressures_are_supplied(monkeypatch):
+    renderer = _renderer(_make_robot(connectors=True))
+    q = jnp.zeros((renderer.robot.num_dofs,))
+    captured = []
+
+    def fake_render_frame(self, q, **kwargs):
+        captured.append((self._current_pressures, self._force_pressure_labels, kwargs))
+        return np.zeros((1, 1, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(
+        "soromox.rendering.viser_renderer.ViserRenderer.render_frame",
+        fake_render_frame,
+    )
+    renderer.render_frame(q)
+    renderer.render_frame(q, pressures=np.full(renderer.robot.num_actuators, 2.0e4))
+
+    assert captured[0][0] is None
+    assert captured[0][1] is False
+    assert captured[1][0].shape == (1, renderer.robot.num_actuators)
+    assert captured[1][1] is True
 
 
 def test_batched_geometry_applies_base_offsets():
@@ -290,3 +453,46 @@ def test_live_controller_updates_custom_geometry_in_place():
     assert renderer._current_geometry_q.shape == (1, renderer.robot.num_dofs)
     assert renderer._robot_visual_handles[0].chamber_handles[0] is first_handle
     assert renderer._server.atomic_calls == 1
+
+
+def test_live_controller_pushes_pressures_with_state():
+    renderer = _renderer(_make_robot(connectors=True))
+    renderer._server = _FakeServer()
+    renderer._scene_handles = SceneHandles()
+    controller = ISupportLiveModeController(renderer)
+    controller.start()
+    q = np.zeros((renderer.robot.num_dofs,))
+    pressures = np.arange(renderer.robot.num_actuators) * 1.0e5
+
+    controller.push_state_with_pressures(q, pressures)
+    controller.stop()
+
+    assert_allclose(renderer._current_pressures[0], pressures)
+    labels = renderer._robot_visual_handles[0].pressure_label_handles
+    assert labels[4].text == "Segment 2 · Chamber 2\n400.0 kPa"
+
+
+def test_sequence_frame_selects_matching_pressures(monkeypatch):
+    renderer = _renderer(_make_robot(connectors=True))
+    q_ts = jnp.zeros((3, renderer.robot.num_dofs))
+    pressure_ts = np.arange(18, dtype=float).reshape(3, 6) * 1.0e4
+
+    def fake_render_sequence(self, ts, q_ts, **kwargs):
+        return None
+
+    def fake_update_frame(self, frame_idx, *args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "soromox.rendering.viser_renderer.ViserRenderer.render_sequence",
+        fake_render_sequence,
+    )
+    monkeypatch.setattr(
+        "soromox.rendering.viser_renderer.ViserRenderer._update_frame",
+        fake_update_frame,
+    )
+    renderer.render_sequence(np.arange(3), q_ts, pressures=pressure_ts)
+    renderer._update_frame(2, q_ts[None, ...])
+
+    assert_allclose(renderer._current_pressures[0], pressure_ts[2])
+    assert renderer._pressure_frame_idx == 2

--- a/tests/rendering/test_isupport_viser_renderer.py
+++ b/tests/rendering/test_isupport_viser_renderer.py
@@ -279,8 +279,6 @@ def test_pressure_colormap_clamps_and_handles_missing_values():
     )
     expected_high = tuple(int(round(255.0 * component)) for component in cmap(1.0)[:3])
 
-    assert config.pressure_colormap_start == pytest.approx(0.50)
-    assert max(expected_low) < 220
     assert renderer._pressure_color(-1.0e5) == expected_low
     assert renderer._pressure_color(0.0) == expected_low
     assert renderer._pressure_color(1.5e5) == expected_mid
@@ -356,15 +354,10 @@ def test_pressure_labels_and_colors_update_in_place():
     )
 
     robot_handles = renderer._robot_visual_handles[0]
-    labels = robot_handles.pressure_label_handles
-    assert len(labels) == 6
-    assert labels[0].text == "Segment 1 · Chamber 1\n20.0 kPa"
-    assert labels[3].text == "Segment 2 · Chamber 1\n--"
-    assert not any(label.visible for label in labels)
+    assert robot_handles.pressure_label_handles == []
+    assert renderer._server.scene.labels == []
     assert robot_handles.chamber_handles[3].color == (145, 145, 145)
     pressure_color = robot_handles.chamber_handles[0].color
-    first_label = labels[0]
-    first_position = np.asarray(first_label.position)
 
     renderer._setup_pressure_gui()
     checkbox = renderer._gui_handles["show_pressure_labels"]
@@ -374,8 +367,14 @@ def test_pressure_labels_and_colors_update_in_place():
     assert colorbar.image.ndim == 3
     assert colorbar.image.shape[-1] == 4
     checkbox.update(True)
+    labels = robot_handles.pressure_label_handles
+    assert len(labels) == 6
+    assert labels[0].text == "Segment 1 · Chamber 1\n20.0 kPa"
+    assert labels[3].text == "Segment 2 · Chamber 1\n--"
     assert all(label.visible for label in labels)
     assert robot_handles.chamber_handles[0].color == pressure_color
+    first_label = labels[0]
+    first_position = np.asarray(first_label.position)
 
     q_next = q.at[1].set(2.0)
     curves_next, frames_next = _curves_and_frames(renderer, q_next)
@@ -385,6 +384,10 @@ def test_pressure_labels_and_colors_update_in_place():
     assert renderer._robot_visual_handles[0].pressure_label_handles[0] is first_label
     assert not np.allclose(first_label.position, first_position)
     assert first_label.visible
+
+    checkbox.update(False)
+    assert robot_handles.pressure_label_handles == []
+    assert first_label.remove_count == 1
 
 
 def test_geometry_without_pressures_uses_default_chamber_style():
@@ -482,6 +485,8 @@ def test_live_controller_pushes_pressures_with_state():
     pressures = np.arange(renderer.robot.num_actuators) * 1.0e5
 
     controller.push_state_with_pressures(q, pressures)
+    assert renderer._robot_visual_handles[0].pressure_label_handles == []
+    renderer._set_pressure_labels_visible(True)
     controller.stop()
 
     assert_allclose(renderer._current_pressures[0], pressures)


### PR DESCRIPTION
## Summary

- add pressure-dependent chamber coloring to `ISupportViserRenderer` using a configurable Matplotlib `Blues` scale
- add optional pressure labels for static, sequence, captured-frame, and live rendering workflows
- keep pressure inputs and color-range configuration in Pa while presenting values in kPa
- calibrate the I-SUPPORT simulation example from its maximum applied pressure
- document the pressure API, channel order, label control, and display behavior

## Motivation

The specialized I-SUPPORT renderer showed chamber geometry but did not expose the pressure currently applied to each chamber. This makes it difficult to connect simulated or streamed actuation inputs to the rendered robot.

## User impact

Callers can pass chamber pressures to `render_frame`, `show`, `render_sequence`, or live-mode helpers. Interactive labels remain hidden until the **Show pressure labels** checkbox is enabled; captured frames show labels automatically when pressures are supplied. Omitting pressures preserves the existing uniform chamber appearance.

## Validation

- `uv run pytest -q tests/rendering` — 60 passed
- targeted Ruff lint and formatting checks passed
- `git diff --check` passed