### PR TITLE
Fix: using Q/Esc to close a window does not hang the terminal

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made the Open3D viewer's Q/Esc shortcuts close windows cleanly so execution
+  continues after the viewer exits.
 - Made bound-aware finite-difference Jacobians compatible with JAX immutable
   arrays and documented the `numerical_jacobian` utility.
 

--- a/src/soromox/rendering/open3d_renderer.py
+++ b/src/soromox/rendering/open3d_renderer.py
@@ -1912,8 +1912,7 @@ class Open3DRenderer(BaseSoftRobotRenderer):
 
         def cb_quit(_):
             state["playing"] = False
-            vis.destroy_window()
-            state["window_destroyed"] = True
+            vis.close()
             return False
 
         vis.register_key_callback(ord(" "), cb_space)
@@ -2346,7 +2345,6 @@ class Open3DRenderer(BaseSoftRobotRenderer):
             "playing": bool(autoplay),
             "last_tick": time.time(),
             "dt_seq": dt_seq,
-            "window_destroyed": False,
         }
 
         def _fallback_to_frames(reason: str):
@@ -2452,5 +2450,4 @@ class Open3DRenderer(BaseSoftRobotRenderer):
                 if video_writer is not None:
                     video_writer.close()
             finally:
-                if not state["window_destroyed"]:
-                    vis.destroy_window()
+                vis.destroy_window()

--- a/tests/rendering/test_open3d_renderer.py
+++ b/tests/rendering/test_open3d_renderer.py
@@ -608,3 +608,29 @@ def test_open3d_closes_window_when_recording_finishes(monkeypatch):
 
     assert update_scene.call_count == 2
     vis.destroy_window.assert_called_once_with()
+
+
+def test_open3d_quit_callback_requests_close_without_destroying_window():
+    renderer = Open3DRenderer(_AnimatingSpatialRobot())
+    callbacks: dict[int, object] = {}
+    vis = Mock()
+    vis.register_key_callback.side_effect = callbacks.__setitem__
+    state = {"idx": 0, "playing": True, "last_tick": 0.0, "dt_seq": np.zeros(1)}
+
+    renderer._register_key_callbacks(
+        vis=vis,
+        ctrl=Mock(),
+        state=state,
+        update_frame=Mock(),
+        save_frame_fn=Mock(),
+        initial_cam=Mock(),
+        saved_cam_holder=[Mock()],
+        print_prefix="[Open3D]",
+    )
+
+    for key in (81, 256):  # Q, Esc
+        assert callbacks[key](vis) is False
+
+    assert state["playing"] is False
+    assert vis.close.call_count == 2
+    vis.destroy_window.assert_not_called()


### PR DESCRIPTION
When running examples that need to open and close an Open3D renderer, if Q or Esc are used to close the window the program just ends abruptly (although using the cross X for the window does work).

This PR fixes that using `close() `instead of `destroy_window()` in `cb_quit()` 

### Before

```bash
ivrolan@bmolegion22:~/soromox$ uv run examples/simulation/gvs/simulate_gvs.py 
An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.
System initialized with 2 segments
max DOFs: 6, max Gauss points: 6.
Total DOFs: 4 (chosen), 24 (real)
/home/ivrolan/soromox/src/soromox/rendering/open3d_renderer.py:2329: RuntimeWarning: Open3D viewer assumes cross_section_geometry is configuration-independent; geometry is frozen to the first frame.
  handles = self._build_scene(
Robot Animation (Open3D): Space=Play/Pause  ←/→=Step  H=Home  S=Snapshot  R=ResetCam  C=CaptureCam  L=LoadCam  V=PrintCam  Q/Esc=Quit
ivrolan@bmolegion22:~/soromox$
```

The example program does not continue after closing the window, which can be confusing for a new user.

### After

```bash

ivrolan@bmolegion22:~/soromox$ uv run examples/simulation/gvs/simulate_gvs.py 
An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.
System initialized with 2 segments
max DOFs: 6, max Gauss points: 6.
Total DOFs: 4 (chosen), 24 (real)
/home/ivrolan/soromox/src/soromox/rendering/open3d_renderer.py:2328: RuntimeWarning: Open3D viewer assumes cross_section_geometry is configuration-independent; geometry is frozen to the first frame.
  handles = self._build_scene(
Robot Animation (Open3D): Space=Play/Pause  ←/→=Step  H=Home  S=Snapshot  R=ResetCam  C=CaptureCam  L=LoadCam  V=PrintCam  Q/Esc=Quit
u =
 [4.18e-01 2.16e-01 9.65e-01 5.75e-01]
Simulation completed with 201 time steps.
/home/ivrolan/soromox/examples/simulation/gvs/simulate_gvs.py:155: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
  plt.show()
/home/ivrolan/soromox/examples/simulation/gvs/simulate_gvs.py:168: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
  plt.show()
Robot Animation (Open3D): Space=Play/Pause  ←/→=Step  H=Home  S=Snapshot  R=ResetCam  C=CaptureCam  L=LoadCam  V=PrintCam  Q/Esc=Quit
╭────── viser (listening *:8080) ───────╮
│             ╷                         │
│   HTTP      │ http://localhost:8080   │
│   Websocket │ ws://localhost:8080     │
│             ╵                         │
╰───────────────────────────────────────╯
[ViserRenderer] Server started at http://localhost:8080
[ViserRenderer] Animation at http://localhost:8080
[ViserRenderer] 201 frames, 2 robot(s)
Gtk-Message: 18:19:27.175: Not loading module "atk-bridge": The functionality is provided by GTK natively. Please try to not load it.
(viser) Connection opened (0, 1 total), 46 persistent messages
^C(viser) Connection closed (0, 0 total)
(viser) Server stopped
[ViserRenderer] Server stopped
ivrolan@bmolegion22:~/soromox$
```

Additionally, I added a test for this case that checks that the window is not destroyed when using the keys Q and Esc

Hope this helps! 