### PR TITLE
Fix release changelog output delimiter

### DIFF
--- a/extract_changelog.py
+++ b/extract_changelog.py
@@ -80,7 +80,7 @@ def main():
         sys.exit(1)
 
     if args.output:
-        Path(args.output).write_text(changelog_content)
+        Path(args.output).write_text(f"{changelog_content}\n")
         print(f"✓ Changelog for v{args.version} written to {args.output}")
     else:
         print(changelog_content)

--- a/tests/test_extract_changelog.py
+++ b/tests/test_extract_changelog.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_output_file_ends_with_newline(tmp_path):
+    changelog = tmp_path / "changelog.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## [0.2.0] - 2026-07-29\n\n"
+        "### Fixed\n\n"
+        "- Preserve the GitHub output delimiter.\n"
+    )
+    output = tmp_path / "release-notes.md"
+    script = Path(__file__).parents[1] / "extract_changelog.py"
+
+    subprocess.run(
+        [
+            sys.executable,
+            script,
+            "0.2.0",
+            "--changelog",
+            changelog,
+            "--output",
+            output,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert output.read_text() == (
+        "### Fixed\n\n- Preserve the GitHub output delimiter.\n"
+    )


### PR DESCRIPTION
Fixes the v0.2.0 release workflow failure before publication.

The changelog extractor now terminates output files with a newline so the GitHub Actions multiline output delimiter remains on its own line. Adds a regression test for the exact output.

Validation:
- 6 focused release-helper tests pass
- Ruff passes
- Failed run: https://github.com/tud-phi/soromox/actions/runs/30490718598

No GitHub release or PyPI artifact was published by the failed run.