### PR TITLE
Correct steady-state window wording

### DIFF
--- a/paper_results/secVc_model_based_control/configuration_space_comparison/README.md
+++ b/paper_results/secVc_model_based_control/configuration_space_comparison/README.md
@@ -82,8 +82,9 @@ setpoint-window MAEs and their equal-weight aggregate for regulation.
 regulation-to-tracking trajectory for all three controlled strains.
 `outputs/regulation_tracking_rmse.pdf` places the full setpoint-regulation RMSE
 next to the steady-state regulation MAE, followed by the trajectory-tracking
-RMSE. The steady-state MAE is computed over the final quarter of each setpoint
-interval and averaged equally across the four setpoints.
+RMSE. The steady-state MAE is computed over the final 10% (0.3 s) of each
+evaluated 3 s setpoint interval after the initial plateau and averaged equally
+across the four intervals.
 Scenario-specific tracking and error plots are reproducible diagnostics and
 remain uncommitted. The checked-in NPZ files were regenerated from scratch with
 the current Section Vc generators.


### PR DESCRIPTION
## Summary

- correct the configuration-space case-study README from the final quarter to the final 10% of each evaluated setpoint interval
- state the equivalent 0.3 s terminal window for the 3 s intervals
- clarify that the initial plateau is excluded and the four evaluated intervals are averaged equally

## Why

The implementation uses `STEADY_STATE_FRACTION = 0.1`, and the canonical NPZ metadata records four 3 s intervals: `[3, 6)`, `[6, 9)`, `[9, 12)`, and `[12, 15)`. Therefore the evaluated terminal windows are the final 0.3 s of each interval, not the final quarter.

The merged PR #133 description has also been corrected directly.

## Validation

- verified `STEADY_STATE_FRACTION` against the metric implementation
- verified the saved NPZ fraction, intervals, initial-interval exclusion, and equal-weight aggregation metadata
- `git diff --check` passed