### PR TITLE
Tune collocated integral-error saturation to tendon scale

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated the dependency metadata and lockfile for a CUDA 13-enabled JAX and
   PyTorch stack, and declared `ipywidgets` with the optional Open3D extras.
+- Made the Section V.d collocated optimizer derive ``gamma`` from a configurable
+  tendon-length error scale (default 10 mm), validate finite saturation
+  parameters, and document stale committed artifacts.
 
 ### Fixed
 

--- a/paper_results/secVd_control_gain_optimization/README.md
+++ b/paper_results/secVd_control_gain_optimization/README.md
@@ -4,6 +4,37 @@ This case compares gain optimization for collocated actuation-space control and
 synergistic operational-space control. Each generator writes a MAT result under
 its controller-specific directory in `data/`; the plotter combines both files.
 
+> [!WARNING]
+> The committed Section Vd MAT files and derived plots are stale. In particular,
+> the collocated results were generated with the former, non-unit-preserving
+> integral-error saturation and the former `gamma=10` setting. Do not treat the
+> current files as canonical results. Regenerate the complete Section Vd results
+> only after the saturation-scale change has been merged and the other open
+> control-gain-optimization issues (#128 and #129) have been fixed.
+
+## Collocated integral-error saturation
+
+The collocated controller integrates tendon-length errors, all expressed in
+meters. It uses the unit-preserving saturation
+
+```text
+sat(e) = tanh(gamma * e) / gamma,
+gamma = 1 / e_sat.
+```
+
+The committed legacy trajectories were inspected to select a physical error
+scale. The undeformed tendon lengths are approximately `-100 mm`, and the
+setpoints are `[-85.49, -96.41, -100.05] mm`. This produces initial errors of
+`[14.51, 3.59, -0.05] mm`. Across the saved initial and optimized trajectories,
+all other initial/transient absolute errors remain below `3.85 mm`.
+
+The default is therefore `e_sat = 10 mm`, or `gamma = 100 1/m`. At the exceptional
+`14.51 mm` reference step, saturation reduces the integral-error derivative by
+about 38%. At `3.85 mm`, the reduction is only about 4.7%, keeping normal
+closed-loop errors nearly linear while limiting integral accumulation during the
+large step. Override the physical scale, if needed, with
+`--integral-error-saturation-scale` in meters.
+
 Run the two optimizations without GUI rendering:
 
 ```bash

--- a/paper_results/secVd_control_gain_optimization/code/control_gain_optimization_with_collocated.py
+++ b/paper_results/secVd_control_gain_optimization/code/control_gain_optimization_with_collocated.py
@@ -1,4 +1,5 @@
 import argparse
+import math
 import pickle
 import time
 from pathlib import Path
@@ -46,6 +47,16 @@ def parse_args() -> argparse.Namespace:
         help="Directory for optional diagnostic figures.",
     )
     parser.add_argument("--num-iters", type=int, default=3)
+    parser.add_argument(
+        "--integral-error-saturation-scale",
+        type=float,
+        default=1e-2,
+        help=(
+            "Tendon-length error scale in meters for tanh integral-error "
+            "saturation. Gamma is its reciprocal (default: 0.01 m, i.e. "
+            "gamma = 100 1/m)."
+        ),
+    )
     parser.add_argument("--save-figures", action="store_true")
     parser.add_argument("--no-show", action="store_true")
     parser.add_argument("--no-render", action="store_true")
@@ -58,6 +69,13 @@ RESULT_DIR = ARGS.result_dir.resolve()
 OUTPUTS_DIR = ARGS.output_dir.resolve()
 if ARGS.num_iters < 1:
     raise ValueError("--num-iters must be at least 1")
+if (
+    not math.isfinite(ARGS.integral_error_saturation_scale)
+    or ARGS.integral_error_saturation_scale <= 0.0
+):
+    raise ValueError(
+        "--integral-error-saturation-scale must be finite and strictly positive"
+    )
 for output_name in ("optimization_results.mat", "animation_data.pkl"):
     output_path = RESULT_DIR / output_name
     if output_path.exists() and not ARGS.force:
@@ -238,12 +256,20 @@ Kp = 5e1 * jnp.ones((num_actuators,))
 Ki = 5e0 * jnp.ones((num_actuators,))
 Kd = 1e0 * jnp.ones((num_actuators,))
 
+# The committed legacy trajectories start from tendon lengths of -100 mm and
+# target [-85.49, -96.41, -100.05] mm. The largest initial error is 14.51 mm,
+# whereas all other observed initial/transient errors remain below 3.85 mm.
+# A 10 mm error scale therefore limits integral accumulation during the large
+# reference step while leaving the ordinary error regime nearly linear.
+tendon_error_saturation_scale = ARGS.integral_error_saturation_scale  # [m]
+tendon_error_gamma = 1.0 / tendon_error_saturation_scale  # [1/m]
+
 pid_control = PIDControl(
     Kp=Kp,
     Ki=Ki,
     Kd=Kd,
     saturation_fn="tanh",
-    gamma=10.0,
+    gamma=tendon_error_gamma,
 )
 
 controller = PotentialCompensationRegulator(

--- a/src/soromox/control/pid_control.py
+++ b/src/soromox/control/pid_control.py
@@ -118,10 +118,10 @@ class PIDControl(eqx.Module):
                   preserves the units and small-error slope of ``e``.
                 - A callable `f(e) -> saturated_e`: Custom saturation function.
             gamma: Inverse error scale for built-in saturation functions. Can be
-                a positive scalar, positive diagonal vector, or symmetric
-                positive-definite matrix. For a scalar or vector, ``1 / gamma``
-                sets the componentwise saturation magnitude. Only used when
-                ``saturation_fn="tanh"``. Defaults to 1.0.
+                a finite positive scalar, finite positive diagonal vector, or
+                finite symmetric positive-definite matrix. For a scalar or vector,
+                ``1 / gamma`` sets the componentwise saturation magnitude. Only
+                used when ``saturation_fn="tanh"``. Defaults to 1.0.
         """
         self.Kp = jnp.atleast_1d(jnp.asarray(Kp))
         self.Ki = jnp.atleast_1d(jnp.asarray(Ki))
@@ -132,6 +132,8 @@ class PIDControl(eqx.Module):
             self._saturation_fn_name = "identity"
             self._custom_saturation_fn = None
         elif saturation_fn == "tanh":
+            if not bool(jnp.all(jnp.isfinite(self.gamma))):
+                raise ValueError("Gamma must be finite for tanh saturation.")
             if self.gamma.ndim == 1:
                 if bool(jnp.any(self.gamma <= 0)):
                     raise ValueError(

--- a/tests/control/test_pid_control.py
+++ b/tests/control/test_pid_control.py
@@ -285,6 +285,26 @@ class TestPIDControlValidation:
                 gamma=gamma,
             )
 
+    @pytest.mark.parametrize(
+        "gamma",
+        [
+            jnp.inf,
+            -jnp.inf,
+            jnp.nan,
+            jnp.array([1.0, jnp.inf]),
+            jnp.array([[1.0, 0.0], [0.0, jnp.nan]]),
+        ],
+    )
+    def test_tanh_gamma_must_be_finite(self, gamma):
+        with pytest.raises(ValueError, match="must be finite"):
+            PIDControl(
+                Kp=1.0,
+                Ki=0.5,
+                Kd=0.1,
+                saturation_fn="tanh",
+                gamma=gamma,
+            )
+
     def test_matrix_gamma_must_be_symmetric_positive_definite(self):
         for gamma in (
             jnp.array([[1.0, 1.0], [0.0, 1.0]]),


### PR DESCRIPTION
## Summary

- replace the collocated optimizer's fixed `gamma=10` with a physically interpretable default tendon-error scale of `e_sat = 10 mm`, i.e. `gamma = 100 1/m`
- expose the scale as `--integral-error-saturation-scale` (meters) and reject non-finite or non-positive values
- reject non-finite `gamma` values universally in `PIDControl` before positivity/SPD validation
- document the trajectory-based derivation and prominently mark the committed Section V.d data and plots as stale

## How we arrived here

PR #133 corrected the built-in saturation from the former `tanh(gamma * e)` expression to the unit-preserving

```text
sat(e) = tanh(gamma * e) / gamma,
gamma = 1 / e_sat.
```

The collocated control-gain optimizer integrates only tendon-length errors, so every controlled coordinate has units of meters and a scalar `gamma` has units `1/m`. The optimizer had retained `gamma=10`, which now means `e_sat=100 mm`: the full segment length and far outside the observed error regime. It retained 99.3% of the largest initial error, making saturation effectively inactive.

I transformed every saved configuration in the six committed initial and optimized collocated trajectories into tendon coordinates and compared them with the tendon-length setpoints:

| Quantity | Tendon 1 | Tendon 2 | Tendon 3 |
| --- | ---: | ---: | ---: |
| undeformed length | -100.00 mm | -100.00 mm | -100.00 mm |
| setpoint | -85.49 mm | -96.41 mm | -100.05 mm |
| initial error | 14.51 mm | 3.59 mm | -0.05 mm |

Apart from the exceptional 14.51 mm reference step, all observed initial/transient absolute errors across the saved trajectories remain below 3.85 mm.

A 10 mm saturation scale is therefore a deliberate boundary between the large reference step and the ordinary closed-loop error regime:

- at 14.51 mm, `sat(e)=8.96 mm`, reducing integral accumulation by 38.25%
- at 3.85 mm, 95.35% of the error is retained
- at 1 mm, 99.67% is retained

This limits windup during the large step without materially reshaping the ordinary transient and regulation errors.

## Result status and regeneration order

> [!IMPORTANT]
> **All currently committed Section V.d MAT files and derived plots must now be considered stale.** The collocated results were generated with the former non-unit-preserving saturation and the former gamma setting. This PR intentionally does not replace any result artifacts.

The complete Section V.d results should be regenerated only after:

1. this PR has been merged; and
2. the other control-gain-optimization defects in #128 and #129 have been fixed.

A one-iteration temporary smoke run completed the simulation/save path, but it reproduced the non-finite optimized gains tracked in #129. Its setpoint rollout also warned that it had not reached steady state. Those outputs were written only under `/tmp` and are not included here.

## Validation

- `ruff check` and `ruff format --check` on the collocated optimizer
- `python -m py_compile` on the collocated optimizer
- `pytest -q tests/control/test_pid_control.py`: 41 passed
- numerical saturation check at 14.51 mm, 3.85 mm, and 1 mm
- one-iteration collocated end-to-end smoke run to temporary output, confirming the new code path and reproducing the separate #129 blocker

@Michele-Martini, could you please review the physical scale selection and the intended regeneration sequencing?