### PR TITLE
Upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,17 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -47,11 +47,11 @@ jobs:
 
       - name: Setup Pages
         if: github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./site
 
@@ -65,4 +65,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -46,7 +46,7 @@ jobs:
           python -m twine check dist/*
 
       - name: Upload distribution artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: soromox-${{ steps.version.outputs.version }}
           path: dist/
@@ -61,17 +61,17 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Download validated distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: soromox-${{ needs.build.outputs.version }}
           path: dist/
@@ -88,7 +88,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: SoRoMoX v${{ needs.build.outputs.version }}
           body: |
@@ -123,7 +123,7 @@ jobs:
       id-token: write
     steps:
       - name: Download validated distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: soromox-${{ needs.build.outputs.version }}
           path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: pip


### PR DESCRIPTION
## Summary

- upgrade the test, documentation, and release workflows to current Node 24-compatible action releases
- upgrade `astral-sh/setup-uv` to the immutable `v9.0.0` release
- adopt setup-uv v9's new `prune-cache: false` default instead of preserving the previous pruning behavior
- keep `pypa/gh-action-pypi-publish@release/v1`, whose current implementation already uses Node 24-compatible internals

## Why

GitHub now runs actions that declare the deprecated Node 20 runtime under Node 24 by default. The old action pins therefore emit deprecation warnings and may stop working once the Node 20 compatibility path is removed.

For setup-uv, retaining the v9 cache default can use somewhat more GitHub cache storage, but it preserves reusable files that would otherwise need to be downloaded again and reduces repeated traffic to PyPI.

## Impact

This only changes CI action versions. The workflow inputs and artifact flow remain the same. No project source or generated research outputs are included.

## Validation

- parsed all three workflow files as YAML
- ran `git diff --check`
- verified every upgraded action tag through the GitHub API
