### PR TITLE
Add cbfpy to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ rl = [
     "stable-baselines3",
 ]
 test = [
+    "cbfpy",
     "codecov",
     "coverage[toml]",
     "matplotlib",

--- a/uv.lock
+++ b/uv.lock
@@ -3574,6 +3574,7 @@ rl = [
     { name = "stable-baselines3" },
 ]
 test = [
+    { name = "cbfpy" },
     { name = "codecov" },
     { name = "coverage", extra = ["toml"] },
     { name = "matplotlib" },
@@ -3593,6 +3594,7 @@ requires-dist = [
     { name = "bump2version", marker = "extra == 'dev'" },
     { name = "cbfpy", marker = "extra == 'all'" },
     { name = "cbfpy", marker = "extra == 'paper-results'" },
+    { name = "cbfpy", marker = "extra == 'test'" },
     { name = "check-manifest", marker = "extra == 'all'" },
     { name = "check-manifest", marker = "extra == 'dev'" },
     { name = "codecov", marker = "extra == 'all'" },


### PR DESCRIPTION
## Summary

- add `cbfpy` to the `test` optional dependency set
- refresh `uv.lock` so `.[test]` installs the dependency in GitHub Actions

## Root cause

The Section Ve rendering test imports `pcs_cf_cbf_clf_common`, which imports `cbfpy` during pytest collection. All Test workflow jobs install `.[test]`, but `cbfpy` was previously declared only in the `paper_results` and `all` extras. Pytest therefore stopped during collection with `ModuleNotFoundError: No module named 'cbfpy'` across Python 3.11–3.14 and the minimum-numerical-dependencies job.

## Validation

- targeted Section Ve regression test: `1 passed`
- remaining suite coverage: `1202 passed` across split runs
- excluded only the pre-existing `test_umarm_viser_live_mode_smoke` local shutdown hang
- `uv lock --check`
- TOML parsing and `git diff --check`
