### PR TITLE
Fix bounded numerical Jacobian and add API docs

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -71,6 +71,7 @@ The [Utilities](utilities/index.md) module includes:
 - **[Geometry](utilities/geometry.md)**: Pose encodings, rotations, and geometric errors
 - **[Lie Algebra](utilities/lie-algebra.md)**: Rigid-body maps and stable Jacobian coefficients
 - **[Constant Strain](utilities/constant-strain.md)**: Planar and spatial rod-segment operators
+- **[Numerical Jacobian](utilities/numerical-jacobian.md)**: Bound-aware finite-difference gradients and Jacobians
 
 ---
 

--- a/docs/api/utilities/index.md
+++ b/docs/api/utilities/index.md
@@ -51,6 +51,11 @@ Rod-segment operators organized into planar and spatial namespaces.
 - Bundled evaluation when several related operators are needed
 - Separate planar and spatial operator namespaces
 
+### [Numerical Jacobian](numerical-jacobian.md)
+
+Finite-difference gradients and Jacobians for scalar- and vector-valued
+functions, including bound-aware one-sided schemes.
+
 ## Quick Links
 
 - [Parameters API Reference](parameters.md) - Parameter management utilities
@@ -58,3 +63,4 @@ Rod-segment operators organized into planar and spatial namespaces.
 - [Geometry API Reference](geometry.md) - Pose, rotation, and error utilities
 - [Lie Algebra API Reference](lie-algebra.md) - Lie group and Jacobian utilities
 - [Constant-Strain API Reference](constant-strain.md) - Rod-segment Lie operators
+- [Numerical Jacobian API Reference](numerical-jacobian.md) - Finite-difference gradients and Jacobians

--- a/docs/api/utilities/numerical-jacobian.md
+++ b/docs/api/utilities/numerical-jacobian.md
@@ -1,0 +1,13 @@
+# Numerical Jacobian
+
+The numerical Jacobian utility estimates gradients and Jacobians with finite
+differences. It supports first-order two-point differences, second-order
+three-point differences, and one-sided schemes when variable bounds prevent a
+central difference.
+
+Use `approx_derivative` when an analytical or automatic Jacobian is unavailable
+or when an independent derivative check is useful.
+
+## API Reference
+
+::: soromox.utils.numerical_jacobian

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made bound-aware finite-difference Jacobians compatible with JAX immutable
+  arrays and documented the `numerical_jacobian` utility.
+
 ## [0.2.3] - 2026-08-19
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
           - Geometry: api/utilities/geometry.md
           - Lie Algebra: api/utilities/lie-algebra.md
           - Constant Strain: api/utilities/constant-strain.md
+          - Numerical Jacobian: api/utilities/numerical-jacobian.md
   - Paper & Results: research.md
   - Citation: citation.md
   - Development:

--- a/src/soromox/utils/numerical_jacobian.py
+++ b/src/soromox/utils/numerical_jacobian.py
@@ -1,41 +1,36 @@
 """Routines for numerical differentiation."""
 
-__all__ = ["approx_derivative"]
 import functools
+from collections.abc import Callable
 
-import jax.numpy as jnp
+from jax import Array
+from jax import numpy as jnp
+
+__all__ = ["approx_derivative"]
 
 
 def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
-    """Adjust final difference scheme to the presence of bounds.
+    """Adjust finite-difference steps to respect variable bounds.
 
-    Parameters
-    ----------
-    x0 : ndarray, shape (n,)
-        Point at which we wish to estimate derivative.
-    h : ndarray, shape (n,)
-        Desired absolute finite difference steps.
-    num_steps : int
-        Number of `h` steps in one direction required to implement finite
-        difference scheme. For example, 2 means that we need to evaluate
-        f(x0 + 2 * h) or f(x0 - 2 * h)
-    scheme : {'1-sided', '2-sided'}
-        Whether steps in one or both directions are required. In other
-        words '1-sided' applies to forward and backward schemes, '2-sided'
-        applies to center schemes.
-    lb : ndarray, shape (n,)
-        Lower bounds on independent variables.
-    ub : ndarray, shape (n,)
-        Upper bounds on independent variables.
+    Args:
+        x0: Point at which to estimate the derivative, with shape ``(n,)``.
+        h: Desired absolute finite-difference steps, with shape ``(n,)``.
+        num_steps: Number of ``h`` steps required in one direction. For
+            example, ``2`` means that the scheme evaluates ``f(x0 + 2 * h)``
+            or ``f(x0 - 2 * h)``.
+        scheme: Whether the scheme requires one or both directions. The
+            ``"1-sided"`` scheme covers forward and backward differences,
+            while ``"2-sided"`` covers central differences.
+        lb: Lower bounds on the independent variables.
+        ub: Upper bounds on the independent variables.
 
-    Returns
-    -------
-    h_adjusted : ndarray, shape (n,)
-        Adjusted absolute step sizes. Step size decreases only if a sign flip
-        or switching to one-sided scheme doesn't allow to take a full step.
-    use_one_sided : ndarray of bool, shape (n,)
-        Whether to switch to one-sided scheme. Informative only for
-        ``scheme='2-sided'``.
+    Returns:
+        A tuple containing the adjusted step sizes and a Boolean mask
+        indicating which entries use a one-sided scheme. The mask is
+        meaningful only for ``scheme="2-sided"``.
+
+    Raises:
+        ValueError: If ``scheme`` is not ``"1-sided"`` or ``"2-sided"``.
     """
     if scheme == "1-sided":
         use_one_sided = jnp.ones_like(h, dtype=bool)
@@ -43,7 +38,7 @@ def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
         h = jnp.abs(h)
         use_one_sided = jnp.zeros_like(h, dtype=bool)
     else:
-        raise ValueError("`scheme` must be '1-sided' or '2-sided'.")
+        raise ValueError('`scheme` must be "1-sided" or "2-sided".')
 
     if jnp.all((lb == -jnp.inf) & (ub == jnp.inf)):
         return h, use_one_sided
@@ -58,117 +53,92 @@ def _adjust_scheme_to_bounds(x0, h, num_steps, scheme, lb, ub):
         x = x0 + h_total
         violated = (x < lb) | (x > ub)
         fitting = jnp.abs(h_total) <= jnp.maximum(lower_dist, upper_dist)
-        h_adjusted[violated & fitting] *= -1
+        h_adjusted = jnp.where(violated & fitting, -h_adjusted, h_adjusted)
 
         forward = (upper_dist >= lower_dist) & ~fitting
-        h_adjusted[forward] = upper_dist[forward] / num_steps
+        h_adjusted = jnp.where(forward, upper_dist / num_steps, h_adjusted)
         backward = (upper_dist < lower_dist) & ~fitting
-        h_adjusted[backward] = -lower_dist[backward] / num_steps
+        h_adjusted = jnp.where(backward, -lower_dist / num_steps, h_adjusted)
     elif scheme == "2-sided":
         central = (lower_dist >= h_total) & (upper_dist >= h_total)
 
         forward = (upper_dist >= lower_dist) & ~central
-        h_adjusted[forward] = jnp.minimum(
-            h[forward], 0.5 * upper_dist[forward] / num_steps
+        h_adjusted = jnp.where(
+            forward, jnp.minimum(h, 0.5 * upper_dist / num_steps), h_adjusted
         )
-        use_one_sided[forward] = True
+        use_one_sided = jnp.where(forward, True, use_one_sided)
 
         backward = (upper_dist < lower_dist) & ~central
-        h_adjusted[backward] = -jnp.minimum(
-            h[backward], 0.5 * lower_dist[backward] / num_steps
+        h_adjusted = jnp.where(
+            backward,
+            -jnp.minimum(h, 0.5 * lower_dist / num_steps),
+            h_adjusted,
         )
-        use_one_sided[backward] = True
+        use_one_sided = jnp.where(backward, True, use_one_sided)
 
         min_dist = jnp.minimum(upper_dist, lower_dist) / num_steps
         adjusted_central = ~central & (jnp.abs(h_adjusted) <= min_dist)
-        h_adjusted[adjusted_central] = min_dist[adjusted_central]
-        use_one_sided[adjusted_central] = False
+        h_adjusted = jnp.where(adjusted_central, min_dist, h_adjusted)
+        use_one_sided = jnp.where(adjusted_central, False, use_one_sided)
 
     return h_adjusted, use_one_sided
 
 
 @functools.lru_cache
 def _eps_for_method(x0_dtype, f0_dtype, method):
+    """Choose a relative step size for a finite-difference method.
+
+    The step is selected from the smallest floating-point dtype among the
+    input and function output. The method-specific power of machine epsilon
+    then balances truncation and round-off error.
+
+    Args:
+        x0_dtype: Dtype of the parameter vector.
+        f0_dtype: Dtype of the function evaluation.
+        method: Finite-difference method, either ``"2-point"`` or
+            ``"3-point"``.
+
+    Returns:
+        The relative step size for ``method``.
+
+    Raises:
+        RuntimeError: If ``method`` is not supported.
     """
-    Calculates relative EPS step to use for a given data type
-    and numdiff step method.
-
-    Progressively smaller steps are used for larger floating point types.
-
-    Parameters
-    ----------
-    f0_dtype: jnp.dtype
-        dtype of function evaluation
-
-    x0_dtype: jnp.dtype
-        dtype of parameter vector
-
-    method: {'2-point', '3-point'}
-
-    Returns
-    -------
-    EPS: float
-        relative step size. May be jnp.float16, jnp.float32, jnp.float64
-
-    Notes
-    -----
-    The default relative step will be jnp.float64. However, if x0 or f0 are
-    smaller floating point types (jnp.float16, jnp.float32), then the smallest
-    floating point type is chosen.
-    """
-    # the default EPS value
-    EPS = jnp.finfo(jnp.float64).eps
+    epsilon = jnp.finfo(jnp.float64).eps
 
     x0_is_fp = False
     if jnp.issubdtype(x0_dtype, jnp.inexact):
-        # if you're a floating point type then over-ride the default EPS
-        EPS = jnp.finfo(x0_dtype).eps
+        epsilon = jnp.finfo(x0_dtype).eps
         x0_itemsize = jnp.dtype(x0_dtype).itemsize
         x0_is_fp = True
 
     if jnp.issubdtype(f0_dtype, jnp.inexact):
         f0_itemsize = jnp.dtype(f0_dtype).itemsize
-        # choose the smallest itemsize between x0 and f0
         if x0_is_fp and f0_itemsize < x0_itemsize:
-            EPS = jnp.finfo(f0_dtype).eps
+            epsilon = jnp.finfo(f0_dtype).eps
 
-    if method in ["2-point"]:
-        return EPS**0.5
-    elif method in ["3-point"]:
-        return EPS ** (1 / 3)
-    else:
-        raise RuntimeError(
-            "Unknown step method, should be one of {'2-point', '3-point'}"
-        )
+    if method == "2-point":
+        return epsilon**0.5
+    if method == "3-point":
+        return epsilon ** (1 / 3)
+    raise RuntimeError("Unknown step method, should be one of {'2-point', '3-point'}")
 
 
 def _compute_absolute_step(rel_step, x0, f0, method):
+    """Compute absolute finite-difference steps from a relative step.
+
+    Args:
+        rel_step: Relative step size, or ``None`` to select it automatically.
+        x0: Parameter vector.
+        f0: Function value at ``x0``.
+        method: Finite-difference method, either ``"2-point"`` or
+            ``"3-point"``.
+
+    Returns:
+        An array of absolute finite-difference steps. The dtype follows the
+        dtypes used to select the machine epsilon.
     """
-    Computes an absolute step from a relative step for finite difference
-    calculation.
-
-    Parameters
-    ----------
-    rel_step: None or array-like
-        Relative step for the finite difference calculation
-    x0 : jnp.ndarray
-        Parameter vector
-    f0 : jnp.ndarray or scalar
-    method : {'2-point', '3-point'}
-
-    Returns
-    -------
-    h : float
-        The absolute step size
-
-    Notes
-    -----
-    `h` will always be jnp.float64. However, if `x0` or `f0` are
-    smaller floating point dtypes (e.g. jnp.float32), then the absolute
-    step size will be calculated from the smallest floating point size.
-    """
-    # this is used instead of jnp.sign(x0) because we need
-    # sign_x0 to be 1 when x0 == 0.
+    # Use 1 rather than 0 for the sign of a zero input.
     sign_x0 = (x0 >= 0).astype(float) * 2 - 1
 
     rstep = _eps_for_method(x0.dtype, f0.dtype, method)
@@ -176,13 +146,10 @@ def _compute_absolute_step(rel_step, x0, f0, method):
     if rel_step is None:
         abs_step = rstep * sign_x0 * jnp.maximum(1.0, jnp.abs(x0))
     else:
-        # User has requested specific relative steps.
-        # Don't multiply by max(1, abs(x0) because if x0 < 1 then their
-        # requested step is not used.
+        # Do not multiply by max(1, abs(x0)) for an explicitly requested step.
         abs_step = rel_step * sign_x0 * jnp.abs(x0)
 
-        # however we don't want an abs_step of 0, which can happen if
-        # rel_step is 0, or x0 is 0. Instead, substitute a realistic step
+        # Avoid a zero step when rel_step or x0 is zero.
         dx = (x0 + abs_step) - x0
         abs_step = jnp.where(
             dx == 0, rstep * sign_x0 * jnp.maximum(1.0, jnp.abs(x0)), abs_step
@@ -192,20 +159,26 @@ def _compute_absolute_step(rel_step, x0, f0, method):
 
 
 def _prepare_bounds(bounds, x0):
-    """
-    Prepares new-style bounds from a two-tuple specifying the lower and upper
-    limits for values in x0. If a value is not bound then the lower/upper bound
-    will be expected to be -jnp.inf/jnp.inf.
+    """Broadcast scalar bounds and convert bounds to JAX arrays.
 
-    Examples
-    --------
-    ```python
-    lower, upper = _prepare_bounds(
-        [(0, 1, 2), (1, 2, jnp.inf)],
-        [0.5, 1.5, 2.5],
-    )
-    # lower = [0, 1, 2] and upper = [1, 2, inf]
-    ```
+    Args:
+        bounds: A ``(lower, upper)`` pair. Each entry may be a scalar or an
+            array with the same shape as ``x0``. Unbounded entries should use
+            ``-jnp.inf`` and ``jnp.inf``.
+        x0: Parameter vector whose shape determines scalar-bound expansion.
+
+    Returns:
+        A tuple ``(lower, upper)`` of JAX arrays with the same shape as
+        ``x0`` when scalar bounds are provided.
+
+    Examples:
+        ```python
+        lower, upper = _prepare_bounds(
+            [(0, 1, 2), (1, 2, jnp.inf)],
+            [0.5, 1.5, 2.5],
+        )
+        # lower = [0, 1, 2] and upper = [1, 2, inf]
+        ```
     """
     lb, ub = (jnp.asarray(b, dtype=float) for b in bounds)
     if lb.ndim == 0:
@@ -218,141 +191,103 @@ def _prepare_bounds(bounds, x0):
 
 
 def approx_derivative(
-    fun,
-    x0,
-    method="3-point",
-    rel_step=None,
-    abs_step=None,
-    f0=None,
-    bounds=(-jnp.inf, jnp.inf),
-    args=(),
-    kwargs=None,
-):
-    """Compute finite difference approximation of the derivatives of a
-    vector-valued function.
+    fun: Callable[..., Array | float],
+    x0: Array | float,
+    method: str = "3-point",
+    rel_step: Array | float | None = None,
+    abs_step: Array | float | None = None,
+    f0: Array | float | None = None,
+    bounds: tuple[Array | float, Array | float] = (-jnp.inf, jnp.inf),
+    args: tuple = (),
+    kwargs: dict | None = None,
+) -> Array:
+    """Compute a finite-difference approximation of a function's Jacobian.
 
-    If a function maps from R^n to R^m, its derivatives form m-by-n matrix
-    called the Jacobian, where an element (i, j) is a partial derivative of
-    f[i] with respect to x[j].
+    If a function maps from ``R^n`` to ``R^m``, the Jacobian has shape
+    ``(m, n)`` and contains the partial derivative of output ``i`` with
+    respect to input ``j`` at entry ``(i, j)``.
 
-    Parameters
-    ----------
-    fun : callable
-        Function of which to estimate the derivatives. The argument x
-        passed to this function is ndarray of shape (n,) (never a scalar
-        even if n=1). It must return 1-D array_like of shape (m,) or a scalar.
-    x0 : array_like of shape (n,) or float
-        Point at which to estimate the derivatives. Float will be converted
-        to a 1-D array.
-    method : {'3-point', '2-point'}, optional
-        Finite difference method to use:
-            - '2-point' - use the first order accuracy forward or backward
-                          difference.
-            - '3-point' - use central difference in interior points and the
-                          second order accuracy forward or backward difference
-                          near the boundary.
-    rel_step : None or array_like, optional
-        Relative step size to use. If None (default) the absolute step size is
-        computed as ``h = rel_step * sign(x0) * max(1, abs(x0))``, with
-        `rel_step` being selected automatically, see Notes. Otherwise
-        ``h = rel_step * sign(x0) * abs(x0)``. For ``method='3-point'`` the
-        sign of `h` is ignored. The calculated step size is possibly adjusted
-        to fit into the bounds.
-    abs_step : array_like, optional
-        Absolute step size to use, possibly adjusted to fit into the bounds.
-        For ``method='3-point'`` the sign of `abs_step` is ignored. By default
-        relative steps are used, only if ``abs_step is not None`` are absolute
-        steps used.
-    f0 : None or array_like, optional
-        If not None it is assumed to be equal to ``fun(x0)``, in this case
-        the ``fun(x0)`` is not called. Default is None.
-    bounds : tuple of array_like, optional
-        Lower and upper bounds on independent variables. Defaults to no bounds.
-        Each bound must match the size of `x0` or be a scalar, in the latter
-        case the bound will be the same for all variables. Use it to limit the
-        range of function evaluation.
-    args, kwargs : tuple and dict, optional
-        Additional arguments passed to `fun`. Both empty by default.
-        The calling signature is ``fun(x, *args, **kwargs)``.
+    Args:
+        fun: Function whose derivatives should be estimated. It receives a
+            one-dimensional array of shape ``(n,)`` and returns a scalar or a
+            one-dimensional array of shape ``(m,)``.
+        x0: Point at which to estimate the derivatives. Scalars are converted
+            to a one-dimensional array.
+        method: Finite-difference method. ``"2-point"`` uses a first-order
+            forward or backward difference. ``"3-point"`` uses a central
+            difference in the interior and a second-order one-sided difference
+            near bounds.
+        rel_step: Relative step size. If ``None``, an appropriate step is
+            selected from the input and output dtypes.
+        abs_step: Absolute step size. If provided, it takes precedence over
+            ``rel_step`` and is adjusted to fit within ``bounds``.
+        f0: Optional value of ``fun(x0)``. Providing it avoids evaluating the
+            function at ``x0``.
+        bounds: Lower and upper bounds on the independent variables. Each
+            bound may be a scalar or an array matching ``x0``. Defaults to no
+            bounds.
+        args: Additional positional arguments passed to ``fun``.
+        kwargs: Additional keyword arguments passed to ``fun``.
 
-    Returns
-    -------
-    J : {ndarray}
-        Finite difference approximation of the Jacobian matrix.
-        It returns a dense ndarray with shape (m, n) is returned. If
-        m=1 it is returned as a 1-D gradient array with shape (n,).
+    Returns:
+        A dense Jacobian. For a scalar-valued function the result has shape
+        ``(n,)``; otherwise it has shape ``(m, n)``.
 
-    See Also
-    --------
-    check_derivative : Check correctness of a function computing derivatives.
+    Raises:
+        ValueError: If ``method`` is unsupported, ``x0`` is not one
+            dimensional, the bounds have incompatible shapes, or ``x0`` lies
+            outside the bounds.
 
-    Notes
-    -----
-    If `rel_step` is not provided, it assigned as ``EPS**(1/s)``, where EPS is
-    determined from the smallest floating point dtype of `x0` or `fun(x0)`,
-    ``jnp.finfo(x0.dtype).eps``, s=2 for '2-point' method and
-    s=3 for '3-point' method. Such relative step approximately minimizes a sum
-    of truncation and round-off errors, see [1]_. Relative steps are used by
-    default. However, absolute steps are used when ``abs_step is not None``.
-    If any of the absolute or relative steps produces an indistinguishable
-    difference from the original `x0`, ``(x0 + dx) - x0 == 0``, then a
-    automatic step size is substituted for that particular entry.
+    Notes:
+        If a requested step is indistinguishable from ``x0`` in the working
+        dtype, an automatic step is substituted for that entry. For the
+        ``"3-point"`` method, central differences are used when both sides fit
+        within the bounds; otherwise a second-order one-sided difference is
+        used.
 
-    A finite difference scheme for '3-point' method is selected automatically.
-    The well-known central difference scheme is used for points sufficiently
-    far from the boundary, and 3-point forward or backward scheme is used for
-    points near the boundary. Both schemes have the second-order accuracy in
-    terms of Taylor expansion. Refer to [2]_ for the formulas of 3-point
-    forward and backward difference schemes.
+        Scalar-valued functions return a one-dimensional gradient for
+        consistency with common autodiff APIs. Use ``jnp.atleast_2d`` when a
+        two-dimensional Jacobian is required in all cases.
 
-    For dense differencing when m=1 Jacobian is returned with a shape (n,),
-    on the other hand when n=1 Jacobian is returned with a shape (m, 1).
-    Our motivation is the following: a) It handles a case of gradient
-    computation (m=1) in a conventional way. b) It clearly separates these two
-    different cases. b) In all cases jnp.atleast_2d can be called to get 2-D
-    Jacobian with correct dimensions.
+    References:
+        - W. H. Press et al., *Numerical Recipes: The Art of Scientific
+          Computing*, 3rd edition, section 5.7.
+        - B. Fornberg, "Generation of Finite Difference Formulas on
+          Arbitrarily Spaced Grids," *Mathematics of Computation*, 51, 1988.
 
-    References
-    ----------
-    .. [1] W. H. Press et. al. "Numerical Recipes. The Art of Scientific
-           Computing. 3rd edition", sec. 5.7.
+    Examples:
+        ```python
+        import jax.numpy as jnp
 
-    .. [3] B. Fornberg, "Generation of Finite Difference Formulas on
-           Arbitrarily Spaced Grids", Mathematics of Computation 51, 1988.
+        from soromox.utils.numerical_jacobian import approx_derivative
 
-    Examples
-    --------
-    ```python
-    import jax.numpy as jnp
+        def f(x, c1, c2):
+            return jnp.array(
+                [
+                    x[0] * jnp.sin(c1 * x[1]),
+                    x[0] * jnp.cos(c2 * x[1]),
+                ]
+            )
 
-    from soromox.utils.numerical_jacobian import approx_derivative
+        x0 = jnp.array([1.0, 0.5 * jnp.pi])
+        jacobian = approx_derivative(f, x0, args=(1, 2))
+        # jacobian is approximately [[1, 0], [-1, 0]]
+        ```
 
-    def f(x, c1, c2):
-        return jnp.array(
-            [
-                x[0] * jnp.sin(c1 * x[1]),
-                x[0] * jnp.cos(c2 * x[1]),
-            ]
-        )
+        Bounds can limit the region of function evaluation:
 
-    x0 = jnp.array([1.0, 0.5 * jnp.pi])
-    jacobian = approx_derivative(f, x0, args=(1, 2))
-    # jacobian is approximately [[1, 0], [-1, 0]]
-    ```
+        ```python
+        def g(x):
+            return x**2 if x >= 1 else x
 
-    Bounds can be used to limit the region of function evaluation.
-    In the example below we compute left and right derivative at point 1.0.
-
-    ```python
-    def g(x):
-        return x**2 if x >= 1 else x
-
-    x0 = 1.0
-    left_derivative = approx_derivative(g, x0, bounds=(-jnp.inf, 1.0))
-    right_derivative = approx_derivative(g, x0, bounds=(1.0, jnp.inf))
-    # left_derivative is [1] and right_derivative is [2]
-    ```
+        x0 = 1.0
+        left_derivative = approx_derivative(g, x0, bounds=(-jnp.inf, 1.0))
+        right_derivative = approx_derivative(g, x0, bounds=(1.0, jnp.inf))
+        # left_derivative is [1] and right_derivative is [2]
+        ```
     """
+    x0 = jnp.atleast_1d(jnp.asarray(x0))
+
     if kwargs is None:
         kwargs = {}
     if method not in ["2-point", "3-point"]:
@@ -367,25 +302,23 @@ def approx_derivative(
         raise ValueError("Inconsistent shapes between bounds and `x0`.")
 
     def fun_wrapped(x):
-        f = fun(x, *args, **kwargs)
-        return f
+        return fun(x, *args, **kwargs)
 
     if f0 is None:
         f0 = fun_wrapped(x0)
+    f0 = jnp.atleast_1d(jnp.asarray(f0))
 
     if jnp.any((x0 < lb) | (x0 > ub)):
         raise ValueError("`x0` violates bound constraints.")
 
-    # by default we use rel_step
     if abs_step is None:
         h = _compute_absolute_step(rel_step, x0, f0, method)
     else:
-        # user specifies an absolute step
         sign_x0 = (x0 >= 0).astype(float) * 2 - 1
         h = abs_step
 
-        # cannot have a zero step. This might happen if x0 is very large
-        # or small. In which case fall back to relative step.
+        # Fall back to a relative step if the requested step is not
+        # distinguishable from x0 in the working dtype.
         dx = (x0 + h) - x0
         h = jnp.where(
             dx == 0,
@@ -397,13 +330,27 @@ def approx_derivative(
 
     if method == "2-point":
         h, use_one_sided = _adjust_scheme_to_bounds(x0, h, 1, "1-sided", lb, ub)
-    elif method == "3-point":
+    else:
         h, use_one_sided = _adjust_scheme_to_bounds(x0, h, 1, "2-sided", lb, ub)
 
     return _dense_difference(fun_wrapped, x0, f0, h, use_one_sided, method)
 
 
 def _dense_difference(fun, x0, f0, h, use_one_sided, method):
+    """Evaluate dense finite differences for prepared steps.
+
+    Args:
+        fun: Function to differentiate.
+        x0: Evaluation point.
+        f0: Function value at ``x0`` with shape ``(m,)``.
+        h: Absolute finite-difference steps with shape ``(n,)``.
+        use_one_sided: Boolean mask selecting one-sided differences.
+        method: Finite-difference method, either ``"2-point"`` or
+            ``"3-point"``.
+
+    Returns:
+        The dense Jacobian or gradient assembled from the finite differences.
+    """
     m = f0.shape[-1]
     n = x0.shape[-1]
 
@@ -412,9 +359,7 @@ def _dense_difference(fun, x0, f0, h, use_one_sided, method):
         if method == "2-point":
             x1 = x0 + jnp.concatenate(
                 [
-                    jnp.zeros(
-                        (i,),
-                    ),
+                    jnp.zeros((i,)),
                     h[i : i + 1],
                     jnp.zeros((n - i - 1,)),
                 ],
@@ -462,6 +407,4 @@ def _dense_difference(fun, x0, f0, h, use_one_sided, method):
     if m == 1:
         J_T = jnp.ravel(J_T)
 
-    J = J_T.T
-
-    return J
+    return J_T.T

--- a/tests/test_numerical_jacobian.py
+++ b/tests/test_numerical_jacobian.py
@@ -2,6 +2,7 @@
 from functools import partial
 
 import jax
+import pytest
 
 jax.config.update("jax_enable_x64", True)  # double precision
 from jax import Array, random
@@ -10,7 +11,8 @@ from jax import numpy as jnp
 from soromox.utils.numerical_jacobian import approx_derivative
 
 
-def test_finite_differences(method="2-point"):
+@pytest.mark.parametrize("method", ["2-point", "3-point"])
+def test_finite_differences(method):
     def fun(x: Array):
         return jnp.stack([x[0] * jnp.sin(x[1]), x[0] * jnp.cos(x[1])])
 
@@ -38,6 +40,29 @@ def test_finite_differences(method="2-point"):
 
         if not jnp.allclose(jac_autodiff, jac_numdiff, atol=1e-6):
             raise ValueError("Jacobian mismatch!")
+
+
+@pytest.mark.parametrize(
+    ("x0", "bounds", "expected"),
+    [
+        (0.0, (0.0, 1.0), 0.0),
+        (1.0, (0.0, 1.0), 2.0),
+    ],
+)
+def test_one_sided_scheme(x0, bounds, expected):
+    def fun(x: Array):
+        return x[0] ** 2
+
+    jac = approx_derivative(fun, jnp.array([x0]), method="3-point", bounds=bounds)
+
+    assert jnp.allclose(jac, jnp.array([expected]))
+
+
+def test_scalar_input_and_output():
+    jac = approx_derivative(lambda x: x[0] ** 2, 1.0, method="3-point")
+
+    assert jac.shape == (1,)
+    assert jnp.allclose(jac, jnp.array([2.0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Port the bounded finite-difference fix from #12 onto current `main` using JAX-functional updates.
- Normalize `numerical_jacobian.py` docstrings to the package’s Google-style convention and add a typed public signature.
- Add regression coverage for both one-sided bounds, both finite-difference methods, and scalar inputs/outputs.
- Add the missing Numerical Jacobian API page and link it at the end of the Utilities listings.

## Validation
- `uv run pytest -q tests/test_numerical_jacobian.py` — 5 passed
- Ruff check and format — passed
- `.venv/bin/zensical build --clean` — passed

This PR supersedes stale PR #12, which is based on an older divergent `main` history.