### PR TITLE
Make SoRoMoX preprint the primary citation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,10 @@ jobs:
             pip install soromox==${{ needs.build.outputs.version }}
             ```
 
+            ## Citation
+
+            If you use SoRoMoX in academic work, please cite the [SoRoMoX preprint](https://doi.org/10.48550/arXiv.2608.06650) and report the exact package version used. See the [complete citation guide](https://tud-phi.github.io/soromox/citation/) for BibTeX and conditional software citations.
+
             See the full [changelog](https://github.com/tud-phi/soromox/blob/v${{ needs.build.outputs.version }}/docs/development/changelog.md).
           files: |
             dist/*.whl

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
+message: "For academic use, cite the preferred paper below. When reproducibility depends on a particular release, also report and, where appropriate, cite the exact software version."
 type: software
 title: "SoRoMoX: Soft Robot Models in JAX"
 abstract: "Kinematic and dynamic models of continuum and articulated soft robots implemented in JAX."
@@ -23,7 +23,8 @@ authors:
   - family-names: "Della Santina"
     given-names: "Cosimo"
 repository-code: "https://github.com/tud-phi/soromox"
-url: "https://github.com/tud-phi/soromox"
+repository-artifact: "https://pypi.org/project/soromox/0.2.1/"
+url: "https://tud-phi.github.io/soromox"
 license: MIT
 version: "0.2.1"
 date-released: "2026-08-03"
@@ -34,3 +35,35 @@ keywords:
   - "Dynamics"
   - "Continuum Soft Robots"
   - "Articulated Soft Robots"
+preferred-citation:
+  type: generic
+  title: "SoRoMoX: Fast, Differentiable, and Parallelizable Soft Robot Models"
+  authors:
+    - family-names: "Stölzle"
+      given-names: "Maximilian"
+    - family-names: "Gribonval"
+      given-names: "Solange"
+    - family-names: "Feliu-Talegon"
+      given-names: "Daniel"
+    - family-names: "Perfetta"
+      given-names: "Vito Daniele"
+    - family-names: "Martini"
+      given-names: "Michele"
+    - family-names: "Zhang"
+      given-names: "Chuhan"
+    - family-names: "Wong"
+      given-names: "Kiwan"
+    - family-names: "Tarnini"
+      given-names: "Mohammed"
+    - family-names: "Mathew"
+      given-names: "Anup Teejo"
+    - family-names: "Renda"
+      given-names: "Federico"
+    - family-names: "Rus"
+      given-names: "Daniela"
+    - family-names: "Della Santina"
+      given-names: "Cosimo"
+  doi: "10.48550/arXiv.2608.06650"
+  status: preprint
+  url: "https://arxiv.org/abs/2608.06650"
+  year: 2026

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Test](https://github.com/tud-phi/soromox/actions/workflows/test.yml/badge.svg)](https://github.com/tud-phi/soromox/actions/workflows/test.yml)
 [![Documentation](https://github.com/tud-phi/soromox/actions/workflows/docs.yml/badge.svg)](https://github.com/tud-phi/soromox/actions/workflows/docs.yml)
 [![PyPI version](https://badge.fury.io/py/soromox.svg)](https://badge.fury.io/py/soromox)
+[![arXiv](https://img.shields.io/badge/arXiv-2608.06650-b31b1b.svg)](https://arxiv.org/abs/2608.06650)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/github/license/tud-phi/soromox.svg)](https://github.com/tud-phi/soromox/blob/main/LICENSE.txt)
 [![Docs](https://img.shields.io/badge/docs-live-brightgreen.svg)](https://tud-phi.github.io/soromox)
@@ -37,55 +38,26 @@ We are happy to receive contributions for other soft robot models. See the [Cont
 
 ## Citation
 
-Please use the following citation if you use our software in your (scientific) work:
+If you use SoRoMoX in academic work, please cite the associated preprint:
 
-### Software Citation
+### Primary Paper
 
 ```bibtex
-@software{soromox2026,
-  title = {SoRoMoX: Soft Robot Models in JAX},
-  author = {Stölzle, Maximilian and Gribonval, Solange and {Feliu-Talegon}, Daniel and Perfetta, Vito Daniele and Martini, Michele and Zhang, Chuhan and Wong, Kiwan and Rus, Daniela and {Della Santina}, Cosimo},
+@misc{stolzle2026soromox,
+  title = {{SoRoMoX}: Fast, Differentiable, and Parallelizable Soft Robot Models},
+  author = {Maximilian St{\"o}lzle and Solange Gribonval and Daniel {Feliu-Talegon} and Vito Daniele Perfetta and Michele Martini and Chuhan Zhang and Kiwan Wong and Mohammed Tarnini and Anup Teejo Mathew and Federico Renda and Daniela Rus and Cosimo {Della Santina}},
   year = {2026},
-  url = {https://github.com/tud-phi/soromox},
-  version = {0.2.1},
-  abstract = {Kinematic and dynamic models of continuum and articulated soft robots implemented in JAX.}
+  eprint = {2608.06650},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.RO},
+  doi = {10.48550/arXiv.2608.06650},
+  url = {https://arxiv.org/abs/2608.06650},
 }
 ```
 
-### Planar HSA Model Citation
-
-The model of the kinematics and dynamics of the planar HSA robot are part of the publication **"An Experimental Study of Model-based Control for Planar Handed Shearing Auxetics Robots"** presented at the *18th International Symposium on Experimental Robotics*.
-
-```bibtex
-@inproceedings{stolzle2023experimental,
-  title={An experimental study of model-based control for planar handed shearing auxetics robots},
-  author={St{\"o}lzle, Maximilian and Rus, Daniela and Della Santina, Cosimo},
-  booktitle={International Symposium on Experimental Robotics},
-  pages={153--167},
-  year={2023},
-  organization={Springer}
-}
-```
-
-### Model-Based Controllers Citation
-
-If you found the implementation of the model-based controllers (e.g., PID, gravity cancellation, potential shaping regulators) useful, please consider also citing the following PhD thesis:
-
-```bibtex
-@phdthesis{stolzle2025phdthesis,
-  title = "Safe yet Precise Soft Robots: Incorporating Physics into Learned Models for Control",
-  keywords = "Soft Robotics, Nonlinear Control, Machine Learning, Artificial Intelligence",
-  author = "Maximilian St{\"o}lzle",
-  year = "2025",
-  month = "9",
-  day = "15",
-  language = "English",
-  type = "Dissertation (TU Delft)",
-  school = "Mechanical Engineering, Delft University of Technology",
-  doi = "10.4233/uuid:24c1f667-8fd6-431a-bb78-11d22f8cb3da",
-  isbn = "978-94-6384-836-7",
-}
-```
+For reproducible computational work, also report the exact version available as
+`soromox.__version__`. See the [complete citation guide](docs/citation.md) for a
+version-specific software citation and additional model or controller references.
 
 ## Installation
 
@@ -323,8 +295,8 @@ The dry run mode will show you:
 
 The version bump process automatically updates:
 - `pyproject.toml` - Main project version
-- `CITATION.cff` - Citation version and release date
-- `README.md` and `docs/index.md` - BibTeX version, year, and citation key
+- `CITATION.cff` - Software version, release date, and PyPI artifact URL
+- `docs/citation.md` - Software BibTeX version, year, key, and release URL
 - `docs/development/changelog.md` - Moves unreleased notes into a dated release
 - `uv.lock` - Local package version
 

--- a/VERSION_BUMP_README.md
+++ b/VERSION_BUMP_README.md
@@ -14,8 +14,8 @@ This directory contains scripts for automated version bumping and GitHub release
 The version bump script updates version information in:
 
 - `pyproject.toml` - Main project version
-- `CITATION.cff` - Citation version and release date
-- `README.md` and `docs/index.md` - BibTeX version, year, and citation key
+- `CITATION.cff` - Software version, release date, and PyPI artifact URL
+- `docs/citation.md` - Software BibTeX version, year, key, and release URL
 - `docs/development/changelog.md` - Dated release entry
 - `uv.lock` - Local package version
 

--- a/bump_version.py
+++ b/bump_version.py
@@ -5,8 +5,7 @@ The script updates the tracked sources of release metadata:
 
 - ``pyproject.toml``
 - ``CITATION.cff``
-- ``README.md``
-- ``docs/index.md``
+- ``docs/citation.md``
 - ``docs/development/changelog.md``
 - ``uv.lock``
 
@@ -24,8 +23,7 @@ from pathlib import Path
 RELEASE_FILES = (
     Path("pyproject.toml"),
     Path("CITATION.cff"),
-    Path("README.md"),
-    Path("docs/index.md"),
+    Path("docs/citation.md"),
     Path("docs/development/changelog.md"),
     Path("uv.lock"),
 )
@@ -88,7 +86,7 @@ def update_pyproject_toml(file_path: Path, new_version: str) -> None:
 
 
 def update_citation_cff(file_path: Path, new_version: str, release_date: date) -> None:
-    """Update the CFF version and release date."""
+    """Update the CFF software version, release date, and artifact URL."""
     content = file_path.read_text()
     content = replace_required(
         content,
@@ -102,24 +100,33 @@ def update_citation_cff(file_path: Path, new_version: str, release_date: date) -
         f'date-released: "{release_date.isoformat()}"',
         description=f"release date in {file_path}",
     )
+    content = replace_required(
+        content,
+        r'^repository-artifact: "[^"]+"',
+        f'repository-artifact: "https://pypi.org/project/soromox/{new_version}/"',
+        description=f"artifact URL in {file_path}",
+    )
     file_path.write_text(content)
 
 
-def update_bibtex_citation(
+def update_software_bibtex_citation(
     file_path: Path, new_version: str, release_date: date
 ) -> None:
     """Update the software BibTeX block embedded in Markdown."""
     content = file_path.read_text()
     block_match = re.search(
-        r"@software\{soromox\d{4},.*?\n\s*\}", content, flags=re.DOTALL
+        r"@software\{soromox_v\d+_\d+_\d+,.*?\n\s*\}",
+        content,
+        flags=re.DOTALL,
     )
     if not block_match:
         raise ValueError(f"Could not find software citation in {file_path}")
 
     block = block_match.group(0)
+    citation_version = new_version.replace(".", "_")
     block = re.sub(
-        r"@software\{soromox\d{4},",
-        f"@software{{soromox{release_date.year},",
+        r"@software\{soromox_v\d+_\d+_\d+,",
+        f"@software{{soromox_v{citation_version},",
         block,
         count=1,
     )
@@ -134,6 +141,12 @@ def update_bibtex_citation(
         r"^(\s*version = )\{[^}]+\},$",
         rf"\g<1>{{{new_version}}},",
         description=f"citation version in {file_path}",
+    )
+    block = replace_required(
+        block,
+        r"^(\s*url = )\{https://github\.com/tud-phi/soromox/releases/tag/v[^}]+\},$",
+        rf"\g<1>{{https://github.com/tud-phi/soromox/releases/tag/v{new_version}}},",
+        description=f"citation release URL in {file_path}",
     )
     file_path.write_text(
         content[: block_match.start()] + block + content[block_match.end() :]
@@ -280,8 +293,9 @@ def main() -> None:
     try:
         update_pyproject_toml(paths[Path("pyproject.toml")], new_version)
         update_citation_cff(paths[Path("CITATION.cff")], new_version, release_date)
-        update_bibtex_citation(paths[Path("README.md")], new_version, release_date)
-        update_bibtex_citation(paths[Path("docs/index.md")], new_version, release_date)
+        update_software_bibtex_citation(
+            paths[Path("docs/citation.md")], new_version, release_date
+        )
         update_changelog(
             paths[Path("docs/development/changelog.md")],
             new_version,

--- a/docs/api/control/index.md
+++ b/docs/api/control/index.md
@@ -214,23 +214,9 @@ This clean separation means the two terms can be designed, tuned, and analyzed i
     > [https://doi.org/10.4233/uuid:24c1f667-8fd6-431a-bb78-11d22f8cb3da](https://doi.org/10.4233/uuid:24c1f667-8fd6-431a-bb78-11d22f8cb3da)
 
 !!! tip "Citation Request"
-    If you find this implementation of model-based controllers useful for your research, please consider citing the following work:
-
-    ```bibtex
-    @phdthesis{stolzle2025phdthesis,
-      title = "Safe yet Precise Soft Robots: Incorporating Physics into Learned Models for Control",
-      keywords = "Soft Robotics, Nonlinear Control, Machine Learning, Artificial Intelligence",
-      author = "Maximilian St{\"o}lzle",
-      year = "2025",
-      month = "9",
-      day = "15",
-      language = "English",
-      type = "Dissertation (TU Delft)",
-      school = "Mechanical Engineering, Delft University of Technology",
-      doi = "10.4233/uuid:24c1f667-8fd6-431a-bb78-11d22f8cb3da",
-      isbn = "978-94-6384-836-7",
-    }
-    ```
+    If these controller formulations or implementation details are material to
+    your research, see the [citation guide](../../citation.md#model-based-controllers)
+    for the recommended BibTeX entry.
 
 ---
 

--- a/docs/api/systems/hsa/index.md
+++ b/docs/api/systems/hsa/index.md
@@ -39,4 +39,10 @@ Planar HSA soft robots with symbolic computation.
 
 The planar HSA model is part of the publication:
 
-Stölzle, M., Rus, D., & Della Santina, C. (2023). An experimental study of model-based control for planar handed shearing auxetics robots. *International Symposium on Experimental Robotics*, 153-167.
+Stölzle, M., Rus, D., & Della Santina, C. (2024). An experimental study of
+model-based control for planar handed shearing auxetics robots. In
+*Experimental Robotics: The 18th International Symposium* (pp. 153–167).
+Springer. [doi:10.1007/978-3-031-63596-0_14](https://doi.org/10.1007/978-3-031-63596-0_14)
+
+See the [citation guide](../../../citation.md#planar-hsa-model) for BibTeX and
+guidance on when to include this additional reference.

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,0 +1,95 @@
+# Citing SoRoMoX
+
+## Primary Paper
+
+If you use SoRoMoX in academic work, please cite the associated preprint:
+
+```bibtex
+@misc{stolzle2026soromox,
+  title = {{SoRoMoX}: Fast, Differentiable, and Parallelizable Soft Robot Models},
+  author = {Maximilian St{\"o}lzle and Solange Gribonval and Daniel {Feliu-Talegon} and Vito Daniele Perfetta and Michele Martini and Chuhan Zhang and Kiwan Wong and Mohammed Tarnini and Anup Teejo Mathew and Federico Renda and Daniela Rus and Cosimo {Della Santina}},
+  year = {2026},
+  eprint = {2608.06650},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.RO},
+  doi = {10.48550/arXiv.2608.06650},
+  url = {https://arxiv.org/abs/2608.06650},
+}
+```
+
+The latest preprint is available at
+[arXiv:2608.06650](https://arxiv.org/abs/2608.06650).
+
+## Reproducibility and Software Version
+
+When SoRoMoX generates results reported in a publication, also state the exact
+package version. It is available at runtime as:
+
+```python
+import soromox
+
+print(soromox.__version__)
+```
+
+If reproducibility depends materially on a particular release, we encourage an
+additional software citation for that release:
+
+```bibtex
+@software{soromox_v0_2_1,
+  title = {{SoRoMoX}: Soft Robot Models in {JAX}},
+  author = {Maximilian St{\"o}lzle and Solange Gribonval and Daniel {Feliu-Talegon} and Vito Daniele Perfetta and Michele Martini and Chuhan Zhang and Kiwan Wong and Daniela Rus and Cosimo {Della Santina}},
+  year = {2026},
+  version = {0.2.1},
+  url = {https://github.com/tud-phi/soromox/releases/tag/v0.2.1},
+}
+```
+
+Use the entry associated with the version that produced the results rather than
+substituting the newest release.
+
+## Additional Model and Method Citations
+
+These references are conditional: cite them when the corresponding model or
+controller implementation is material to the work.
+
+### Planar HSA Model
+
+For the kinematic and dynamic model of the planar Handed Shearing Auxetics
+robot, also cite:
+
+```bibtex
+@inproceedings{stolzle2024experimental,
+  title = {An Experimental Study of Model-Based Control for Planar Handed Shearing Auxetics Robots},
+  author = {Maximilian St{\"o}lzle and Daniela Rus and Cosimo {Della Santina}},
+  booktitle = {Experimental Robotics: The 18th International Symposium},
+  series = {Springer Proceedings in Advanced Robotics},
+  volume = {30},
+  pages = {153--167},
+  publisher = {Springer},
+  year = {2024},
+  doi = {10.1007/978-3-031-63596-0_14},
+}
+```
+
+### Model-Based Controllers
+
+If the controller formulations or implementation details described in Chapter 2
+of the following thesis are material to the work, also cite:
+
+```bibtex
+@phdthesis{stolzle2025phdthesis,
+  title = {Safe yet Precise Soft Robots: Incorporating Physics into Learned Models for Control},
+  author = {Maximilian St{\"o}lzle},
+  year = {2025},
+  type = {Dissertation},
+  school = {Delft University of Technology},
+  doi = {10.4233/uuid:24c1f667-8fd6-431a-bb78-11d22f8cb3da},
+  isbn = {978-94-6384-836-7},
+}
+```
+
+## Citation and License
+
+The citation guidance above is a scholarly request. SoRoMoX is distributed
+under the MIT License; redistribution requirements are defined by
+[`LICENSE.txt`](https://github.com/tud-phi/soromox/blob/main/LICENSE.txt).

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Made the SoRoMoX arXiv preprint the primary academic citation, centralized
+  citation guidance, and retained an exact-release software citation for
+  reproducibility-sensitive work.
+
 ### Fixed
 
 ## [0.2.1] - 2026-08-03

--- a/docs/index.md
+++ b/docs/index.md
@@ -253,55 +253,14 @@ All renderers support:
 
 ## Citation
 
-!!! quote "If you use our software in your research, please cite:"
+!!! quote "If you use SoRoMoX in academic work"
 
-    ### Software Citation
+    Please cite **“SoRoMoX: Fast, Differentiable, and Parallelizable Soft
+    Robot Models”**, available as
+    [arXiv:2608.06650](https://arxiv.org/abs/2608.06650).
 
-    ```bibtex
-    @software{soromox2026,
-      title = {SoRoMoX: Soft Robot Models in JAX},
-      author = {Stölzle, Maximilian and Gribonval, Solange and {Feliu-Talegon}, Daniel and Perfetta, Vito Daniele and Martini, Michele and Zhang, Chuhan and Wong, Kiwan and Rus, Daniela and {Della Santina}, Cosimo},
-      year = {2026},
-      url = {https://github.com/tud-phi/soromox},
-      version = {0.2.1},
-      abstract = {Kinematic and dynamic models of continuum and articulated soft robots implemented in JAX.}
-    }
-    ```
-
-    ### Planar HSA Model Citation
-
-    The model of the kinematics and dynamics of the planar HSA robot are part of the publication **"An Experimental Study of Model-based Control for Planar Handed Shearing Auxetics Robots"** presented at the *18th International Symposium on Experimental Robotics*.
-
-    ```bibtex
-    @inproceedings{stolzle2023experimental,
-      title={An experimental study of model-based control for planar handed shearing auxetics robots},
-      author={St{\"o}lzle, Maximilian and Rus, Daniela and Della Santina, Cosimo},
-      booktitle={International Symposium on Experimental Robotics},
-      pages={153--167},
-      year={2023},
-      organization={Springer}
-    }
-    ```
-
-    ### Model-Based Controllers Citation
-
-    If you found the implementation of the model-based controllers (e.g., PID, gravity cancellation, potential shaping regulators) useful, please consider also citing the following PhD thesis:
-
-    ```bibtex
-    @phdthesis{stolzle2025phdthesis,
-      title = "Safe yet Precise Soft Robots: Incorporating Physics into Learned Models for Control",
-      keywords = "Soft Robotics, Nonlinear Control, Machine Learning, Artificial Intelligence",
-      author = "Maximilian St{\"o}lzle",
-      year = "2025",
-      month = "9",
-      day = "15",
-      language = "English",
-      type = "Dissertation (TU Delft)",
-      school = "Mechanical Engineering, Delft University of Technology",
-      doi = "10.4233/uuid:24c1f667-8fd6-431a-bb78-11d22f8cb3da",
-      isbn = "978-94-6384-836-7",
-    }
-    ```
+    See the [complete citation guide](citation.md) for BibTeX, exact-version
+    software citations, and model- or controller-specific references.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ theme:
 
 nav:
   - Home: index.md
+  - Citation: citation.md
   - Installation: installation.md
   - User Guide:
     - Quick Start: user-guide/quick-start.md
@@ -198,6 +199,9 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/tud-phi/soromox
       name: View on GitHub
+    - icon: fontawesome/solid/file-lines
+      link: https://arxiv.org/abs/2608.06650
+      name: Read the SoRoMoX paper
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/soromox/
       name: View on PyPI

--- a/paper_results/README.md
+++ b/paper_results/README.md
@@ -1,9 +1,10 @@
 # Paper Results
 
-This directory maps paper sections to the code, data, and canonical outputs used
-to produce the reported results. Each section keeps scripts under `code/`, source
-or generated artifacts under `data/`, and publication figures/videos under
-`outputs/`.
+This directory maps sections of the
+[SoRoMoX preprint](https://arxiv.org/abs/2608.06650) to the code, data, and
+canonical outputs used to produce the reported results. Each section keeps
+scripts under `code/`, source or generated artifacts under `data/`, and
+publication figures/videos under `outputs/`.
 
 | Paper section | Directory | Reproduced artifacts |
 | --- | --- | --- |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,6 +258,8 @@ all = [
 "Documentation" = "https://tud-phi.github.io/soromox"
 "Changelog" = "https://tud-phi.github.io/soromox/development/changelog/"
 "Bug Reports" = "https://github.com/tud-phi/soromox/issues"
+"Paper" = "https://doi.org/10.48550/arXiv.2608.06650"
+"Citation" = "https://tud-phi.github.io/soromox/citation/"
 "Source" = "https://github.com/tud-phi/soromox"
 
 # The following would provide a command line executable called `sample`

--- a/src/soromox/systems/hsa/planar_hsa.py
+++ b/src/soromox/systems/hsa/planar_hsa.py
@@ -87,9 +87,10 @@ class PlanarHSA(SoftRobot):
       when consider_hysteresis=True.
 
     References:
-        Stölzle, M., Rus, D., & Della Santina, C. (2023). An experimental study of
+        Stölzle, M., Rus, D., & Della Santina, C. (2024). An experimental study of
         model-based control for planar handed shearing auxetics robots. In
-        International Symposium on Experimental Robotics (pp. 153-167). Springer.
+        Experimental Robotics: The 18th International Symposium (pp. 153-167).
+        Springer. https://doi.org/10.1007/978-3-031-63596-0_14
     """
 
     # static settings

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -66,23 +66,46 @@ def test_update_citations_synchronizes_version_date_and_year(tmp_path):
     cff.write_text(
         'version: "0.1.0"\n'
         'date-released: "2025-09-01"\n'
+        'repository-artifact: "https://pypi.org/project/soromox/0.1.0/"\n'
+        "preferred-citation:\n"
+        '  title: "Paper metadata must remain unchanged"\n'
+        "  year: 2025\n"
     )
-    markdown = tmp_path / "README.md"
+    markdown = tmp_path / "citation.md"
     markdown.write_text(
+        "@misc{paper2025,\n"
+        "  title = {Paper metadata must remain unchanged},\n"
+        "  year = {2025},\n"
+        "}\n\n"
         "```bibtex\n"
-        "@software{soromox2025,\n"
+        "@software{soromox_v0_1_0,\n"
         "  year = {2025},\n"
         "  version = {0.1.0},\n"
+        "  url = {https://github.com/tud-phi/soromox/releases/tag/v0.1.0},\n"
         "}\n"
         "```\n"
     )
 
     release_date = date(2026, 7, 29)
     bump_version.update_citation_cff(cff, "0.2.0", release_date)
-    bump_version.update_bibtex_citation(markdown, "0.2.0", release_date)
+    bump_version.update_software_bibtex_citation(markdown, "0.2.0", release_date)
 
-    assert 'version: "0.2.0"' in cff.read_text()
-    assert 'date-released: "2026-07-29"' in cff.read_text()
-    assert "@software{soromox2026," in markdown.read_text()
-    assert "year = {2026}," in markdown.read_text()
-    assert "version = {0.2.0}," in markdown.read_text()
+    cff_content = cff.read_text()
+    assert 'version: "0.2.0"' in cff_content
+    assert 'date-released: "2026-07-29"' in cff_content
+    assert (
+        'repository-artifact: "https://pypi.org/project/soromox/0.2.0/"' in cff_content
+    )
+    assert 'title: "Paper metadata must remain unchanged"' in cff_content
+    assert "  year: 2025" in cff_content
+
+    markdown_content = markdown.read_text()
+    assert "@software{soromox_v0_2_0," in markdown_content
+    assert "year = {2026}," in markdown_content
+    assert "version = {0.2.0}," in markdown_content
+    assert (
+        "url = {https://github.com/tud-phi/soromox/releases/tag/v0.2.0},"
+        in markdown_content
+    )
+    assert "@misc{paper2025," in markdown_content
+    assert "title = {Paper metadata must remain unchanged}," in markdown_content

--- a/tests/test_citation_metadata.py
+++ b/tests/test_citation_metadata.py
@@ -1,0 +1,85 @@
+import re
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARXIV_ID = "2608.06650"
+ARXIV_DOI = f"10.48550/arXiv.{ARXIV_ID}"
+PAPER_TITLE = "SoRoMoX: Fast, Differentiable, and Parallelizable Soft Robot Models"
+
+
+def _extract_bibtex(text: str, entry_type: str, key: str) -> str:
+    match = re.search(
+        rf"@{re.escape(entry_type)}\{{{re.escape(key)},.*?^\}}$",
+        text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert match is not None
+    return match.group(0)
+
+
+def test_preprint_is_primary_citation_with_distinct_authorship():
+    cff = (ROOT / "CITATION.cff").read_text()
+    root_metadata, preferred = cff.split("preferred-citation:\n", maxsplit=1)
+
+    assert root_metadata.count("family-names:") == 9
+    assert preferred.count("family-names:") == 12
+    assert PAPER_TITLE in preferred
+    assert f'doi: "{ARXIV_DOI}"' in preferred
+    assert f'url: "https://arxiv.org/abs/{ARXIV_ID}"' in preferred
+    assert "status: preprint" in preferred
+    for paper_only_author in ("Tarnini", "Mathew", "Renda"):
+        assert paper_only_author not in root_metadata
+        assert f'family-names: "{paper_only_author}"' in preferred
+
+
+def test_readme_and_docs_share_primary_bibtex_and_badge():
+    readme = (ROOT / "README.md").read_text()
+    citation_docs = (ROOT / "docs" / "citation.md").read_text()
+
+    readme_bibtex = _extract_bibtex(readme, "misc", "stolzle2026soromox")
+    docs_bibtex = _extract_bibtex(citation_docs, "misc", "stolzle2026soromox")
+    assert readme_bibtex == docs_bibtex
+    assert ARXIV_ID in readme_bibtex
+    assert ARXIV_DOI in readme_bibtex
+    assert (
+        f"[![arXiv](https://img.shields.io/badge/arXiv-{ARXIV_ID}-b31b1b.svg)]"
+        f"(https://arxiv.org/abs/{ARXIV_ID})" in readme
+    )
+
+
+def test_software_release_and_project_urls_are_version_specific():
+    cff = (ROOT / "CITATION.cff").read_text()
+    citation_docs = (ROOT / "docs" / "citation.md").read_text()
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+
+    assert 'repository-artifact: "https://pypi.org/project/soromox/0.2.1/"' in cff
+    software_bibtex = _extract_bibtex(citation_docs, "software", "soromox_v0_2_1")
+    assert "version = {0.2.1}," in software_bibtex
+    assert (
+        "url = {https://github.com/tud-phi/soromox/releases/tag/v0.2.1},"
+        in software_bibtex
+    )
+    assert project["urls"]["Paper"] == f"https://doi.org/{ARXIV_DOI}"
+    assert project["urls"]["Citation"] == "https://tud-phi.github.io/soromox/citation/"
+
+
+def test_controller_citation_identifies_relevant_thesis_chapter():
+    citation_docs = (ROOT / "docs" / "citation.md").read_text()
+
+    assert "described in Chapter 2" in citation_docs
+
+
+def test_hsa_citation_uses_final_publication_metadata():
+    paths = (
+        ROOT / "README.md",
+        ROOT / "docs" / "citation.md",
+        ROOT / "docs" / "api" / "systems" / "hsa" / "index.md",
+        ROOT / "src" / "soromox" / "systems" / "hsa" / "planar_hsa.py",
+    )
+    contents = "\n".join(path.read_text() for path in paths)
+
+    assert "stolzle2023experimental" not in contents
+    assert "stolzle2024experimental" in contents
+    assert "10.1007/978-3-031-63596-0_14" in contents

--- a/tests/test_create_anonymized_archive.py
+++ b/tests/test_create_anonymized_archive.py
@@ -96,7 +96,17 @@ authors:
   - family-names: "Reviewer"
     given-names: "Bob"
 repository-code: "https://github.com/identifying-group/review-project"
+repository-artifact: "https://pypi.org/project/review-project/1.0.0/"
 url: "https://identifying.example/review-project"
+preferred-citation:
+  type: generic
+  title: Identifying Review Project Paper
+  authors:
+    - family-names: "Paper"
+      given-names: "Carol"
+  repository: "https://arxiv.org/abs/9999.99999"
+  status: preprint
+  year: 2026
 """,
     )
     _write(
@@ -140,7 +150,7 @@ Alice Example maintains this package at https://github.com/identifying-group/rev
 @software{package, author={Example, Alice}}
 ```
 
-### Related Reference
+## Related Reference
 
 Example, A. (2024). A legitimate scholarly reference.
 
@@ -155,6 +165,14 @@ Please cite the revealing PhD thesis.
 ## Acknowledgments
 
 Our previous work was funded by Grant 123.
+""",
+    )
+    _write(
+        repo / "docs" / "citation.md",
+        """\
+# Citing Review Project
+
+Please cite Carol Paper and the identifying review-project preprint.
 """,
     )
     _write(
@@ -253,6 +271,11 @@ def test_archive_uses_committed_files_and_anonymizes(
         assert "revealing PhD thesis" not in control_docs
         assert "Public controller documentation" in control_docs
 
+        citation_docs = archive.read(f"{root}/docs/citation.md").decode()
+        assert "withheld for double-anonymous review" in citation_docs
+        assert "Carol Paper" not in citation_docs
+        assert "review-project preprint" not in citation_docs
+
         project = tomllib.loads(archive.read(f"{root}/pyproject.toml").decode())
         assert project["project"]["authors"] == [{"name": "Anonymous"}]
         assert project["project"]["maintainers"] == [{"name": "Anonymous"}]
@@ -265,7 +288,10 @@ def test_archive_uses_committed_files_and_anonymizes(
         cff = archive.read(f"{root}/CITATION.cff").decode()
         assert 'name: "Anonymous"' in cff
         assert "repository-code" not in cff
+        assert "repository-artifact" not in cff
+        assert "preferred-citation" not in cff
         assert "Alice" not in cff
+        assert "Carol" not in cff
 
         assert "figure.png" not in readme
 

--- a/tools/create_anonymized_archive.py
+++ b/tools/create_anonymized_archive.py
@@ -136,7 +136,7 @@ SENSITIVE_ASSET_REFERENCE_RE = re.compile(
     r"\b(?:headshots?|logos?|portraits?)\b", re.IGNORECASE
 )
 IDENTIFYING_CITATION_SECTION_RE = re.compile(
-    r"^(?:software citation|planar hsa model citation|"
+    r"^(?:citation|software citation|planar hsa model citation|"
     r"model-based controllers citation|references and citation)$",
     re.IGNORECASE,
 )
@@ -150,9 +150,7 @@ RETAINED_VISUAL_PATHS = frozenset(
         "docs/assets/logo/soromox_logo_s.png",
     }
 )
-PNG_METADATA_CHUNKS = frozenset(
-    {b"caBX", b"eXIf", b"iTXt", b"tEXt", b"tIME", b"zTXt"}
-)
+PNG_METADATA_CHUNKS = frozenset({b"caBX", b"eXIf", b"iTXt", b"tEXt", b"tIME", b"zTXt"})
 PDF_INFO_VALUE_RE = re.compile(
     rb"/(Author|Creator|Producer|CreationDate|ModDate|Title|Subject|Keywords)"
     rb"\s*(\((?:\\.|[^\\)])*\)|<[0-9A-Fa-f\s]*>)",
@@ -492,9 +490,7 @@ def _remove_markdown_sections(text: str, title_pattern: re.Pattern[str]) -> str:
     return "".join(output)
 
 
-def _remove_markdown_admonitions_containing(
-    text: str, marker: re.Pattern[str]
-) -> str:
+def _remove_markdown_admonitions_containing(text: str, marker: re.Pattern[str]) -> str:
     """Remove a MkDocs admonition whose title or body contains ``marker``."""
 
     lines = text.splitlines(keepends=True)
@@ -538,8 +534,17 @@ def _sanitize_cff(text: str) -> str:
     lines = text.splitlines(keepends=True)
     output: list[str] = []
     skipping_authors = False
+    skipping_preferred_citation = False
     found_authors = False
     for line in lines:
+        if line.rstrip("\r\n") == "preferred-citation:":
+            skipping_preferred_citation = True
+            continue
+        if skipping_preferred_citation:
+            if line and not line[0].isspace():
+                skipping_preferred_citation = False
+            else:
+                continue
         if line.rstrip("\r\n") == "authors:":
             output.extend(("authors:\n", '  - name: "Anonymous"\n'))
             skipping_authors = True
@@ -550,7 +555,7 @@ def _sanitize_cff(text: str) -> str:
                 skipping_authors = False
             else:
                 continue
-        if re.match(r"^(?:repository-code|url):", line):
+        if re.match(r"^(?:repository-artifact|repository-code|url):", line):
             continue
         output.append(line)
     if not found_authors:
@@ -659,6 +664,10 @@ def _replace_affiliations(text: str, rules: IdentityRules) -> str:
 def sanitize_text(path: str, text: str, rules: IdentityRules) -> str:
     """Return anonymized UTF-8 text while preserving scholarly references."""
 
+    if path == "docs/citation.md":
+        return (
+            "# Citation\n\nCitation guidance is withheld for double-anonymous review.\n"
+        )
     if path == "docs/authors.md":
         return (
             "# Authors & Maintainers\n\n"
@@ -857,9 +866,7 @@ def _sanitize_pdf_metadata(data: bytes) -> bytes:
 
     prefix = b"\n"
     object_offset = len(scrubbed) + len(prefix)
-    info_object = (
-        f"{new_object} 0 obj\n<< /Producer (Anonymous) >>\nendobj\n".encode()
-    )
+    info_object = f"{new_object} 0 obj\n<< /Producer (Anonymous) >>\nendobj\n".encode()
     xref_offset = object_offset + len(info_object)
     incremental_update = (
         prefix
@@ -929,9 +936,7 @@ def _safe_nested_name(name: str) -> None:
         raise AnonymizationError(f"Unsafe nested ZIP member name: {name}")
 
 
-def _canonicalize_nested_zip(
-    data: bytes, *, xlsx: bool, rules: IdentityRules
-) -> bytes:
+def _canonicalize_nested_zip(data: bytes, *, xlsx: bool, rules: IdentityRules) -> bytes:
     """Normalize nested ZIP metadata and scrub known identifying members."""
 
     source_buffer = io.BytesIO(data)
@@ -941,13 +946,16 @@ def _canonicalize_nested_zip(
     except (OSError, zipfile.BadZipFile) as exc:
         raise AnonymizationError(f"Unreadable retained ZIP container: {exc}") from exc
 
-    with source, zipfile.ZipFile(
-        output_buffer,
-        "w",
-        compression=zipfile.ZIP_DEFLATED,
-        compresslevel=9,
-        strict_timestamps=True,
-    ) as destination:
+    with (
+        source,
+        zipfile.ZipFile(
+            output_buffer,
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+            compresslevel=9,
+            strict_timestamps=True,
+        ) as destination,
+    ):
         destination.comment = b""
         for original_info in source.infolist():
             _safe_nested_name(original_info.filename)
@@ -974,22 +982,25 @@ def _canonicalize_nested_zip(
                         + rb"\b[^>]*>.*?</dcterms:"
                         + date_field
                         + rb">",
-                        b'<dcterms:'
+                        b"<dcterms:"
                         + date_field
                         + b' xsi:type="dcterms:W3CDTF">1980-01-01T00:00:00Z</dcterms:'
                         + date_field
-                        + b'>',
+                        + b">",
                         payload,
                         flags=re.DOTALL,
                     )
-            elif not xlsx and PurePosixPath(original_info.filename).name == "system_info.txt":
+            elif (
+                not xlsx
+                and PurePosixPath(original_info.filename).name == "system_info.txt"
+            ):
                 payload = b"System information removed for double-anonymous review.\n"
             elif not xlsx:
                 nested_text = _safe_decode(payload)
                 if nested_text is not None:
-                    payload = sanitize_text(original_info.filename, nested_text, rules).encode(
-                        "utf-8"
-                    )
+                    payload = sanitize_text(
+                        original_info.filename, nested_text, rules
+                    ).encode("utf-8")
             executable = bool((original_info.external_attr >> 16) & 0o111)
             destination.writestr(
                 _zip_info(original_info.filename, executable=executable), payload
@@ -1010,7 +1021,9 @@ def _sanitize_binary_metadata(
             "PNG textual, EXIF, timestamp, and content-credential chunks removed",
         )
     if suffix == ".mat":
-        return _sanitize_mat_metadata(data), "MATLAB platform and timestamp header replaced"
+        return _sanitize_mat_metadata(
+            data
+        ), "MATLAB platform and timestamp header replaced"
     if suffix == ".xlsx":
         return (
             _canonicalize_nested_zip(data, xlsx=True, rules=rules),
@@ -1062,8 +1075,7 @@ def _report(
     if metadata_sanitized:
         lines.extend(("", "Sanitized retained-file metadata:"))
         lines.extend(
-            f"- {path} ({description})"
-            for path, description in metadata_sanitized
+            f"- {path} ({description})" for path, description in metadata_sanitized
         )
     if sanitized:
         lines.extend(("", "Sanitized text files:"))
@@ -1261,10 +1273,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"Anonymization report: {result.report}")
     print(f"Included committed files: {result.included_count}")
     print(f"Sanitized text files: {len(result.sanitized_paths)}")
-    print(
-        "Metadata-sanitized retained files: "
-        f"{len(result.metadata_sanitized_paths)}"
-    )
+    print(f"Metadata-sanitized retained files: {len(result.metadata_sanitized_paths)}")
     print(f"Excluded risky files: {len(result.excluded_paths)}")
     status = _run_git(repo, ["status", "--porcelain"]).stdout
     if status:


### PR DESCRIPTION
## Summary

- make the SoRoMoX arXiv preprint the preferred academic citation while preserving the nine-author software record
- add a canonical citation guide, README paper badge, project URLs, and concise links throughout the documentation
- retain an optional exact-release software citation using a version-specific key such as `soromox_v0_2_1`
- update the final 2024 planar HSA reference and explicitly identify Chapter 2 of the controller thesis
- synchronize citation metadata through the version-bump and release tooling, including anonymized-archive handling
- add regression coverage for citation authorship, metadata, BibTeX, version updates, and anonymization

## Why

The repository previously presented a versioned package citation as the primary academic reference and duplicated that guidance across several pages. With the associated preprint now available, academic users should primarily cite the paper, while still reporting—and when appropriate citing—the exact software release used for reproducibility.

A version-derived software citation key avoids collisions when multiple SoRoMoX releases occur in the same year.

## User impact

Users now get one consistent citation policy: cite the preprint, report `soromox.__version__`, add the exact tagged software release when reproducibility materially depends on it, and include model- or method-specific references only when relevant.

## Validation

- `pytest tests/test_bump_version.py tests/test_create_anonymized_archive.py tests/test_citation_metadata.py` — 24 passed
- `cffconvert --validate`
- `zensical build --clean`
- `python -m build` and Twine checks for wheel and sdist
- focused Ruff formatting and `git diff --check`
- `python bump_version.py --patch --dry-run`
