### PR TITLE
Release SoRoMoX 0.2.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v6
@@ -53,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v6

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,11 +23,11 @@ authors:
   - family-names: "Della Santina"
     given-names: "Cosimo"
 repository-code: "https://github.com/tud-phi/soromox"
-repository-artifact: "https://pypi.org/project/soromox/0.2.2/"
+repository-artifact: "https://pypi.org/project/soromox/0.2.3/"
 url: "https://tud-phi.github.io/soromox"
 license: MIT
-version: "0.2.2"
-date-released: "2026-08-11"
+version: "0.2.3"
+date-released: "2026-08-19"
 keywords:
   - "JAX"
   - "Soft Robotics"

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -35,12 +35,12 @@ If reproducibility depends materially on a particular release, we encourage an
 additional software citation for that release:
 
 ```bibtex
-@software{soromox_v0_2_2,
+@software{soromox_v0_2_3,
   title = {{SoRoMoX}: Soft Robot Models in {JAX}},
   author = {Maximilian St{\"o}lzle and Solange Gribonval and Daniel {Feliu-Talegon} and Vito Daniele Perfetta and Michele Martini and Chuhan Zhang and Kiwan Wong and Daniela Rus and Cosimo {Della Santina}},
   year = {2026},
-  version = {0.2.2},
-  url = {https://github.com/tud-phi/soromox/releases/tag/v0.2.2},
+  version = {0.2.3},
+  url = {https://github.com/tud-phi/soromox/releases/tag/v0.2.3},
 }
 ```
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.2.3] - 2026-08-19
+
+### Added
+
 - Reverse-mode-safe numerical primitives, strict singularity diagnostics, and
   pytree finiteness reporting for locating and handling degenerate model
   configurations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ name = "soromox"  # Required
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "0.2.2"  # Required
+version = "0.2.3"  # Required
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:

--- a/tests/test_citation_metadata.py
+++ b/tests/test_citation_metadata.py
@@ -53,11 +53,11 @@ def test_software_release_and_project_urls_are_version_specific():
     citation_docs = (ROOT / "docs" / "citation.md").read_text()
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert 'repository-artifact: "https://pypi.org/project/soromox/0.2.2/"' in cff
-    software_bibtex = _extract_bibtex(citation_docs, "software", "soromox_v0_2_2")
-    assert "version = {0.2.2}," in software_bibtex
+    assert 'repository-artifact: "https://pypi.org/project/soromox/0.2.3/"' in cff
+    software_bibtex = _extract_bibtex(citation_docs, "software", "soromox_v0_2_3")
+    assert "version = {0.2.3}," in software_bibtex
     assert (
-        "url = {https://github.com/tud-phi/soromox/releases/tag/v0.2.2},"
+        "url = {https://github.com/tud-phi/soromox/releases/tag/v0.2.3},"
         in software_bibtex
     )
     assert project["urls"]["Paper"] == f"https://doi.org/{ARXIV_DOI}"

--- a/uv.lock
+++ b/uv.lock
@@ -4003,7 +4003,7 @@ wheels = [
 
 [[package]]
 name = "soromox"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "diffrax" },


### PR DESCRIPTION
## Summary

Prepare the 0.2.3 patch release from `origin/main` at `abfa73c`.

- synchronize `pyproject.toml`, `CITATION.cff`, `docs/citation.md`, `docs/development/changelog.md`, and `uv.lock`
- move the accumulated unreleased notes into the dated 0.2.3 changelog entry
- update the version-specific citation regression expectation

## Validation

The release metadata was generated with the repository's `bump_version.py 0.2.3` workflow. Local release checks passed; the release tag will be created only on the verified merged `main` commit.