### PR TITLE
Support compiled parameter updates

### DIFF
--- a/docs/api/actuation/index.md
+++ b/docs/api/actuation/index.md
@@ -117,8 +117,11 @@ robot = robot.update_passive_element_params(0, stiffness=new_stiffness)
 Each component also provides `params`, `with_params(...)`, and
 `update_params(...)`. Parameter replacement is immutable. Numeric fields may be
 updated, while changing component type, channel count, routing count, or segment
-span requires reconstructing the component and robot. Visual styling is configured
-on renderers rather than stored in actuator parameters.
+span requires reconstructing the component and robot. The `with_*_params`
+delegates are JAX-transformable when PyTree structure, shapes, dtypes, and
+topology remain fixed. Threadlike segment spans and McKibben joint-pair indices
+are precomputed topology; compiled numeric updates retain them. Visual styling
+is configured on renderers rather than stored in actuator parameters.
 
 See [Joint-space actuation](joint-space.md) for affine articulated coordinates,
 [Threadlike actuation](threadlike.md) for routed continuum examples, and the

--- a/docs/api/utilities/parameters.md
+++ b/docs/api/utilities/parameters.md
@@ -52,6 +52,12 @@ robot = robot.with_params(new_params)
 Same-shape, same-dtype parameter updates preserve the JAX compilation layout.
 Changing the number of segments, tendons, active strains, GVS basis layout, or
 quadrature layout is a structural change and requires reconstruction.
+Pass the complete PyTree to `with_params(...)` as a dynamic argument inside
+`eqx.filter_jit`; use
+`with_actuator_params(...)` and
+`with_passive_element_params(...)` for installed components. See
+[Compiled update contract](../../user-guide/parameters-and-optimization.md#compiled-update-contract)
+for a compiled example and the eager-versus-traced validation boundary.
 
 For GVS specifically, `GVS.from_segments(...)` is the recommended constructor.
 It accepts user-facing segment specs, stores canonical link and joint matrices

--- a/docs/api/utilities/parameters.md
+++ b/docs/api/utilities/parameters.md
@@ -59,15 +59,17 @@ Pass the complete PyTree to `with_params(...)` as a dynamic argument inside
 [Compiled update contract](../../user-guide/parameters-and-optimization.md#compiled-update-contract)
 for a compiled example and the eager-versus-traced validation boundary.
 
-During tracing, `BaseSystemParams` runs only tracer-safe structural validation;
-eager validation additionally enforces concrete numeric invariants. Subclasses
-implement these phases in `validate_structure()` and `validate_values()`.
-
 For GVS specifically, `GVS.from_segments(...)` is the recommended constructor.
 It accepts user-facing segment specs, stores canonical link and joint matrices
 in `GVSParams`, and stores stripped static choices in `GVSStructure`.
 `IsotropicMaterialParams` remains a separate caller-owned optimization PyTree,
 so runtime and material representations are not duplicated.
+
+## Validation
+
+During tracing, `BaseSystemParams` runs only tracer-safe structural validation;
+eager validation additionally enforces concrete numeric invariants. Subclasses
+implement these phases in `validate_structure()` and `validate_values()`.
 
 ## Naming
 

--- a/docs/api/utilities/parameters.md
+++ b/docs/api/utilities/parameters.md
@@ -67,9 +67,11 @@ so runtime and material representations are not duplicated.
 
 ## Validation
 
-During tracing, `BaseSystemParams` runs only tracer-safe structural validation;
-eager validation additionally enforces concrete numeric invariants. Subclasses
-implement these phases in `validate_structure()` and `validate_values()`.
+`BaseSystemParams` always runs tracer-safe structural validation. Parameter
+trees containing dynamic tracers skip concrete numeric checks, while eager and
+closed-over concrete trees run `validate_values()` eagerly or at JAX trace time.
+Subclasses implement these two phases in `validate_structure()` and
+`validate_values()`.
 
 ## Naming
 

--- a/docs/api/utilities/parameters.md
+++ b/docs/api/utilities/parameters.md
@@ -59,6 +59,10 @@ Pass the complete PyTree to `with_params(...)` as a dynamic argument inside
 [Compiled update contract](../../user-guide/parameters-and-optimization.md#compiled-update-contract)
 for a compiled example and the eager-versus-traced validation boundary.
 
+During tracing, `BaseSystemParams` runs only tracer-safe structural validation;
+eager validation additionally enforces concrete numeric invariants. Subclasses
+implement these phases in `validate_structure()` and `validate_values()`.
+
 For GVS specifically, `GVS.from_segments(...)` is the recommended constructor.
 It accepts user-facing segment specs, stores canonical link and joint matrices
 in `GVSParams`, and stores stripped static choices in `GVSStructure`.

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -141,11 +141,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Made same-PyTree, same-shape, same-dtype system, environment, actuator, and
-  passive-element replacements usable inside JIT-compiled code across
-  Pendulum, articulated systems, PCS, PlanarPCS, PlanarHSA, I-SUPPORT, and GVS.
-  Concrete eager calls retain value validation, while traced calls enforce the
-  statically observable type and shape contract.
+- Made same-PyTree, same-shape, same-dtype system, environment, actuator,
+  passive-element, and isotropic-material replacements usable inside
+  JIT-compiled code. Concrete eager calls retain value validation, while traced
+  calls enforce the statically observable type and shape contract.
 - Reused I-SUPPORT routing spans and McKibben joint-pair topology during
   compiled numeric updates, and kept GVS cross-section index dtypes stable when
   refreshing parameter-dependent caches.

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [parameter-API migration](../user-guide/parameter-api-migration.md)
   documentation with complete PCS and GVS examples.
 
+- Compiled parameter-update examples and regression coverage for every public
+  system family, routed actuators, passive elements, gradients, eager cache
+  refreshes, static-structure rejection, and no-retrace same-layout updates.
+
 ### Changed
 
 - Accelerated PlanarPCS, PCS, and GVS forward dynamics through fused dynamics
@@ -137,6 +141,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made same-PyTree, same-shape, same-dtype system, environment, actuator, and
+  passive-element replacements usable inside JIT-compiled code across
+  Pendulum, articulated systems, PCS, PlanarPCS, PlanarHSA, I-SUPPORT, and GVS.
+  Concrete eager calls retain value validation, while traced calls enforce the
+  statically observable type and shape contract.
+- Reused I-SUPPORT routing spans and McKibben joint-pair topology during
+  compiled numeric updates, and kept GVS cross-section index dtypes stable when
+  refreshing parameter-dependent caches.
 - Included stored GVS joint stiffness and damping in global stiffness and
   damping assembly.
 - Resolved omitted GVS padding values in the advanced `GVS(params, structure)`

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -145,6 +145,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passive-element, and isotropic-material replacements usable inside
   JIT-compiled code. Concrete eager calls retain value validation, while traced
   calls enforce the statically observable type and shape contract.
+- Split parameter validation into explicit `validate_structure()` and
+  `validate_values()` subclass hooks, with framework-owned eager and traced
+  dispatch for intrinsic and model-structure-dependent validation.
 - Reused I-SUPPORT routing spans and McKibben joint-pair topology during
   compiled numeric updates, and kept GVS cross-section index dtypes stable when
   refreshing parameter-dependent caches.

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -147,7 +147,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   calls enforce the statically observable type and shape contract.
 - Split parameter validation into explicit `validate_structure()` and
   `validate_values()` subclass hooks, with framework-owned eager and traced
-  dispatch for intrinsic and model-structure-dependent validation.
+  dispatch for intrinsic and model-structure-dependent validation. Closed-over
+  concrete values are checked at JAX trace time, while dynamic leaves retain
+  structure-only validation. Component-to-robot checks use the same structural
+  and concrete-value phases.
 - Reused I-SUPPORT routing spans and McKibben joint-pair topology during
   compiled numeric updates, and kept GVS cross-section index dtypes stable when
   refreshing parameter-dependent caches.

--- a/docs/user-guide/parameters-and-optimization.md
+++ b/docs/user-guide/parameters-and-optimization.md
@@ -204,8 +204,10 @@ runtime numeric candidates must therefore remain in their physical domains.
 Use constrained parameterizations where appropriate, and validate externally
 supplied values eagerly before a compiled optimization or simulation loop.
 Parameter subclasses express this boundary through separate tracer-safe
-`validate_structure()` and eager-only `validate_values()` hooks; the framework
-owns the composed `validate()` and dispatched `validate_for_update()` methods.
+`validate_structure()` and concrete-only `validate_values()` hooks. The
+framework owns the composed `validate()` and dispatched `validate_for_update()`
+methods. Closed-over concrete values encountered during JAX tracing are checked
+at trace time, while value checks for dynamic tracer leaves remain deferred.
 
 Start from `robot.params` so constructor-resolved defaults already have their
 runtime PyTree representation.

--- a/docs/user-guide/parameters-and-optimization.md
+++ b/docs/user-guide/parameters-and-optimization.md
@@ -203,6 +203,9 @@ only validation based on statically observable types and shapes is possible;
 runtime numeric candidates must therefore remain in their physical domains.
 Use constrained parameterizations where appropriate, and validate externally
 supplied values eagerly before a compiled optimization or simulation loop.
+Parameter subclasses express this boundary through separate tracer-safe
+`validate_structure()` and eager-only `validate_values()` hooks; the framework
+owns the composed `validate()` and dispatched `validate_for_update()` methods.
 
 Start from `robot.params` so constructor-resolved defaults already have their
 runtime PyTree representation.

--- a/docs/user-guide/parameters-and-optimization.md
+++ b/docs/user-guide/parameters-and-optimization.md
@@ -157,6 +157,56 @@ Updates may change numeric values but not static layout. Changing the number of
 links, GVS basis orders, active strain selectors, joint types, matrix padding,
 or quadrature padding requires reconstruction.
 
+## Compiled update contract
+
+`with_params(...)` can participate in JAX transformations when the model's
+static structure remains fixed. Close over the constructed robot and pass its
+complete parameter PyTree as a dynamic argument:
+
+```python
+import equinox as eqx
+
+q = jnp.zeros(pcs.num_dofs)
+
+@eqx.filter_jit
+def energy(params, configuration):
+    candidate = pcs.with_params(params)
+    return candidate.potential_energy(configuration)
+
+baseline = energy(pcs.params, q)
+candidate_params = pcs.params.replace(
+    link=pcs.params.link.replace(
+        density=1.05 * pcs.params.link.density,
+        stiffness=0.95 * pcs.params.link.stiffness,
+    )
+)
+candidate = energy(candidate_params, q)
+```
+
+The two calls share one compiled executable when every parameter leaf keeps
+the same PyTree position, shape, and dtype. Numeric system, environment,
+actuator, and passive-element values are dynamic under this contract. Updates
+remain differentiable and vectorizable with `grad`, `value_and_grad`, and
+`vmap`.
+
+Installed components use the corresponding immutable delegates:
+`with_actuator_params(...)` and `with_passive_element_params(...)`. The same
+fixed-layout rule applies to their parameter PyTrees.
+
+The distinction between dynamic params and static structure is described in
+the parameter API [Overview](../api/utilities/parameters.md#overview). Changing
+structure, or changing a parameter leaf's shape, dtype, or `None`/array
+presence, requires reconstruction and normally a new compilation.
+
+Eager updates perform both structural and value validation. During tracing,
+only validation based on statically observable types and shapes is possible;
+runtime numeric candidates must therefore remain in their physical domains.
+Use constrained parameterizations where appropriate, and validate externally
+supplied values eagerly before a compiled optimization or simulation loop.
+
+Start from `robot.params` so constructor-resolved defaults already have their
+runtime PyTree representation.
+
 ## Isotropic material updates
 
 Generalized stiffness and damping matrices are the canonical runtime values.

--- a/src/soromox/actuation/core.py
+++ b/src/soromox/actuation/core.py
@@ -9,13 +9,13 @@ those coordinates, and generalized actuation forces are ``A(q) @ effort``.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, final
 
 import equinox as eqx
-from jax import Array
+from jax import Array, ensure_compile_time_eval
 from jax import numpy as jnp
 
-from soromox.systems.params import BaseSystemParams
+from soromox.systems.params import BaseSystemParams, _contains_tracer
 
 if TYPE_CHECKING:
     from soromox.systems.soft_robot import SoftRobot
@@ -121,9 +121,26 @@ class PassiveElement(eqx.Module):
     def update_params(self, **updates) -> PassiveElement:
         return self.with_params(self.params.replace(**updates))
 
-    def validate_for_robot(self, robot: SoftRobot) -> None:
-        """Validate static component topology against ``robot``."""
+    def validate_structure_for_robot(self, robot: SoftRobot) -> None:
+        """Validate tracer-safe component compatibility with ``robot``."""
         del robot
+
+    def validate_values_for_robot(self, robot: SoftRobot) -> None:
+        """Validate concrete component values against ``robot``."""
+        del robot
+
+    def _robot_value_validation_tree(self):
+        """Return the leaves used by concrete robot-compatibility checks."""
+        return self.params
+
+    @final
+    def validate_for_robot(self, robot: SoftRobot) -> None:
+        """Validate robot compatibility without concretizing dynamic leaves."""
+        self.validate_structure_for_robot(robot)
+        if _contains_tracer(self._robot_value_validation_tree()):
+            return
+        with ensure_compile_time_eval():
+            self.validate_values_for_robot(robot)
 
     def elastic_force(self, robot: SoftRobot, q: Array) -> Array:
         return jnp.zeros((robot.num_dofs,), dtype=q.dtype)
@@ -181,9 +198,26 @@ class Actuator(eqx.Module):
         velocity = self.velocities(robot, q, qd)
         return self.effort_model.effort(control, coordinate, velocity)
 
-    def validate_for_robot(self, robot: SoftRobot) -> None:
-        """Validate static component topology against ``robot``."""
+    def validate_structure_for_robot(self, robot: SoftRobot) -> None:
+        """Validate tracer-safe component compatibility with ``robot``."""
         del robot
+
+    def validate_values_for_robot(self, robot: SoftRobot) -> None:
+        """Validate concrete component values against ``robot``."""
+        del robot
+
+    def _robot_value_validation_tree(self):
+        """Return the leaves used by concrete robot-compatibility checks."""
+        return self.params
+
+    @final
+    def validate_for_robot(self, robot: SoftRobot) -> None:
+        """Validate robot compatibility without concretizing dynamic leaves."""
+        self.validate_structure_for_robot(robot)
+        if _contains_tracer(self._robot_value_validation_tree()):
+            return
+        with ensure_compile_time_eval():
+            self.validate_values_for_robot(robot)
 
     @abstractmethod
     def with_params(self, params: BaseSystemParams) -> Actuator: ...
@@ -253,7 +287,7 @@ class IdentityActuator(Actuator):
     def metadata(self) -> ActuatorMetadata:
         return self._metadata
 
-    def validate_for_robot(self, robot: SoftRobot) -> None:
+    def validate_structure_for_robot(self, robot: SoftRobot) -> None:
         if self.num_channels != robot.num_dofs:
             raise ValueError(
                 "IdentityActuator must have one channel per robot degree of "

--- a/src/soromox/actuation/joint.py
+++ b/src/soromox/actuation/joint.py
@@ -8,7 +8,7 @@ import equinox as eqx
 from jax import Array
 from jax import numpy as jnp
 
-from soromox.systems.params import BaseSystemParams, _contains_tracer
+from soromox.systems.params import BaseSystemParams
 
 from .core import (
     Actuator,
@@ -29,8 +29,8 @@ def _channel_array(value: Any, count: int, name: str) -> Array:
     return array
 
 
-def _validate_tendon_routing(matrix: Array, num_dofs: int, name: str) -> None:
-    """Validate articulated tendon rank and contiguous proximal routing."""
+def _validate_tendon_routing_structure(matrix: Array, num_dofs: int, name: str) -> None:
+    """Validate articulated tendon shape against a robot."""
     matrix = jnp.asarray(matrix)
     if matrix.ndim != 2:
         raise ValueError(f"{name} must be two-dimensional.")
@@ -39,8 +39,11 @@ def _validate_tendon_routing(matrix: Array, num_dofs: int, name: str) -> None:
             f"{name} must have one column per degree of freedom; expected "
             f"{num_dofs}, got {matrix.shape[1]}."
         )
-    if _contains_tracer(matrix):
-        return
+
+
+def _validate_tendon_routing_values(matrix: Array, num_dofs: int, name: str) -> None:
+    """Validate concrete articulated tendon routing values."""
+    matrix = jnp.asarray(matrix)
     count = matrix.shape[0]
     if count > 0 and int(jnp.linalg.matrix_rank(matrix)) != count:
         raise ValueError(f"{name} must be full row rank.")
@@ -286,13 +289,23 @@ class ArticulatedTendonActuator(Actuator):
     def metadata(self) -> ActuatorMetadata:
         return self._metadata
 
-    def validate_for_robot(self, robot) -> None:
+    def validate_structure_for_robot(self, robot) -> None:
         _validate_articulated_tendon_host(robot)
-        _validate_tendon_routing(
+        _validate_tendon_routing_structure(
             self.params.transmission.routing_matrix,
             robot.num_dofs,
             "routing_matrix",
         )
+
+    def validate_values_for_robot(self, robot) -> None:
+        _validate_tendon_routing_values(
+            self.params.transmission.routing_matrix,
+            robot.num_dofs,
+            "routing_matrix",
+        )
+
+    def _robot_value_validation_tree(self):
+        return self.params.transmission.routing_matrix
 
     def with_params(self, params: BaseSystemParams) -> ArticulatedTendonActuator:
         if not isinstance(params, ArticulatedTendonActuatorParams):
@@ -401,13 +414,23 @@ class ArticulatedTendonImpedance(PassiveElement):
     def params(self) -> ArticulatedTendonImpedanceParams:
         return self._params
 
-    def validate_for_robot(self, robot) -> None:
+    def validate_structure_for_robot(self, robot) -> None:
         _validate_articulated_tendon_host(robot)
-        _validate_tendon_routing(
+        _validate_tendon_routing_structure(
             self.params.transmission.routing_matrix,
             robot.num_dofs,
             "routing_matrix",
         )
+
+    def validate_values_for_robot(self, robot) -> None:
+        _validate_tendon_routing_values(
+            self.params.transmission.routing_matrix,
+            robot.num_dofs,
+            "routing_matrix",
+        )
+
+    def _robot_value_validation_tree(self):
+        return self.params.transmission.routing_matrix
 
     def with_params(self, params: BaseSystemParams) -> ArticulatedTendonImpedance:
         if not isinstance(params, ArticulatedTendonImpedanceParams):

--- a/src/soromox/actuation/joint.py
+++ b/src/soromox/actuation/joint.py
@@ -8,7 +8,7 @@ import equinox as eqx
 from jax import Array
 from jax import numpy as jnp
 
-from soromox.systems.params import BaseSystemParams
+from soromox.systems.params import BaseSystemParams, _contains_tracer
 
 from .core import (
     Actuator,
@@ -39,6 +39,8 @@ def _validate_tendon_routing(matrix: Array, num_dofs: int, name: str) -> None:
             f"{name} must have one column per degree of freedom; expected "
             f"{num_dofs}, got {matrix.shape[1]}."
         )
+    if _contains_tracer(matrix):
+        return
     count = matrix.shape[0]
     if count > 0 and int(jnp.linalg.matrix_rank(matrix)) != count:
         raise ValueError(f"{name} must be full row rank.")

--- a/src/soromox/actuation/joint.py
+++ b/src/soromox/actuation/joint.py
@@ -88,7 +88,7 @@ class AffineJointTransmissionParams(BaseSystemParams):
     coordinate_offset: Array
 
     def __check_init__(self) -> None:
-        self.validate()
+        self.validate_for_update()
 
     @property
     def num_channels(self) -> int:
@@ -98,7 +98,7 @@ class AffineJointTransmissionParams(BaseSystemParams):
     def num_dofs(self) -> int:
         return int(jnp.asarray(self.routing_matrix).shape[1])
 
-    def validate(self) -> None:
+    def validate_structure(self) -> None:
         matrix = jnp.asarray(self.routing_matrix)
         if matrix.ndim != 2:
             raise ValueError("routing_matrix must be two-dimensional.")
@@ -126,7 +126,7 @@ class AffineJointTransmission(Transmission):
     def __init__(self, params: AffineJointTransmissionParams) -> None:
         if not isinstance(params, AffineJointTransmissionParams):
             raise TypeError("params must be AffineJointTransmissionParams.")
-        params.validate()
+        params.validate_for_update()
         self.params = params
 
     @property
@@ -148,7 +148,7 @@ class AffineJointTransmission(Transmission):
         self, params: AffineJointTransmissionParams
     ) -> AffineJointTransmission:
         self.params.assert_same_topology(params)
-        params.validate()
+        params.validate_for_update()
         return AffineJointTransmission(params)
 
     def update_params(self, **updates: Any) -> AffineJointTransmission:
@@ -163,15 +163,18 @@ class ArticulatedTendonActuatorParams(BaseSystemParams):
     upper_bounds: Array
 
     def __check_init__(self) -> None:
-        self.validate()
+        self.validate_for_update()
 
-    def validate(self) -> None:
-        self.transmission.validate()
+    def validate_structure(self) -> None:
+        self.transmission.validate_structure()
         count = self.transmission.num_channels
         for name in ("lower_bounds", "upper_bounds"):
             value = jnp.asarray(getattr(self, name))
             if value.shape != (count,):
                 raise ValueError(f"{name} must have shape ({count},).")
+
+    def validate_values(self) -> None:
+        self.transmission.validate_values()
 
 
 class ArticulatedTendonActuator(Actuator):
@@ -192,7 +195,7 @@ class ArticulatedTendonActuator(Actuator):
     ) -> None:
         if not isinstance(params, ArticulatedTendonActuatorParams):
             raise TypeError("params must be ArticulatedTendonActuatorParams.")
-        params.validate()
+        params.validate_for_update()
         count = params.transmission.num_channels
         if labels is None:
             labels = tuple(f"tendon_tension_{index}" for index in range(count))
@@ -295,7 +298,7 @@ class ArticulatedTendonActuator(Actuator):
         if not isinstance(params, ArticulatedTendonActuatorParams):
             raise TypeError("params must be ArticulatedTendonActuatorParams.")
         self.params.transmission.assert_same_topology(params.transmission)
-        params.validate()
+        params.validate_for_update()
         return ArticulatedTendonActuator(
             params=params,
             labels=self.metadata.labels,
@@ -311,14 +314,17 @@ class ArticulatedTendonImpedanceParams(BaseSystemParams):
     damping: Array
 
     def __check_init__(self) -> None:
-        self.validate()
+        self.validate_for_update()
 
-    def validate(self) -> None:
-        self.transmission.validate()
+    def validate_structure(self) -> None:
+        self.transmission.validate_structure()
         count = self.transmission.num_channels
         for name in ("stiffness", "damping"):
             if jnp.asarray(getattr(self, name)).shape != (count,):
                 raise ValueError(f"{name} must have shape ({count},).")
+
+    def validate_values(self) -> None:
+        self.transmission.validate_values()
 
 
 class ArticulatedTendonImpedance(PassiveElement):
@@ -336,7 +342,7 @@ class ArticulatedTendonImpedance(PassiveElement):
     ) -> None:
         if not isinstance(params, ArticulatedTendonImpedanceParams):
             raise TypeError("params must be ArticulatedTendonImpedanceParams.")
-        params.validate()
+        params.validate_for_update()
         self._params = params
         self.transmission = AffineJointTransmission(params.transmission)
         self.name = name
@@ -407,7 +413,7 @@ class ArticulatedTendonImpedance(PassiveElement):
         if not isinstance(params, ArticulatedTendonImpedanceParams):
             raise TypeError("params must be ArticulatedTendonImpedanceParams.")
         self.params.transmission.assert_same_topology(params.transmission)
-        params.validate()
+        params.validate_for_update()
         return ArticulatedTendonImpedance(params=params, name=self.name)
 
     def coordinates(self, robot, q: Array) -> Array:

--- a/src/soromox/actuation/mckibben.py
+++ b/src/soromox/actuation/mckibben.py
@@ -481,22 +481,23 @@ class ArticulatedMcKibbenActuator(Actuator):
     def metadata(self) -> ActuatorMetadata:
         return self._metadata
 
-    def validate_for_robot(self, robot) -> None:
+    def validate_structure_for_robot(self, robot) -> None:
         if not callable(getattr(robot, "_kinematic_frames", None)):
             raise TypeError(
                 "ArticulatedMcKibbenActuator requires a spatial articulated host "
                 "implementing the _kinematic_frames geometry contract."
             )
+
+    def validate_values_for_robot(self, robot) -> None:
         indices = self.params.transmission.joint_pair_indices
-        if (
-            indices.shape[0] > 0
-            and not _contains_tracer(indices)
-            and (
-                np.any(np.asarray(indices) < 0)
-                or np.any(np.asarray(indices) >= robot.num_dofs)
-            )
+        if indices.shape[0] > 0 and (
+            np.any(np.asarray(indices) < 0)
+            or np.any(np.asarray(indices) >= robot.num_dofs)
         ):
             raise ValueError("joint_pair_indices must reference valid robot DOFs.")
+
+    def _robot_value_validation_tree(self):
+        return self.params.transmission.joint_pair_indices
 
     def with_params(self, params: BaseSystemParams) -> ArticulatedMcKibbenActuator:
         if not isinstance(params, ArticulatedMcKibbenActuatorParams):

--- a/src/soromox/actuation/mckibben.py
+++ b/src/soromox/actuation/mckibben.py
@@ -42,7 +42,7 @@ class ArticulatedMcKibbenTransmissionParams(BaseSystemParams):
     joint_pair_indices: Array
 
     def __check_init__(self) -> None:
-        self.validate()
+        self.validate_for_update()
 
     @property
     def group_shape(self) -> tuple[int, int]:
@@ -79,8 +79,8 @@ class ArticulatedMcKibbenTransmissionParams(BaseSystemParams):
                     f"{name} must have shape {expected_shape}, got {value.shape}."
                 )
 
-    def validate(self) -> None:
-        self.validate_structure()
+    def validate_values(self) -> None:
+        """Validate eager McKibben topology values."""
         shape = jnp.asarray(self.thread_length).shape
         joint_pair_indices = jnp.asarray(self.joint_pair_indices)
         if shape[0] > 0 and bool(
@@ -373,14 +373,19 @@ class ArticulatedMcKibbenActuatorParams(BaseSystemParams):
     upper_bounds: Array
 
     def __check_init__(self) -> None:
-        self.validate()
+        self.validate_for_update()
 
-    def validate(self) -> None:
-        self.transmission.validate_for_update()
+    def validate_structure(self) -> None:
+        """Validate McKibben actuator parameter structure."""
+        self.transmission.validate_structure()
         count = self.transmission.num_channels
         for name in ("lower_bounds", "upper_bounds"):
             if jnp.asarray(getattr(self, name)).shape != (count,):
                 raise ValueError(f"{name} must have shape ({count},).")
+
+    def validate_values(self) -> None:
+        """Validate eager nested McKibben transmission values."""
+        self.transmission.validate_values()
 
 
 class ArticulatedMcKibbenActuator(Actuator):

--- a/src/soromox/actuation/mckibben.py
+++ b/src/soromox/actuation/mckibben.py
@@ -19,7 +19,7 @@ import numpy as np
 from jax import Array
 from jax import numpy as jnp
 
-from soromox.systems.params import BaseSystemParams
+from soromox.systems.params import BaseSystemParams, _contains_tracer
 from soromox.utils.geometry.rotations import (
     principal_axis_rotation_matrix,
     principal_axis_rotation_matrix_derivative,
@@ -56,7 +56,7 @@ class ArticulatedMcKibbenTransmissionParams(BaseSystemParams):
     def num_channels(self) -> int:
         return self.group_shape[0] * self.group_shape[1]
 
-    def validate(self) -> None:
+    def validate_structure(self) -> None:
         shape = jnp.asarray(self.thread_length).shape
         if len(shape) != 2:
             raise ValueError(
@@ -78,6 +78,10 @@ class ArticulatedMcKibbenTransmissionParams(BaseSystemParams):
                 raise ValueError(
                     f"{name} must have shape {expected_shape}, got {value.shape}."
                 )
+
+    def validate(self) -> None:
+        self.validate_structure()
+        shape = jnp.asarray(self.thread_length).shape
         joint_pair_indices = jnp.asarray(self.joint_pair_indices)
         if shape[0] > 0 and bool(
             jnp.any(joint_pair_indices[:, 0] == joint_pair_indices[:, 1])
@@ -95,7 +99,10 @@ class ArticulatedMcKibbenTransmissionParams(BaseSystemParams):
             raise ValueError(
                 "Changing McKibben group topology requires reconstruction."
             )
-        if not bool(jnp.array_equal(other.joint_pair_indices, self.joint_pair_indices)):
+        if not _contains_tracer(other.joint_pair_indices) and not np.array_equal(
+            np.asarray(other.joint_pair_indices),
+            np.asarray(self.joint_pair_indices),
+        ):
             raise ValueError(
                 "Changing McKibben joint-pair topology requires reconstruction."
             )
@@ -144,7 +151,7 @@ class ArticulatedMcKibbenTransmission(Transmission):
     def __init__(self, params: ArticulatedMcKibbenTransmissionParams) -> None:
         if not isinstance(params, ArticulatedMcKibbenTransmissionParams):
             raise TypeError("params must be ArticulatedMcKibbenTransmissionParams.")
-        params.validate()
+        params.validate_for_update()
         self.params = params
 
     @property
@@ -349,7 +356,12 @@ class ArticulatedMcKibbenTransmission(Transmission):
         self, params: ArticulatedMcKibbenTransmissionParams
     ) -> ArticulatedMcKibbenTransmission:
         self.params.assert_same_topology(params)
-        params.validate()
+        params.validate_for_update()
+        params = eqx.tree_at(
+            lambda current: current.joint_pair_indices,
+            params,
+            self.params.joint_pair_indices,
+        )
         return ArticulatedMcKibbenTransmission(params)
 
 
@@ -364,7 +376,7 @@ class ArticulatedMcKibbenActuatorParams(BaseSystemParams):
         self.validate()
 
     def validate(self) -> None:
-        self.transmission.validate()
+        self.transmission.validate_for_update()
         count = self.transmission.num_channels
         for name in ("lower_bounds", "upper_bounds"):
             if jnp.asarray(getattr(self, name)).shape != (count,):
@@ -396,7 +408,7 @@ class ArticulatedMcKibbenActuator(Actuator):
     ) -> None:
         if not isinstance(params, ArticulatedMcKibbenActuatorParams):
             raise TypeError("params must be ArticulatedMcKibbenActuatorParams.")
-        params.validate()
+        params.validate_for_update()
         count = params.transmission.num_channels
         if labels is None:
             labels = tuple(f"mckibben_pressure_{index}" for index in range(count))
@@ -471,8 +483,13 @@ class ArticulatedMcKibbenActuator(Actuator):
                 "implementing the _kinematic_frames geometry contract."
             )
         indices = self.params.transmission.joint_pair_indices
-        if indices.shape[0] > 0 and (
-            bool(jnp.any(indices < 0)) or bool(jnp.any(indices >= robot.num_dofs))
+        if (
+            indices.shape[0] > 0
+            and not _contains_tracer(indices)
+            and (
+                np.any(np.asarray(indices) < 0)
+                or np.any(np.asarray(indices) >= robot.num_dofs)
+            )
         ):
             raise ValueError("joint_pair_indices must reference valid robot DOFs.")
 
@@ -480,7 +497,12 @@ class ArticulatedMcKibbenActuator(Actuator):
         if not isinstance(params, ArticulatedMcKibbenActuatorParams):
             raise TypeError("params must be ArticulatedMcKibbenActuatorParams.")
         self.params.transmission.assert_same_topology(params.transmission)
-        params.validate()
+        params.validate_for_update()
+        params = eqx.tree_at(
+            lambda current: current.transmission.joint_pair_indices,
+            params,
+            self.params.transmission.joint_pair_indices,
+        )
         return ArticulatedMcKibbenActuator(
             params=params, labels=self.metadata.labels, name=self.name
         )

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -9,7 +9,7 @@ import equinox as eqx
 from jax import Array, vmap
 from jax import numpy as jnp
 
-from soromox.systems.params import BaseSystemParams, _contains_tracer
+from soromox.systems.params import BaseSystemParams
 
 from .core import (
     Actuator,
@@ -22,8 +22,8 @@ from .core import (
 ThreadlikeKind = Literal["tendon", "push_rod", "muscle", "pneumatic", "generic"]
 
 
-def _validate_routing_for_robot(routing: ThreadlikeRouting, robot) -> None:
-    """Validate routing topology and host-specific geometric constraints."""
+def _validate_routing_structure_for_robot(routing: ThreadlikeRouting, robot) -> None:
+    """Validate routing topology and tracer-safe host compatibility."""
     required_hooks = (
         "_threadlike_path_lengths",
         "_threadlike_moment_matrix",
@@ -39,7 +39,7 @@ def _validate_routing_for_robot(routing: ThreadlikeRouting, robot) -> None:
             "Threadlike components require continuum segment topology through "
             "num_segments."
         )
-    routing.params.validate_for_robot(robot.num_segments)
+    routing.params.validate_structure_for_robot(robot.num_segments)
     if not robot.is_planar:
         return
     if not hasattr(robot, "L_cum"):
@@ -56,10 +56,21 @@ def _validate_routing_for_robot(routing: ThreadlikeRouting, robot) -> None:
             "ThreadlikeRouting.offset_fn must return material-frame [x, y, z] "
             "offsets with final shape (3,)."
         )
+
+
+def _validate_routing_values_for_robot(routing: ThreadlikeRouting, robot) -> None:
+    """Validate concrete routing values and host-specific geometry."""
+    routing.params.validate_values()
+    if not robot.is_planar:
+        return
+    samples = jnp.linspace(0.0, robot.L_cum[-1], 17)
+    offsets = vmap(
+        lambda path_params: vmap(lambda s: routing.offset(path_params, s))(samples)
+    )(routing.params)
     leaves_planar_frame = jnp.any(offsets[..., 0] != 0.0) | jnp.any(
         offsets[..., 2] != 0.0
     )
-    if not _contains_tracer(offsets) and bool(leaves_planar_frame):
+    if bool(leaves_planar_frame):
         raise ValueError(
             "PlanarPCS threadlike routing must remain in the local-y direction; "
             "its sampled local x and z offsets must be zero."
@@ -122,8 +133,8 @@ class BaseThreadlikeRoutingParams(BaseSystemParams):
     def end_segment_index_array(self) -> Array:
         return jnp.asarray(self.end_segment_index, dtype=jnp.int32)
 
-    def validate_for_robot(self, num_segments: int) -> None:
-        self.validate_for_update()
+    def validate_structure_for_robot(self, num_segments: int) -> None:
+        self.validate_structure()
         for start, end in zip(self.start_segment_index, self.end_segment_index):
             if start < 0 or start > end or end >= num_segments:
                 raise ValueError(
@@ -633,8 +644,14 @@ class ThreadlikeActuator(Actuator):
             kind=self.kind,
         )
 
-    def validate_for_robot(self, robot) -> None:
-        _validate_routing_for_robot(self.transmission.routing, robot)
+    def validate_structure_for_robot(self, robot) -> None:
+        _validate_routing_structure_for_robot(self.transmission.routing, robot)
+
+    def validate_values_for_robot(self, robot) -> None:
+        _validate_routing_values_for_robot(self.transmission.routing, robot)
+
+    def _robot_value_validation_tree(self):
+        return self.transmission.routing.params
 
     def path_lengths(self, robot, q: Array) -> Array:
         return self.transmission.path_lengths(robot, q)
@@ -727,8 +744,14 @@ class ThreadlikeImpedance(PassiveElement):
         params.validate_for_update()
         return self._from_params(params, name=self.name, routing=self.routing)
 
-    def validate_for_robot(self, robot) -> None:
-        _validate_routing_for_robot(self.routing, robot)
+    def validate_structure_for_robot(self, robot) -> None:
+        _validate_routing_structure_for_robot(self.routing, robot)
+
+    def validate_values_for_robot(self, robot) -> None:
+        _validate_routing_values_for_robot(self.routing, robot)
+
+    def _robot_value_validation_tree(self):
+        return self.routing.params
 
     def path_lengths(self, robot, q: Array) -> Array:
         """Return the raw lengths of the passive routed paths."""

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -174,7 +174,7 @@ class LinearThreadlikeRoutingParams(BaseThreadlikeRoutingParams):
     end_segment_index: tuple[int, ...] = eqx.field(static=True, converter=_index_tuple)
 
     def __check_init__(self) -> None:
-        self.validate()
+        self.validate_for_update()
 
     @property
     def num_paths(self) -> int:
@@ -220,8 +220,8 @@ class LinearThreadlikeRoutingParams(BaseThreadlikeRoutingParams):
                     "end_segment_index."
                 )
 
-    def validate(self) -> None:
-        self.validate_structure()
+    def validate_values(self) -> None:
+        """Validate eager linear-routing values."""
         intercept = jnp.asarray(self.intercept)
         slope = jnp.asarray(self.slope)
         if bool(jnp.any(intercept[:, 0] != 0.0)):
@@ -328,16 +328,21 @@ class ThreadlikeTransmissionParams(BaseSystemParams):
     coordinate_scale: Array
 
     def __check_init__(self) -> None:
-        self.validate()
+        self.validate_for_update()
 
-    def validate(self) -> None:
-        self.routing.validate_for_update()
+    def validate_structure(self) -> None:
+        """Validate threadlike transmission parameter structure."""
+        self.routing.validate_structure()
         scale = jnp.asarray(self.coordinate_scale)
         if scale.shape != (self.routing.num_paths,):
             raise ValueError(
                 "coordinate_scale must have shape "
                 f"({self.routing.num_paths},), got {scale.shape}."
             )
+
+    def validate_values(self) -> None:
+        """Validate eager nested routing values."""
+        self.routing.validate_values()
 
 
 class ThreadlikeTransmission(Transmission):
@@ -410,10 +415,11 @@ class ThreadlikeActuatorParams(BaseSystemParams):
     upper_bounds: Array
 
     def __check_init__(self) -> None:
-        self.validate()
+        self.validate_for_update()
 
-    def validate(self) -> None:
-        self.transmission.validate_for_update()
+    def validate_structure(self) -> None:
+        """Validate threadlike actuator parameter structure."""
+        self.transmission.validate_structure()
         count = self.transmission.routing.num_paths
         for name in ("lower_bounds", "upper_bounds"):
             value = jnp.asarray(getattr(self, name))
@@ -421,6 +427,10 @@ class ThreadlikeActuatorParams(BaseSystemParams):
                 raise ValueError(
                     f"{name} must have shape ({count},), got {value.shape}."
                 )
+
+    def validate_values(self) -> None:
+        """Validate eager nested threadlike transmission values."""
+        self.transmission.validate_values()
 
 
 class ThreadlikeActuator(Actuator):
@@ -645,10 +655,11 @@ class ThreadlikeImpedanceParams(BaseSystemParams):
     rest_length: Array
 
     def __check_init__(self) -> None:
-        self.validate()
+        self.validate_for_update()
 
-    def validate(self) -> None:
-        self.routing.validate_for_update()
+    def validate_structure(self) -> None:
+        """Validate threadlike impedance parameter structure."""
+        self.routing.validate_structure()
         count = self.routing.num_paths
         for name in ("stiffness", "damping", "rest_length"):
             value = jnp.asarray(getattr(self, name))
@@ -656,6 +667,10 @@ class ThreadlikeImpedanceParams(BaseSystemParams):
                 raise ValueError(
                     f"{name} must have shape ({count},), got {value.shape}."
                 )
+
+    def validate_values(self) -> None:
+        """Validate eager nested threadlike routing values."""
+        self.routing.validate_values()
 
 
 class ThreadlikeImpedance(PassiveElement):

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -9,7 +9,7 @@ import equinox as eqx
 from jax import Array, vmap
 from jax import numpy as jnp
 
-from soromox.systems.params import BaseSystemParams
+from soromox.systems.params import BaseSystemParams, _contains_tracer
 
 from .core import (
     Actuator,
@@ -56,7 +56,10 @@ def _validate_routing_for_robot(routing: ThreadlikeRouting, robot) -> None:
             "ThreadlikeRouting.offset_fn must return material-frame [x, y, z] "
             "offsets with final shape (3,)."
         )
-    if bool(jnp.any(offsets[..., 0] != 0.0) | jnp.any(offsets[..., 2] != 0.0)):
+    leaves_planar_frame = jnp.any(offsets[..., 0] != 0.0) | jnp.any(
+        offsets[..., 2] != 0.0
+    )
+    if not _contains_tracer(offsets) and bool(leaves_planar_frame):
         raise ValueError(
             "PlanarPCS threadlike routing must remain in the local-y direction; "
             "its sampled local x and z offsets must be zero."
@@ -120,7 +123,7 @@ class BaseThreadlikeRoutingParams(BaseSystemParams):
         return jnp.asarray(self.end_segment_index, dtype=jnp.int32)
 
     def validate_for_robot(self, num_segments: int) -> None:
-        self.validate()
+        self.validate_for_update()
         for start, end in zip(self.start_segment_index, self.end_segment_index):
             if start < 0 or start > end or end >= num_segments:
                 raise ValueError(
@@ -195,7 +198,7 @@ class LinearThreadlikeRoutingParams(BaseThreadlikeRoutingParams):
             end_segment_index=(),
         )
 
-    def validate(self) -> None:
+    def validate_structure(self) -> None:
         intercept = jnp.asarray(self.intercept)
         slope = jnp.asarray(self.slope)
         if intercept.ndim != 2 or intercept.shape[1:] != (3,):
@@ -203,16 +206,6 @@ class LinearThreadlikeRoutingParams(BaseThreadlikeRoutingParams):
         if slope.shape != intercept.shape:
             raise ValueError(
                 f"slope must have shape {intercept.shape}, got {slope.shape}."
-            )
-        if bool(jnp.any(intercept[:, 0] != 0.0)):
-            raise ValueError(
-                "intercept local-x components must be zero because the backbone "
-                "is aligned with the local x-axis."
-            )
-        if bool(jnp.any(slope[:, 0] != 0.0)):
-            raise ValueError(
-                "slope local-x components must be zero because the backbone is "
-                "aligned with the local x-axis."
             )
         if len(self.start_segment_index) != self.num_paths:
             raise ValueError("start_segment_index must contain one entry per path.")
@@ -226,6 +219,21 @@ class LinearThreadlikeRoutingParams(BaseThreadlikeRoutingParams):
                     "each threadlike routing must have start_segment_index <= "
                     "end_segment_index."
                 )
+
+    def validate(self) -> None:
+        self.validate_structure()
+        intercept = jnp.asarray(self.intercept)
+        slope = jnp.asarray(self.slope)
+        if bool(jnp.any(intercept[:, 0] != 0.0)):
+            raise ValueError(
+                "intercept local-x components must be zero because the backbone "
+                "is aligned with the local x-axis."
+            )
+        if bool(jnp.any(slope[:, 0] != 0.0)):
+            raise ValueError(
+                "slope local-x components must be zero because the backbone is "
+                "aligned with the local x-axis."
+            )
 
 
 def linear_threadlike_routing(params: LinearThreadlikeRoutingParams, s: Array) -> Array:
@@ -302,7 +310,7 @@ class ThreadlikeRouting(eqx.Module):
         if not isinstance(params, BaseThreadlikeRoutingParams):
             raise TypeError("params must be BaseThreadlikeRoutingParams.")
         self.params.assert_same_topology(params)
-        params.validate()
+        params.validate_for_update()
         return ThreadlikeRouting(
             params=params,
             offset_fn=self.offset_fn,
@@ -323,7 +331,7 @@ class ThreadlikeTransmissionParams(BaseSystemParams):
         self.validate()
 
     def validate(self) -> None:
-        self.routing.validate()
+        self.routing.validate_for_update()
         scale = jnp.asarray(self.coordinate_scale)
         if scale.shape != (self.routing.num_paths,):
             raise ValueError(
@@ -346,7 +354,7 @@ class ThreadlikeTransmission(Transmission):
     ) -> None:
         if not isinstance(params, ThreadlikeTransmissionParams):
             raise TypeError("params must be ThreadlikeTransmissionParams.")
-        params.validate()
+        params.validate_for_update()
         self.params = params
         if routing is None:
             if not isinstance(params.routing, LinearThreadlikeRoutingParams):
@@ -387,7 +395,7 @@ class ThreadlikeTransmission(Transmission):
         if not isinstance(params, ThreadlikeTransmissionParams):
             raise TypeError("params must be ThreadlikeTransmissionParams.")
         self.params.routing.assert_same_topology(params.routing)
-        params.validate()
+        params.validate_for_update()
         return ThreadlikeTransmission(params, routing=self.routing)
 
     def update_params(self, **updates: Any) -> ThreadlikeTransmission:
@@ -405,7 +413,7 @@ class ThreadlikeActuatorParams(BaseSystemParams):
         self.validate()
 
     def validate(self) -> None:
-        self.transmission.validate()
+        self.transmission.validate_for_update()
         count = self.transmission.routing.num_paths
         for name in ("lower_bounds", "upper_bounds"):
             value = jnp.asarray(getattr(self, name))
@@ -435,7 +443,7 @@ class ThreadlikeActuator(Actuator):
         name: str,
         kind: ThreadlikeKind,
     ) -> None:
-        params.validate()
+        params.validate_for_update()
         count = params.transmission.routing.num_paths
         if len(labels) != count:
             raise ValueError("labels must contain one entry per threadlike path.")
@@ -605,7 +613,7 @@ class ThreadlikeActuator(Actuator):
         self.params.transmission.routing.assert_same_topology(
             params.transmission.routing
         )
-        params.validate()
+        params.validate_for_update()
         return ThreadlikeActuator(
             params=params,
             routing=self.transmission.routing,
@@ -640,7 +648,7 @@ class ThreadlikeImpedanceParams(BaseSystemParams):
         self.validate()
 
     def validate(self) -> None:
-        self.routing.validate()
+        self.routing.validate_for_update()
         count = self.routing.num_paths
         for name in ("stiffness", "damping", "rest_length"):
             value = jnp.asarray(getattr(self, name))
@@ -701,7 +709,7 @@ class ThreadlikeImpedance(PassiveElement):
         if not isinstance(params, ThreadlikeImpedanceParams):
             raise TypeError("params must be ThreadlikeImpedanceParams.")
         self.params.routing.assert_same_topology(params.routing)
-        params.validate()
+        params.validate_for_update()
         return self._from_params(params, name=self.name, routing=self.routing)
 
     def validate_for_robot(self, robot) -> None:

--- a/src/soromox/systems/articulated/articulated_soft_robot.py
+++ b/src/soromox/systems/articulated/articulated_soft_robot.py
@@ -939,7 +939,7 @@ class ArticulatedSoftRobot(SoftRobot):
         """Return an updated copy with a full typed parameter object."""
         if not isinstance(params, ArticulatedSoftRobotParams):
             raise TypeError("params must be an ArticulatedSoftRobotParams instance.")
-        params.validate()
+        params.validate_for_update()
         if params.mass.shape != self.params.mass.shape:
             raise ValueError(
                 "mass shape changes the model structure; construct a new ArticulatedSoftRobot."

--- a/src/soromox/systems/articulated/params.py
+++ b/src/soromox/systems/articulated/params.py
@@ -64,7 +64,7 @@ class ArticulatedSoftRobotParams(BaseArticulatedSoftRobotParams):
         self.center_of_mass_inertia = jnp.asarray(center_of_mass_inertia)
         self.radius = jnp.asarray(radius)
 
-    def validate(self) -> None:
+    def validate_structure(self) -> None:
         joint_screw = jnp.asarray(self.joint_screw)
         if joint_screw.ndim != 2 or joint_screw.shape[1] != 6:
             raise ValueError(
@@ -91,6 +91,13 @@ class ArticulatedSoftRobotParams(BaseArticulatedSoftRobotParams):
                 raise ValueError(
                     f"{name} must have shape {expected_shape}, got {value.shape}."
                 )
+        if jnp.asarray(self.base_pose).shape != (7,):
+            raise ValueError(
+                f"base_pose must have shape (7,), got {self.base_pose.shape}."
+            )
+
+    def validate_values(self) -> None:
+        """Validate eager articulated-system parameter values."""
         validate_quaternion_base_pose("base_pose", self.base_pose, (7,))
 
 
@@ -217,8 +224,8 @@ class McKibbenActuatedUMArmParams(ArticulatedSoftRobotParams):
             + (skew @ skew) * ((1.0 - cos_angle) / (sin_angle**2))
         )
 
-    def validate(self) -> None:
-        super().validate()
+    def validate_structure(self) -> None:
+        super().validate_structure()
         num_links = int(jnp.asarray(self.joint_screw).shape[0])
         if jnp.asarray(self.joint_armature).shape != (num_links,):
             raise ValueError(

--- a/src/soromox/systems/components/cross_sections.py
+++ b/src/soromox/systems/components/cross_sections.py
@@ -8,7 +8,6 @@ from typing import Literal
 
 import jax.numpy as jnp
 from jax import Array
-from jax.errors import ConcretizationTypeError, TracerBoolConversionError
 
 from soromox.systems.params import BaseSystemParams
 
@@ -53,10 +52,7 @@ class LinearProfile:
                 positive.
         """
         values = jnp.asarray([self.base, self.tip])
-        try:
-            valid = bool(jnp.all(jnp.isfinite(values) & (values > 0.0)))
-        except (ConcretizationTypeError, TracerBoolConversionError):
-            return
+        valid = bool(jnp.all(jnp.isfinite(values) & (values > 0.0)))
         if not valid:
             raise ValueError(
                 "LinearProfile base and tip must be finite and strictly positive."
@@ -81,7 +77,7 @@ class CrossSectionParams(BaseSystemParams):
 
     def __check_init__(self) -> None:
         object.__setattr__(self, "coefficients", jnp.asarray(self.coefficients))
-        self.validate()
+        self.validate_for_update()
 
     def _normalize_replacement(self, name: str, value: object) -> object:
         """Normalize replacement coefficient values to JAX arrays."""
@@ -89,16 +85,15 @@ class CrossSectionParams(BaseSystemParams):
             return jnp.asarray(value)
         return value
 
-    def validate(self) -> None:
-        """Validate the batched cross-section coefficient array.
+    def validate_structure(self) -> None:
+        """Validate the batched cross-section coefficient array shape.
 
         Returns:
             None.
 
         Raises:
             ValueError: If ``coefficients`` is not a nonempty two-dimensional
-                array, contains non-finite or negative values, or has a row
-                without any positive geometric coefficient.
+                array.
         """
         coefficients = jnp.asarray(self.coefficients)
         if coefficients.ndim != 2:
@@ -108,13 +103,14 @@ class CrossSectionParams(BaseSystemParams):
             )
         if coefficients.shape[0] < 1 or coefficients.shape[1] < 1:
             raise ValueError("cross-section coefficients must be non-empty.")
-        try:
-            finite_and_nonnegative = bool(
-                jnp.all(jnp.isfinite(coefficients) & (coefficients >= 0.0))
-            )
-            positive_per_link = bool(jnp.all(jnp.any(coefficients > 0.0, axis=1)))
-        except (ConcretizationTypeError, TracerBoolConversionError):
-            return
+
+    def validate_values(self) -> None:
+        """Validate eager cross-section coefficient values."""
+        coefficients = jnp.asarray(self.coefficients)
+        finite_and_nonnegative = bool(
+            jnp.all(jnp.isfinite(coefficients) & (coefficients >= 0.0))
+        )
+        positive_per_link = bool(jnp.all(jnp.any(coefficients > 0.0, axis=1)))
         if not finite_and_nonnegative:
             raise ValueError(
                 "cross-section coefficients must be finite and nonnegative."

--- a/src/soromox/systems/components/joints.py
+++ b/src/soromox/systems/components/joints.py
@@ -71,7 +71,7 @@ class JointParams(BaseSystemParams):
     def __check_init__(self) -> None:
         object.__setattr__(self, "stiffness", jnp.asarray(self.stiffness))
         object.__setattr__(self, "damping", jnp.asarray(self.damping))
-        self.validate()
+        self.validate_for_update()
 
     def _normalize_replacement(self, name: str, value: object) -> object:
         """Normalize replacement joint-matrix values to JAX arrays."""
@@ -79,16 +79,15 @@ class JointParams(BaseSystemParams):
             return jnp.asarray(value)
         return value
 
-    def validate(self) -> None:
-        """Validate joint matrix shapes, finiteness, and symmetry.
+    def validate_structure(self) -> None:
+        """Validate joint matrix shapes.
 
         Returns:
             None.
 
         Raises:
-            ValueError: If stiffness is not a batch of square matrices, damping
-                has a different shape, or either matrix batch is non-finite or
-                asymmetric.
+            ValueError: If stiffness is not a batch of square matrices or
+                damping has a different shape.
         """
         stiffness = jnp.asarray(self.stiffness)
         damping = jnp.asarray(self.damping)
@@ -101,8 +100,11 @@ class JointParams(BaseSystemParams):
             raise ValueError(
                 f"joint damping must have shape {stiffness.shape}, got {damping.shape}."
             )
-        _validate_symmetric("joint stiffness", stiffness)
-        _validate_symmetric("joint damping", damping)
+
+    def validate_values(self) -> None:
+        """Validate eager joint matrix finiteness and symmetry."""
+        _validate_symmetric("joint stiffness", self.stiffness)
+        _validate_symmetric("joint damping", self.damping)
 
 
 @dataclass

--- a/src/soromox/systems/components/links.py
+++ b/src/soromox/systems/components/links.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 
 import jax.numpy as jnp
 from jax import Array
-from jax.errors import ConcretizationTypeError, TracerBoolConversionError
 
 from soromox.systems.params import BaseSystemParams
 
@@ -22,11 +21,8 @@ __all__ = ["ContinuumLinkParams", "LinkSpec"]
 
 
 def _validate_symmetric(name: str, value: Array) -> None:
-    try:
-        finite = bool(jnp.all(jnp.isfinite(value)))
-        symmetric = bool(jnp.allclose(value, jnp.swapaxes(value, -1, -2)))
-    except (ConcretizationTypeError, TracerBoolConversionError):
-        return
+    finite = bool(jnp.all(jnp.isfinite(value)))
+    symmetric = bool(jnp.allclose(value, jnp.swapaxes(value, -1, -2)))
     if not finite:
         raise ValueError(f"{name} must contain only finite values.")
     if not symmetric:
@@ -36,13 +32,10 @@ def _validate_symmetric(name: str, value: Array) -> None:
 def _validate_finite_domain(
     name: str, value: Array | float, *, strictly_positive: bool = False
 ) -> None:
-    """Validate concrete numeric values while remaining safe under JAX tracing."""
+    """Validate eager numeric values."""
     array = jnp.asarray(value)
-    try:
-        finite = bool(jnp.all(jnp.isfinite(array)))
-        positive = bool(jnp.all(array > 0.0)) if strictly_positive else True
-    except (ConcretizationTypeError, TracerBoolConversionError):
-        return
+    finite = bool(jnp.all(jnp.isfinite(array)))
+    positive = bool(jnp.all(array > 0.0)) if strictly_positive else True
     if not finite:
         raise ValueError(f"{name} must contain only finite values.")
     if not positive:
@@ -75,7 +68,7 @@ class ContinuumLinkParams(BaseSystemParams):
     def __check_init__(self) -> None:
         for name in ("length", "density", "reference_strain", "stiffness", "damping"):
             object.__setattr__(self, name, jnp.asarray(getattr(self, name)))
-        self.validate()
+        self.validate_for_update()
 
     def _normalize_replacement(self, name: str, value: object) -> object:
         """Normalize replacement link-array values to JAX arrays."""
@@ -83,19 +76,16 @@ class ContinuumLinkParams(BaseSystemParams):
             return jnp.asarray(value)
         return value
 
-    def validate(self) -> None:
-        """Validate link-array shapes and canonical matrix properties.
+    def validate_structure(self) -> None:
+        """Validate link-array and canonical matrix shapes.
 
         Returns:
             None.
 
         Raises:
             ValueError: If link fields disagree on ``num_links``, reference
-                strain or coefficient arrays are not two-dimensional, canonical
-                matrices are not equally shaped square batches, or a canonical
-                matrix contains non-finite values or is not symmetric, length
-                or density is non-finite or not strictly positive, or reference
-                strain contains non-finite values.
+                strain or coefficient arrays are not two-dimensional, or
+                canonical matrices are not equally shaped square batches.
         """
         length = jnp.asarray(self.length)
         if length.ndim != 1 or length.shape[0] < 1:
@@ -106,8 +96,6 @@ class ContinuumLinkParams(BaseSystemParams):
             raise ValueError(
                 f"density must have shape ({num_links},), got {density.shape}."
             )
-        _validate_finite_domain("length", length, strictly_positive=True)
-        _validate_finite_domain("density", density, strictly_positive=True)
         reference_strain = jnp.asarray(self.reference_strain)
         if (
             reference_strain.ndim != 2
@@ -117,8 +105,7 @@ class ContinuumLinkParams(BaseSystemParams):
             raise ValueError(
                 "reference_strain must have shape (num_links, strain_dimension)."
             )
-        _validate_finite_domain("reference_strain", reference_strain)
-        self.cross_section.validate()
+        self.cross_section.validate_structure()
         if self.cross_section.coefficients.shape[0] != num_links:
             raise ValueError("cross-section coefficients must have one row per link.")
         stiffness = jnp.asarray(self.stiffness)
@@ -134,8 +121,15 @@ class ContinuumLinkParams(BaseSystemParams):
             raise ValueError(
                 f"damping must have shape {stiffness.shape}, got {damping.shape}."
             )
-        _validate_symmetric("stiffness", stiffness)
-        _validate_symmetric("damping", damping)
+
+    def validate_values(self) -> None:
+        """Validate eager link values and canonical matrix properties."""
+        _validate_finite_domain("length", self.length, strictly_positive=True)
+        _validate_finite_domain("density", self.density, strictly_positive=True)
+        _validate_finite_domain("reference_strain", self.reference_strain)
+        self.cross_section.validate_values()
+        _validate_symmetric("stiffness", self.stiffness)
+        _validate_symmetric("damping", self.damping)
 
 
 def _profile(
@@ -246,15 +240,12 @@ class LinkSpec:
             )
         if self.poisson_ratio is not None:
             _validate_finite_domain("poisson_ratio", self.poisson_ratio)
-            try:
-                valid_poisson_ratio = bool(
-                    jnp.all(
-                        (jnp.asarray(self.poisson_ratio) > -1.0)
-                        & (jnp.asarray(self.poisson_ratio) < 0.5)
-                    )
+            valid_poisson_ratio = bool(
+                jnp.all(
+                    (jnp.asarray(self.poisson_ratio) > -1.0)
+                    & (jnp.asarray(self.poisson_ratio) < 0.5)
                 )
-            except (ConcretizationTypeError, TracerBoolConversionError):
-                valid_poisson_ratio = True
+            )
             if not valid_poisson_ratio:
                 raise ValueError(
                     "poisson_ratio must be greater than -1 and less than 0.5."
@@ -263,12 +254,9 @@ class LinkSpec:
             _validate_finite_domain(
                 "material_damping_coefficient", self.material_damping_coefficient
             )
-            try:
-                nonnegative_damping = bool(
-                    jnp.all(jnp.asarray(self.material_damping_coefficient) >= 0.0)
-                )
-            except (ConcretizationTypeError, TracerBoolConversionError):
-                nonnegative_damping = True
+            nonnegative_damping = bool(
+                jnp.all(jnp.asarray(self.material_damping_coefficient) >= 0.0)
+            )
             if not nonnegative_damping:
                 raise ValueError("material_damping_coefficient must be nonnegative.")
         for name in ("stiffness", "damping"):

--- a/src/soromox/systems/components/materials.py
+++ b/src/soromox/systems/components/materials.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 from jax import Array
-from jax.errors import ConcretizationTypeError, TracerBoolConversionError
 
 from soromox.systems.params import BaseSystemParams
 
@@ -70,7 +69,7 @@ class IsotropicMaterialParams(BaseSystemParams):
             value = getattr(self, name)
             if value is not None:
                 object.__setattr__(self, name, jnp.asarray(value))
-        self.validate()
+        self.validate_for_update()
 
     def _normalize_replacement(self, name: str, value: object) -> object:
         """Normalize replacement material values to JAX arrays."""
@@ -87,8 +86,8 @@ class IsotropicMaterialParams(BaseSystemParams):
             return jnp.asarray(value)
         return value
 
-    def validate(self) -> None:
-        """Validate material field dimensionality and physical values.
+    def validate_structure(self) -> None:
+        """Validate the material parameterization and static array layout.
 
         Returns:
             None.
@@ -96,9 +95,7 @@ class IsotropicMaterialParams(BaseSystemParams):
         Raises:
             ValueError: If both or neither of ``shear_modulus`` and
                 ``poisson_ratio`` are provided; any active material field has
-                more than one dimension; either modulus is non-finite or not
-                strictly positive; Poisson's ratio is outside ``(-1, 0.5)``;
-                or the material damping coefficient is non-finite or negative.
+                more than one dimension; or a one-dimensional field is empty.
         """
         if (self.shear_modulus is None) == (self.poisson_ratio is None):
             raise ValueError("Provide exactly one of shear_modulus and poisson_ratio.")
@@ -117,16 +114,37 @@ class IsotropicMaterialParams(BaseSystemParams):
                 raise ValueError(f"{name} must be scalar or one-dimensional.")
             if value.ndim == 1 and value.shape[0] < 1:
                 raise ValueError(f"{name} must not be empty.")
-            try:
-                finite = bool(jnp.all(jnp.isfinite(value)))
-                if name == "material_damping_coefficient":
-                    valid_domain = bool(jnp.all(value >= 0.0))
-                elif name == "poisson_ratio":
-                    valid_domain = bool(jnp.all((value > -1.0) & (value < 0.5)))
-                else:
-                    valid_domain = bool(jnp.all(value > 0.0))
-            except (ConcretizationTypeError, TracerBoolConversionError):
+
+    def validate(self) -> None:
+        """Validate material structure and eager physical values.
+
+        Returns:
+            None.
+
+        Raises:
+            ValueError: If structural validation fails; either modulus is
+                non-finite or not strictly positive; Poisson's ratio is outside
+                ``(-1, 0.5)``; or the material damping coefficient is
+                non-finite or negative.
+        """
+        self.validate_structure()
+        for name in (
+            "young_modulus",
+            "shear_modulus",
+            "poisson_ratio",
+            "material_damping_coefficient",
+        ):
+            field_value = getattr(self, name)
+            if field_value is None:
                 continue
+            value = jnp.asarray(field_value)
+            finite = bool(jnp.all(jnp.isfinite(value)))
+            if name == "material_damping_coefficient":
+                valid_domain = bool(jnp.all(value >= 0.0))
+            elif name == "poisson_ratio":
+                valid_domain = bool(jnp.all((value > -1.0) & (value < 0.5)))
+            else:
+                valid_domain = bool(jnp.all(value > 0.0))
             if not finite:
                 raise ValueError(f"{name} must contain only finite values.")
             if not valid_domain:

--- a/src/soromox/systems/components/materials.py
+++ b/src/soromox/systems/components/materials.py
@@ -115,19 +115,17 @@ class IsotropicMaterialParams(BaseSystemParams):
             if value.ndim == 1 and value.shape[0] < 1:
                 raise ValueError(f"{name} must not be empty.")
 
-    def validate(self) -> None:
-        """Validate material structure and eager physical values.
+    def validate_values(self) -> None:
+        """Validate eager material physical values.
 
         Returns:
             None.
 
         Raises:
-            ValueError: If structural validation fails; either modulus is
-                non-finite or not strictly positive; Poisson's ratio is outside
-                ``(-1, 0.5)``; or the material damping coefficient is
-                non-finite or negative.
+            ValueError: If either modulus is non-finite or not strictly
+                positive; Poisson's ratio is outside ``(-1, 0.5)``; or the
+                material damping coefficient is non-finite or negative.
         """
-        self.validate_structure()
         for name in (
             "young_modulus",
             "shear_modulus",

--- a/src/soromox/systems/gvs/_assembly.py
+++ b/src/soromox/systems/gvs/_assembly.py
@@ -144,7 +144,7 @@ def assign_gvs_runtime_arrays(
     basis_type_index = jnp.empty((n_segments,), dtype=int)
     basis_active_params = jnp.empty((n_segments, 6))
     basis_order_params = jnp.empty((n_segments, 6))
-    cross_section_geometry = jnp.empty((n_segments,), dtype=int)
+    cross_section_geometry = jnp.empty((n_segments,), dtype=jnp.int32)
     radius_params = jnp.empty((n_segments, 2))
     height_params = jnp.empty((n_segments, 2))
     width_params = jnp.empty((n_segments, 2))

--- a/src/soromox/systems/gvs/construction.py
+++ b/src/soromox/systems/gvs/construction.py
@@ -57,7 +57,7 @@ def _link_dof(segment: GVSSegmentStructure) -> int:
 
 def _resolve_structure(params: GVSParams, structure: GVSStructure) -> GVSStructure:
     """Return a fully resolved GVS structure compatible with ``params``."""
-    params.validate_against_structure(structure)
+    params.validate_for_update_against_structure(structure)
     max_dof = (
         int(params.link.stiffness.shape[-1])
         if structure.max_dof is None
@@ -130,7 +130,7 @@ def material_operators_from_params(
             coefficients, unsupported cross-section data, or invalid quadrature
             configuration.
     """
-    params.validate_against_structure(structure)
+    params.validate_for_update_against_structure(structure)
     max_dof = (
         int(params.link.stiffness.shape[-1])
         if structure.max_dof is None

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -843,7 +843,6 @@ class GVS(SoftRobot):
         Raises:
             ValueError: If link params do not contain one entry per segment.
         """
-        link.validate_for_update()
         if link.length.shape != (self.num_segments,):
             raise ValueError(
                 "link params must contain one entry per segment, "

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -843,7 +843,7 @@ class GVS(SoftRobot):
         Raises:
             ValueError: If link params do not contain one entry per segment.
         """
-        link.validate()
+        link.validate_for_update()
         if link.length.shape != (self.num_segments,):
             raise ValueError(
                 "link params must contain one entry per segment, "
@@ -979,7 +979,7 @@ class GVS(SoftRobot):
         """
         if not isinstance(params, GVSParams):
             raise TypeError("params must be a GVSParams instance.")
-        params.validate_against_structure(self.structure)
+        params.validate_for_update_against_structure(self.structure)
         link_arrays = self._link_parameter_arrays(params.link)
         (
             xi_ref_joint,

--- a/src/soromox/systems/gvs/params.py
+++ b/src/soromox/systems/gvs/params.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 import jax.numpy as jnp
-from jax.errors import ConcretizationTypeError, TracerBoolConversionError
 
 from soromox.systems.components import ContinuumLinkParams, JointParams
 from soromox.systems.params import BaseSoftRobotParams, validate_quaternion_base_pose
@@ -34,19 +33,19 @@ class GVSParams(BaseSoftRobotParams):
     link: ContinuumLinkParams
     joint: JointParams
 
-    def validate(self) -> None:
-        """Validate intrinsic shapes and values of the GVS parameters.
+    def validate_structure(self) -> None:
+        """Validate intrinsic GVS parameter structure.
 
         Returns:
             ``None`` after successful validation.
 
         Raises:
-            ValueError: If a component is invalid, link and joint batch shapes
-                disagree, reference strains do not have six components, or the
-                gravity and base-pose arrays have invalid shapes or values.
+            ValueError: If a component shape is invalid, link and joint batch
+                shapes disagree, reference strains do not have six components,
+                or the gravity and base-pose arrays have invalid shapes.
         """
-        self.link.validate()
-        self.joint.validate()
+        self.link.validate_structure()
+        self.joint.validate_structure()
         num_segments = self.link.length.shape[0]
         if self.link.reference_strain.shape != (num_segments, 6):
             raise ValueError(
@@ -62,10 +61,19 @@ class GVSParams(BaseSoftRobotParams):
         gravity = jnp.asarray(self.gravity)
         if gravity.shape != (3,):
             raise ValueError(f"gravity must have shape (3,), got {gravity.shape}.")
+        if jnp.asarray(self.base_pose).shape != (7,):
+            raise ValueError(
+                f"base_pose must have shape (7,), got {self.base_pose.shape}."
+            )
+
+    def validate_values(self) -> None:
+        """Validate eager GVS component and base-pose values."""
+        self.link.validate_values()
+        self.joint.validate_values()
         validate_quaternion_base_pose("base_pose", self.base_pose, (7,))
 
-    def validate_against_structure(self, structure: GVSStructure) -> None:
-        """Validate dynamic arrays against a static padded GVS layout.
+    def validate_structure_compatibility(self, structure: GVSStructure) -> None:
+        """Validate dynamic array shapes against a static padded GVS layout.
 
         Args:
             structure: Static :class:`GVSStructure` defining the number of
@@ -79,7 +87,7 @@ class GVSParams(BaseSoftRobotParams):
             TypeError: If ``structure`` is not a :class:`GVSStructure`.
             ValueError: If the structure is empty or any parameter batch,
                 padded matrix, cross-section coefficient array, basis DOF, or
-                quadrature setting is inconsistent with ``structure``.
+                quadrature setting is structurally inconsistent.
         """
         from soromox.systems.gvs.primitives import Joint
         from soromox.systems.gvs.structures import GVSStructure
@@ -88,7 +96,6 @@ class GVSParams(BaseSoftRobotParams):
             raise TypeError("structure must be a GVSStructure instance.")
         if not structure.segments:
             raise ValueError("GVS requires at least one segment.")
-        self.validate()
         num_segments = len(structure.segments)
         if self.link.length.shape != (num_segments,):
             raise ValueError(f"link params must contain {num_segments} links.")
@@ -103,19 +110,6 @@ class GVSParams(BaseSoftRobotParams):
                 f"{expected_cross_section_shape}, got "
                 f"{self.link.cross_section.coefficients.shape}."
             )
-        for index, segment in enumerate(structure.segments):
-            count = sum(segment.link.cross_section_profile_parameter_counts)
-            active_coefficients = self.link.cross_section.coefficients[index, :count]
-            try:
-                valid_dimensions = bool(jnp.all(active_coefficients > 0.0))
-            except (ConcretizationTypeError, TracerBoolConversionError):
-                continue
-            if not valid_dimensions:
-                raise ValueError(
-                    "Active cross-section coefficients must be strictly positive "
-                    f"for GVS segment {index}."
-                )
-
         joint_dofs = [
             Joint.DICT_JOINT_TYPE_DOF[segment.joint.type]
             for segment in structure.segments
@@ -166,4 +160,15 @@ class GVSParams(BaseSoftRobotParams):
             ):
                 raise ValueError(
                     "max_num_gauss_points must cover every segment quadrature rule."
+                )
+
+    def validate_value_compatibility(self, structure: GVSStructure) -> None:
+        """Validate eager geometry values against the static GVS layout."""
+        for index, segment in enumerate(structure.segments):
+            count = sum(segment.link.cross_section_profile_parameter_counts)
+            active_coefficients = self.link.cross_section.coefficients[index, :count]
+            if not bool(jnp.all(active_coefficients > 0.0)):
+                raise ValueError(
+                    "Active cross-section coefficients must be strictly positive "
+                    f"for GVS segment {index}."
                 )

--- a/src/soromox/systems/params.py
+++ b/src/soromox/systems/params.py
@@ -12,11 +12,16 @@ from dataclasses import fields
 from typing import Any, ClassVar, Literal
 
 import equinox as eqx
-from jax import Array
+from jax import Array, core, tree_util
 from jax import numpy as jnp
 from jax.errors import ConcretizationTypeError, TracerBoolConversionError
 
 DEFAULT_GRAVITY_MAGNITUDE = 9.81
+
+
+def _contains_tracer(tree: Any) -> bool:
+    """Return whether a parameter PyTree is currently under a JAX transform."""
+    return any(isinstance(leaf, core.Tracer) for leaf in tree_util.tree_leaves(tree))
 
 
 def _validate_finite_array(
@@ -132,7 +137,7 @@ class BaseSystemParams(eqx.Module):
                 value,
                 is_leaf=lambda leaf: leaf is None,
             )
-        updated.validate()
+        updated.validate_for_update()
         return updated
 
     def _normalize_replacement(self, name: str, value: Any) -> Any:
@@ -147,6 +152,17 @@ class BaseSystemParams(eqx.Module):
             shapes, values, or component relationships.
         """
         return None
+
+    def validate_structure(self) -> None:
+        """Validate the shape/type contract observable during JAX tracing."""
+        self.validate()
+
+    def validate_for_update(self) -> None:
+        """Validate fully in eager code and structurally under JAX transforms."""
+        if _contains_tracer(self):
+            self.validate_structure()
+        else:
+            self.validate()
 
     def validate_against_structure(self, structure: Any) -> None:
         """Validate parameters against static construction choices.

--- a/src/soromox/systems/params.py
+++ b/src/soromox/systems/params.py
@@ -12,7 +12,7 @@ from dataclasses import fields
 from typing import Any, ClassVar, Literal, final
 
 import equinox as eqx
-from jax import Array, core, tree_util
+from jax import Array, core, ensure_compile_time_eval, tree_util
 from jax import numpy as jnp
 
 DEFAULT_GRAVITY_MAGNITUDE = 9.81
@@ -160,11 +160,12 @@ class BaseSystemParams(eqx.Module):
 
     @final
     def validate_for_update(self) -> None:
-        """Validate fully in eager code and structurally under JAX transforms."""
+        """Validate values when concrete and structure when dynamically traced."""
+        self.validate_structure()
         if _contains_tracer(self):
-            self.validate_structure()
-        else:
-            self.validate()
+            return
+        with ensure_compile_time_eval():
+            self.validate_values()
 
     def validate_structure_compatibility(self, structure: Any) -> None:
         """Validate statically observable compatibility with a model structure."""
@@ -193,12 +194,16 @@ class BaseSystemParams(eqx.Module):
 
     @final
     def validate_for_update_against_structure(self, structure: Any) -> None:
-        """Validate structure compatibility at the active JAX trace level."""
+        """Validate concrete values and traced structure against a model."""
+        self.validate_structure()
         if _contains_tracer(self):
-            self.validate_structure()
             self.validate_structure_compatibility(structure)
-        else:
-            self.validate_against_structure(structure)
+            return
+        with ensure_compile_time_eval():
+            self.validate_values()
+        self.validate_structure_compatibility(structure)
+        with ensure_compile_time_eval():
+            self.validate_value_compatibility(structure)
 
 
 class BaseSoftRobotParams(BaseSystemParams):

--- a/src/soromox/systems/params.py
+++ b/src/soromox/systems/params.py
@@ -9,12 +9,11 @@ __all__ = [
 ]
 
 from dataclasses import fields
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, final
 
 import equinox as eqx
 from jax import Array, core, tree_util
 from jax import numpy as jnp
-from jax.errors import ConcretizationTypeError, TracerBoolConversionError
 
 DEFAULT_GRAVITY_MAGNITUDE = 9.81
 
@@ -27,15 +26,11 @@ def _contains_tracer(tree: Any) -> bool:
 def _validate_finite_array(
     name: str, value: Array, expected_shape: tuple[int, ...]
 ) -> Array:
-    """Validate array shape and concrete finite values when available."""
+    """Validate an eager array's shape and finite values."""
     array = jnp.asarray(value)
     if array.shape != expected_shape:
         raise ValueError(f"{name} must have shape {expected_shape}, got {array.shape}.")
-    try:
-        all_finite = bool(jnp.isfinite(array).all())
-    except (ConcretizationTypeError, TracerBoolConversionError):
-        return array
-    if not all_finite:
+    if not bool(jnp.isfinite(array).all()):
         raise ValueError(f"{name} must contain only finite values.")
     return array
 
@@ -54,9 +49,7 @@ def validate_planar_base_pose(name: str, value: Array) -> None:
         None.
 
     Raises:
-        ValueError: If the shape is not ``(3,)`` or any concrete entry is
-            non-finite. During JAX tracing, only the static shape check is
-            performed.
+        ValueError: If the shape is not ``(3,)`` or any entry is non-finite.
     """
     _validate_finite_array(name, value, (3,))
 
@@ -78,10 +71,9 @@ def validate_quaternion_base_pose(
         expected_shape: Required full pose shape, typically ``(7,)``.
         min_norm: Minimum allowed Euclidean norm for the quaternion component.
 
-    Concrete parameter objects are checked for finite entries and nonzero
-    quaternion norm. During JAX tracing, only the static shape check is
-    performed; transform helpers still avoid zero-norm division to keep traced
-    code finite.
+    Parameter objects are checked for finite entries and nonzero quaternion
+    norm. Transform helpers still avoid zero-norm division to keep runtime code
+    finite.
 
     Returns:
         ``None`` after successful validation.
@@ -92,10 +84,7 @@ def validate_quaternion_base_pose(
             safely.
     """
     pose = _validate_finite_array(name, value, expected_shape)
-    try:
-        quaternion_norm = float(jnp.linalg.norm(pose[:4]))
-    except (ConcretizationTypeError, TracerBoolConversionError):
-        return
+    quaternion_norm = float(jnp.linalg.norm(pose[:4]))
     if quaternion_norm <= min_norm:
         raise ValueError(
             f"{name} quaternion must have norm greater than {min_norm}, "
@@ -144,19 +133,32 @@ class BaseSystemParams(eqx.Module):
         """Normalize a field replacement before rebuilding the PyTree."""
         return value
 
-    def validate(self) -> None:
-        """Validate intrinsic parameter consistency.
+    def validate_structure(self) -> None:
+        """Validate statically observable parameter structure.
 
         Returns:
-            ``None``. Subclasses override this method to raise on invalid
-            shapes, values, or component relationships.
+            ``None``. Subclasses override this hook to raise on invalid types,
+            shapes, PyTree layout, or static topology. Implementations must be
+            safe when array leaves are JAX tracers.
         """
         return None
 
-    def validate_structure(self) -> None:
-        """Validate the shape/type contract observable during JAX tracing."""
-        self.validate()
+    def validate_values(self) -> None:
+        """Validate eager value-dependent parameter invariants.
 
+        Returns:
+            ``None``. Subclasses override this hook for finiteness, physical
+            domains, symmetry, and other checks requiring concrete values.
+        """
+        return None
+
+    @final
+    def validate(self) -> None:
+        """Validate both parameter structure and eager numeric values."""
+        self.validate_structure()
+        self.validate_values()
+
+    @final
     def validate_for_update(self) -> None:
         """Validate fully in eager code and structurally under JAX transforms."""
         if _contains_tracer(self):
@@ -164,8 +166,17 @@ class BaseSystemParams(eqx.Module):
         else:
             self.validate()
 
+    def validate_structure_compatibility(self, structure: Any) -> None:
+        """Validate statically observable compatibility with a model structure."""
+        del structure
+
+    def validate_value_compatibility(self, structure: Any) -> None:
+        """Validate eager value compatibility with a model structure."""
+        del structure
+
+    @final
     def validate_against_structure(self, structure: Any) -> None:
-        """Validate parameters against static construction choices.
+        """Validate parameters fully against static construction choices.
 
         Args:
             structure: System-specific static structure to validate against.
@@ -174,10 +185,20 @@ class BaseSystemParams(eqx.Module):
             ``None`` after successful validation.
 
         Raises:
-            ValueError: If intrinsic or structure-dependent validation fails in
-                a subclass implementation.
+            ValueError: If intrinsic or structure-dependent validation fails.
         """
         self.validate()
+        self.validate_structure_compatibility(structure)
+        self.validate_value_compatibility(structure)
+
+    @final
+    def validate_for_update_against_structure(self, structure: Any) -> None:
+        """Validate structure compatibility at the active JAX trace level."""
+        if _contains_tracer(self):
+            self.validate_structure()
+            self.validate_structure_compatibility(structure)
+        else:
+            self.validate_against_structure(structure)
 
 
 class BaseSoftRobotParams(BaseSystemParams):

--- a/src/soromox/systems/pcs/isupport.py
+++ b/src/soromox/systems/pcs/isupport.py
@@ -1,4 +1,3 @@
-import math
 from typing import Any
 
 import equinox as eqx
@@ -7,6 +6,7 @@ from jax import Array, vmap
 
 from soromox.actuation import ThreadlikeActuator, ThreadlikeRouting
 from soromox.systems.components import ContinuumLinkParams, CrossSectionParams
+from soromox.systems.params import _contains_tracer
 from soromox.systems.pcs.params import ISupportParams
 from soromox.systems.pcs.structures import ISupportStructure, PCSStructure
 
@@ -81,6 +81,30 @@ def _pneumatic_chamber_actuator(
         routing,
         effective_areas=effective_areas,
     )
+
+
+def _with_pneumatic_chamber_params(
+    actuator: ThreadlikeActuator,
+    params: ISupportParams,
+) -> ThreadlikeActuator:
+    """Refresh chamber geometry while retaining precomputed routing spans."""
+    angles = jnp.asarray(params.chamber_azimuth_angles, dtype=jnp.float64)
+    distances = jnp.asarray(params.chamber_distance, dtype=jnp.float64)[:, None]
+    y_offsets = (distances * jnp.cos(angles)).reshape(-1)
+    z_offsets = (distances * jnp.sin(angles)).reshape(-1)
+    intercept = jnp.stack((jnp.zeros_like(y_offsets), y_offsets, z_offsets), axis=-1)
+    num_chambers = angles.shape[1]
+
+    actuator_params = actuator.params
+    transmission = actuator_params.transmission
+    routing = transmission.routing.replace(intercept=intercept)
+    transmission = transmission.replace(
+        routing=routing,
+        coordinate_scale=jnp.repeat(
+            _resolve_chamber_effective_pressure_area(params), num_chambers
+        ),
+    )
+    return actuator.with_params(actuator_params.replace(transmission=transmission))
 
 
 def _straight_reference_strain(dtype: jnp.dtype) -> Array:
@@ -167,7 +191,8 @@ def _resolve_pcs_segment_lengths(
             "pcs_segment_lengths must contain one length per pneumatic PCS segment; "
             f"expected {expected_num_pcs_segments}, got {pcs_segment_lengths.shape[0]}."
         )
-    if not bool(jnp.all(pcs_segment_lengths > 0.0)):
+    tracing_values = _contains_tracer((pcs_segment_lengths, physical_lengths))
+    if not tracing_values and not bool(jnp.all(pcs_segment_lengths > 0.0)):
         raise ValueError("pcs_segment_lengths entries must be positive.")
 
     segment_lengths_by_pneumatic_segment = []
@@ -175,14 +200,15 @@ def _resolve_pcs_segment_lengths(
     for i, count in enumerate(pcs_segment_counts):
         stop = start + count
         child_lengths = pcs_segment_lengths[start:stop]
-        child_length_sum = float(jnp.sum(child_lengths))
-        pneumatic_length = float(physical_lengths[pneumatic_physical_indices[i]])
-        if not math.isclose(
+        child_length_sum = jnp.sum(child_lengths)
+        pneumatic_length = physical_lengths[pneumatic_physical_indices[i]]
+        matching_length = jnp.isclose(
             child_length_sum,
             pneumatic_length,
-            rel_tol=1e-9,
-            abs_tol=1e-12,
-        ):
+            rtol=1e-9,
+            atol=1e-12,
+        )
+        if not tracing_values and not bool(matching_length):
             raise ValueError(
                 "Each pcs_segment_lengths group must sum to the matching "
                 "pneumatic segment length; "
@@ -199,7 +225,7 @@ def _expand_isupport_layout(
     structure: ISupportStructure,
 ) -> tuple[ISupportParams, PCSStructure, ISupportStructure, Array, Array]:
     params = _with_default_chamber_azimuth_angles(params)
-    params.validate()
+    params.validate_for_update()
     structure = _normalize_structure_for_params(params, structure)
 
     num_physical_segments = int(params.link.length.shape[0])
@@ -218,8 +244,13 @@ def _expand_isupport_layout(
     ).reshape(num_physical_segments, 6)
     straight_reference_strain = _straight_reference_strain(reference_strain.dtype)
     for physical_index, is_rigid in enumerate(structure.rigid_segment_selector):
-        if is_rigid and not bool(
-            jnp.allclose(reference_strain[physical_index], straight_reference_strain)
+        rigid_reference_matches = jnp.allclose(
+            reference_strain[physical_index], straight_reference_strain
+        )
+        if (
+            is_rigid
+            and not _contains_tracer(reference_strain)
+            and not bool(rigid_reference_matches)
         ):
             raise ValueError(
                 "Rigid segment reference_strain entries must equal "
@@ -601,18 +632,11 @@ class ISupport(PCS):
             pcs_params,
             _,
             _,
-            pcs_segment_to_pneumatic_segment,
+            _,
             _,
         ) = _expand_isupport_layout(params, self.structure)
-        chamber_actuator = _pneumatic_chamber_actuator(
-            params, pcs_segment_to_pneumatic_segment
-        )
         current_actuator = self.actuators[0]
-        chamber_actuator_params = chamber_actuator.params.replace(
-            lower_bounds=current_actuator.params.lower_bounds,
-            upper_bounds=current_actuator.params.upper_bounds,
-        )
-        chamber_actuator = current_actuator.with_params(chamber_actuator_params)
+        chamber_actuator = _with_pneumatic_chamber_params(current_actuator, params)
         chamber_arrays = (
             jnp.asarray(pcs_params.chamber_inner_radius, dtype=jnp.float64),
             jnp.asarray(pcs_params.chamber_outer_radius, dtype=jnp.float64),

--- a/src/soromox/systems/pcs/params.py
+++ b/src/soromox/systems/pcs/params.py
@@ -154,18 +154,8 @@ class ISupportParams(PCSParams):
     pcs_segment_lengths: Array | None = None
     chamber_effective_pressure_area: Array | None = None
 
-    def validate(self) -> None:
-        """Validate PCS and pneumatic chamber parameters.
-
-        Returns:
-            ``None`` after successful validation.
-
-        Raises:
-            ValueError: If inherited PCS fields are invalid; chamber arrays
-                disagree in shape; radii, effective areas, or segment lengths
-                are invalid; or chamber azimuths are non-finite or not uniformly
-                distributed.
-        """
+    def validate_structure(self) -> None:
+        """Validate array shapes independently of runtime chamber values."""
         super().validate()
         chamber_inner_radius = jnp.asarray(self.chamber_inner_radius)
         if chamber_inner_radius.ndim != 1:
@@ -185,6 +175,49 @@ class ISupportParams(PCSParams):
         ):
             _require_shape(name, getattr(self, name), (n_pneumatic_segments,))
 
+        if self.chamber_effective_pressure_area is not None:
+            effective_area = jnp.asarray(self.chamber_effective_pressure_area)
+            _require_shape(
+                "chamber_effective_pressure_area",
+                effective_area,
+                (n_pneumatic_segments,),
+            )
+
+        if self.chamber_azimuth_angles is not None:
+            angles = jnp.asarray(self.chamber_azimuth_angles)
+            if (
+                angles.ndim != 2
+                or angles.shape[0] != n_pneumatic_segments
+                or angles.shape[1] < 1
+            ):
+                raise ValueError(
+                    "chamber_azimuth_angles must have shape "
+                    "(num_pneumatic_segments, num_chambers_per_segment) with at "
+                    "least one chamber per segment"
+                )
+
+        if self.pcs_segment_lengths is not None:
+            pcs_segment_lengths = jnp.asarray(self.pcs_segment_lengths)
+            if pcs_segment_lengths.ndim != 1:
+                raise ValueError(
+                    "pcs_segment_lengths must be one-dimensional with shape "
+                    "(num_pcs_segments,)."
+                )
+
+    def validate(self) -> None:
+        """Validate PCS and pneumatic chamber parameters.
+
+        Returns:
+            ``None`` after successful validation.
+
+        Raises:
+            ValueError: If inherited PCS fields are invalid; chamber arrays
+                disagree in shape; radii, effective areas, or segment lengths
+                are invalid; or chamber azimuths are non-finite or not uniformly
+                distributed.
+        """
+        self.validate_structure()
+        chamber_inner_radius = jnp.asarray(self.chamber_inner_radius)
         chamber_outer_radius = jnp.asarray(self.chamber_outer_radius)
         if not bool(
             jnp.all(
@@ -205,11 +238,6 @@ class ISupportParams(PCSParams):
 
         if self.chamber_effective_pressure_area is not None:
             effective_area = jnp.asarray(self.chamber_effective_pressure_area)
-            _require_shape(
-                "chamber_effective_pressure_area",
-                effective_area,
-                (n_pneumatic_segments,),
-            )
             if not bool(jnp.all(jnp.isfinite(effective_area) & (effective_area > 0.0))):
                 raise ValueError(
                     "chamber_effective_pressure_area entries must be finite and positive"
@@ -217,16 +245,6 @@ class ISupportParams(PCSParams):
 
         if self.chamber_azimuth_angles is not None:
             angles = jnp.asarray(self.chamber_azimuth_angles)
-            if (
-                angles.ndim != 2
-                or angles.shape[0] != n_pneumatic_segments
-                or angles.shape[1] < 1
-            ):
-                raise ValueError(
-                    "chamber_azimuth_angles must have shape "
-                    "(num_pneumatic_segments, num_chambers_per_segment) with at "
-                    "least one chamber per segment"
-                )
             if not bool(jnp.all(jnp.isfinite(angles))):
                 raise ValueError("chamber_azimuth_angles entries must be finite")
             wrapped = jnp.mod(angles, 2.0 * jnp.pi)
@@ -240,14 +258,6 @@ class ISupportParams(PCSParams):
                 raise ValueError(
                     "chamber_azimuth_angles must be uniformly distributed around "
                     "the full circle for every pneumatic segment"
-                )
-
-        if self.pcs_segment_lengths is not None:
-            pcs_segment_lengths = jnp.asarray(self.pcs_segment_lengths)
-            if pcs_segment_lengths.ndim != 1:
-                raise ValueError(
-                    "pcs_segment_lengths must be one-dimensional with shape "
-                    "(num_pcs_segments,)."
                 )
 
 

--- a/src/soromox/systems/pcs/params.py
+++ b/src/soromox/systems/pcs/params.py
@@ -27,13 +27,13 @@ def _require_shape(name: str, value: Array, expected_shape: tuple[int, ...]) -> 
         raise ValueError(f"{name} must have shape {expected_shape}, got {value.shape}.")
 
 
-def _validate_continuum_base(
+def _validate_continuum_structure(
     params: BaseContinuumSoftRobotParams,
     *,
     strain_dim: int,
     gravity_dim: int,
 ) -> int:
-    params.link.validate()
+    params.link.validate_structure()
     n_segments = params.link.length.shape[0]
     _require_shape("gravity", params.gravity, (gravity_dim,))
     expected_reference_shape = (n_segments, strain_dim)
@@ -72,18 +72,23 @@ class PCSParams(BaseContinuumSoftRobotParams):
 
     link: ContinuumLinkParams
 
-    def validate(self) -> None:
-        """Validate spatial PCS parameter shapes and values.
+    def validate_structure(self) -> None:
+        """Validate spatial PCS parameter structure.
 
         Returns:
             ``None`` after successful validation.
 
         Raises:
-            ValueError: If link fields are invalid; reference strain, canonical
-                matrices, cross-section coefficients, or gravity have the wrong
-                shape; or the spatial base pose is invalid.
+            ValueError: If link fields, reference strain, canonical matrices,
+                cross-section coefficients, gravity, or base pose have invalid
+                shapes.
         """
-        _validate_continuum_base(self, strain_dim=6, gravity_dim=3)
+        _validate_continuum_structure(self, strain_dim=6, gravity_dim=3)
+        _require_shape("base_pose", self.base_pose, (7,))
+
+    def validate_values(self) -> None:
+        """Validate eager spatial PCS parameter values."""
+        self.link.validate_values()
         validate_quaternion_base_pose("base_pose", self.base_pose, (7,))
 
 
@@ -106,18 +111,23 @@ class PlanarPCSParams(BaseContinuumSoftRobotParams):
 
     link: ContinuumLinkParams
 
-    def validate(self) -> None:
-        """Validate planar PCS parameter shapes and values.
+    def validate_structure(self) -> None:
+        """Validate planar PCS parameter structure.
 
         Returns:
             ``None`` after successful validation.
 
         Raises:
-            ValueError: If link fields are invalid; reference strain, canonical
-                matrices, cross-section coefficients, gravity, or the planar
-                base pose has the wrong shape or contains invalid values.
+            ValueError: If link fields, reference strain, canonical matrices,
+                cross-section coefficients, gravity, or base pose have invalid
+                shapes.
         """
-        _validate_continuum_base(self, strain_dim=3, gravity_dim=2)
+        _validate_continuum_structure(self, strain_dim=3, gravity_dim=2)
+        _require_shape("base_pose", self.base_pose, (3,))
+
+    def validate_values(self) -> None:
+        """Validate eager planar PCS parameter values."""
+        self.link.validate_values()
         validate_planar_base_pose("base_pose", self.base_pose)
 
 
@@ -156,7 +166,7 @@ class ISupportParams(PCSParams):
 
     def validate_structure(self) -> None:
         """Validate array shapes independently of runtime chamber values."""
-        super().validate()
+        super().validate_structure()
         chamber_inner_radius = jnp.asarray(self.chamber_inner_radius)
         if chamber_inner_radius.ndim != 1:
             raise ValueError(
@@ -204,19 +214,17 @@ class ISupportParams(PCSParams):
                     "(num_pcs_segments,)."
                 )
 
-    def validate(self) -> None:
-        """Validate PCS and pneumatic chamber parameters.
+    def validate_values(self) -> None:
+        """Validate eager PCS and pneumatic chamber values.
 
         Returns:
             ``None`` after successful validation.
 
         Raises:
-            ValueError: If inherited PCS fields are invalid; chamber arrays
-                disagree in shape; radii, effective areas, or segment lengths
-                are invalid; or chamber azimuths are non-finite or not uniformly
-                distributed.
+            ValueError: If inherited PCS values, chamber radii, effective
+                areas, segment lengths, or chamber azimuths are invalid.
         """
-        self.validate_structure()
+        super().validate_values()
         chamber_inner_radius = jnp.asarray(self.chamber_inner_radius)
         chamber_outer_radius = jnp.asarray(self.chamber_outer_radius)
         if not bool(
@@ -336,7 +344,7 @@ class PlanarHSAParams(BaseSoftRobotParams):
                 }
             )
 
-    def validate(self) -> None:
+    def validate_structure(self) -> None:
         length = jnp.asarray(self.length)
         if len(length.shape) != 1:
             raise ValueError(
@@ -409,7 +417,7 @@ class PlanarHSAParams(BaseSoftRobotParams):
                 raise ValueError(
                     f"{name} must have shape {expected_shape}, got {value.shape}."
                 )
-        validate_planar_base_pose("base_pose", self.base_pose)
+        _require_shape("base_pose", self.base_pose, (3,))
 
         hysteresis_basis = jnp.asarray(self.hysteresis_basis)
         if hysteresis_basis.size == 0:
@@ -437,3 +445,7 @@ class PlanarHSAParams(BaseSoftRobotParams):
                 "hysteresis_alpha must have shape "
                 f"({3 * n_segments},), got {hysteresis_alpha.shape}."
             )
+
+    def validate_values(self) -> None:
+        """Validate eager planar HSA parameter values."""
+        validate_planar_base_pose("base_pose", self.base_pose)

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -516,7 +516,7 @@ class PCS(SoftRobot):
         current_params = self._current_body_params()
         if not isinstance(params, PCSParams):
             raise TypeError("params must be a PCSParams instance.")
-        params.validate()
+        params.validate_for_update()
         if params.link.length.shape != current_params.link.length.shape:
             raise ValueError(
                 "length shape changes the model structure; construct a new PCS."

--- a/src/soromox/systems/pcs/planar_hsa.py
+++ b/src/soromox/systems/pcs/planar_hsa.py
@@ -422,7 +422,7 @@ class PlanarHSA(PlanarPCS):
         """
         if not isinstance(params, PlanarHSAParams):
             raise TypeError("params must be a PlanarHSAParams instance.")
-        params.validate()
+        params.validate_for_update()
         if params.length.shape != self.L.shape:
             raise ValueError(
                 "length shape changes the model structure; construct a new PlanarHSA."

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -490,7 +490,7 @@ class PlanarPCS(SoftRobot):
         current_params = self._current_body_params()
         if not isinstance(params, PlanarPCSParams):
             raise TypeError("params must be a PlanarPCSParams instance.")
-        params.validate()
+        params.validate_for_update()
         if params.link.length.shape != current_params.link.length.shape:
             raise ValueError(
                 "length shape changes the model structure; construct a new PlanarPCS."

--- a/src/soromox/systems/pendulum/params.py
+++ b/src/soromox/systems/pendulum/params.py
@@ -31,7 +31,7 @@ class PendulumParams(BaseArticulatedSoftRobotParams):
     center_of_mass_length: Array
     radius: Array
 
-    def validate(self) -> None:
+    def validate_structure(self) -> None:
         mass = jnp.asarray(self.mass)
         if len(mass.shape) != 1:
             raise ValueError("mass must be one-dimensional with shape (num_links,).")
@@ -59,4 +59,11 @@ class PendulumParams(BaseArticulatedSoftRobotParams):
         gravity = jnp.asarray(self.gravity)
         if gravity.shape != (2,):
             raise ValueError(f"gravity must have shape (2,), got {gravity.shape}.")
+        if jnp.asarray(self.base_pose).shape != (3,):
+            raise ValueError(
+                f"base_pose must have shape (3,), got {self.base_pose.shape}."
+            )
+
+    def validate_values(self) -> None:
+        """Validate eager pendulum parameter values."""
         validate_planar_base_pose("base_pose", self.base_pose)

--- a/src/soromox/systems/pendulum/pendulum.py
+++ b/src/soromox/systems/pendulum/pendulum.py
@@ -172,7 +172,7 @@ class Pendulum(SoftRobot):
         current_params = self._current_body_params()
         if not isinstance(params, PendulumParams):
             raise TypeError("params must be a PendulumParams instance.")
-        params.validate()
+        params.validate_for_update()
         if params.mass.shape != current_params.mass.shape:
             raise ValueError(
                 "mass shape changes the model structure; construct a new Pendulum."

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -19,7 +19,6 @@ from soromox.actuation.core import (
 from soromox.autodiff import custom_jvp_enabled
 from soromox.systems.dynamical_system import DynamicalSystem
 from soromox.systems.params import (
-    BaseSystemParams,
     validate_planar_base_pose,
     validate_quaternion_base_pose,
 )
@@ -196,7 +195,7 @@ class SoftRobot(DynamicalSystem):
         """Metadata groups in the same order used to concatenate controls."""
         return tuple(actuator.metadata for actuator in self.actuators)
 
-    def with_actuator_params(self, index: int, params: BaseSystemParams) -> Self:
+    def with_actuator_params(self, index: int, params) -> Self:
         """Return a robot with one actuator's complete parameter object replaced."""
         if not 0 <= index < len(self.actuators):
             raise IndexError(f"actuator index {index} is out of range.")
@@ -213,7 +212,7 @@ class SoftRobot(DynamicalSystem):
             index, self.actuators[index].params.replace(**updates)
         )
 
-    def with_passive_element_params(self, index: int, params: BaseSystemParams) -> Self:
+    def with_passive_element_params(self, index: int, params) -> Self:
         """Return a robot with one passive element's complete params replaced."""
         if not 0 <= index < len(self.passive_elements):
             raise IndexError(f"passive element index {index} is out of range.")

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -3,7 +3,7 @@ __all__ = [
 ]
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Self
 
 import equinox as eqx
 from jax import Array, grad, jacfwd, jvp, lax, vmap
@@ -19,6 +19,7 @@ from soromox.actuation.core import (
 from soromox.autodiff import custom_jvp_enabled
 from soromox.systems.dynamical_system import DynamicalSystem
 from soromox.systems.params import (
+    BaseSystemParams,
     validate_planar_base_pose,
     validate_quaternion_base_pose,
 )
@@ -41,6 +42,13 @@ class SoftRobot(DynamicalSystem):
     - Forward kinematics and Jacobians at arbitrary points along the backbone
     - Dynamical matrices (inertia, Coriolis, damping, etc.) in configuration space
     - Energy computation methods
+
+    Concrete parameterized models expose ``params`` and implement
+    ``with_params(...)`` and ``update_params(...)``. A complete parameter
+    replacement must return a new model, refresh every parameter-dependent
+    runtime array and cache, and preserve the model's static structure. It must
+    not mutate the original model or rely on the constructor-time
+    :meth:`precompute` hook.
 
     Attributes:
         num_dofs (int): Number of degrees of freedom (configuration variables).
@@ -137,12 +145,14 @@ class SoftRobot(DynamicalSystem):
             self.global_eps = 1e1 * float(jnp.finfo(jnp.float64).eps)
 
     def precompute(self) -> None:
-        """
-        Optional hook for refreshing state-independent cached quantities.
+        """Optionally initialize state-independent cached quantities.
 
         Subclasses with cached mass, stiffness, damping, basis, or quadrature
-        data can override this method and call it during initialization. Models
-        without such caches can inherit this no-op implementation.
+        data can override this method and call it during construction. Models
+        without such caches can inherit this no-op implementation. Immutable
+        parameter updates must instead refresh dependent caches functionally on
+        the model returned by ``with_params(...)``; they must not call this
+        potentially mutating constructor hook.
         """
         return None
 
@@ -186,7 +196,7 @@ class SoftRobot(DynamicalSystem):
         """Metadata groups in the same order used to concatenate controls."""
         return tuple(actuator.metadata for actuator in self.actuators)
 
-    def with_actuator_params(self, index: int, params) -> "SoftRobot":
+    def with_actuator_params(self, index: int, params: BaseSystemParams) -> Self:
         """Return a robot with one actuator's complete parameter object replaced."""
         if not 0 <= index < len(self.actuators):
             raise IndexError(f"actuator index {index} is out of range.")
@@ -195,7 +205,7 @@ class SoftRobot(DynamicalSystem):
         actuators[index].validate_for_robot(self)
         return eqx.tree_at(lambda robot: robot.actuators, self, tuple(actuators))
 
-    def update_actuator_params(self, index: int, **updates) -> "SoftRobot":
+    def update_actuator_params(self, index: int, **updates: Any) -> Self:
         """Return a robot with selected fields of one actuator's params replaced."""
         if not 0 <= index < len(self.actuators):
             raise IndexError(f"actuator index {index} is out of range.")
@@ -203,7 +213,7 @@ class SoftRobot(DynamicalSystem):
             index, self.actuators[index].params.replace(**updates)
         )
 
-    def with_passive_element_params(self, index: int, params) -> "SoftRobot":
+    def with_passive_element_params(self, index: int, params: BaseSystemParams) -> Self:
         """Return a robot with one passive element's complete params replaced."""
         if not 0 <= index < len(self.passive_elements):
             raise IndexError(f"passive element index {index} is out of range.")
@@ -212,7 +222,7 @@ class SoftRobot(DynamicalSystem):
         elements[index].validate_for_robot(self)
         return eqx.tree_at(lambda robot: robot.passive_elements, self, tuple(elements))
 
-    def update_passive_element_params(self, index: int, **updates) -> "SoftRobot":
+    def update_passive_element_params(self, index: int, **updates: Any) -> Self:
         """Return a robot with selected passive-element parameter fields replaced."""
         if not 0 <= index < len(self.passive_elements):
             raise IndexError(f"passive element index {index} is out of range.")

--- a/tests/actuation/test_joint.py
+++ b/tests/actuation/test_joint.py
@@ -125,6 +125,64 @@ def test_articulated_actuator_and_passive_parameter_updates_compile_once():
     assert_allclose(actual, _component_summary(eager, q))
 
 
+def test_articulated_compiled_partial_component_updates_match_eager_behavior():
+    actuator = _actuator()
+    passive = _passive()
+    robot = Pendulum(_body_params(), actuators=actuator, passive_elements=(passive,))
+    q = jnp.array([0.2, -0.15, 0.1])
+    upper_bounds = actuator.params.upper_bounds + 1.0
+    stiffness = 1.1 * passive.params.stiffness
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_upper_bounds, current_stiffness):
+        trace_count["value"] += 1
+        updated = robot.update_actuator_params(0, upper_bounds=current_upper_bounds)
+        updated = updated.update_passive_element_params(0, stiffness=current_stiffness)
+        return jnp.concatenate(
+            [
+                updated.actuators[0].metadata.upper_bounds,
+                _component_summary(updated, q),
+            ]
+        )
+
+    baseline = compiled_summary(
+        actuator.params.upper_bounds,
+        passive.params.stiffness,
+    )
+    actual = compiled_summary(upper_bounds, stiffness)
+    eager = robot.update_actuator_params(0, upper_bounds=upper_bounds)
+    eager = eager.update_passive_element_params(0, stiffness=stiffness)
+    expected = jnp.concatenate(
+        [eager.actuators[0].metadata.upper_bounds, _component_summary(eager, q)]
+    )
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert_allclose(actual, expected)
+
+
+def test_articulated_compiled_partial_update_retains_closed_routing_validation():
+    actuator = _actuator()
+    robot = Pendulum(_body_params(), actuators=actuator)
+    invalid_routing = actuator.params.transmission.routing_matrix.at[1].set(
+        2.0 * actuator.params.transmission.routing_matrix[0]
+    )
+    invalid_transmission = actuator.params.transmission.replace(
+        routing_matrix=invalid_routing
+    )
+    invalid_params = actuator.params.replace(transmission=invalid_transmission)
+
+    @eqx.filter_jit
+    def compiled_upper_bounds(current_upper_bounds):
+        current = invalid_params.replace(upper_bounds=current_upper_bounds)
+        updated = robot.with_actuator_params(0, current)
+        return updated.actuators[0].metadata.upper_bounds
+
+    with pytest.raises(ValueError, match="full row rank"):
+        compiled_upper_bounds(actuator.params.upper_bounds)
+
+
 def _spatial_articulated_robot(*, actuators=None):
     params = articulated_params(
         joint_screw=jnp.array([[0.0, 0.0, 1.0, 0.0, 0.0, 0.0]]),

--- a/tests/actuation/test_joint.py
+++ b/tests/actuation/test_joint.py
@@ -3,6 +3,7 @@ import jax
 
 jax.config.update("jax_enable_x64", True)
 
+import equinox as eqx
 import jax.numpy as jnp
 import pytest
 from numpy.testing import assert_allclose
@@ -57,6 +58,71 @@ def _passive():
         reference_configuration=jnp.array([0.1, -0.05, 0.02]),
         coordinate_offset=jnp.array([0.03, 0.04]),
     )
+
+
+def _updated_component_params():
+    actuator = _actuator().params
+    actuator_transmission = actuator.transmission.replace(
+        routing_matrix=1.01 * actuator.transmission.routing_matrix,
+        reference_configuration=actuator.transmission.reference_configuration + 0.01,
+        coordinate_offset=actuator.transmission.coordinate_offset + 0.01,
+    )
+    updated_actuator = actuator.replace(
+        transmission=actuator_transmission,
+        lower_bounds=actuator.lower_bounds + 0.1,
+        upper_bounds=actuator.upper_bounds,
+    )
+
+    passive = _passive().params
+    passive_transmission = passive.transmission.replace(
+        routing_matrix=1.01 * passive.transmission.routing_matrix,
+        reference_configuration=passive.transmission.reference_configuration + 0.01,
+        coordinate_offset=passive.transmission.coordinate_offset + 0.01,
+    )
+    updated_passive = passive.replace(
+        transmission=passive_transmission,
+        stiffness=1.02 * passive.stiffness,
+        damping=1.03 * passive.damping,
+    )
+    return updated_actuator, updated_passive
+
+
+def _component_summary(robot, q):
+    return jnp.concatenate(
+        [
+            robot.actuator_coordinates(q),
+            robot.actuation_matrix(q).reshape(-1),
+            robot.passive_elastic_force(q),
+            robot.passive_damping_matrix(q).reshape(-1),
+        ]
+    )
+
+
+def test_articulated_actuator_and_passive_parameter_updates_compile_once():
+    robot = Pendulum(
+        _body_params(), actuators=_actuator(), passive_elements=(_passive(),)
+    )
+    q = jnp.array([0.2, -0.15, 0.1])
+    actuator_params, passive_params = _updated_component_params()
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_actuator, current_passive):
+        trace_count["value"] += 1
+        updated = robot.with_actuator_params(0, current_actuator)
+        updated = updated.with_passive_element_params(0, current_passive)
+        return _component_summary(updated, q)
+
+    baseline = compiled_summary(
+        robot.actuators[0].params, robot.passive_elements[0].params
+    )
+    actual = compiled_summary(actuator_params, passive_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    eager = robot.with_actuator_params(0, actuator_params)
+    eager = eager.with_passive_element_params(0, passive_params)
+    assert_allclose(actual, _component_summary(eager, q))
 
 
 def _spatial_articulated_robot(*, actuators=None):

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -115,6 +115,81 @@ def _routing(*, count=2):
     )
 
 
+def _threadlike_components():
+    routing = _routing()
+    actuator = ThreadlikeActuator.tendons(routing)
+    passive = ThreadlikeImpedance(
+        routing=routing,
+        stiffness=jnp.array([10.0, 20.0]),
+        damping=jnp.array([0.1, 0.2]),
+        rest_length=jnp.array([0.09, 0.1]),
+    )
+    return actuator, passive
+
+
+def _updated_threadlike_component_params(actuator, passive):
+    actuator_params = actuator.params
+    actuator_routing = actuator_params.transmission.routing.replace(
+        intercept=1.01 * actuator_params.transmission.routing.intercept,
+        slope=1.02 * actuator_params.transmission.routing.slope,
+    )
+    actuator_transmission = actuator_params.transmission.replace(
+        routing=actuator_routing,
+        coordinate_scale=1.03 * actuator_params.transmission.coordinate_scale,
+    )
+    updated_actuator = actuator_params.replace(transmission=actuator_transmission)
+
+    passive_params = passive.params
+    passive_routing = passive_params.routing.replace(
+        intercept=1.01 * passive_params.routing.intercept,
+        slope=1.02 * passive_params.routing.slope,
+    )
+    updated_passive = passive_params.replace(
+        routing=passive_routing,
+        stiffness=1.03 * passive_params.stiffness,
+        damping=1.04 * passive_params.damping,
+        rest_length=1.01 * passive_params.rest_length,
+    )
+    return updated_actuator, updated_passive
+
+
+def _threadlike_component_summary(robot, q):
+    return jnp.concatenate(
+        [
+            robot.actuator_coordinates(q),
+            robot.actuation_matrix(q).reshape(-1),
+            robot.passive_elastic_force(q),
+            robot.passive_damping_matrix(q).reshape(-1),
+        ]
+    )
+
+
+def test_threadlike_actuator_and_passive_parameter_updates_compile_once():
+    actuator, passive = _threadlike_components()
+    robot = _spatial_pcs(actuators=actuator, passive_elements=(passive,))
+    q = jnp.array([0.01, -0.02, 0.03, 0.01, 0.02, -0.01])
+    actuator_params, passive_params = _updated_threadlike_component_params(
+        actuator, passive
+    )
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_actuator, current_passive):
+        trace_count["value"] += 1
+        updated = robot.with_actuator_params(0, current_actuator)
+        updated = updated.with_passive_element_params(0, current_passive)
+        return _threadlike_component_summary(updated, q)
+
+    baseline = compiled_summary(actuator.params, passive.params)
+    actual = compiled_summary(actuator_params, passive_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    eager = robot.with_actuator_params(0, actuator_params)
+    eager = eager.with_passive_element_params(0, passive_params)
+    assert_allclose(actual, _threadlike_component_summary(eager, q))
+
+
 class SinusoidalRoutingParams(BaseThreadlikeRoutingParams):
     amplitude: jax.Array
     frequency: jax.Array

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -190,6 +190,71 @@ def test_threadlike_actuator_and_passive_parameter_updates_compile_once():
     assert_allclose(actual, _threadlike_component_summary(eager, q))
 
 
+def test_threadlike_compiled_partial_component_updates_match_eager_behavior():
+    actuator, passive = _threadlike_components()
+    robot = _spatial_pcs(actuators=actuator, passive_elements=(passive,))
+    q = jnp.array([0.01, -0.02, 0.03, 0.01, 0.02, -0.01])
+    lower_bounds = actuator.params.lower_bounds - 1.0
+    stiffness = 1.1 * passive.params.stiffness
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_lower_bounds, current_stiffness):
+        trace_count["value"] += 1
+        updated = robot.update_actuator_params(0, lower_bounds=current_lower_bounds)
+        updated = updated.update_passive_element_params(0, stiffness=current_stiffness)
+        return jnp.concatenate(
+            [
+                updated.actuators[0].metadata.lower_bounds,
+                updated.passive_elastic_force(q),
+            ]
+        )
+
+    baseline = compiled_summary(
+        actuator.params.lower_bounds,
+        passive.params.stiffness,
+    )
+    actual = compiled_summary(lower_bounds, stiffness)
+    eager = robot.update_actuator_params(0, lower_bounds=lower_bounds)
+    eager = eager.update_passive_element_params(0, stiffness=stiffness)
+    expected = jnp.concatenate(
+        [
+            eager.actuators[0].metadata.lower_bounds,
+            eager.passive_elastic_force(q),
+        ]
+    )
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert_allclose(actual, expected)
+
+
+def test_planar_threadlike_dynamic_routing_updates_compile_once():
+    actuator, passive = _threadlike_components()
+    robot = _planar_pcs(actuators=actuator, passive_elements=(passive,))
+    q = jnp.array([0.01, -0.02, 0.03])
+    actuator_params, passive_params = _updated_threadlike_component_params(
+        actuator, passive
+    )
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_actuator, current_passive):
+        trace_count["value"] += 1
+        updated = robot.with_actuator_params(0, current_actuator)
+        updated = updated.with_passive_element_params(0, current_passive)
+        return _threadlike_component_summary(updated, q)
+
+    baseline = compiled_summary(actuator.params, passive.params)
+    actual = compiled_summary(actuator_params, passive_params)
+    eager = robot.with_actuator_params(0, actuator_params)
+    eager = eager.with_passive_element_params(0, passive_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert_allclose(actual, _threadlike_component_summary(eager, q))
+
+
 class SinusoidalRoutingParams(BaseThreadlikeRoutingParams):
     amplitude: jax.Array
     frequency: jax.Array

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -200,7 +200,7 @@ class SinusoidalRoutingParams(BaseThreadlikeRoutingParams):
     def num_paths(self) -> int:
         return int(self.amplitude.shape[0])
 
-    def validate(self) -> None:
+    def validate_structure(self) -> None:
         if self.frequency.shape != self.amplitude.shape:
             raise ValueError("frequency must match amplitude shape.")
 

--- a/tests/systems/test_articulated_soft_robot.py
+++ b/tests/systems/test_articulated_soft_robot.py
@@ -2,6 +2,7 @@
 import jax
 
 jax.config.update("jax_enable_x64", True)
+import equinox as eqx
 import jax.numpy as jnp
 import numpy as onp
 import pytest
@@ -36,6 +37,87 @@ def make_articulated_robot(num_links: int = 2) -> ArticulatedSoftRobot:
         gravity=jnp.array([0.0, -9.81, 0.0]),
     )
     return ArticulatedSoftRobot(params)
+
+
+def _updated_articulated_params(params):
+    return params.replace(
+        base_pose=params.base_pose.at[4].set(0.15),
+        gravity=params.gravity.at[2].set(-9.7),
+        mass=params.mass + 0.1,
+        center_of_mass_inertia=1.02 * params.center_of_mass_inertia,
+        joint_stiffness=params.joint_stiffness + 0.2 * jnp.eye(params.mass.shape[0]),
+    )
+
+
+def _articulated_parameter_summary(robot):
+    return jnp.concatenate(
+        [
+            robot.base_pose,
+            robot.g,
+            robot.m,
+            robot.I_com.reshape(-1),
+            robot.K.reshape(-1),
+        ]
+    )
+
+
+def test_parameter_updates_refresh_eager_runtime_arrays_immutably():
+    robot = make_articulated_robot()
+    updated_params = _updated_articulated_params(robot.params)
+    before = _articulated_parameter_summary(robot)
+
+    updated = robot.with_params(updated_params)
+
+    assert_allclose(_articulated_parameter_summary(robot), before)
+    assert not jnp.allclose(_articulated_parameter_summary(updated), before)
+
+
+def test_same_structure_parameter_updates_compile_once():
+    robot = make_articulated_robot()
+    updated_params = _updated_articulated_params(robot.params)
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_params):
+        trace_count["value"] += 1
+        return _articulated_parameter_summary(robot.with_params(current_params))
+
+    baseline = compiled_summary(robot.params)
+    actual = compiled_summary(updated_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert_allclose(
+        actual, _articulated_parameter_summary(robot.with_params(updated_params))
+    )
+
+
+def test_parameter_gradient_passes_through_compiled_update():
+    robot = make_articulated_robot()
+
+    @eqx.filter_jit
+    def scalar_summary(current_params):
+        return jnp.sum(
+            _articulated_parameter_summary(robot.with_params(current_params))
+        )
+
+    gradient = eqx.filter_grad(scalar_summary)(robot.params)
+
+    assert gradient.mass.shape == robot.params.mass.shape
+    assert jnp.all(jnp.isfinite(gradient.mass))
+    assert jnp.any(gradient.mass != 0.0)
+
+
+def test_parameter_structure_changes_require_reconstruction():
+    robot = make_articulated_robot()
+    wrong_shape = eqx.tree_at(
+        lambda params: params.mass,
+        robot.params,
+        jnp.ones((3,), dtype=jnp.float64),
+    )
+
+    with pytest.raises(ValueError, match="shape|structure|construct"):
+        robot.with_params(wrong_shape)
 
 
 def make_matching_pendulum(num_links: int = 2) -> Pendulum:

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as onp
@@ -31,6 +32,52 @@ TIP_ATOL = 1e-8
 RTOL = Tolerance.rtol()
 ATOL = Tolerance.atol()
 NUM_RANDOM_SAMPLES = 5
+
+
+def _updated_gvs_params(robot: GVS):
+    params = robot.params
+    return params.replace(
+        base_pose=params.base_pose.at[4].set(0.05),
+        gravity=params.gravity.at[2].set(-9.7),
+        link=params.link.replace(
+            length=1.02 * params.link.length,
+            density=1.01 * params.link.density,
+            reference_strain=params.link.reference_strain.at[:, 1].add(1e-3),
+            cross_section=params.link.cross_section.replace(
+                coefficients=1.01 * params.link.cross_section.coefficients
+            ),
+            stiffness=1.03 * params.link.stiffness,
+            damping=params.link.damping
+            + 1e-4 * jnp.eye(params.link.damping.shape[-1])[None, :, :],
+        ),
+        joint=params.joint.replace(
+            stiffness=params.joint.stiffness
+            + 1e-4 * jnp.eye(params.joint.stiffness.shape[-1])[None, :, :],
+            damping=params.joint.damping
+            + 1e-4 * jnp.eye(params.joint.damping.shape[-1])[None, :, :],
+        ),
+    )
+
+
+def _gvs_runtime_summary(robot: GVS):
+    return jnp.concatenate(
+        [
+            robot.base_pose,
+            robot.g,
+            robot.segment_lengths,
+            robot.mass_matrices.reshape(-1),
+            robot.K_full.reshape(-1),
+            robot.D_full.reshape(-1),
+        ]
+    )
+
+
+def _array_signature(tree):
+    return tuple(
+        (leaf.shape, leaf.dtype)
+        for leaf in jax.tree.leaves(tree)
+        if isinstance(leaf, Array)
+    )
 
 
 def build_matched_gvs_pcs(
@@ -102,6 +149,65 @@ def build_matched_gvs_pcs(
     )
 
     return robot_gvs, robot_pcs
+
+
+def test_gvs_parameter_updates_are_immutable_and_refresh_eager_runtime_arrays():
+    robot, _ = build_matched_gvs_pcs()
+    updated_params = _updated_gvs_params(robot)
+    before = _gvs_runtime_summary(robot)
+
+    updated = robot.with_params(updated_params)
+
+    assert_allclose(_gvs_runtime_summary(robot), before)
+    assert not jnp.allclose(_gvs_runtime_summary(updated), before)
+    assert _array_signature(updated) == _array_signature(robot)
+
+
+def test_gvs_same_structure_parameter_updates_compile_once():
+    robot, _ = build_matched_gvs_pcs()
+    params = robot.params
+    updated_params = _updated_gvs_params(robot)
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_params):
+        trace_count["value"] += 1
+        return _gvs_runtime_summary(robot.with_params(current_params))
+
+    baseline = compiled_summary(params)
+    actual = compiled_summary(updated_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert_allclose(actual, _gvs_runtime_summary(robot.with_params(updated_params)))
+
+
+def test_gvs_parameter_gradient_passes_through_compiled_update():
+    robot, _ = build_matched_gvs_pcs()
+    params = robot.params
+
+    @eqx.filter_jit
+    def mass_summary(density):
+        current = params.replace(link=params.link.replace(density=density))
+        return jnp.sum(robot.with_params(current).mass_matrices)
+
+    gradient = jax.grad(mass_summary)(params.link.density)
+
+    assert gradient.shape == params.link.density.shape
+    assert jnp.all(jnp.isfinite(gradient))
+    assert jnp.any(gradient != 0.0)
+
+
+def test_gvs_parameter_structure_changes_require_reconstruction():
+    robot, _ = build_matched_gvs_pcs()
+    wrong_shape = eqx.tree_at(
+        lambda params: params.link.length,
+        robot.params,
+        jnp.ones((2,), dtype=jnp.float64),
+    )
+
+    with pytest.raises(ValueError, match="shape|contain"):
+        robot.with_params(wrong_shape)
 
 
 def test_params_from_segments_stores_resolved_max_dof():

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -182,6 +182,58 @@ def test_gvs_same_structure_parameter_updates_compile_once():
     assert_allclose(actual, _gvs_runtime_summary(robot.with_params(updated_params)))
 
 
+def test_gvs_compiled_partial_base_pose_updates_match_eager_forces():
+    robot, _ = build_matched_gvs_pcs()
+    q = jnp.linspace(-0.02, 0.02, robot.num_dofs)
+    sqrt_half = jnp.sqrt(jnp.asarray(0.5, dtype=jnp.float64))
+    base_poses = (
+        robot.params.base_pose,
+        jnp.array([sqrt_half, 0.0, sqrt_half, 0.0, 0.01, -0.02, 0.03]),
+    )
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_force(base_pose, configuration):
+        trace_count["value"] += 1
+        return robot.update_params(base_pose=base_pose).potential_force(configuration)
+
+    actual = tuple(compiled_force(base_pose, q) for base_pose in base_poses)
+    expected = tuple(
+        robot.update_params(base_pose=base_pose).potential_force(q)
+        for base_pose in base_poses
+    )
+
+    assert trace_count["value"] == 1
+    for compiled, eager in zip(actual, expected, strict=True):
+        assert_allclose(compiled, eager)
+    assert not jnp.allclose(actual[0], actual[1])
+
+
+def test_gvs_closed_over_complete_params_validate_inside_compiled_evaluation():
+    robot, _ = build_matched_gvs_pcs()
+    q = jnp.linspace(-0.02, 0.02, robot.num_dofs)
+
+    @eqx.filter_jit
+    def compiled_force(configuration):
+        return robot.with_params(robot.params).potential_force(configuration)
+
+    assert_allclose(
+        compiled_force(q),
+        robot.with_params(robot.params).potential_force(q),
+    )
+
+
+def test_gvs_compiled_partial_update_rejects_base_pose_shape_change():
+    robot, _ = build_matched_gvs_pcs()
+
+    @eqx.filter_jit
+    def compiled_base_pose(base_pose):
+        return robot.update_params(base_pose=base_pose).base_pose
+
+    with pytest.raises(ValueError, match="base_pose must have shape"):
+        compiled_base_pose(jnp.ones((6,), dtype=jnp.float64))
+
+
 def test_gvs_parameter_gradient_passes_through_compiled_update():
     robot, _ = build_matched_gvs_pcs()
     params = robot.params

--- a/tests/systems/test_mckibben_umarm.py
+++ b/tests/systems/test_mckibben_umarm.py
@@ -351,6 +351,95 @@ def test_mckibben_optional_qd_power_jit_and_independent_updates() -> None:
     )
 
 
+def _updated_umarm_parameter_pair(robot):
+    body = robot.params.replace(
+        base_pose=robot.params.base_pose.at[4].set(0.05),
+        gravity=robot.params.gravity.at[2].set(-9.7),
+        mass=1.01 * robot.params.mass,
+        joint_armature=robot.params.joint_armature + 1.0e-5,
+    )
+    actuator = robot.actuators[0].params
+    transmission = actuator.transmission.replace(
+        moving_points=actuator.transmission.moving_points + 1.0e-5,
+        length_offset=actuator.transmission.length_offset + 1.0e-5,
+        thread_length=1.001 * actuator.transmission.thread_length,
+        num_turns=1.001 * actuator.transmission.num_turns,
+    )
+    return body, actuator.replace(
+        transmission=transmission,
+        lower_bounds=actuator.lower_bounds + 1.0,
+        upper_bounds=actuator.upper_bounds,
+    )
+
+
+def _umarm_parameter_summary(robot):
+    transmission = robot.actuators[0].params.transmission
+    return jnp.concatenate(
+        [
+            robot.base_pose,
+            robot.g,
+            robot.m,
+            robot.joint_armature,
+            transmission.moving_points.reshape(-1),
+            transmission.length_offset.reshape(-1),
+            transmission.thread_length.reshape(-1),
+            transmission.num_turns.reshape(-1),
+        ]
+    )
+
+
+def test_umarm_body_and_actuator_parameter_updates_refresh_eager_runtime_arrays():
+    robot = make_robot()
+    body_params, actuator_params = _updated_umarm_parameter_pair(robot)
+    before = _umarm_parameter_summary(robot)
+
+    updated = robot.with_params(body_params).with_actuator_params(0, actuator_params)
+
+    assert_allclose(_umarm_parameter_summary(robot), before)
+    assert not jnp.allclose(_umarm_parameter_summary(updated), before)
+
+
+def test_umarm_body_and_actuator_parameter_updates_compile_once():
+    robot = make_robot()
+    body_params, actuator_params = _updated_umarm_parameter_pair(robot)
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_body, current_actuator):
+        trace_count["value"] += 1
+        updated = robot.with_params(current_body).with_actuator_params(
+            0, current_actuator
+        )
+        return _umarm_parameter_summary(updated)
+
+    baseline = compiled_summary(robot.params, robot.actuators[0].params)
+    actual = compiled_summary(body_params, actuator_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    eager = robot.with_params(body_params).with_actuator_params(0, actuator_params)
+    assert_allclose(actual, _umarm_parameter_summary(eager))
+
+
+def test_umarm_parameter_gradient_passes_through_compiled_updates():
+    robot = make_robot()
+    q = jnp.linspace(-0.1, 0.1, robot.num_dofs)
+    actuator_params = robot.actuators[0].params
+
+    @eqx.filter_jit
+    def coordinate_sum(length_offset):
+        transmission = actuator_params.transmission.replace(length_offset=length_offset)
+        current = actuator_params.replace(transmission=transmission)
+        updated = robot.with_actuator_params(0, current)
+        return jnp.sum(updated.actuator_coordinates(q))
+
+    gradient = jax.grad(coordinate_sum)(actuator_params.transmission.length_offset)
+
+    assert gradient.shape == actuator_params.transmission.length_offset.shape
+    assert jnp.all(jnp.isfinite(gradient))
+    assert jnp.any(gradient != 0.0)
+
+
 def test_mckibben_forward_dynamics_is_inherited_and_matches_dense_equation() -> None:
     assert (
         McKibbenActuatedUMArm.forward_dynamics is ArticulatedSoftRobot.forward_dynamics

--- a/tests/systems/test_mckibben_umarm.py
+++ b/tests/systems/test_mckibben_umarm.py
@@ -421,6 +421,26 @@ def test_umarm_body_and_actuator_parameter_updates_compile_once():
     assert_allclose(actual, _umarm_parameter_summary(eager))
 
 
+def test_umarm_compiled_partial_actuator_update_matches_eager_metadata():
+    robot = make_robot()
+    lower_bounds = robot.actuators[0].params.lower_bounds + 1.0
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_lower_bounds(current_lower_bounds):
+        trace_count["value"] += 1
+        updated = robot.update_actuator_params(0, lower_bounds=current_lower_bounds)
+        return updated.actuators[0].metadata.lower_bounds
+
+    baseline = compiled_lower_bounds(robot.actuators[0].params.lower_bounds)
+    actual = compiled_lower_bounds(lower_bounds)
+    eager = robot.update_actuator_params(0, lower_bounds=lower_bounds)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert_allclose(actual, eager.actuators[0].metadata.lower_bounds)
+
+
 def test_umarm_parameter_gradient_passes_through_compiled_updates():
     robot = make_robot()
     q = jnp.linspace(-0.1, 0.1, robot.num_dofs)

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 import numpy as onp
 import pytest
@@ -60,6 +61,87 @@ def make_pcs(
     )
 
     return model, params
+
+
+def _updated_pcs_params(params):
+    return params.replace(
+        base_pose=params.base_pose.at[4].set(0.15),
+        gravity=params.gravity.at[2].set(-9.7),
+        link=params.link.replace(
+            length=params.link.length + 0.01,
+            density=params.link.density + 10.0,
+            stiffness=1.02 * params.link.stiffness,
+            damping=1.03 * params.link.damping,
+        ),
+    )
+
+
+def _pcs_parameter_summary(model):
+    return jnp.concatenate(
+        [
+            model.base_pose,
+            model.g,
+            model.L,
+            model.rho,
+            model.K_full.reshape(-1),
+            model.D_full.reshape(-1),
+        ]
+    )
+
+
+def test_parameter_updates_refresh_eager_runtime_arrays_immutably():
+    model, params = make_pcs()
+    updated_params = _updated_pcs_params(params)
+    before = _pcs_parameter_summary(model)
+
+    updated = model.with_params(updated_params)
+
+    assert_allclose(_pcs_parameter_summary(model), before)
+    assert not jnp.allclose(_pcs_parameter_summary(updated), before)
+
+
+def test_same_structure_parameter_updates_compile_once():
+    model, params = make_pcs()
+    updated_params = _updated_pcs_params(params)
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_params):
+        trace_count["value"] += 1
+        return _pcs_parameter_summary(model.with_params(current_params))
+
+    baseline = compiled_summary(params)
+    actual = compiled_summary(updated_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert_allclose(actual, _pcs_parameter_summary(model.with_params(updated_params)))
+
+
+def test_parameter_gradient_passes_through_compiled_update():
+    model, params = make_pcs()
+
+    @eqx.filter_jit
+    def scalar_summary(current_params):
+        return jnp.sum(_pcs_parameter_summary(model.with_params(current_params)))
+
+    gradient = eqx.filter_grad(scalar_summary)(params)
+
+    assert gradient.link.density.shape == params.link.density.shape
+    assert jnp.all(jnp.isfinite(gradient.link.density))
+    assert jnp.any(gradient.link.density != 0.0)
+
+
+def test_parameter_structure_changes_require_reconstruction():
+    model, params = make_pcs()
+    wrong_shape = eqx.tree_at(
+        lambda current: current.link.length,
+        params,
+        jnp.ones((3,), dtype=jnp.float64),
+    )
+
+    with pytest.raises(ValueError, match="shape|structure|construct"):
+        model.with_params(wrong_shape)
 
 
 def sample_arc_lengths(model: PCS) -> list[float]:

--- a/tests/systems/test_pendulum.py
+++ b/tests/systems/test_pendulum.py
@@ -1,4 +1,5 @@
 # ruff: noqa: E402
+import equinox as eqx
 import jax
 
 jax.config.update("jax_enable_x64", True)  # double precision
@@ -35,6 +36,64 @@ def make_pendulum(N: int = 2):
         gravity=jnp.array([0.0, -9.81]),
     )
     return Pendulum(params)
+
+
+def _parameter_summary(model):
+    return jnp.concatenate([model.base_pose, model.g, model.m, model.K.reshape(-1)])
+
+
+def test_parameter_updates_refresh_eager_runtime_arrays_immutably():
+    robot = make_pendulum(2)
+    params = robot.params
+    updated_params = params.replace(
+        base_pose=params.base_pose.at[1].set(0.15),
+        gravity=params.gravity.at[1].set(-9.7),
+        mass=params.mass + 0.1,
+        joint_stiffness=params.joint_stiffness + 0.2 * jnp.eye(2),
+    )
+    before = _parameter_summary(robot)
+
+    updated = robot.with_params(updated_params)
+
+    assert_allclose(_parameter_summary(robot), before)
+    assert not jnp.allclose(_parameter_summary(updated), before)
+
+
+def test_same_structure_parameter_updates_compile_once():
+    robot = make_pendulum(2)
+    params = robot.params
+    updated_params = params.replace(
+        base_pose=params.base_pose.at[1].set(0.15),
+        gravity=params.gravity.at[1].set(-9.7),
+        mass=params.mass + 0.1,
+        joint_stiffness=params.joint_stiffness + 0.2 * jnp.eye(2),
+    )
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_params):
+        trace_count["value"] += 1
+        return _parameter_summary(robot.with_params(current_params))
+
+    baseline = compiled_summary(params)
+    actual = compiled_summary(updated_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert_allclose(actual, _parameter_summary(robot.with_params(updated_params)))
+
+
+def test_grad_differentiates_through_typed_params():
+    robot = make_pendulum(2)
+    params = robot.params
+    q = jnp.array([0.25, -0.15], dtype=jnp.float64)
+
+    def energy_for_first_mass(mass_0):
+        current = params.replace(mass=params.mass.at[0].set(mass_0))
+        return robot.with_params(current).potential_energy(q)
+
+    grad_value = jax.grad(energy_for_first_mass)(params.mass[0])
+    assert jnp.isfinite(grad_value)
 
 
 def test_pendulum_update_rejects_all_fixed_size_shape_changes():

--- a/tests/systems/test_planar_hsa.py
+++ b/tests/systems/test_planar_hsa.py
@@ -1,8 +1,10 @@
 # ruff: noqa: E402
 from pathlib import Path
 
+import equinox as eqx
 import jax
 import numpy as np
+import pytest
 
 jax.config.update("jax_enable_x64", True)  # double precision
 
@@ -33,6 +35,87 @@ def _create_robot():
         params=typed_params,
         structure=PlanarHSAStructure(),
     )
+
+
+def _updated_typed_params():
+    return typed_params.replace(
+        base_pose=typed_params.base_pose.at[1].set(0.05),
+        gravity=typed_params.gravity.at[1].set(-9.7),
+        length=1.01 * typed_params.length,
+        rod_density=1.02 * typed_params.rod_density,
+        nominal_bending_stiffness=1.03 * typed_params.nominal_bending_stiffness,
+        bending_damping=1.04 * typed_params.bending_damping,
+    )
+
+
+def _parameter_runtime_summary(robot):
+    return jnp.concatenate(
+        [
+            robot.base_pose,
+            robot.g,
+            robot.L,
+            robot.rod_density.reshape(-1),
+            robot.K_full.reshape(-1),
+            robot.D_full.reshape(-1),
+        ]
+    )
+
+
+def test_planar_hsa_parameter_updates_are_immutable_and_refresh_eager_caches():
+    robot = _create_robot()
+    updated_params = _updated_typed_params()
+    before = _parameter_runtime_summary(robot)
+
+    updated = robot.with_params(updated_params)
+
+    assert_allclose(_parameter_runtime_summary(robot), before)
+    assert not jnp.allclose(_parameter_runtime_summary(updated), before)
+
+
+def test_planar_hsa_same_structure_parameter_updates_compile_once():
+    robot = _create_robot()
+    updated_params = _updated_typed_params()
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_params):
+        trace_count["value"] += 1
+        return _parameter_runtime_summary(robot.with_params(current_params))
+
+    baseline = compiled_summary(typed_params)
+    actual = compiled_summary(updated_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert_allclose(
+        actual, _parameter_runtime_summary(robot.with_params(updated_params))
+    )
+
+
+def test_planar_hsa_parameter_gradient_passes_through_compiled_update():
+    robot = _create_robot()
+
+    @eqx.filter_jit
+    def mass_summary(rod_density):
+        current = typed_params.replace(rod_density=rod_density)
+        return jnp.sum(robot.with_params(current).rod_mass_matrices)
+
+    gradient = jax.grad(mass_summary)(typed_params.rod_density)
+
+    assert gradient.shape == typed_params.rod_density.shape
+    assert jnp.all(jnp.isfinite(gradient))
+    assert jnp.any(gradient != 0.0)
+
+
+def test_planar_hsa_parameter_structure_changes_require_reconstruction():
+    wrong_shape = eqx.tree_at(
+        lambda params: params.length,
+        typed_params,
+        jnp.ones((2,), dtype=jnp.float64),
+    )
+
+    with pytest.raises(ValueError, match="shape|structure|construct"):
+        _create_robot().with_params(wrong_shape)
 
 
 def _sample_configuration(rng, num_segments):

--- a/tests/systems/test_planar_pcs.py
+++ b/tests/systems/test_planar_pcs.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 import numpy as onp
 import pytest
@@ -68,6 +69,89 @@ def make_planar_pcs(
     )
 
     return model, params
+
+
+def _updated_planar_pcs_params(params):
+    return params.replace(
+        base_pose=params.base_pose.at[1].set(0.15),
+        gravity=params.gravity.at[1].set(-9.7),
+        link=params.link.replace(
+            length=params.link.length + 0.01,
+            density=params.link.density + 10.0,
+            stiffness=1.02 * params.link.stiffness,
+            damping=1.03 * params.link.damping,
+        ),
+    )
+
+
+def _planar_pcs_parameter_summary(model):
+    return jnp.concatenate(
+        [
+            model.base_pose,
+            model.g,
+            model.L,
+            model.rho,
+            model.K_full.reshape(-1),
+            model.D_full.reshape(-1),
+        ]
+    )
+
+
+def test_parameter_updates_refresh_eager_runtime_arrays_immutably():
+    model, params = make_planar_pcs()
+    updated_params = _updated_planar_pcs_params(params)
+    before = _planar_pcs_parameter_summary(model)
+
+    updated = model.with_params(updated_params)
+
+    assert_allclose(_planar_pcs_parameter_summary(model), before)
+    assert not jnp.allclose(_planar_pcs_parameter_summary(updated), before)
+
+
+def test_same_structure_parameter_updates_compile_once():
+    model, params = make_planar_pcs()
+    updated_params = _updated_planar_pcs_params(params)
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_params):
+        trace_count["value"] += 1
+        return _planar_pcs_parameter_summary(model.with_params(current_params))
+
+    baseline = compiled_summary(params)
+    actual = compiled_summary(updated_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert_allclose(
+        actual, _planar_pcs_parameter_summary(model.with_params(updated_params))
+    )
+
+
+def test_parameter_gradient_passes_through_compiled_update():
+    model, params = make_planar_pcs()
+
+    @eqx.filter_jit
+    def scalar_summary(current_params):
+        return jnp.sum(_planar_pcs_parameter_summary(model.with_params(current_params)))
+
+    gradient = eqx.filter_grad(scalar_summary)(params)
+
+    assert gradient.link.density.shape == params.link.density.shape
+    assert jnp.all(jnp.isfinite(gradient.link.density))
+    assert jnp.any(gradient.link.density != 0.0)
+
+
+def test_parameter_structure_changes_require_reconstruction():
+    model, params = make_planar_pcs()
+    wrong_shape = eqx.tree_at(
+        lambda current: current.link.length,
+        params,
+        jnp.ones((3,), dtype=jnp.float64),
+    )
+
+    with pytest.raises(ValueError, match="shape|structure|construct"):
+        model.with_params(wrong_shape)
 
 
 def sample_arc_lengths(model: PlanarPCS) -> list[float]:

--- a/tests/systems/test_pressure_actuated_pcs_models.py
+++ b/tests/systems/test_pressure_actuated_pcs_models.py
@@ -3,6 +3,7 @@ import jax
 
 jax.config.update("jax_enable_x64", True)
 
+import equinox as eqx
 import jax.numpy as jnp
 import pytest
 from system_param_builders import spatial_base_pose
@@ -99,6 +100,111 @@ def expected_isupport_segment_actuation(
             )
         )
     return jnp.stack(expected_columns, axis=-1)
+
+
+def updated_isupport_params(params):
+    return params.replace(
+        base_pose=params.base_pose.at[4].set(0.05),
+        gravity=params.gravity.at[2].set(-9.7),
+        link=params.link.replace(
+            length=1.02 * params.link.length,
+            density=1.01 * params.link.density,
+            stiffness=1.03 * params.link.stiffness,
+            damping=1.04 * params.link.damping,
+        ),
+        chamber_outer_radius=1.05 * params.chamber_outer_radius,
+        chamber_distance=1.06 * params.chamber_distance,
+        chamber_azimuth_angles=params.chamber_azimuth_angles + 0.1,
+    )
+
+
+def isupport_runtime_summary(robot):
+    actuator = robot.actuators[0]
+    return jnp.concatenate(
+        [
+            robot.base_pose,
+            robot.g,
+            robot.L,
+            robot.rho,
+            robot.r_chamber_out,
+            robot.d_chamber,
+            robot.K_full.reshape(-1),
+            robot.D_full.reshape(-1),
+            actuator.params.transmission.routing.intercept.reshape(-1),
+            actuator.params.transmission.coordinate_scale,
+        ]
+    )
+
+
+def test_isupport_parameter_updates_are_immutable_and_refresh_eager_caches():
+    params = make_isupport_params()
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(num_gauss_points=1),
+    )
+    updated_params = updated_isupport_params(params)
+    before = isupport_runtime_summary(robot)
+
+    updated = robot.with_params(updated_params)
+
+    assert jnp.allclose(isupport_runtime_summary(robot), before)
+    assert not jnp.allclose(isupport_runtime_summary(updated), before)
+
+
+def test_isupport_same_structure_parameter_updates_compile_once():
+    params = make_isupport_params()
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(num_gauss_points=1),
+    )
+    updated_params = updated_isupport_params(params)
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_summary(current_params):
+        trace_count["value"] += 1
+        return isupport_runtime_summary(robot.with_params(current_params))
+
+    baseline = compiled_summary(params)
+    actual = compiled_summary(updated_params)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual, baseline)
+    assert jnp.allclose(
+        actual, isupport_runtime_summary(robot.with_params(updated_params))
+    )
+
+
+def test_isupport_parameter_gradient_passes_through_compiled_update():
+    params = make_isupport_params()
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(num_gauss_points=1),
+    )
+
+    @eqx.filter_jit
+    def pressure_scale(outer_radius):
+        current = params.replace(chamber_outer_radius=outer_radius)
+        updated = robot.with_params(current)
+        return jnp.sum(updated.actuators[0].params.transmission.coordinate_scale)
+
+    gradient = jax.grad(pressure_scale)(params.chamber_outer_radius)
+
+    assert gradient.shape == params.chamber_outer_radius.shape
+    assert jnp.all(jnp.isfinite(gradient))
+    assert jnp.any(gradient != 0.0)
+
+
+def test_isupport_chamber_count_change_requires_reconstruction():
+    params = make_isupport_params()
+    robot = ISupport(
+        params=params,
+        structure=make_pneumatic_isupport_structure(num_gauss_points=1),
+    )
+    four_angles = 2.0 * jnp.pi * jnp.arange(4, dtype=jnp.float64)[None, :] / 4.0
+
+    with pytest.raises(ValueError, match="number of chambers|reconstruction"):
+        robot.with_params(params.replace(chamber_azimuth_angles=four_angles))
 
 
 def test_isupport_geometry_helpers_and_actuation_matrix_shape():

--- a/tests/systems/test_shared_continuum_components.py
+++ b/tests/systems/test_shared_continuum_components.py
@@ -24,11 +24,11 @@ jax.config.update("jax_enable_x64", True)
 REFERENCE = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
 
 
-def _material() -> IsotropicMaterialParams:
+def _material(*, damping: bool = True) -> IsotropicMaterialParams:
     return IsotropicMaterialParams(
         young_modulus=jnp.array([1.0e6]),
         shear_modulus=jnp.array([3.4e5]),
-        material_damping_coefficient=jnp.array([1.0e4]),
+        material_damping_coefficient=(jnp.array([1.0e4]) if damping else None),
     )
 
 
@@ -51,6 +51,22 @@ def _pcs() -> PCS:
                 shear_modulus=3.4e5,
                 material_damping_coefficient=1.0e4,
                 reference_strain=REFERENCE,
+            )
+        ]
+    )
+
+
+def _planar_pcs() -> PlanarPCS:
+    return PlanarPCS.from_links(
+        [
+            LinkSpec.circular(
+                length=0.2,
+                radius=0.012,
+                density=1000.0,
+                young_modulus=1.0e6,
+                shear_modulus=3.4e5,
+                material_damping_coefficient=1.0e4,
+                reference_strain=[0.0, 0.0, 1.0],
             )
         ]
     )
@@ -439,7 +455,7 @@ def test_poisson_ratio_construction_and_omitted_damping_for_all_systems() -> Non
 
 
 def test_poisson_material_gradients_and_disabled_damping_are_jittable() -> None:
-    for robot in (_pcs(), _gvs()):
+    for robot in (_pcs(), _planar_pcs(), _gvs()):
         material = _poisson_material(damping=False)
 
         def objective(candidate, robot=robot):
@@ -470,8 +486,8 @@ def test_poisson_material_gradients_and_disabled_damping_are_jittable() -> None:
         assert gradient.material_damping_coefficient is None
 
 
-def test_material_gradients_and_jit_for_pcs_and_gvs() -> None:
-    for robot in (_pcs(), _gvs()):
+def test_material_gradients_and_jit_for_continuum_systems() -> None:
+    for robot in (_pcs(), _planar_pcs(), _gvs()):
         material = _material()
 
         def objective(candidate, robot=robot):
@@ -493,6 +509,46 @@ def test_material_gradients_and_jit_for_pcs_and_gvs() -> None:
             gradient.material_damping_coefficient,
             jnp.sum(robot.material_damping_operator, axis=(1, 2)),
         )
+
+
+@pytest.mark.parametrize(
+    "robot_factory",
+    [
+        pytest.param(_pcs, id="pcs"),
+        pytest.param(_planar_pcs, id="planar-pcs"),
+        pytest.param(_gvs, id="gvs"),
+    ],
+)
+@pytest.mark.parametrize(
+    "material_factory",
+    [
+        pytest.param(_material, id="shear-damped"),
+        pytest.param(lambda: _material(damping=False), id="shear-undamped"),
+        pytest.param(_poisson_material, id="poisson-damped"),
+        pytest.param(lambda: _poisson_material(damping=False), id="poisson-undamped"),
+    ],
+)
+def test_same_structure_material_updates_compile_once(
+    robot_factory, material_factory
+) -> None:
+    robot = robot_factory()
+    material = material_factory()
+    updated_material = material.replace(young_modulus=1.05 * material.young_modulus)
+    trace_count = {"value": 0}
+
+    @jax.jit
+    def compiled_matrices(candidate):
+        trace_count["value"] += 1
+        return robot.link_matrices_from_material(candidate)
+
+    baseline = compiled_matrices(material)
+    actual = compiled_matrices(updated_material)
+    expected = robot.link_matrices_from_material(updated_material)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(actual[0], baseline[0])
+    assert_allclose(actual[0], expected[0])
+    assert_allclose(actual[1], expected[1])
 
 
 def test_poisson_material_gradient_matches_finite_difference() -> None:

--- a/tests/systems/test_typed_params_api.py
+++ b/tests/systems/test_typed_params_api.py
@@ -1,6 +1,5 @@
 from dataclasses import fields
 
-import equinox as eqx
 import jax
 import pytest
 from jax import Array, vmap
@@ -338,37 +337,6 @@ def test_planar_params_validate_base_pose_finite_values():
     )
     with pytest.raises(ValueError, match="finite"):
         planar.validate()
-
-
-def test_same_shape_param_updates_do_not_retrace_under_filter_jit():
-    params = _pendulum_params()
-    robot = Pendulum(params=params)
-    q = jnp.array([0.2, -0.1], dtype=jnp.float64)
-    trace_count = {"value": 0}
-
-    @eqx.filter_jit
-    def potential_energy(current_params, current_q):
-        trace_count["value"] += 1
-        return robot.with_params(current_params).potential_energy(current_q)
-
-    potential_energy(params, q)
-    potential_energy(params.replace(mass=params.mass + 0.1), q)
-    potential_energy(params.replace(gravity=params.gravity.at[1].set(-9.7)), q)
-
-    assert trace_count["value"] == 1
-
-
-def test_grad_differentiates_through_typed_params():
-    params = _pendulum_params()
-    robot = Pendulum(params=params)
-    q = jnp.array([0.25, -0.15], dtype=jnp.float64)
-
-    def energy_for_first_mass(mass_0):
-        current = params.replace(mass=params.mass.at[0].set(mass_0))
-        return robot.with_params(current).potential_energy(q)
-
-    grad_value = jax.grad(energy_for_first_mass)(params.mass[0])
-    assert jnp.isfinite(grad_value)
 
 
 def test_articulated_tendon_impedance_stores_per_tendon_mechanics():

--- a/tests/systems/test_typed_params_api.py
+++ b/tests/systems/test_typed_params_api.py
@@ -25,10 +25,25 @@ from soromox.systems import (
     PendulumParams,
     PlanarPCSParams,
 )
+from soromox.systems.params import BaseSystemParams
 from soromox.utils.array_math import blk_diag
 from soromox.utils.geometry import poses
 
 jax.config.update("jax_enable_x64", True)
+
+
+class SplitValidationParams(BaseSystemParams):
+    """Test parameter whose value validation cannot run on tracers."""
+
+    value: Array
+
+    def validate_structure(self) -> None:
+        if self.value.shape != (1,):
+            raise ValueError("value must have shape (1,).")
+
+    def validate_values(self) -> None:
+        if not bool(jnp.all(self.value > 0.0)):
+            raise ValueError("value must be positive.")
 
 
 def _pendulum_params():
@@ -41,6 +56,21 @@ def _pendulum_params():
         joint_stiffness=jnp.eye(2, dtype=jnp.float64),
         joint_damping=0.1 * jnp.eye(2, dtype=jnp.float64),
     )
+
+
+def test_validation_hooks_separate_traced_structure_from_eager_values():
+    params = SplitValidationParams(value=jnp.ones((1,), dtype=jnp.float64))
+
+    with pytest.raises(ValueError, match="positive"):
+        params.replace(value=-jnp.ones((1,), dtype=jnp.float64))
+
+    @jax.jit
+    def traced_replace(value):
+        return params.replace(value=value).value
+
+    assert_allclose(traced_replace(-jnp.ones((1,), dtype=jnp.float64)), [-1.0])
+    with pytest.raises(ValueError, match="shape"):
+        traced_replace(jnp.ones((2,), dtype=jnp.float64))
 
 
 def _pcs_params(num_segments: int = 2):

--- a/tests/systems/test_typed_params_api.py
+++ b/tests/systems/test_typed_params_api.py
@@ -1,5 +1,6 @@
 from dataclasses import fields
 
+import equinox as eqx
 import jax
 import pytest
 from jax import Array, vmap
@@ -46,6 +47,24 @@ class SplitValidationParams(BaseSystemParams):
             raise ValueError("value must be positive.")
 
 
+class SplitCompatibilityValidationParams(SplitValidationParams):
+    """Test parameter with structure-dependent concrete value checks."""
+
+    def validate_structure_compatibility(
+        self, structure: tuple[tuple[int, ...], float]
+    ) -> None:
+        expected_shape, _ = structure
+        if self.value.shape != expected_shape:
+            raise ValueError("value has an incompatible shape.")
+
+    def validate_value_compatibility(
+        self, structure: tuple[tuple[int, ...], float]
+    ) -> None:
+        _, minimum = structure
+        if not bool(jnp.all(self.value >= minimum)):
+            raise ValueError("value is below the compatible minimum.")
+
+
 def _pendulum_params():
     return pendulum_params(
         mass=jnp.array([1.0, 1.2], dtype=jnp.float64),
@@ -71,6 +90,45 @@ def test_validation_hooks_separate_traced_structure_from_eager_values():
     assert_allclose(traced_replace(-jnp.ones((1,), dtype=jnp.float64)), [-1.0])
     with pytest.raises(ValueError, match="shape"):
         traced_replace(jnp.ones((2,), dtype=jnp.float64))
+
+
+def test_closed_over_concrete_parameter_validation_is_safe_inside_jit():
+    params = SplitValidationParams(value=jnp.ones((1,), dtype=jnp.float64))
+
+    @jax.jit
+    def validated_sum(offset):
+        params.validate_for_update()
+        return jnp.sum(params.value) + offset
+
+    assert_allclose(validated_sum(jnp.array(2.0)), 3.0)
+
+
+def test_closed_over_concrete_compatibility_validation_is_safe_inside_jit():
+    params = SplitCompatibilityValidationParams(value=jnp.ones((1,), dtype=jnp.float64))
+
+    @jax.jit
+    def validated_sum(offset):
+        params.validate_for_update_against_structure(((1,), 0.0))
+        return jnp.sum(params.value) + offset
+
+    assert_allclose(validated_sum(jnp.array(2.0)), 3.0)
+
+
+def test_closed_over_parameter_structure_validation_remains_active_inside_jit():
+    params = SplitValidationParams(value=jnp.ones((1,), dtype=jnp.float64))
+    invalid = eqx.tree_at(
+        lambda current: current.value,
+        params,
+        jnp.ones((2,), dtype=jnp.float64),
+    )
+
+    @jax.jit
+    def validated_sum(offset):
+        invalid.validate_for_update()
+        return jnp.sum(invalid.value) + offset
+
+    with pytest.raises(ValueError, match="shape"):
+        validated_sum(jnp.array(2.0))
 
 
 def _pcs_params(num_segments: int = 2):


### PR DESCRIPTION
## Motivation

PR #152 exposed a real limitation in the parameter-update API: rebuilding a GVS model from updated parameters inside a JAX transformation could execute Python value validation and static-layout reconstruction on traced arrays, leading to a `ConcretizationTypeError`. Although the motivating example updated a base orientation, the underlying problem was broader than that field and broader than GVS.

Parameter identification, optimization, batched evaluation, and differentiable simulation all benefit from treating a model's numeric parameters as a dynamic PyTree argument while retaining one already-constructed model as the source of static structure. Before this PR, that pattern was not consistently supported across the system, actuator, passive-element, and caller-owned material implementations.

This PR establishes and tests a general fixed-layout parameter-update contract rather than adding a special case for the original GVS example.

## Update contract

A constructed system owns the static model structure. Its complete parameter PyTree may be passed as a dynamic argument to `with_params(...)` inside `eqx.filter_jit`:

```python
@eqx.filter_jit
def evaluate(params, q):
    candidate = robot.with_params(params)
    return candidate.potential_energy(q)
```

Calls reuse the same compiled executable when the parameter PyTree retains:

- the same tree structure;
- the same leaf shapes and dtypes;
- the same optional `None`/array layout; and
- the same model and component topology.

Numeric model, environment, actuator, passive-element, and isotropic-material values remain differentiable and can participate in `grad`, `value_and_grad`, and `vmap`.

Changes to static structure still require reconstruction and normally recompilation. Examples include segment or channel counts, active-strain and GVS basis layouts, quadrature or padding, joint/component types, chamber counts, routing spans, McKibben joint-pair topology, and selection between optional material fields.

## Implementation strategy

### Two-stage validation

Parameter validation now distinguishes between two contexts:

- **Eager updates** perform complete structural and value validation, preserving the existing error reporting for invalid physical parameters.
- **Traced updates** perform validation based on statically observable properties such as types, PyTree structure, and array shapes. They do not attempt to convert runtime tracer values to Python booleans or integers.

`BaseSystemParams` owns the composed `validate()` and dispatched `validate_for_update()` methods. Every parameter subclass implements tracer-safe `validate_structure()` and eager-only `validate_values()` hooks; structure-aware families use matching compatibility hooks. This makes the eager-versus-traced boundary explicit by construction.

Compiled callers remain responsible for keeping runtime candidates inside their physical domains. Constrained parameterizations or eager validation of externally supplied inputs are recommended before entering an optimization or simulation loop.

### Functional cache refresh

Each concrete `with_params(...)` implementation continues to rebuild its parameter-dependent runtime representation immutably. The original system is unchanged, while the returned system receives refreshed geometry, mass, stiffness, damping, reference, or other cached arrays as appropriate for that model.

The `SoftRobot` documentation now makes this contract explicit and clarifies that `precompute()` is a constructor-time, potentially mutating hook rather than the mechanism for immutable compiled updates. Component parameter delegates return `Self`, preserving the concrete robot type; their parameter arguments use the component-level `BaseParams` type.

### Static component topology

Some components contain numeric parameters together with topology that must remain fixed for a compiled model:

- I-SUPPORT chamber updates reuse the actuator's precomputed routing spans instead of reconstructing routing topology from traced values.
- McKibben updates retain the installed joint-pair indices while allowing the remaining numeric transmission and actuator values to change.
- Threadlike routing and articulated tendon validation retain their eager topology checks while allowing compatible numeric leaves to be traced.

Topology-changing eager updates are still rejected and require component/robot reconstruction.

### Stable GVS runtime layout

GVS cache refreshes preserve the integer dtype of cross-section geometry indices. This prevents a same-layout parameter update from changing a PyTree leaf dtype and therefore triggering an avoidable recompilation.

### Isotropic material layouts from #139

The caller-owned `IsotropicMaterialParams` uses the same explicit validation split. Construction and replacement call `validate_for_update()`; `validate_structure()` checks the active optional-field selection and array layout, while `validate_values()` provides the finite-value and physical-domain checks used by eager validation.

The shear-modulus versus Poisson-ratio choice and damped versus undamped choice deliberately produce four different PyTree structures. Each structure compiles separately, while repeated numeric updates within that structure reuse the compiled executable. This preserves the new material API from #139 without exception-based tracer detection inside the material validator.

## Test strategy

Regression coverage was added before and alongside the implementation changes. The tests exercise:

- immutable eager updates and refreshed runtime arrays;
- same-layout compiled updates with a trace counter proving no retrace;
- differentiation through updated parameter PyTrees;
- rejection of shape or topology changes that require reconstruction;
- system body parameters;
- actuator parameters;
- passive-element parameters;
- the previously problematic GVS and I-SUPPORT/McKibben paths; and
- shear/Poisson and damped/undamped isotropic-material layouts on PCS, PlanarPCS, and GVS.

System-specific coverage lives in each concrete system's test module. Component-level coverage lives in the joint, threadlike-actuation, and shared continuum-component tests.

## Implications and tradeoffs

- Numeric parameter sweeps and optimization loops can update compatible parameters within compiled code without reconstructing the static model or compiling once per numeric value.
- The model returned by `with_params(...)` remains immutable and has consistent refreshed caches.
- Value-dependent Python exceptions cannot be produced from arbitrary runtime tracers. This is an inherent JAX tracing boundary, not a relaxation of eager validation.
- Structural updates remain deliberately outside the compiled update contract.
- Retaining precomputed topology means traced topology leaves are not a mechanism for changing routing or connectivity; reconstruct the component instead.
- Optional material selections remain structural, so changing between shear and Poisson input or enabling/disabling damping requires a different compilation.
- The implementation gives every parameter class explicit structural and value validation hooks and adds broader tests, but avoids moving model-specific cache logic into `SoftRobot`, where it could not be implemented correctly for all systems.

## Documentation

The user guide documents the compiled update pattern, its eager-versus-traced validation boundary, and the distinction between dynamic parameters and static structure. The parameter, continuum-component, and actuation API pages link the relevant concepts, and the changelog records the new behavior.

## Stack and related work

This PR originally built on #139, whose shear/Poisson and optional-damping material layouts are now part of `main`. The branch is current with `main`.

It supersedes the focused GVS fix in #152 by addressing the same failure mode through a general parameter-update contract across the library.

## Validation

Validation on the current head:

- Shared component, actuation, and typed-parameter suites: **133 passed**
- Articulated, pendulum, HSA, I-SUPPORT, and default-system suites: **142 passed**
- Full PCS, PlanarPCS, and GVS suites: **323 passed**
- Cross-system compiled/eager parameter-update selection: **29 passed** (**421 deselected**)
- Ruff lint and touched-file formatting checks: **passed**
- Zensical documentation build: **passed**