### PR TITLE
Remove unused ffmpeg-python dependency

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated the dependency metadata and lockfile for a CUDA 13-enabled JAX and
   PyTorch stack, and declared `ipywidgets` with the optional Open3D extras.
+- Simplified rendering, example, paper-result, and complete installations by
+  removing an unused video-encoding package; video output continues to use the
+  system `ffmpeg` executable.
 - Made the Section V.d collocated optimizer derive ``gamma`` from a configurable
   tendon-length error scale (default 10 mm), validate finite saturation
   parameters, and document stale committed artifacts.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,12 +93,11 @@ pip install soromox[rendering]
 - `opencv-python` - 2D rendering for planar robots
 
 !!! note "FFmpeg Video Encoding"
-    Video output uses the `ffmpeg` executable directly; the `ffmpeg-python`
-    package is neither required nor used. Install FFmpeg separately with your
-    system package manager and ensure `ffmpeg` is available on `PATH`, for
-    example with `brew install ffmpeg` on macOS or `sudo apt install ffmpeg`
-    on Debian/Ubuntu. Some renderers fall back to image sequences or OpenCV
-    video encoding when FFmpeg is unavailable.
+    Video output uses the `ffmpeg` executable. Install FFmpeg separately with
+    your system package manager and ensure `ffmpeg` is available on `PATH`, for
+    example with `brew install ffmpeg` on macOS or `sudo apt install ffmpeg` on
+    Debian/Ubuntu. Some renderers fall back to image sequences or OpenCV video
+    encoding when FFmpeg is unavailable.
 
 !!! note "Open3D Compatibility"
     Open3D rendering is currently not compatible with Python 3.13+. If you need 3D visualization, please use Python 3.12 or earlier, or use the `viser` renderer instead.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -91,7 +91,14 @@ pip install soromox[rendering]
 - `open3d` - High-quality 3D visualization
 - `viser` - Web-based interactive rendering
 - `opencv-python` - 2D rendering for planar robots
-- ``ffmpeg`` - Video encoding and processing
+
+!!! note "FFmpeg Video Encoding"
+    Video output uses the `ffmpeg` executable directly; the `ffmpeg-python`
+    package is neither required nor used. Install FFmpeg separately with your
+    system package manager and ensure `ffmpeg` is available on `PATH`, for
+    example with `brew install ffmpeg` on macOS or `sudo apt install ffmpeg`
+    on Debian/Ubuntu. Some renderers fall back to image sequences or OpenCV
+    video encoding when FFmpeg is unavailable.
 
 !!! note "Open3D Compatibility"
     Open3D rendering is currently not compatible with Python 3.13+. If you need 3D visualization, please use Python 3.12 or earlier, or use the `viser` renderer instead.
@@ -106,7 +113,6 @@ pip install soromox[examples]
 
 **Includes:**
 
-- `ffmpeg-python` - Video encoding and processing
 - `ipython` - Enhanced interactive Python shell
 - `matplotlib` - Publication-ready plotting and visualization
 - `open3d` - High-quality 3D visualization

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -367,7 +367,7 @@ D_x = 10.0 * jnp.eye(3)   # Damping matrix
 | **Missing example dependencies** | Install examples group with `pip install -e ".[examples]"` |
 | **Missing renderers** | Ensure SoRoMoX is installed with `pip install -e ".[rendering]"` or `pip install -e ".[all]"` |
 | **JAX precision warnings or simulation instability** | Most simulations require double precision. Enable with `jax.config.update("jax_enable_x64", True)` at the beginning of the script |
-| **Video codec issues** | Install the FFmpeg executable with your system package manager and verify it is available with `ffmpeg -version`; `ffmpeg-python` does not install FFmpeg |
+| **Video codec issues** | Install FFmpeg with your system package manager and verify the executable is available with `ffmpeg -version` |
 | **Matplotlib backend errors** | Try setting backend: `export MPLBACKEND=Agg` for headless systems |
 | **Out of memory errors** | Reduce batch sizes or use smaller simulation parameters |
 | **Optimization convergence issues** | Check initial parameter guesses and optimization settings in system identification examples |

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -367,7 +367,7 @@ D_x = 10.0 * jnp.eye(3)   # Damping matrix
 | **Missing example dependencies** | Install examples group with `pip install -e ".[examples]"` |
 | **Missing renderers** | Ensure SoRoMoX is installed with `pip install -e ".[rendering]"` or `pip install -e ".[all]"` |
 | **JAX precision warnings or simulation instability** | Most simulations require double precision. Enable with `jax.config.update("jax_enable_x64", True)` at the beginning of the script |
-| **Video codec issues** | Ensure FFmpeg is properly installed: `pip install ffmpeg-python` |
+| **Video codec issues** | Install the FFmpeg executable with your system package manager and verify it is available with `ffmpeg -version`; `ffmpeg-python` does not install FFmpeg |
 | **Matplotlib backend errors** | Try setting backend: `export MPLBACKEND=Agg` for headless systems |
 | **Out of memory errors** | Reduce batch sizes or use smaller simulation parameters |
 | **Optimization convergence issues** | Check initial parameter guesses and optimization settings in system identification examples |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,6 @@ docs = [
     # Do not add mkdocs-section-index unless we intentionally reintroduce the MkDocs plugin runtime.
 ]
 examples = [
-    "ffmpeg-python",
     "ipython",
     "matplotlib",
     "numpy",
@@ -167,7 +166,6 @@ examples = [
 ]
 paper_results = [
     "cbfpy",
-    "ffmpeg-python",
     "gymnasium",
     "ipython",
     "matplotlib",
@@ -187,7 +185,6 @@ paper_results = [
     "viser",
 ]
 rendering = [
-    "ffmpeg-python",
     "matplotlib",
     "open3d>=0.18",
     "ipywidgets>=8.0.4",
@@ -222,7 +219,6 @@ all = [
     "codecov",
     "coverage[toml]",
     "pyelastica",
-    "ffmpeg-python",
     "gymnasium",
     "ipython",
     "matplotlib",

--- a/uv.lock
+++ b/uv.lock
@@ -901,18 +901,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ffmpeg-python"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "future" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl", hash = "sha256:ac441a0404e053f8b6a1113a77c0f452f1cfc62f6344a769475ffdc0f56c23c5", size = 25024, upload-time = "2019-07-06T00:19:07.215Z" },
-]
-
-[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1008,15 +996,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
-]
-
-[[package]]
-name = "future"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
 ]
 
 [[package]]
@@ -4043,7 +4022,6 @@ all = [
     { name = "check-manifest" },
     { name = "codecov" },
     { name = "coverage", extra = ["toml"] },
-    { name = "ffmpeg-python" },
     { name = "gymnasium" },
     { name = "ipython" },
     { name = "ipywidgets" },
@@ -4095,7 +4073,6 @@ docs = [
     { name = "zensical" },
 ]
 examples = [
-    { name = "ffmpeg-python" },
     { name = "ipython" },
     { name = "ipywidgets" },
     { name = "matplotlib" },
@@ -4111,7 +4088,6 @@ examples = [
 ]
 paper-results = [
     { name = "cbfpy" },
-    { name = "ffmpeg-python" },
     { name = "gymnasium" },
     { name = "ipython" },
     { name = "ipywidgets" },
@@ -4131,7 +4107,6 @@ paper-results = [
     { name = "viser" },
 ]
 rendering = [
-    { name = "ffmpeg-python" },
     { name = "ipywidgets" },
     { name = "matplotlib" },
     { name = "open3d" },
@@ -4177,10 +4152,6 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'" },
     { name = "diffrax", specifier = ">=0.7.2" },
     { name = "equinox" },
-    { name = "ffmpeg-python", marker = "extra == 'all'" },
-    { name = "ffmpeg-python", marker = "extra == 'examples'" },
-    { name = "ffmpeg-python", marker = "extra == 'paper-results'" },
-    { name = "ffmpeg-python", marker = "extra == 'rendering'" },
     { name = "gymnasium", marker = "extra == 'all'" },
     { name = "gymnasium", marker = "extra == 'paper-results'" },
     { name = "gymnasium", marker = "extra == 'rl'" },


### PR DESCRIPTION
## Summary

- remove the unused `ffmpeg-python` package from the `rendering`, `examples`, `paper_results`, and `all` extras
- refresh `uv.lock`, removing both `ffmpeg-python` and its orphaned `future` dependency
- document the system FFmpeg prerequisite and correct the troubleshooting guidance
- record the installation change in the unreleased changelog

## Why

SoRoMoX invokes `ffmpeg` directly through `subprocess` and Matplotlib and does not import the `ffmpeg-python` wrapper. Installing the wrapper therefore did not provide the executable required for video encoding and could mislead users into thinking FFmpeg was available.

## Impact

Optional Python extras no longer install an unused wrapper. Users who need FFmpeg-backed video encoding should install FFmpeg with their system package manager and ensure the executable is available on `PATH`. Existing renderer fallbacks remain unchanged.

## Validation

- `uv lock --check --no-cache`
- `.venv/bin/zensical build --clean`
- parsed `pyproject.toml` with Python `tomllib`
- `git diff --check`
- verified there are no Python imports of `ffmpeg` in the repository