### PR TITLE
Migrate I-SUPPORT to tendon-based actuation

### DIFF
--- a/docs/api/systems/pcs/isupport.md
+++ b/docs/api/systems/pcs/isupport.md
@@ -4,7 +4,9 @@
 
 ## Overview
 
-`ISupport` is a specialized PCS implementation for 3D pneumatic soft robots with chamber-based actuation. It extends the base `PCS` class with:
+`ISupport` is a specialized tendon-actuated PCS implementation for 3D pneumatic
+soft robots. Each pressure chamber is represented internally by a straight,
+segment-local virtual tendon:
 
 - **3 chambers per segment**: Radially arranged pneumatic chambers
 - **Pressure-based control**: Direct pressure input for actuation
@@ -91,6 +93,8 @@ params = ISupportParams(
     chamber_outer_radius=jnp.array([7.79e-3]),
     chamber_distance=jnp.array([20e-3]),
     chamber_azimuth_angles=(2.0 * jnp.pi * jnp.arange(3) / 3)[None, :],
+    # Optional override. The default is pi * (r_outer**2 - r_inner**2).
+    chamber_effective_pressure_area=None,
 )
 robot = ISupport(
     params,
@@ -137,7 +141,28 @@ order differs from that default.
 
 ### Actuation Mapping
 
-Pressure inputs are mapped to strains via the actuation basis matrix, converting chamber pressures to the 6 strain components (curvatures and linear strains).
+The control input remains chamber pressure in pascals. For chamber `k`, the
+model converts pressure to a virtual tendon force using
+
+`f_k = p_k * A_k`.
+
+`chamber_effective_pressure_area` has shape `(num_pneumatic_segments,)`; one
+area is shared by all chambers in a pneumatic segment. If it is omitted, the
+model uses
+
+`A = pi * (chamber_outer_radius**2 - chamber_inner_radius**2)`.
+
+The pressure actuation matrix is the configuration-dependent, length-integrated
+`TendonActuatedPCS` matrix with each column scaled by its effective pressure
+area. Virtual tendons contribute only to the PCS children of their own
+pneumatic segment, so pressure sections remain independent. Consequently, this
+matrix intentionally differs from the former configuration-independent local
+wrench approximation.
+
+The pressure-conjugate actuation coordinates are available through
+`robot.chamber_volumes(q)` and `robot.actuated_coordinates(q)`. They are modeled
+as effective area times virtual tendon length, and their Jacobian is the
+transpose of the pressure actuation matrix.
 
 ## API Reference
 

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -71,6 +71,8 @@ if __name__ == "__main__":
         chamber_inner_radius=6.39 * 1e-3 * jnp.ones((num_pneumatic_segments,)),
         chamber_outer_radius=7.79 * 1e-3 * jnp.ones((num_pneumatic_segments,)),
         chamber_distance=20 * 1e-3 * jnp.ones((num_pneumatic_segments,)),
+        # chamber_effective_pressure_area may override the default annular area
+        # pi * (chamber_outer_radius**2 - chamber_inner_radius**2).
         # Explicit [0, 2*pi/3, 4*pi/3] = [0, 120, 240] degrees for each
         # pneumatic segment. Array index is the corresponding pressure channel.
         chamber_azimuth_angles=jnp.tile(
@@ -113,7 +115,8 @@ if __name__ == "__main__":
     # A = robot.actuation_matrix(q0)
     # print("A:\n", A)
 
-    # Actuation pressures
+    # Actuation pressures [Pa]. Internally, each local virtual tendon receives
+    # force = pressure * chamber_effective_pressure_area.
     u = (
         jnp.repeat(
             jnp.array([2e-1, 0.0, 0.0])[None, :],

--- a/src/soromox/systems/pcs/isupport.py
+++ b/src/soromox/systems/pcs/isupport.py
@@ -1,15 +1,17 @@
 import math
+from collections.abc import Callable
 from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp
 from jax import Array, vmap
 
-from soromox.systems.pcs.params import ISupportParams
+from soromox.systems.params import BaseTendonRoutingParams, LinearTendonRoutingParams
+from soromox.systems.pcs.params import ISupportParams, TendonActuatedPCSParams
 from soromox.systems.pcs.structures import ISupportStructure, PCSStructure
 from soromox.utils.array_math import blk_diag
 
-from .pcs import PCS
+from .tendon_actuated_pcs import TendonActuatedPCS
 
 _RIGID_CONNECTOR_PARENT = -1
 
@@ -24,6 +26,52 @@ def _with_default_chamber_azimuth_angles(params: ISupportParams) -> ISupportPara
         chamber_azimuth_angles=jnp.tile(
             canonical_angles[None, :], (num_pneumatic_segments, 1)
         )
+    )
+
+
+def _resolve_chamber_effective_pressure_area(params: ISupportParams) -> Array:
+    """Return one pressure-to-force area per physical pneumatic segment."""
+    if params.chamber_effective_pressure_area is not None:
+        return jnp.asarray(params.chamber_effective_pressure_area, dtype=jnp.float64)
+    r_inner = jnp.asarray(params.chamber_inner_radius, dtype=jnp.float64)
+    r_outer = jnp.asarray(params.chamber_outer_radius, dtype=jnp.float64)
+    return jnp.pi * (r_outer**2 - r_inner**2)
+
+
+def _pneumatic_chamber_routing(
+    params: ISupportParams,
+    pcs_segment_to_pneumatic_segment: Array,
+) -> LinearTendonRoutingParams:
+    """Build straight, segment-local virtual tendons in pressure-channel order."""
+    angles = jnp.asarray(params.chamber_azimuth_angles, dtype=jnp.float64)
+    distances = jnp.asarray(params.chamber_distance, dtype=jnp.float64)[:, None]
+    y_intercept = (distances * jnp.cos(angles)).reshape(-1)
+    z_intercept = (distances * jnp.sin(angles)).reshape(-1)
+
+    parent_by_pcs_segment = tuple(
+        int(parent) for parent in jnp.asarray(pcs_segment_to_pneumatic_segment).tolist()
+    )
+    num_pneumatic_segments, num_chambers = angles.shape
+    final_child_indices = tuple(
+        max(
+            index
+            for index, candidate_parent in enumerate(parent_by_pcs_segment)
+            if candidate_parent == pneumatic_segment
+        )
+        for pneumatic_segment in range(num_pneumatic_segments)
+    )
+    attachment_segment_indices = tuple(
+        final_child_indices[pneumatic_segment]
+        for pneumatic_segment in range(num_pneumatic_segments)
+        for _ in range(num_chambers)
+    )
+
+    return LinearTendonRoutingParams(
+        y_intercept=y_intercept,
+        y_slope=jnp.zeros_like(y_intercept),
+        z_intercept=z_intercept,
+        z_slope=jnp.zeros_like(z_intercept),
+        attachment_segment_index=attachment_segment_indices,
     )
 
 
@@ -333,7 +381,7 @@ def _expand_isupport_layout(
     )
 
 
-class ISupport(PCS):
+class ISupport(TendonActuatedPCS):
     """
     A kinematic and dynamic model for the (AM) I-Support robot based on the Piecewise Constant Strain shape parametrization.
 
@@ -395,6 +443,7 @@ class ISupport(PCS):
     d_chamber: Array  # radial distance of the center of the chambers from the centerline of the backbone, shape (num_segments,)
     # Expanded per-PCS-segment copy of the resolved channel layout.
     chamber_azimuth_angles: Array
+    chamber_effective_pressure_area: Array
 
     num_chambers_per_segment: int = eqx.field(
         static=True, default=3
@@ -436,10 +485,18 @@ class ISupport(PCS):
             pcs_segment_to_pneumatic_segment,
             pcs_segment_is_rigid,
         ) = _expand_isupport_layout(params, structure)
-        # Geometry-dependent caches are constructed by PCS.__init__, so expose
-        # the expanded type mask before delegating to it.
+        # Geometry-dependent caches and virtual-tendon validation are constructed
+        # by the parent initializers, so expose the expanded topology first.
         self.pcs_segment_is_rigid = pcs_segment_is_rigid
-        super().__init__(pcs_params, structure=pcs_structure, **kwargs)
+        self.pcs_segment_to_pneumatic_segment = pcs_segment_to_pneumatic_segment
+        pneumatic_chamber_routing = _pneumatic_chamber_routing(
+            params, pcs_segment_to_pneumatic_segment
+        )
+        tendon_params = TendonActuatedPCSParams(
+            body=pcs_params,
+            active_tendon_routing=pneumatic_chamber_routing,
+        )
+        super().__init__(tendon_params, structure=pcs_structure, **kwargs)
 
         self.params = params
         self.pcs_params = pcs_params
@@ -450,9 +507,9 @@ class ISupport(PCS):
         self.num_pcs_segments = self.num_segments
         self.pcs_segment_to_pneumatic_segment = pcs_segment_to_pneumatic_segment
         self.pcs_segment_is_rigid = pcs_segment_is_rigid
-        self.num_actuators = (
-            self.num_pneumatic_segments * self.num_chambers_per_segment
-        )  # each pneumatic segment has one pressure input per chamber
+        self.chamber_effective_pressure_area = _resolve_chamber_effective_pressure_area(
+            params
+        )
 
     def _set_params(self, params: ISupportParams):
         """
@@ -553,13 +610,24 @@ class ISupport(PCS):
         if not isinstance(params, ISupportParams):
             raise TypeError("params must be an ISupportParams instance.")
         params = _with_default_chamber_azimuth_angles(params)
+        if params.chamber_azimuth_angles.shape[1] != self.num_chambers_per_segment:
+            raise ValueError(
+                "Changing the number of chambers per pneumatic segment requires "
+                "reconstruction."
+            )
         (
             pcs_params,
             _,
             _,
-            _,
+            pcs_segment_to_pneumatic_segment,
             _,
         ) = _expand_isupport_layout(params, self.structure)
+        pneumatic_chamber_routing = _pneumatic_chamber_routing(
+            params, pcs_segment_to_pneumatic_segment
+        )
+        chamber_effective_pressure_area = _resolve_chamber_effective_pressure_area(
+            params
+        )
         chamber_arrays = (
             jnp.asarray(pcs_params.chamber_inner_radius, dtype=jnp.float64),
             jnp.asarray(pcs_params.chamber_outer_radius, dtype=jnp.float64),
@@ -574,9 +642,16 @@ class ISupport(PCS):
                 model.r_chamber_out,
                 model.d_chamber,
                 model.chamber_azimuth_angles,
+                model.active_tendon_routing,
+                model.chamber_effective_pressure_area,
             ),
             updated_self,
-            (pcs_params, *chamber_arrays),
+            (
+                pcs_params,
+                *chamber_arrays,
+                pneumatic_chamber_routing,
+                chamber_effective_pressure_area,
+            ),
         )
         return updated_self._with_refreshed_precomputed_matrices()
 
@@ -743,96 +818,98 @@ class ISupport(PCS):
         rigid_moments = super()._local_second_moment_of_area(i)
         return jnp.where(self.pcs_segment_is_rigid[i], rigid_moments, pneumatic_moments)
 
+    def _check_tendon_routing_in_body(
+        self,
+        tendon_routing_params: BaseTendonRoutingParams,
+        d_s: Callable,
+    ) -> bool:
+        """Check virtual tendons only where their pneumatic segment exists."""
+        if tendon_routing_params.num_tendons == 0:
+            return False
+
+        sample_s = jnp.stack([self.L_cum[:-1], self.L_cum[1:]], axis=-1).reshape(-1)
+        sample_segment_indices = jnp.repeat(jnp.arange(self.num_segments), 2)
+        tendon_positions = vmap(
+            vmap(d_s, in_axes=(None, 0), out_axes=0),
+            in_axes=(0, None),
+            out_axes=0,
+        )(tendon_routing_params, sample_s)
+        tendon_radii = jnp.linalg.norm(tendon_positions[..., 1:], axis=-1)
+
+        sample_parents = self.pcs_segment_to_pneumatic_segment[sample_segment_indices]
+        attachment_parents = self.pcs_segment_to_pneumatic_segment[
+            tendon_routing_params.attachment_segment_index_array
+        ]
+        local_samples = (attachment_parents[:, None] >= 0) & (
+            attachment_parents[:, None] == sample_parents[None, :]
+        )
+        body_radii = self.r[sample_segment_indices]
+        return bool(jnp.any(local_samples & (tendon_radii > body_radii[None, :])))
+
     @eqx.filter_jit
-    def actuation_matrix(self, q: Array) -> Array:
-        """
-        Compute the actuation matrix of the robot.
-        We assume that each pneumatic segment contains
-        self.num_chambers_per_segment identical and symmetric pneumatic chambers
-        that are pressurized to p1=u1, p2=u2, p3=u3, etc. If a pneumatic
-        segment is split into multiple PCS segments, the same pressure columns
-        are applied to each child PCS segment. Rigid connector PCS segments do
-        not contribute to the actuation matrix.
-        Chamber columns follow ``chamber_azimuth_angles`` without reordering.
+    def _local_actuation_basis(
+        self,
+        i: Array,
+        xi_i: Array,
+        s: Array,
+        tendon_routing_params_k: BaseTendonRoutingParams,
+        d_s_fn: Callable,
+        dd_s_ds_fn: Callable,
+        attachment_segment_idx: Array | None = None,
+    ) -> Array:
+        """Restrict a virtual tendon to the children of its pneumatic segment."""
+        if attachment_segment_idx is None:
+            attachment_segment_idx = tendon_routing_params_k.attachment_segment_index
+        tendon_basis = super()._local_actuation_basis(
+            i,
+            xi_i,
+            s,
+            tendon_routing_params_k,
+            d_s_fn,
+            dd_s_ds_fn,
+            attachment_segment_idx,
+        )
+        current_parent = self.pcs_segment_to_pneumatic_segment[i]
+        attachment_parent = self.pcs_segment_to_pneumatic_segment[
+            attachment_segment_idx
+        ]
+        is_local = (current_parent >= 0) & (current_parent == attachment_parent)
+        return is_local * tendon_basis
 
-        Args:
-            q (Array): generalized coordinates of shape (num_active_strains,).
-
-        Returns:
-            A (Array): Actuation matrix of shape (num_active_strains, num_actuators)
-        """
-
-        def _actuation_matrix_one_chamber(i: Array, varphi: Array) -> Array:
-            # Area of one pneumatic chamber
-            A_one_chamber = jnp.pi * self.r_chamber_in[i] ** 2
-
-            # force contribution of the chamber
-            force_contrib = jnp.array(
-                [A_one_chamber, 0.0, 0.0]
-            )  # force along local x-axis
-
-            # compute the centroids of the chambers
-            centroid_chamber = self._local_actuator_centroid(i, varphi)
-
-            # compute the contribution of the chamber on the (rotational) backbone torque
-            torque_contrib = jnp.cross(centroid_chamber, force_contrib)
-
-            A_single_chamber = jnp.concatenate(
-                [
-                    torque_contrib,
-                    jnp.array(
-                        [
-                            A_one_chamber,  # axial strain
-                            0.0,  # shear strain local y-dir
-                            0.0,  # shear strain local z-dir
-                        ]
-                    ),
-                ]
-            )
-
-            return A_single_chamber
-
-        def _actuation_matrix_pcs_segment_i(i: Array) -> Array:
-            # compute the local polar chamber angles
-            varphi_chambers = self.chamber_azimuth_angles[i]
-
-            # build the actuation matrix
-            A_columns_i = vmap(lambda varphi: _actuation_matrix_one_chamber(i, varphi))(
-                varphi_chambers
-            )
-            A_segment_i = jnp.stack(
-                A_columns_i, axis=-1
-            )  # shape (6, num_chambers_per_segment)
-
-            return A_segment_i
-
-        def _actuation_matrix_pcs_segment_full(i: Array) -> Array:
-            A_segment_i = _actuation_matrix_pcs_segment_i(i)
-            pneumatic_segment_i = self.pcs_segment_to_pneumatic_segment[i]
-            local_column_indices = (
-                jnp.arange(self.num_actuators)
-                - pneumatic_segment_i * self.num_chambers_per_segment
-            )
-            valid_columns = (
-                (pneumatic_segment_i >= 0)
-                & (local_column_indices >= 0)
-                & (local_column_indices < self.num_chambers_per_segment)
-            )
-            local_column_indices = jnp.clip(
-                local_column_indices, 0, self.num_chambers_per_segment - 1
-            )
-            return jnp.where(
-                valid_columns[None, :],
-                A_segment_i[:, local_column_indices],
-                0.0,
-            )
-
-        A_blocks_tot = vmap(_actuation_matrix_pcs_segment_full)(
-            jnp.arange(self.num_segments),
+    def _effective_pressure_area_per_chamber(self) -> Array:
+        """Expand per-segment effective areas into pressure-channel order."""
+        return jnp.repeat(
+            self.chamber_effective_pressure_area,
+            self.num_chambers_per_segment,
         )
 
-        # assemble the contributions of the actuation of each PCS segment
-        A_full = A_blocks_tot.reshape(self.num_strains, self.num_actuators)
-        A = self.B_xi.T @ A_full  # shape (num_active_strains, num_actuators)
+    @eqx.filter_jit
+    def actuation_matrix(self, q: Array) -> Array:
+        """Map chamber pressures to generalized forces via virtual tendons."""
+        tendon_matrix = super().actuation_matrix(q)
+        pressure_area = self._effective_pressure_area_per_chamber()
+        return tendon_matrix * pressure_area[None, :]
 
-        return A
+    @eqx.filter_jit
+    def virtual_tendon_force(self, pressure: Array) -> Array:
+        """Convert chamber pressure inputs in pascals to virtual tendon forces."""
+        return pressure * self._effective_pressure_area_per_chamber()
+
+    @eqx.filter_jit
+    def chamber_volumes(self, q: Array) -> Array:
+        """Return pressure-conjugate chamber volume coordinates ``A * length``."""
+        pressure_area = self._effective_pressure_area_per_chamber()
+        return pressure_area * self.active_tendon_length(q)
+
+    actuated_coordinates = chamber_volumes
+
+    def actuator_visual_layers(
+        self,
+        q: Array,
+        s_points: Array,
+        *,
+        actuator_inputs: Array | None = None,
+    ) -> tuple:
+        """Keep virtual tendons out of generic renderers."""
+        del q, s_points, actuator_inputs
+        return ()

--- a/src/soromox/systems/pcs/params.py
+++ b/src/soromox/systems/pcs/params.py
@@ -246,10 +246,14 @@ class ISupportParams(PCSParams):
     azimuth is right-handed about local +X, measured from +Y toward +Z; array
     index ``j`` is pressure channel ``j``. If ``chamber_azimuth_angles`` is
     omitted, ``ISupport`` uses 0, 120, and 240 degrees for every pneumatic
-    segment. Damping can be supplied as ``material_damping_coefficient`` or as a
-    full ``damping_matrix``. A custom ``damping_matrix`` is expressed in flattened
-    pneumatic-segment strain coordinates and must be block diagonal by pneumatic
-    segment when the model is constructed.
+    segment. ``chamber_effective_pressure_area`` converts each chamber pressure
+    to its virtual tendon force. It contains one value per pneumatic segment and
+    is shared by all chambers in that segment. When omitted, it is derived as
+    ``pi * (chamber_outer_radius**2 - chamber_inner_radius**2)``. Damping can be
+    supplied as ``material_damping_coefficient`` or as a full ``damping_matrix``.
+    A custom ``damping_matrix`` is expressed in flattened pneumatic-segment
+    strain coordinates and must be block diagonal by pneumatic segment when the
+    model is constructed.
 
     ``pcs_segment_lengths`` optionally stores flattened PCS segment lengths in
     the order defined by ``ISupportStructure.pcs_segment_counts``. If omitted,
@@ -265,6 +269,7 @@ class ISupportParams(PCSParams):
     chamber_distance: Array
     chamber_azimuth_angles: Array | None = None
     pcs_segment_lengths: Array | None = None
+    chamber_effective_pressure_area: Array | None = None
 
     def validate(self) -> None:
         super().validate()
@@ -285,6 +290,36 @@ class ISupportParams(PCSParams):
             "chamber_distance",
         ):
             _require_shape(name, getattr(self, name), (n_pneumatic_segments,))
+
+        chamber_outer_radius = jnp.asarray(self.chamber_outer_radius)
+        if not bool(
+            jnp.all(
+                jnp.isfinite(chamber_inner_radius) & jnp.isfinite(chamber_outer_radius)
+            )
+        ):
+            raise ValueError("chamber radii entries must be finite")
+        if not bool(
+            jnp.all(
+                (chamber_inner_radius >= 0.0)
+                & (chamber_outer_radius > chamber_inner_radius)
+            )
+        ):
+            raise ValueError(
+                "chamber radii must satisfy 0 <= chamber_inner_radius < "
+                "chamber_outer_radius"
+            )
+
+        if self.chamber_effective_pressure_area is not None:
+            effective_area = jnp.asarray(self.chamber_effective_pressure_area)
+            _require_shape(
+                "chamber_effective_pressure_area",
+                effective_area,
+                (n_pneumatic_segments,),
+            )
+            if not bool(jnp.all(jnp.isfinite(effective_area) & (effective_area > 0.0))):
+                raise ValueError(
+                    "chamber_effective_pressure_area entries must be finite and positive"
+                )
 
         if self.chamber_azimuth_angles is not None:
             angles = jnp.asarray(self.chamber_azimuth_angles)

--- a/tests/systems/test_pressure_actuated_pcs_models.py
+++ b/tests/systems/test_pressure_actuated_pcs_models.py
@@ -16,6 +16,7 @@ from soromox.systems import (
     PlanarPCSStructure,
     PressureActuatedPlanarPCS,
     PressureActuatedPlanarPCSParams,
+    TendonActuatedPCS,
 )
 
 
@@ -65,14 +66,25 @@ def make_pneumatic_isupport_structure(num_segments=1, **kwargs):
     )
 
 
-def expected_isupport_segment_actuation(params, segment_idx, num_chambers=3):
-    chamber_area = jnp.pi * params.chamber_inner_radius[segment_idx] ** 2
-    chamber_distance = params.chamber_distance[segment_idx]
-    chamber_angles = params.chamber_azimuth_angles[segment_idx]
+def expected_isupport_segment_actuation(
+    params, pneumatic_segment_idx, segment_length=None, num_chambers=3
+):
+    if params.chamber_effective_pressure_area is None:
+        chamber_area = jnp.pi * (
+            params.chamber_outer_radius[pneumatic_segment_idx] ** 2
+            - params.chamber_inner_radius[pneumatic_segment_idx] ** 2
+        )
+    else:
+        chamber_area = params.chamber_effective_pressure_area[pneumatic_segment_idx]
+    if segment_length is None:
+        segment_length = params.length[pneumatic_segment_idx]
+    chamber_distance = params.chamber_distance[pneumatic_segment_idx]
+    chamber_angles = params.chamber_azimuth_angles[pneumatic_segment_idx]
     expected_columns = []
     for angle in chamber_angles:
         expected_columns.append(
-            jnp.array(
+            segment_length
+            * jnp.array(
                 [
                     0.0,
                     chamber_distance * jnp.sin(angle) * chamber_area,
@@ -275,9 +287,108 @@ def test_isupport_actuation_matrix_matches_per_segment_chamber_model():
     assert actuation_matrix.shape == (6, robot.num_chambers_per_segment)
     assert jnp.allclose(
         actuation_matrix,
-        expected_isupport_segment_actuation(params, 0, robot.num_chambers_per_segment),
+        expected_isupport_segment_actuation(
+            params, 0, num_chambers=robot.num_chambers_per_segment
+        ),
     )
     assert jnp.all(jnp.linalg.norm(actuation_matrix, axis=0) > 0.0)
+
+
+def test_isupport_inherits_tendon_actuation_and_resolves_pressure_area():
+    params = make_isupport_params()
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(num_gauss_points=2),
+    )
+
+    expected_area = jnp.pi * (
+        params.chamber_outer_radius**2 - params.chamber_inner_radius**2
+    )
+    assert isinstance(robot, TendonActuatedPCS)
+    assert isinstance(robot.params, ISupportParams)
+    assert robot.n_p == 0
+    assert robot.active_tendon_routing.num_tendons == robot.num_actuators
+    assert jnp.allclose(robot.chamber_effective_pressure_area, expected_area)
+    assert jnp.allclose(
+        robot.virtual_tendon_force(jnp.ones((robot.num_actuators,))),
+        jnp.repeat(expected_area, robot.num_chambers_per_segment),
+    )
+    assert (
+        robot.actuator_visual_layers(
+            jnp.zeros((robot.num_dofs,)), jnp.linspace(0.0, robot.length, 5)
+        )
+        == ()
+    )
+
+
+def test_isupport_pressure_force_and_volume_coordinate_consistency():
+    params = make_isupport_params().replace(
+        chamber_effective_pressure_area=jnp.array([2.5e-5])
+    )
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(num_gauss_points=3),
+    )
+    q = jnp.array([0.2, -0.1, 0.15, 0.03, 0.04, -0.02])
+    pressure = jnp.array([1.0e4, 2.0e4, 3.0e4])
+
+    tendon_matrix = robot._actuation_matrix(
+        q,
+        robot.active_tendon_routing,
+        robot.active_d_s,
+        robot.active_dd_s_ds,
+    )
+    tendon_force = robot.virtual_tendon_force(pressure)
+    assert jnp.allclose(tendon_force, pressure * 2.5e-5)
+    assert jnp.allclose(
+        robot.actuation_force(q, pressure), tendon_matrix @ tendon_force
+    )
+    assert jnp.allclose(
+        jax.jacobian(robot.chamber_volumes)(q),
+        robot.actuation_matrix(q).T,
+        rtol=1e-7,
+        atol=1e-10,
+    )
+    assert not jnp.allclose(
+        robot.actuation_matrix(q),
+        robot.actuation_matrix(jnp.zeros_like(q)),
+        rtol=1e-7,
+        atol=1e-12,
+    )
+
+
+def test_isupport_pressure_area_validation_and_update_semantics():
+    params = make_isupport_params()
+    structure = make_pneumatic_isupport_structure(num_gauss_points=1)
+    robot = ISupport(params=params, structure=structure)
+
+    updated_derived = robot.update_params(
+        chamber_outer_radius=jnp.array([0.005]),
+        chamber_distance=jnp.array([0.012]),
+    )
+    assert updated_derived.params.chamber_effective_pressure_area is None
+    assert jnp.allclose(
+        updated_derived.chamber_effective_pressure_area,
+        jnp.pi * (0.005**2 - params.chamber_inner_radius**2),
+    )
+    assert jnp.allclose(updated_derived.active_tendon_routing.y_intercept[0], 0.012)
+
+    explicit_area = jnp.array([7.5e-5])
+    explicit_robot = ISupport(
+        params.replace(chamber_effective_pressure_area=explicit_area),
+        structure=structure,
+    )
+    updated_explicit = explicit_robot.update_params(
+        chamber_outer_radius=jnp.array([0.005])
+    )
+    assert jnp.allclose(updated_explicit.chamber_effective_pressure_area, explicit_area)
+
+    with pytest.raises(ValueError, match="chamber radii"):
+        params.replace(chamber_outer_radius=params.chamber_inner_radius).validate()
+    with pytest.raises(ValueError, match="chamber_effective_pressure_area"):
+        params.replace(chamber_effective_pressure_area=jnp.array([-1.0])).validate()
+    with pytest.raises(ValueError, match="shape"):
+        params.replace(chamber_effective_pressure_area=jnp.array([1.0, 2.0])).validate()
 
 
 def test_isupport_actuation_matrix_assembles_segments_block_diagonal():
@@ -298,8 +409,12 @@ def test_isupport_actuation_matrix_assembles_segments_block_diagonal():
 
     actuation_matrix = robot.actuation_matrix(jnp.zeros((robot.num_dofs,)))
     num_chambers = robot.num_chambers_per_segment
-    expected_segment_0 = expected_isupport_segment_actuation(params, 0, num_chambers)
-    expected_segment_1 = expected_isupport_segment_actuation(params, 1, num_chambers)
+    expected_segment_0 = expected_isupport_segment_actuation(
+        params, 0, num_chambers=num_chambers
+    )
+    expected_segment_1 = expected_isupport_segment_actuation(
+        params, 1, num_chambers=num_chambers
+    )
 
     assert robot.num_actuators == 2 * num_chambers
     assert actuation_matrix.shape == (12, robot.num_actuators)
@@ -508,14 +623,21 @@ def test_isupport_actuation_groups_pressures_after_generalized_expansion():
     assert actuation_matrix.shape == (18, 2 * num_chambers)
     assert jnp.allclose(
         actuation_matrix[:6, :num_chambers],
-        expected_isupport_segment_actuation(params, 0, num_chambers),
+        expected_isupport_segment_actuation(
+            params, 0, segment_length=0.04, num_chambers=num_chambers
+        ),
     )
     assert jnp.allclose(
-        actuation_matrix[6:12, :num_chambers], actuation_matrix[:6, :num_chambers]
+        actuation_matrix[6:12, :num_chambers],
+        expected_isupport_segment_actuation(
+            params, 0, segment_length=0.06, num_chambers=num_chambers
+        ),
     )
     assert jnp.allclose(
         actuation_matrix[12:, num_chambers:],
-        expected_isupport_segment_actuation(params, 1, num_chambers),
+        expected_isupport_segment_actuation(
+            params, 1, segment_length=0.20, num_chambers=num_chambers
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

- make `ISupport` inherit from `TendonActuatedPCS`
- represent pneumatic chambers as segment-local straight tendon routings
- convert chamber pressure to virtual tendon force with an optional effective pressure area
- expose pressure-conjugate chamber-volume coordinates while preserving pressure inputs and channel ordering
- update parameter validation, runtime updates, documentation, examples, and analytical regression coverage

## Why

The previous I-SUPPORT actuation matrix applied a configuration-independent wrench at each chamber cross-section. That captures the axial force and its nominal moment arm in the straight configuration, but it does not account for how the chamber's direction and leverage change as the bellows bends, shears, twists, or extends.

A threadlike transmission is a better reduced-order representation for an I-SUPPORT bellows chamber because the chamber runs longitudinally and off-axis along the deformable segment. Pressure acting on an effective area produces an axial resultant,

`f = p A_eff`,

which follows the chamber path in the same way that a routed tensile element follows its routing. The tendon formulation then integrates the local force direction and moment arm along the complete pneumatic section. This provides several useful properties:

- **Configuration-dependent loading:** the generalized pressure force changes with the current strain state instead of remaining fixed at its straight-configuration value.
- **Distributed actuation:** pressure acts along the bellows length rather than as a lumped cross-section wrench.
- **Consistent PCS subdivision:** when one physical pneumatic section is represented by several PCS children, the same pressure channel contributes through the length-integrated routing of every child.
- **Local pneumatic sections:** generated chamber routings are masked to their owning pneumatic section, so they do not transmit actuation through the robot base, rigid connectors, or preceding pneumatic sections.
- **Virtual-work consistency:** with the reduced-order approximation `V ≈ A_eff l`, pressure work satisfies `p dV = (p A_eff) dl`. Consequently, the pressure actuation matrix is the transpose of the Jacobian of the modeled chamber-volume coordinates, which also makes it compatible with the existing actuation-space dynamics machinery.

This remains a reduced-order model: it assumes a constant effective pressure area and a material-frame chamber-center routing. It does not attempt to model detailed bellows-wall contact, radial expansion, hysteresis, or a pressure-dependent effective area. Those effects can be introduced later through the explicit `chamber_effective_pressure_area` parameter or a richer constitutive transmission model.

## User impact

`ISupportParams` gains an optional `chamber_effective_pressure_area` with one value per pneumatic segment. When omitted, it defaults to `pi * (r_out**2 - r_in**2)`. Existing pressure inputs remain in pascals.

## Validation

- `202 passed` across I-SUPPORT, typed-parameter, and actuation-space focused suites on the final commit
- changed-file Ruff formatting and lint checks passed
- `git diff --check` passed
- full repository suite passed earlier in the implementation cycle (`1107 passed`), before the final cache-removal and helper-renaming cleanup