### PR TITLE
Preserve traced continuous rollout save times

### DIFF
--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -2,7 +2,7 @@ __all__ = ["DynamicalSystem"]
 import math
 import warnings
 from abc import abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -76,18 +76,24 @@ class DynamicalSystem(eqx.Module):
         t1: float | Array,
         solver_dt: float | Array,
         save_dt: float | Array | None,
-        save_ts: Array | None = None,
+        save_ts: Array | Sequence[float] | None = None,
     ) -> Array:
         """Build the array of time stamps to save during integration."""
         if save_ts is not None:
-            return save_ts
+            return jnp.asarray(save_ts)
 
         assert save_dt is not None, "Either save_ts or save_dt must be provided."
         assert save_dt > 0.0, "save_dt must be positive."
         assert save_dt >= solver_dt, (
             "save_dt must be greater than or equal to the solver step size."
         )
-        return jnp.arange(t0, t1 + save_dt, save_dt)
+        assert t1 >= t0, "t1 must be greater than or equal to t0."
+
+        # Stopping at (rather than beyond) t1 ensures that round-off cannot
+        # produce an invalid save time after the integration interval. Append
+        # t1 explicitly so the final requested time is represented exactly.
+        save_times = jnp.arange(t0, t1, save_dt)
+        return jnp.concatenate([save_times, jnp.atleast_1d(t1)])
 
     @staticmethod
     def _zero_like_pytree(state: Any | None) -> Any | None:
@@ -261,7 +267,7 @@ class DynamicalSystem(eqx.Module):
         t1: float | Array = 10.0,
         solver_dt: float | Array = 1e-4,
         save_dt: float | Array | None = 0.01,
-        save_ts: Array | None = None,
+        save_ts: Array | Sequence[float] | None = None,
         solver: AbstractSolver | None = None,
         stepsize_controller: AbstractStepSizeController | None = ConstantStepSize(),
         max_steps: int | None = None,
@@ -364,8 +370,8 @@ class DynamicalSystem(eqx.Module):
         | None = None,
         t1: float | Array = 10.0,
         solver_dt: float | Array = 1e-4,
-        save_dt: float | Array = 0.01,
-        save_ts: Array | None = None,
+        save_dt: float | Array | None = 0.01,
+        save_ts: Array | Sequence[float] | None = None,
         solver: AbstractSolver | None = None,
         stepsize_controller: AbstractStepSizeController | None = ConstantStepSize(),
         max_steps: int | None = None,

--- a/tests/systems/test_dynamical_system_rollout.py
+++ b/tests/systems/test_dynamical_system_rollout.py
@@ -72,6 +72,89 @@ class _ConstantStateDotEnvironment(eqx.Module):
         return jnp.zeros((q_len,)), jnp.array(0.0)
 
 
+def test_compute_save_times_ends_exactly_at_t1_without_overshooting():
+    divisible = Pendulum._compute_save_times(
+        t0=0.0, t1=0.1, solver_dt=0.001, save_dt=0.05
+    )
+    nondivisible = Pendulum._compute_save_times(
+        t0=0.0, t1=0.11, solver_dt=0.001, save_dt=0.05
+    )
+
+    assert jnp.array_equal(divisible, jnp.array([0.0, 0.05, 0.1]))
+    assert jnp.array_equal(nondivisible, jnp.array([0.0, 0.05, 0.1, 0.11]))
+    assert jnp.all(divisible <= 0.1)
+    assert jnp.all(nondivisible <= 0.11)
+
+
+def test_continuous_rollouts_are_jittable_with_explicit_save_times():
+    robot = Pendulum(_pendulum_params())
+    save_ts = jnp.array([0.0, 0.001, 0.002])
+    controller = ZeroController(num_actuators=robot.num_actuators)
+
+    def run(t0: jnp.ndarray, y0: jnp.ndarray):
+        initial_state = SystemState(t=t0, y=y0, u=jnp.zeros((robot.num_actuators,)))
+        open_loop = robot.rollout_to(
+            initial_state=initial_state,
+            t1=save_ts[-1],
+            solver_dt=1e-3,
+            save_dt=None,
+            save_ts=save_ts,
+        )
+        closed_loop = robot.rollout_closed_loop_to(
+            initial_state=initial_state,
+            controller=controller,
+            t1=save_ts[-1],
+            solver_dt=1e-3,
+            save_dt=None,
+            save_ts=save_ts,
+        )
+        return open_loop, closed_loop
+
+    y0 = jnp.zeros((2 * robot.num_dofs,))
+    open_loop, closed_loop = jax.jit(run)(jnp.array(0.0), y0)
+
+    assert jnp.array_equal(open_loop.t, save_ts)
+    assert jnp.array_equal(closed_loop.t, save_ts)
+    assert jnp.all(jnp.isfinite(open_loop.y))
+    assert jnp.all(jnp.isfinite(closed_loop.y))
+
+
+def test_continuous_rollouts_are_vmappable_with_explicit_save_times():
+    robot = Pendulum(_pendulum_params())
+    save_ts = jnp.array([0.0, 0.001, 0.002])
+    controller = ZeroController(num_actuators=robot.num_actuators)
+
+    def run(t0: jnp.ndarray, q0: jnp.ndarray):
+        y0 = jnp.concatenate([q0, jnp.zeros_like(q0)])
+        initial_state = SystemState(t=t0, y=y0, u=jnp.zeros_like(q0))
+        open_loop = robot.rollout_to(
+            initial_state=initial_state,
+            t1=save_ts[-1],
+            solver_dt=1e-3,
+            save_dt=None,
+            save_ts=save_ts,
+        )
+        closed_loop = robot.rollout_closed_loop_to(
+            initial_state=initial_state,
+            controller=controller,
+            t1=save_ts[-1],
+            solver_dt=1e-3,
+            save_dt=None,
+            save_ts=save_ts,
+        )
+        return open_loop.y, closed_loop.y
+
+    t0s = jnp.zeros((3,))
+    q0s = jnp.array([[0.0, 0.0], [0.1, -0.1], [-0.2, 0.05]])
+    open_loop_ys, closed_loop_ys = jax.jit(jax.vmap(run))(t0s, q0s)
+
+    expected_shape = (q0s.shape[0], save_ts.shape[0], 2 * robot.num_dofs)
+    assert open_loop_ys.shape == expected_shape
+    assert closed_loop_ys.shape == expected_shape
+    assert jnp.all(jnp.isfinite(open_loop_ys))
+    assert jnp.all(jnp.isfinite(closed_loop_ys))
+
+
 def test_rollout_to_keeps_equilibrium():
     robot = Pendulum(_pendulum_params())
 


### PR DESCRIPTION
## Summary

- build regular continuous-rollout save grids strictly before the final time and append the exact endpoint
- keep explicit `save_ts` sequences on the JAX path without converting traced times through Python `float`
- cover open- and closed-loop rollouts under `jax.jit` and `jax.vmap`, plus divisible and non-divisible save grids

## Stack order

This PR targets `main` directly. It and #149 are independent prerequisites for #139.

## Validation

- `pytest tests/systems/test_dynamical_system_rollout.py -q` (16 passed)
- Ruff on the changed source and tests
- Section Vc setpoint-regulation smoke with `t1=0.1`, `save_dt=0.05` (3 exact samples, no Diffrax boundary error)
