### PR TITLE
fix(gvs): make GVS.update_params jittable

### DIFF
--- a/src/soromox/systems/gvs/params.py
+++ b/src/soromox/systems/gvs/params.py
@@ -2,6 +2,7 @@ __all__ = ["GVSLinkParams", "GVSParams"]
 
 from typing import ClassVar
 
+import jax
 from jax import Array
 from jax import numpy as jnp
 
@@ -148,17 +149,18 @@ class GVSParams(BaseSoftRobotParams):
             Joint.DICT_JOINT_TYPE_DOF[segment.joint.type]
             for segment in structure.segments
         ]
-        dofs_link = [
-            int(
-                Basis.DOF_BRANCHES[Basis.BASISTYPE_MAP[segment.basis.type]](
-                    (
-                        jnp.asarray(segment.basis.active),
-                        jnp.asarray(segment.basis.orders),
+        with jax.ensure_compile_time_eval():
+            dofs_link = [
+                int(
+                    Basis.DOF_BRANCHES[Basis.BASISTYPE_MAP[segment.basis.type]](
+                        (
+                            jnp.asarray(segment.basis.active),
+                            jnp.asarray(segment.basis.orders),
+                        )
                     )
                 )
-            )
-            for segment in structure.segments
-        ]
+                for segment in structure.segments
+            ]
         real_max_dof = max(dofs_joint + dofs_link)
         max_dof = real_max_dof if structure.max_dof is None else structure.max_dof
         if max_dof < real_max_dof:

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1665,6 +1665,32 @@ def test_cached_constant_matrices_refresh_after_update_params() -> None:
     assert not jnp.isnan(updated.D_full).any()
 
 
+def test_update_params_is_jittable():
+    selector_per_segment = (False, False, True, True, False, False)
+    robot = build_constant_strain_gvs(
+        num_segments=2,
+        selector_per_segment=selector_per_segment,
+        max_dof=6,
+    )
+
+    @jax.jit
+    def potential_force(base_pose, q):
+        displaced_robot = robot.update_params(base_pose=base_pose)
+        return displaced_robot.potential_force(q)
+
+    # Change orientation of the 2 poses
+    base_pose_1 = jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    base_pose_2 = jnp.array([0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0])
+    q = jnp.zeros(robot.num_dofs)
+
+    force_1 = potential_force(base_pose_1, q)
+    force_2 = potential_force(base_pose_2, q)
+
+    assert not jnp.isnan(force_1).any()
+    assert not jnp.isnan(force_2).any()
+    assert not onp.allclose(force_1, force_2, rtol=RTOL, atol=ATOL)
+
+
 def test_active_dof_map_creation_matches_joint_and_link_dofs() -> None:
     robot = build_varied_basis_gvs(num_segments=3)
 


### PR DESCRIPTION
Hi @mstoelzle ,

This PR addresses a limitation I found when using the `soromox` library, specifically when needing to update parameters of a GVS-based systems in a `jax.jit` context.

***TL;DR***:

- `ec4a25f` adds a regression test showing that a function calling `GVS.update_params` in a `jax.jit` context fails;
- `84b9744` proposes a focused commit that fixes the problem by wrapping the failing code into a [`jax.ensure_compile_time_eval`](https://docs.jax.dev/en/latest/_autosummary/jax.ensure_compile_time_eval.html) context.


## Problem statement

I am modelling a passive planar deformable linear object with a restricted-strain GVS model. Its base is fixed at the origin but has a prescribed orientation parameterised by an angle $\theta$.

For repeated forward-dynamics or equilibrium evaluations, I need to evaluate quantities such as the potential force as a function of both the Lagrangian coordinates $q$ and the base orientation $\theta$. This requires updating `base_pose` inside a `jax.jit`-compiled function.

With current GVS implementation, this fails with `jax.errors.ConcretizationTypeError` in `GVSParams.validate_against_structure()`.


## Bug reproduction

To formalise the above described problem, I created a focused regression test that exactly tests the behavior.

1. check-out to the test commit:
   ```bash
   git checkout ec4a25f
   ```
1. run the focused test:
   ```bash
   uv run pytest tests/systems/test_gvs.py::test_update_params_is_jittable
   ```
   It fails at [`src/soromox/systems/gvs/params.py:152`](https://github.com/tud-phi/soromox/blob/9535d286f3697bba1629b456a19e8c9ac03da54b/src/soromox/systems/gvs/params.py#L152-L159) with a `ConcretizationTypeError` reporting
   ```
   jax.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected: traced array with shape int64[]
   The problem arose with the `int` function. If trying to convert the data type of a value, try using `x.astype(int)` or `jnp.array(x, int)` instead.
   ```

The fix proposed in `84b9744` makes the test pass.


## Proposed fix

`GVSParams.validate_against_structure()` derives the link DOF count from each segment's basis type, active components, and polynomial orders. These values describe the fixed GVS layout, but converting them with `jnp.asarray(...)` during JIT tracing makes the derived count a tracer. The subsequent `int(...)` conversion therefore fails.

The fix evaluates only these static link DOF counts inside [`jax.ensure_compile_time_eval`](https://docs.jax.dev/en/latest/_autosummary/jax.ensure_compile_time_eval.html). The existing layout validation remains unchanged, while dynamic values such as `base_pose` can remain traced when `GVS.update_params(...)` is called inside `jax.jit`.


## Testing

- `uv run pytest` succeeds locally;
- `uv run ruff check src/soromox/systems/gvs/params.py tests/systems/test_gvs.py` succeeds locally;
- `uv run ruff format --check src/soromox/systems/gvs/params.py tests/systems/test_gvs.py` ensures proper formatting of the files.


## Scope and follow-up

This is intentionally a small fix for a specific `GVS.update_params(...)` use case.
I would appreciate feedback on whether it fits the intended GVS parameter architecture.

- The change preserves the existing fixed-layout model: structural values such as the basis type, active components, and orders remain static under `jax.jit`.
- The regression test covers updating `base_pose` and evaluating the potential force. It should remain useful even if a different implementation is preferred.
- I noticed the ongoing PCS/GVS parameter-model harmonisation work in #139. If this should be addressed there instead, I am happy to adapt the PR.
- I have not investigated equivalent update paths in other systems, but I can help add coverage or explore them if that would be useful.
