### PR TITLE
Optimize model-based controllers with fused dynamics terms

### DIFF
--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -61,6 +61,23 @@ For each system/function pair the script prints:
 The plots group results by system, highlighting how complexity evolves with segment
 count for each tracked method.
 
+For PCS and GVS, the method benchmark also exposes paired
+`dynamics_terms_separate` / `dynamics_terms`,
+`model_based_control_separate` / `model_based_control`,
+`actuation_dynamics_terms_separate` / `actuation_dynamics_terms`, and
+`operational_dynamics_terms_separate` / `operational_dynamics_terms` cases.
+These compare the legacy composition of individual public methods against the
+contracted fused paths used by model-based controllers:
+
+```bash
+python tools/benchmarks/benchmark_system_methods.py \
+  --systems pcs gvs \
+  --segment-counts 1 4 \
+  --gauss-points 5 \
+  --methods dynamics_terms_separate dynamics_terms \
+  --execution-repeats 50
+```
+
 For `articulated_soft_robot`, the method benchmark includes both the default
 articulated-body forward dynamics path and a dense Jacobian-energy forward
 dynamics solve (`forward_dynamics_dense`). Comparing these two cases is useful

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -4,6 +4,8 @@ Soromox ships development benchmarking CLIs under `tools/benchmarks`:
 
 - `benchmark_system_methods.py` profiles individual model routines (forward kinematics,
   dynamics, etc.) to track JIT compile and steady-state execution costs.
+- `benchmark_model_based_control.py` profiles the default model-based controller
+  and controller-facing transformed-dynamics paths for PCS and GVS.
 - `benchmark_derivative_paths.py` compares direct analytical derivative hooks,
   protected autograd fallbacks, and public APIs with custom JVPs enabled or disabled
   for PlanarPCS, PCS, and GVS systems.
@@ -61,27 +63,31 @@ For each system/function pair the script prints:
 The plots group results by system, highlighting how complexity evolves with segment
 count for each tracked method.
 
-For PCS and GVS, the method benchmark also exposes paired
-`dynamics_terms_separate` / `dynamics_terms`,
-`model_based_control_separate` / `model_based_control`,
-`actuation_dynamics_terms_separate` / `actuation_dynamics_terms`, and
-`operational_dynamics_terms_separate` / `operational_dynamics_terms` cases.
-These compare the legacy composition of individual public methods against the
-contracted fused paths used by model-based controllers:
-
-```bash
-python tools/benchmarks/benchmark_system_methods.py \
-  --systems pcs gvs \
-  --segment-counts 1 4 \
-  --gauss-points 5 \
-  --methods dynamics_terms_separate dynamics_terms \
-  --execution-repeats 50
-```
-
 For `articulated_soft_robot`, the method benchmark includes both the default
 articulated-body forward dynamics path and a dense Jacobian-energy forward
 dynamics solve (`forward_dynamics_dense`). Comparing these two cases is useful
 for tracking ABA performance against the controller-facing dense dynamics API.
+
+## Benchmarking model-based control
+
+`benchmark_model_based_control.py` measures the checked-out implementation of
+the computed-torque and configuration-/actuation-space feedforward terms, plus
+the operational-space dynamics terms used by operational controllers. The
+benchmark intentionally contains no legacy strategy switch: compare revisions
+by running the same command in separate clean worktrees.
+
+```bash
+python tools/benchmarks/benchmark_model_based_control.py \
+  --systems pcs gvs \
+  --segment-counts 1 4 \
+  --gauss-points 5 \
+  --execution-repeats 50 \
+  --json /tmp/model-based-control.json
+```
+
+Use `--methods` to select individual controller paths and `--csv` for a
+tabular export. Each row reports derived compile time and synchronized warm
+execution time for the default implementation on that revision.
 
 ## Benchmarking derivative paths
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Routed exact inverse-dynamics controllers through the contracted
+  `dynamics_terms` interface and fused actuation- and operational-space term
+  transformations to avoid repeated inertia, Coriolis, gravity, Jacobian, and
+  matrix-factorization work.
+
 ### Fixed
 
 - Made the Open3D viewer's Q/Esc shortcuts close windows cleanly so execution

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Routed exact inverse-dynamics controllers through the contracted
   `dynamics_terms` interface and fused actuation- and operational-space term
   transformations to avoid repeated inertia, Coriolis, gravity, Jacobian, and
-  matrix-factorization work.
+  matrix-factorization work. Across affected PCS and GVS controller paths with
+  one and four segments, this reduced runtime by 38.3% on a geometric-mean
+  basis (up to 55.9%).
 
 ### Fixed
 

--- a/docs/development/extending.md
+++ b/docs/development/extending.md
@@ -1012,13 +1012,11 @@ def model_based_term(
     q_des, qd_des, qdd_des = self.reference_trajectory.get_state(t)
 
     # Compute inverse dynamics
-    M = self.robot.inertia_matrix(q_des)
-    C = self.robot.coriolis_matrix(q_des, qd_des)
-    G = self.robot.gravitational_force(q_des)
+    M, Cqd, G = self.robot.dynamics_terms(q_des, qd_des)
     tau_el = self.robot.elastic_force(q_des)
 
     # Feedforward torque
-    tau_ff = M @ qdd_des + C @ qd_des + G + tau_el
+    tau_ff = M @ qdd_des + Cqd + G + tau_el
 
     # Map to actuation space
     A = self.robot.actuation_matrix(q_des)

--- a/src/soromox/control/actuation_space/feedforward_compensation_tracker.py
+++ b/src/soromox/control/actuation_space/feedforward_compensation_tracker.py
@@ -192,10 +192,10 @@ class FeedforwardCompensationTracker(PIDController):
         yd_des = self.reference_trajectory.xd_des_fn(t)
         ydd_des = self.reference_trajectory.xdd_des_fn(t)
 
-        # Compute actuation-space dynamics at DESIRED configuration q_des
-        M_y_des = asd.inertia_matrix(q_des)
-        eta_y_des = asd.coriolis_matrix(q_des, qd_des)
-        G_y_des = asd.gravitational_force(q_des)
+        # Compute the coupled actuation-space dynamics at the desired state.
+        # The returned Coriolis term is already contracted with yd_des because
+        # yd_des = J(q_des) @ qd_des for the converted reference trajectory.
+        M_y_des, Cyd_des, G_y_des = asd.dynamics_terms(q_des, qd_des)
         tau_el_y_des = asd.elastic_force(q_des)
         D_y_des = asd.damping_matrix(q_des)
 
@@ -203,7 +203,7 @@ class FeedforwardCompensationTracker(PIDController):
         # Using yd_des and ydd_des (actuation-space velocities/accelerations)
         tau_model_y = (
             M_y_des @ ydd_des
-            + eta_y_des @ yd_des
+            + Cyd_des
             + G_y_des
             + tau_el_y_des
             + D_y_des @ yd_des

--- a/src/soromox/control/configuration_space/computed_torque_tracker.py
+++ b/src/soromox/control/configuration_space/computed_torque_tracker.py
@@ -99,8 +99,7 @@ class ComputedTorqueTracker(ClosedFormModelBasedController):
 
         Args:
             robot: The soft robot system to be controlled.
-                Must have `actuation_matrix(q)`, `inertia_matrix(q)`,
-                `coriolis_matrix(q, qd)`, `gravitational_force(q)`,
+                Must have `actuation_matrix(q)`, `dynamics_terms(q, qd)`,
                 `elastic_force(q)`, and `damping_matrix(q)` methods.
             reference_trajectory: The desired trajectory to track.
                 Must provide x_des_fn (desired configuration), xd_des_fn
@@ -201,16 +200,15 @@ class ComputedTorqueTracker(ClosedFormModelBasedController):
         assert self.reference_trajectory.xdd_des_fn is not None
         qdd_des = self.reference_trajectory.xdd_des_fn(t)
 
-        # Compute dynamics matrices at current configuration and velocity
-        M = self.robot.inertia_matrix(q)
-        C = self.robot.coriolis_matrix(q, qd)
-        G = self.robot.gravitational_force(q)
+        # Compute the coupled dynamics terms at the current state. The returned
+        # Coriolis term is already contracted with the supplied velocity.
+        M, Cqd, G = self.robot.dynamics_terms(q, qd)
         tau_el = self.robot.elastic_force(q)
         D = self.robot.damping_matrix(q)
 
         # Compute the inverse dynamics: cancel all forces and apply desired acceleration
         # tau = M(q) @ qdd_des + C(q, qd) @ qd + G(q) + tau_el(q) + D(q) @ qd
-        tau_model = M @ qdd_des + C @ qd + G + tau_el + D @ qd
+        tau_model = M @ qdd_des + Cqd + G + tau_el + D @ qd
 
         # Get the actuation matrix at current configuration
         A = self.robot.actuation_matrix(q)

--- a/src/soromox/control/configuration_space/feedforward_compensation_tracker.py
+++ b/src/soromox/control/configuration_space/feedforward_compensation_tracker.py
@@ -77,8 +77,7 @@ class FeedforwardCompensationTracker(PIDController):
 
         Args:
             robot: The soft robot system to be controlled.
-                Must have `actuation_matrix(q)`, `inertia_matrix(q)`,
-                `coriolis_matrix(q, qd)`, `gravitational_force(q)`,
+                Must have `actuation_matrix(q)`, `dynamics_terms(q, qd)`,
                 `elastic_force(q)`, and `damping_matrix(q)` methods.
             reference_trajectory: The desired trajectory to track.
                 Must provide x_des_fn (desired configuration), xd_des_fn
@@ -140,17 +139,16 @@ class FeedforwardCompensationTracker(PIDController):
         qd_des = self.reference_trajectory.xd_des_fn(t)
         qdd_des = self.reference_trajectory.xdd_des_fn(t)
 
-        # Compute dynamics matrices at desired trajectory
-        B_des = self.robot.inertia_matrix(q_des)
-        C_des = self.robot.coriolis_matrix(q_des, qd_des)
-        G_des = self.robot.gravitational_force(q_des)
+        # Compute the coupled dynamics terms at the desired trajectory. The
+        # returned Coriolis term is already contracted with qd_des.
+        B_des, Cqd_des, G_des = self.robot.dynamics_terms(q_des, qd_des)
         tau_el_des = self.robot.elastic_force(q_des)
         D_des = self.robot.damping_matrix(q_des)
 
         # Compute inverse dynamics at desired trajectory
         # tau = B @ qdd + C @ qd + G + tau_el + D @ qd
         tau_model = (
-            B_des @ qdd_des + C_des @ qd_des + G_des + tau_el_des + D_des @ qd_des
+            B_des @ qdd_des + Cqd_des + G_des + tau_el_des + D_des @ qd_des
         )
 
         # Get the actuation matrix at current configuration

--- a/src/soromox/coordinate_transformations/actuation_space.py
+++ b/src/soromox/coordinate_transformations/actuation_space.py
@@ -552,9 +552,16 @@ class ActuationSpaceDynamics(eqx.Module):
             Cyd: Actuation space Coriolis/centrifugal force of shape (num_dofs,).
             G_y: Actuation space gravitational force of shape (num_dofs,).
         """
-        M_y = self.inertia_matrix(q)
-        Cyd = self.coriolis_force(q, qd)
-        G_y = self.gravitational_force(q)
+        J_inv = self.jacobian_inverse(q)
+        J_inv_T = J_inv.T
+        M, Cqd, G = self.robot.dynamics_terms(q, qd)
+
+        # For yd = J @ qd, the existing actuation-space Coriolis definition
+        # contracts to J^{-T} @ (C @ qd). Reusing the robot's contracted term
+        # avoids materializing C and recomputing M, J, and their inverses.
+        M_y = J_inv_T @ M @ J_inv
+        Cyd = J_inv_T @ Cqd
+        G_y = J_inv_T @ G
         return M_y, Cyd, G_y
 
     # =========================================================================

--- a/src/soromox/coordinate_transformations/operational_space_dynamics.py
+++ b/src/soromox/coordinate_transformations/operational_space_dynamics.py
@@ -1264,7 +1264,20 @@ class OperationalSpaceDynamics(eqx.Module):
             G_x: Operational space gravitational force of shape
                 (n_operational_space,).
         """
-        Lambda = self.inertia_matrix(q)
-        Cxd = self.coriolis_force(q, qd)
-        G_x = self.gravitational_force(q)
+        J, Jd = self.jacobian_and_time_derivative(q, qd)
+        M, Cqd, G = self.robot.dynamics_terms(q, qd)
+
+        # Solve once for all M^{-1}-weighted quantities needed below. This
+        # preserves the existing operational-space definitions while avoiding
+        # separate inertia, Coriolis-force, and gravity call graphs.
+        solve_rhs = jnp.concatenate([J.T, Cqd[:, None]], axis=1)
+        solved = jnp.linalg.solve(M, solve_rhs)
+        M_inv_J_T = solved[:, : J.shape[0]]
+        M_inv_Cqd = solved[:, J.shape[0]]
+
+        Lambda_inv = J @ M_inv_J_T
+        Lambda = jnp.linalg.inv(Lambda_inv)
+        J_bar = M_inv_J_T @ Lambda
+        Cxd = Lambda @ (J @ M_inv_Cqd - Jd @ qd)
+        G_x = J_bar.T @ G
         return Lambda, Cxd, G_x

--- a/tests/control/conftest.py
+++ b/tests/control/conftest.py
@@ -30,6 +30,7 @@ class BrokenActuationRobot:
 class FakeDynamicsRobot(FakeRobot):
     def __init__(self, actuation_matrix):
         super().__init__(actuation_matrix)
+        self.dynamics_terms_calls = 0
         self._M = jnp.array([[2.0, 0.5], [0.5, 3.0]])
         self._C = jnp.array([[0.0, 0.25], [-0.1, 0.0]])
         self._G = jnp.array([0.3, -0.2])
@@ -50,6 +51,10 @@ class FakeDynamicsRobot(FakeRobot):
 
     def damping_matrix(self, q):
         return self._D
+
+    def dynamics_terms(self, q, qd):
+        self.dynamics_terms_calls += 1
+        return self._M, self._C @ qd, self._G
 
 
 def make_reference(x_des, xd_des, xdd_des=None):

--- a/tests/control/test_actuation_space_controllers.py
+++ b/tests/control/test_actuation_space_controllers.py
@@ -1,16 +1,24 @@
 import jax.numpy as jnp
+import pytest
 
 from soromox.control import PIDControl, PIDControllerState
-from soromox.control.actuation_space import PIDController as ActuationSpacePIDController
+from soromox.control.actuation_space import (
+    FeedforwardCompensationTracker,
+)
+from soromox.control.actuation_space import (
+    PIDController as ActuationSpacePIDController,
+)
 from soromox.systems.system_state import SystemState
 
 
 class FakeActuationSpaceDynamics:
     n_actuated = 2
+    n_unactuated = 1
 
     def __init__(self, robot, converted_reference=None):
         self.robot = robot
         self.converted_reference = converted_reference
+        self.dynamics_terms_calls = 0
 
     def convert_reference_trajectory(self, reference_trajectory):
         return self.converted_reference
@@ -26,6 +34,23 @@ class FakeActuationSpaceDynamics:
                 [0.0, 0.0, 1.0],
             ]
         )
+
+    def dynamics_terms(self, q, qd):
+        del q, qd
+        self.dynamics_terms_calls += 1
+        return (
+            jnp.diag(jnp.array([2.0, 3.0, 4.0])),
+            jnp.array([0.1, -0.2, 0.3]),
+            jnp.array([0.4, 0.5, -0.6]),
+        )
+
+    def elastic_force(self, q):
+        del q
+        return jnp.array([0.2, -0.1, 0.3])
+
+    def damping_matrix(self, q):
+        del q
+        return jnp.diag(jnp.array([0.5, 0.25, 0.1]))
 
 
 def test_actuation_space_pid_uses_actuated_coordinates_and_updates_gains(
@@ -85,3 +110,48 @@ def test_actuation_space_pid_converts_configuration_space_reference(
 
     assert controller.reference_trajectory_config_space is original_reference
     assert controller.reference_trajectory is converted_reference
+
+
+def test_actuation_space_feedforward_uses_contracted_dynamics_terms(
+    fake_robot_factory, make_reference_factory
+):
+    reference = make_reference_factory(
+        x_des=[0.2, -0.1, 0.3],
+        xd_des=[0.1, 0.2, -0.1],
+        xdd_des=[0.3, -0.2, 0.1],
+    )
+    converted_reference = make_reference_factory(
+        x_des=[1.2, -1.1, 0.3],
+        xd_des=[0.1, 0.4, -0.1],
+        xdd_des=[0.3, -0.4, 0.1],
+    )
+    asd = FakeActuationSpaceDynamics(
+        fake_robot_factory(jnp.eye(3, 2)),
+        converted_reference=converted_reference,
+    )
+
+    with pytest.warns(UserWarning, match="underactuated"):
+        controller = FeedforwardCompensationTracker(
+            asd,
+            reference,
+            PIDControl(0.0, 0.0, 0.0),
+            reference_in_configuration_space=True,
+        )
+
+    state = SystemState(t=jnp.array(0.0), y=jnp.zeros((6,)))
+    tau_model, control_state_dot = controller.model_based_term(state)
+
+    M_y, Cyd, G_y = (
+        jnp.diag(jnp.array([2.0, 3.0, 4.0])),
+        jnp.array([0.1, -0.2, 0.3]),
+        jnp.array([0.4, 0.5, -0.6]),
+    )
+    yd_des = converted_reference.xd_des_fn(state.t)
+    ydd_des = converted_reference.xdd_des_fn(state.t)
+    tau_el = asd.elastic_force(reference.x_des_fn(state.t))
+    D_y = asd.damping_matrix(reference.x_des_fn(state.t))
+    expected = (M_y @ ydd_des + Cyd + G_y + tau_el + D_y @ yd_des)[:2]
+
+    assert jnp.allclose(tau_model, expected)
+    assert asd.dynamics_terms_calls == 1
+    assert control_state_dot is None

--- a/tests/control/test_configuration_space_controllers.py
+++ b/tests/control/test_configuration_space_controllers.py
@@ -38,6 +38,7 @@ def test_computed_torque_model_based_term_uses_inverse_dynamics_and_actuation_in
     )
     expected = jnp.linalg.inv(robot.actuation_matrix(q)) @ tau_model
     assert jnp.allclose(u_model, expected)
+    assert robot.dynamics_terms_calls == 1
     assert control_state_dot is None
 
 
@@ -98,6 +99,7 @@ def test_computed_torque_supports_overactuated_pseudoinverse_and_rejects_underac
     assert jnp.allclose(
         u_model, jnp.linalg.pinv(overactuated_robot.actuation_matrix(q)) @ tau_model
     )
+    assert overactuated_robot.dynamics_terms_calls == 1
 
     with pytest.raises(ValueError, match="underactuated"):
         ComputedTorqueTracker(
@@ -257,4 +259,8 @@ def test_configuration_space_model_based_controllers_compute_expected_terms(
     u_model, control_state_dot = controller.model_based_term(state)
 
     assert jnp.allclose(u_model, expected_fn(robot, reference, state))
+    expected_dynamics_terms_calls = (
+        1 if controller_cls is FeedforwardCompensationTracker else 0
+    )
+    assert robot.dynamics_terms_calls == expected_dynamics_terms_calls
     assert control_state_dot is None

--- a/tests/coordinate_transformations/test_actuation_space_dynamics.py
+++ b/tests/coordinate_transformations/test_actuation_space_dynamics.py
@@ -829,6 +829,18 @@ class TestActuationSpaceDynamicsSystemIndependent:
         assert asd.n_unactuated == robot.num_dofs - robot.num_actuators
         assert asd.n_actuated + asd.n_unactuated == robot.num_dofs
 
+    def test_dynamics_terms_match_individual_methods(self, robot):
+        """Fused dynamics agree for articulated and nonlinear PCS mappings."""
+        asd = ActuationSpaceDynamics(robot)
+        q = random_configuration(robot)
+        qd = random_configuration(robot, key=jax.random.PRNGKey(1))
+
+        M_y, Cyd, G_y = asd.dynamics_terms(q, qd)
+
+        assert_allclose(M_y, asd.inertia_matrix(q), rtol=1e-9, atol=1e-12)
+        assert_allclose(Cyd, asd.coriolis_force(q, qd), rtol=1e-9, atol=1e-12)
+        assert_allclose(G_y, asd.gravitational_force(q), rtol=1e-9, atol=1e-12)
+
     def test_h_unactuated_shape(self, robot):
         """Test that H_unactuated has correct shape."""
         asd = ActuationSpaceDynamics(robot)

--- a/tests/coordinate_transformations/test_operational_space_dynamics.py
+++ b/tests/coordinate_transformations/test_operational_space_dynamics.py
@@ -415,6 +415,35 @@ class TestOperationalSpaceForces:
             atol=Tolerance.atol(),
         )
 
+    def test_pcs_dynamics_terms_match_individual_methods(self, pcs_robot):
+        """Fused operational dynamics agree for a quadrature-based PCS."""
+        op_space = OperationalSpaceDynamics(
+            robot=pcs_robot, s_ps=jnp.atleast_1d(pcs_robot.length)
+        )
+        q = jnp.linspace(-0.1, 0.1, pcs_robot.num_dofs)
+        qd = jnp.linspace(0.2, -0.2, pcs_robot.num_dofs)
+
+        Lambda, Cxd, G_x = op_space.dynamics_terms(q, qd)
+
+        assert_allclose(
+            Lambda,
+            op_space.inertia_matrix(q),
+            rtol=Tolerance.rtol(),
+            atol=Tolerance.atol(),
+        )
+        assert_allclose(
+            Cxd,
+            op_space.coriolis_force(q, qd),
+            rtol=Tolerance.rtol(),
+            atol=Tolerance.atol(),
+        )
+        assert_allclose(
+            G_x,
+            op_space.gravitational_force(q),
+            rtol=Tolerance.rtol(),
+            atol=Tolerance.atol(),
+        )
+
 
 # -----------------------
 # Null space projector tests

--- a/tests/tools/test_benchmark_model_based_control.py
+++ b/tests/tools/test_benchmark_model_based_control.py
@@ -1,0 +1,44 @@
+from tools.benchmarks.benchmark_model_based_control import (
+    _benchmark_cases,
+    _system_registry,
+    parse_args,
+)
+
+
+def test_registry_is_limited_to_controller_benchmark_systems():
+    assert tuple(_system_registry()) == ("pcs", "gvs")
+
+
+def test_cases_track_only_current_default_paths():
+    names = {case.name for case in _benchmark_cases()}
+    assert names == {
+        "computed_torque_model_based",
+        "configuration_feedforward_model_based",
+        "actuation_feedforward_model_based",
+        "operational_dynamics_terms",
+    }
+    assert all("separate" not in name and "fused" not in name for name in names)
+
+
+def test_parse_args_normalizes_systems_and_selects_methods():
+    args = parse_args(
+        [
+            "--systems",
+            "PCS",
+            "GVS",
+            "--segment-counts",
+            "2",
+            "--gauss-points",
+            "7",
+            "--methods",
+            "computed_torque_model_based",
+            "--execution-repeats",
+            "3",
+        ]
+    )
+
+    assert args.systems == ["pcs", "gvs"]
+    assert args.segment_counts == [2]
+    assert args.gauss_points == [7]
+    assert args.methods == ["computed_torque_model_based"]
+    assert args.execution_repeats == 3

--- a/tests/tools/test_benchmark_model_based_control.py
+++ b/tests/tools/test_benchmark_model_based_control.py
@@ -12,10 +12,10 @@ def test_registry_is_limited_to_controller_benchmark_systems():
 def test_cases_track_only_current_default_paths():
     names = {case.name for case in _benchmark_cases()}
     assert names == {
-        "computed_torque_model_based",
-        "configuration_feedforward_model_based",
-        "actuation_feedforward_model_based",
-        "operational_dynamics_terms",
+        "configuration_space_computed_torque",
+        "configuration_space_feedforward_compensation",
+        "actuation_space_feedforward_compensation",
+        "operational_space_dynamics_terms",
     }
     assert all("separate" not in name and "fused" not in name for name in names)
 
@@ -31,7 +31,7 @@ def test_parse_args_normalizes_systems_and_selects_methods():
             "--gauss-points",
             "7",
             "--methods",
-            "computed_torque_model_based",
+            "configuration_space_computed_torque",
             "--execution-repeats",
             "3",
         ]
@@ -40,5 +40,5 @@ def test_parse_args_normalizes_systems_and_selects_methods():
     assert args.systems == ["pcs", "gvs"]
     assert args.segment_counts == [2]
     assert args.gauss_points == [7]
-    assert args.methods == ["computed_torque_model_based"]
+    assert args.methods == ["configuration_space_computed_torque"]
     assert args.execution_repeats == 3

--- a/tools/benchmarks/benchmark_model_based_control.py
+++ b/tools/benchmarks/benchmark_model_based_control.py
@@ -139,15 +139,21 @@ def _build_operational_dynamics_case(system: Any, context: Mapping[str, Array]):
 def _benchmark_cases() -> tuple[BenchmarkCase, ...]:
     """Return controller paths whose implementation is tracked over revisions."""
     return (
-        BenchmarkCase("computed_torque_model_based", _build_computed_torque_case),
         BenchmarkCase(
-            "configuration_feedforward_model_based",
+            "configuration_space_computed_torque", _build_computed_torque_case
+        ),
+        BenchmarkCase(
+            "configuration_space_feedforward_compensation",
             _build_configuration_feedforward_case,
         ),
         BenchmarkCase(
-            "actuation_feedforward_model_based", _build_actuation_feedforward_case
+            "actuation_space_feedforward_compensation",
+            _build_actuation_feedforward_case,
         ),
-        BenchmarkCase("operational_dynamics_terms", _build_operational_dynamics_case),
+        BenchmarkCase(
+            "operational_space_dynamics_terms",
+            _build_operational_dynamics_case,
+        ),
     )
 
 

--- a/tools/benchmarks/benchmark_model_based_control.py
+++ b/tools/benchmarks/benchmark_model_based_control.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Benchmark the default model-based controller evaluation paths.
+
+Run this script on two revisions to quantify controller performance changes. It
+intentionally benchmarks only the implementation provided by the checked-out
+revision instead of keeping legacy and current strategies in one benchmark.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+import time
+import warnings
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from soromox.control import PIDControl, ReferenceTrajectory  # noqa: E402
+from soromox.control.actuation_space import (  # noqa: E402
+    FeedforwardCompensationTracker as ActuationFeedforwardCompensationTracker,
+)
+from soromox.control.configuration_space import (  # noqa: E402
+    ComputedTorqueTracker,
+    FeedforwardCompensationTracker,
+)
+from soromox.coordinate_transformations import (  # noqa: E402
+    ActuationSpaceDynamics,
+    OperationalSpaceDynamics,
+)
+from soromox.systems import SystemState  # noqa: E402
+from tools.benchmarks._benchmark_common import (  # noqa: E402
+    add_gauss_point_args,
+    add_system_selection_args,
+    block_until_ready,
+    build_system_with_gauss_points,
+    gauss_point_sweep_values,
+    get_system_registry,
+    normalize_gauss_point_values,
+    normalize_system_names,
+    system_gauss_point_metadata,
+)
+
+Array = jax.Array
+Tree = Any
+OUTPUT_FIELDS = (
+    "system",
+    "method",
+    "size_label",
+    "size_value",
+    "gauss_points",
+    "integration_points",
+    "jit_compile_time_s",
+    "jit_execution_time_s",
+    "execution_repeats",
+)
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """One default controller or controller-facing dynamics evaluation."""
+
+    name: str
+    builder: Callable[[Any, Mapping[str, Array]], tuple[Callable[..., Tree], tuple]]
+
+
+def _reference_trajectory(context: Mapping[str, Array]) -> ReferenceTrajectory:
+    """Build a deterministic smooth-state reference for controller timing."""
+    q_des = 0.5 * context["q"]
+    qd_des = 0.5 * context["qd"]
+    qdd_des = -0.5 * context["qd"]
+    return ReferenceTrajectory(
+        ts=jnp.array([0.0, 1.0]),
+        x_des_fn=lambda t: q_des,
+        xd_des_fn=lambda t: qd_des,
+        xdd_des_fn=lambda t: qdd_des,
+    )
+
+
+def _system_state(context: Mapping[str, Array]) -> SystemState:
+    """Return the deterministic state shared by controller cases."""
+    return SystemState(t=context["t"], y=context["y"])
+
+
+def _build_computed_torque_case(system: Any, context: Mapping[str, Array]):
+    controller = ComputedTorqueTracker(
+        system,
+        _reference_trajectory(context),
+        PIDControl(0.0, 0.0, 0.0),
+    )
+    return controller.model_based_term, (_system_state(context),)
+
+
+def _build_configuration_feedforward_case(
+    system: Any, context: Mapping[str, Array]
+):
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="FeedforwardCompensationTracker: For full theoretical guarantees",
+            category=UserWarning,
+        )
+        controller = FeedforwardCompensationTracker(
+            system,
+            _reference_trajectory(context),
+            PIDControl(0.0, 0.0, 0.0),
+        )
+    return controller.model_based_term, (_system_state(context),)
+
+
+def _build_actuation_feedforward_case(system: Any, context: Mapping[str, Array]):
+    dynamics = ActuationSpaceDynamics(system)
+    controller = ActuationFeedforwardCompensationTracker(
+        dynamics,
+        _reference_trajectory(context),
+        PIDControl(0.0, 0.0, 0.0),
+    )
+    return controller.model_based_term, (_system_state(context),)
+
+
+def _build_operational_dynamics_case(system: Any, context: Mapping[str, Array]):
+    dynamics = OperationalSpaceDynamics(
+        system, jnp.atleast_1d(context["s_tip"])
+    )
+    return dynamics.dynamics_terms, (context["q"], context["qd"])
+
+
+def _benchmark_cases() -> tuple[BenchmarkCase, ...]:
+    """Return controller paths whose implementation is tracked over revisions."""
+    return (
+        BenchmarkCase("computed_torque_model_based", _build_computed_torque_case),
+        BenchmarkCase(
+            "configuration_feedforward_model_based",
+            _build_configuration_feedforward_case,
+        ),
+        BenchmarkCase(
+            "actuation_feedforward_model_based", _build_actuation_feedforward_case
+        ),
+        BenchmarkCase("operational_dynamics_terms", _build_operational_dynamics_case),
+    )
+
+
+def _measure_jitted_call(
+    fn: Callable[..., Tree], args: tuple[Any, ...], repeats: int
+) -> tuple[float, float]:
+    """Return derived compile time and mean synchronized warm runtime."""
+    jitted_fn = jax.jit(lambda *call_args: fn(*call_args))
+
+    start = time.perf_counter()
+    first = jitted_fn(*args)
+    block_until_ready(first)
+    first_time = time.perf_counter() - start
+
+    execution_times = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        output = jitted_fn(*args)
+        block_until_ready(output)
+        execution_times.append(time.perf_counter() - start)
+
+    execution_time = sum(execution_times) / len(execution_times)
+    return max(0.0, first_time - execution_time), execution_time
+
+
+def _write_json(rows: Sequence[Mapping[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(rows, file, indent=2)
+
+
+def _write_csv(rows: Sequence[Mapping[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=OUTPUT_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _system_registry() -> Mapping[str, Any]:
+    shared = get_system_registry()
+    return {name: shared[name] for name in ("pcs", "gvs")}
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    registry = _system_registry()
+    cases = _benchmark_cases()
+    parser = argparse.ArgumentParser(
+        description="Benchmark default model-based controller paths"
+    )
+    add_system_selection_args(
+        parser,
+        registry,
+        default_segment_counts=[1, 4],
+        default_systems=["pcs", "gvs"],
+    )
+    add_gauss_point_args(parser)
+    parser.add_argument(
+        "--methods",
+        nargs="*",
+        choices=[case.name for case in cases],
+        default=None,
+        help="Controller paths to benchmark (default: all)",
+    )
+    parser.add_argument(
+        "--execution-repeats",
+        type=int,
+        default=10,
+        help="Number of synchronized warm executions to average",
+    )
+    parser.add_argument("--json", type=Path, help="Optional JSON output path")
+    parser.add_argument("--csv", type=Path, help="Optional CSV output path")
+    args = parser.parse_args(argv)
+
+    try:
+        args.systems = normalize_system_names(args.systems, registry)
+    except ValueError as error:
+        parser.error(str(error))
+    if any(size < 1 for size in args.segment_counts):
+        parser.error("All --segment-counts entries must be >= 1.")
+    if args.execution_repeats < 1:
+        parser.error("--execution-repeats must be >= 1.")
+    if args.gauss_points is not None:
+        if any(value < 1 for value in args.gauss_points):
+            parser.error("All --gauss-points entries must be >= 1.")
+        args.gauss_points = normalize_gauss_point_values(args.gauss_points)
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    registry = _system_registry()
+    selected_cases = [
+        case
+        for case in _benchmark_cases()
+        if args.methods is None or case.name in args.methods
+    ]
+    rows: list[dict[str, Any]] = []
+
+    for system_name in args.systems:
+        config = registry[system_name]
+        for size in args.segment_counts:
+            for requested_gauss_points in gauss_point_sweep_values(
+                config, args.gauss_points
+            ):
+                system = build_system_with_gauss_points(
+                    config, size, requested_gauss_points
+                )
+                context = config.build_context(system)
+                gauss_points, integration_points = system_gauss_point_metadata(system)
+                print(
+                    f"\n=== {system_name}: {config.size_label}={size}, "
+                    f"gauss_points={gauss_points} ==="
+                )
+
+                for case in selected_cases:
+                    fn, call_args = case.builder(system, context)
+                    compile_time, execution_time = _measure_jitted_call(
+                        fn, call_args, args.execution_repeats
+                    )
+                    print(
+                        f"  {case.name}: compile {compile_time:.4f}s | "
+                        f"exec {execution_time:.6f}s"
+                    )
+                    rows.append(
+                        {
+                            "system": system_name,
+                            "method": case.name,
+                            "size_label": config.size_label,
+                            "size_value": size,
+                            "gauss_points": gauss_points,
+                            "integration_points": integration_points,
+                            "jit_compile_time_s": compile_time,
+                            "jit_execution_time_s": execution_time,
+                            "execution_repeats": args.execution_repeats,
+                        }
+                    )
+
+    if args.json:
+        _write_json(rows, args.json)
+        print(f"Wrote JSON results to {args.json.resolve()}")
+    if args.csv:
+        _write_csv(rows, args.csv)
+        print(f"Wrote CSV results to {args.csv.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/benchmarks/benchmark_system_methods.py
+++ b/tools/benchmarks/benchmark_system_methods.py
@@ -35,6 +35,10 @@ except ImportError as exc:  # pragma: no cover - this is a runtime guard
 
 import matplotlib.pyplot as plt
 
+from soromox.coordinate_transformations import (
+    ActuationSpaceDynamics,
+    OperationalSpaceDynamics,
+)
 from soromox.systems import SystemState
 from tools.benchmarks._benchmark_common import (
     add_gauss_point_args,
@@ -126,6 +130,135 @@ def _dense_forward_dynamics(
     )
     qdd = jnp.linalg.solve(M, rhs)
     return jnp.concatenate([qd, qdd])
+
+
+def _separate_dynamics_terms(system: Any, q: Array, qd: Array) -> tuple[Array, ...]:
+    """Assemble the dynamics tuple through the separate public methods."""
+    return (
+        system.inertia_matrix(q),
+        system.coriolis_matrix(q, qd) @ qd,
+        system.gravitational_force(q),
+    )
+
+
+def _model_based_control(
+    system: Any, q: Array, qd: Array, qdd: Array, *, fused: bool
+) -> Array:
+    """Evaluate the common full inverse-dynamics controller term."""
+    if fused:
+        M, Cqd, G = system.dynamics_terms(q, qd)
+    else:
+        M, Cqd, G = _separate_dynamics_terms(system, q, qd)
+
+    generalized_force = (
+        M @ qdd
+        + Cqd
+        + G
+        + system.elastic_force(q)
+        + system.damping_matrix(q) @ qd
+    )
+    A = system.actuation_matrix(q)
+    if A.shape[0] == A.shape[1]:
+        return jnp.linalg.inv(A) @ generalized_force
+    return jnp.linalg.pinv(A) @ generalized_force
+
+
+def _model_based_control_cases() -> tuple[BenchmarkCase, ...]:
+    """Return separate/fused full inverse-dynamics controller cases."""
+    return (
+        BenchmarkCase(
+            name="model_based_control_separate",
+            description="Full inverse dynamics through separate dynamics methods",
+            builder=lambda sys, ctx, _: (
+                lambda q, qd, qdd: _model_based_control(
+                    sys, q, qd, qdd, fused=False
+                ),
+                (ctx["q"], ctx["qd"], -0.5 * ctx["qd"]),
+            ),
+        ),
+        BenchmarkCase(
+            name="model_based_control",
+            description="Full inverse dynamics through fused dynamics_terms",
+            builder=lambda sys, ctx, _: (
+                lambda q, qd, qdd: _model_based_control(
+                    sys, q, qd, qdd, fused=True
+                ),
+                (ctx["q"], ctx["qd"], -0.5 * ctx["qd"]),
+            ),
+        ),
+    )
+
+
+def _build_actuation_dynamics_terms_case(
+    system: Any, ctx: Mapping[str, Array], *, fused: bool
+) -> tuple[Callable[..., Tree], tuple[Array, Array]]:
+    """Build a transformed actuation-space dynamics benchmark case."""
+    dynamics = ActuationSpaceDynamics(system)
+    if fused:
+        fn = dynamics.dynamics_terms
+    else:
+
+        def fn(q: Array, qd: Array) -> tuple[Array, ...]:
+            return (
+                dynamics.inertia_matrix(q),
+                dynamics.coriolis_force(q, qd),
+                dynamics.gravitational_force(q),
+            )
+
+    return fn, (ctx["q"], ctx["qd"])
+
+
+def _build_operational_dynamics_terms_case(
+    system: Any, ctx: Mapping[str, Array], *, fused: bool
+) -> tuple[Callable[..., Tree], tuple[Array, Array]]:
+    """Build a transformed tip operational-space dynamics benchmark case."""
+    dynamics = OperationalSpaceDynamics(system, jnp.atleast_1d(ctx["s_tip"]))
+    if fused:
+        fn = dynamics.dynamics_terms
+    else:
+
+        def fn(q: Array, qd: Array) -> tuple[Array, ...]:
+            return (
+                dynamics.inertia_matrix(q),
+                dynamics.coriolis_force(q, qd),
+                dynamics.gravitational_force(q),
+            )
+
+    return fn, (ctx["q"], ctx["qd"])
+
+
+def _transformed_dynamics_cases() -> tuple[BenchmarkCase, ...]:
+    """Return separate/fused actuation- and operational-space cases."""
+    return (
+        BenchmarkCase(
+            name="actuation_dynamics_terms_separate",
+            description="Actuation-space terms through separate public methods",
+            builder=lambda sys, ctx, _: _build_actuation_dynamics_terms_case(
+                sys, ctx, fused=False
+            ),
+        ),
+        BenchmarkCase(
+            name="actuation_dynamics_terms",
+            description="Fused actuation-space dynamics terms",
+            builder=lambda sys, ctx, _: _build_actuation_dynamics_terms_case(
+                sys, ctx, fused=True
+            ),
+        ),
+        BenchmarkCase(
+            name="operational_dynamics_terms_separate",
+            description="Operational-space terms through separate public methods",
+            builder=lambda sys, ctx, _: _build_operational_dynamics_terms_case(
+                sys, ctx, fused=False
+            ),
+        ),
+        BenchmarkCase(
+            name="operational_dynamics_terms",
+            description="Fused operational-space dynamics terms",
+            builder=lambda sys, ctx, _: _build_operational_dynamics_terms_case(
+                sys, ctx, fused=True
+            ),
+        ),
+    )
 
 
 def _measure_jitted_call(
@@ -385,6 +518,22 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             ),
         ),
         BenchmarkCase(
+            name="dynamics_terms_separate",
+            description="M, C @ qd, and G through separate public methods",
+            builder=lambda sys, ctx, _: (
+                lambda q, qd: _separate_dynamics_terms(sys, q, qd),
+                (ctx["q"], ctx["qd"]),
+            ),
+        ),
+        BenchmarkCase(
+            name="dynamics_terms",
+            description="Fused M, C @ qd, and G path",
+            builder=lambda sys, ctx, _: (
+                sys.dynamics_terms,
+                (ctx["q"], ctx["qd"]),
+            ),
+        ),
+        BenchmarkCase(
             name="forward_dynamics",
             builder=lambda sys, ctx, _: (
                 lambda t, y, args: sys.forward_dynamics(t, y, args),
@@ -418,7 +567,7 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
                 ),
             ),
         ),
-    )
+    ) + _model_based_control_cases() + _transformed_dynamics_cases()
 
     gvs_cases = (
         BenchmarkCase(
@@ -469,6 +618,22 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             builder=lambda sys, ctx, _: (sys.gravitational_force, (ctx["q"],)),
         ),
         BenchmarkCase(
+            name="dynamics_terms_separate",
+            description="M, C @ qd, and G through separate public methods",
+            builder=lambda sys, ctx, _: (
+                lambda q, qd: _separate_dynamics_terms(sys, q, qd),
+                (ctx["q"], ctx["qd"]),
+            ),
+        ),
+        BenchmarkCase(
+            name="dynamics_terms",
+            description="Fused M, C @ qd, and G path",
+            builder=lambda sys, ctx, _: (
+                sys.dynamics_terms,
+                (ctx["q"], ctx["qd"]),
+            ),
+        ),
+        BenchmarkCase(
             name="forward_dynamics",
             builder=lambda sys, ctx, _: (
                 lambda t, y, args: sys.forward_dynamics(t, y, args),
@@ -502,7 +667,7 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
                 ),
             ),
         ),
-    )
+    ) + _model_based_control_cases() + _transformed_dynamics_cases()
 
     return {
         "pendulum": SystemBenchmark(

--- a/tools/benchmarks/benchmark_system_methods.py
+++ b/tools/benchmarks/benchmark_system_methods.py
@@ -35,10 +35,6 @@ except ImportError as exc:  # pragma: no cover - this is a runtime guard
 
 import matplotlib.pyplot as plt
 
-from soromox.coordinate_transformations import (
-    ActuationSpaceDynamics,
-    OperationalSpaceDynamics,
-)
 from soromox.systems import SystemState
 from tools.benchmarks._benchmark_common import (
     add_gauss_point_args,
@@ -130,135 +126,6 @@ def _dense_forward_dynamics(
     )
     qdd = jnp.linalg.solve(M, rhs)
     return jnp.concatenate([qd, qdd])
-
-
-def _separate_dynamics_terms(system: Any, q: Array, qd: Array) -> tuple[Array, ...]:
-    """Assemble the dynamics tuple through the separate public methods."""
-    return (
-        system.inertia_matrix(q),
-        system.coriolis_matrix(q, qd) @ qd,
-        system.gravitational_force(q),
-    )
-
-
-def _model_based_control(
-    system: Any, q: Array, qd: Array, qdd: Array, *, fused: bool
-) -> Array:
-    """Evaluate the common full inverse-dynamics controller term."""
-    if fused:
-        M, Cqd, G = system.dynamics_terms(q, qd)
-    else:
-        M, Cqd, G = _separate_dynamics_terms(system, q, qd)
-
-    generalized_force = (
-        M @ qdd
-        + Cqd
-        + G
-        + system.elastic_force(q)
-        + system.damping_matrix(q) @ qd
-    )
-    A = system.actuation_matrix(q)
-    if A.shape[0] == A.shape[1]:
-        return jnp.linalg.inv(A) @ generalized_force
-    return jnp.linalg.pinv(A) @ generalized_force
-
-
-def _model_based_control_cases() -> tuple[BenchmarkCase, ...]:
-    """Return separate/fused full inverse-dynamics controller cases."""
-    return (
-        BenchmarkCase(
-            name="model_based_control_separate",
-            description="Full inverse dynamics through separate dynamics methods",
-            builder=lambda sys, ctx, _: (
-                lambda q, qd, qdd: _model_based_control(
-                    sys, q, qd, qdd, fused=False
-                ),
-                (ctx["q"], ctx["qd"], -0.5 * ctx["qd"]),
-            ),
-        ),
-        BenchmarkCase(
-            name="model_based_control",
-            description="Full inverse dynamics through fused dynamics_terms",
-            builder=lambda sys, ctx, _: (
-                lambda q, qd, qdd: _model_based_control(
-                    sys, q, qd, qdd, fused=True
-                ),
-                (ctx["q"], ctx["qd"], -0.5 * ctx["qd"]),
-            ),
-        ),
-    )
-
-
-def _build_actuation_dynamics_terms_case(
-    system: Any, ctx: Mapping[str, Array], *, fused: bool
-) -> tuple[Callable[..., Tree], tuple[Array, Array]]:
-    """Build a transformed actuation-space dynamics benchmark case."""
-    dynamics = ActuationSpaceDynamics(system)
-    if fused:
-        fn = dynamics.dynamics_terms
-    else:
-
-        def fn(q: Array, qd: Array) -> tuple[Array, ...]:
-            return (
-                dynamics.inertia_matrix(q),
-                dynamics.coriolis_force(q, qd),
-                dynamics.gravitational_force(q),
-            )
-
-    return fn, (ctx["q"], ctx["qd"])
-
-
-def _build_operational_dynamics_terms_case(
-    system: Any, ctx: Mapping[str, Array], *, fused: bool
-) -> tuple[Callable[..., Tree], tuple[Array, Array]]:
-    """Build a transformed tip operational-space dynamics benchmark case."""
-    dynamics = OperationalSpaceDynamics(system, jnp.atleast_1d(ctx["s_tip"]))
-    if fused:
-        fn = dynamics.dynamics_terms
-    else:
-
-        def fn(q: Array, qd: Array) -> tuple[Array, ...]:
-            return (
-                dynamics.inertia_matrix(q),
-                dynamics.coriolis_force(q, qd),
-                dynamics.gravitational_force(q),
-            )
-
-    return fn, (ctx["q"], ctx["qd"])
-
-
-def _transformed_dynamics_cases() -> tuple[BenchmarkCase, ...]:
-    """Return separate/fused actuation- and operational-space cases."""
-    return (
-        BenchmarkCase(
-            name="actuation_dynamics_terms_separate",
-            description="Actuation-space terms through separate public methods",
-            builder=lambda sys, ctx, _: _build_actuation_dynamics_terms_case(
-                sys, ctx, fused=False
-            ),
-        ),
-        BenchmarkCase(
-            name="actuation_dynamics_terms",
-            description="Fused actuation-space dynamics terms",
-            builder=lambda sys, ctx, _: _build_actuation_dynamics_terms_case(
-                sys, ctx, fused=True
-            ),
-        ),
-        BenchmarkCase(
-            name="operational_dynamics_terms_separate",
-            description="Operational-space terms through separate public methods",
-            builder=lambda sys, ctx, _: _build_operational_dynamics_terms_case(
-                sys, ctx, fused=False
-            ),
-        ),
-        BenchmarkCase(
-            name="operational_dynamics_terms",
-            description="Fused operational-space dynamics terms",
-            builder=lambda sys, ctx, _: _build_operational_dynamics_terms_case(
-                sys, ctx, fused=True
-            ),
-        ),
-    )
 
 
 def _measure_jitted_call(
@@ -518,14 +385,6 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             ),
         ),
         BenchmarkCase(
-            name="dynamics_terms_separate",
-            description="M, C @ qd, and G through separate public methods",
-            builder=lambda sys, ctx, _: (
-                lambda q, qd: _separate_dynamics_terms(sys, q, qd),
-                (ctx["q"], ctx["qd"]),
-            ),
-        ),
-        BenchmarkCase(
             name="dynamics_terms",
             description="Fused M, C @ qd, and G path",
             builder=lambda sys, ctx, _: (
@@ -567,7 +426,7 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
                 ),
             ),
         ),
-    ) + _model_based_control_cases() + _transformed_dynamics_cases()
+    )
 
     gvs_cases = (
         BenchmarkCase(
@@ -618,14 +477,6 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             builder=lambda sys, ctx, _: (sys.gravitational_force, (ctx["q"],)),
         ),
         BenchmarkCase(
-            name="dynamics_terms_separate",
-            description="M, C @ qd, and G through separate public methods",
-            builder=lambda sys, ctx, _: (
-                lambda q, qd: _separate_dynamics_terms(sys, q, qd),
-                (ctx["q"], ctx["qd"]),
-            ),
-        ),
-        BenchmarkCase(
             name="dynamics_terms",
             description="Fused M, C @ qd, and G path",
             builder=lambda sys, ctx, _: (
@@ -667,7 +518,7 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
                 ),
             ),
         ),
-    ) + _model_based_control_cases() + _transformed_dynamics_cases()
+    )
 
     return {
         "pendulum": SystemBenchmark(


### PR DESCRIPTION
## Motivation

The affected model-based control paths previously requested the inertia matrix,
Coriolis matrix/force, and gravity independently. For PCS and GVS, each public
call traces overlapping kinematics, quadrature, and dynamics work. This had
three concrete drawbacks:

- the same system state was traversed repeatedly to assemble related equation-of-motion terms;
- controllers materialized the full Coriolis matrix even though inverse dynamics only needs the contracted `C(q, qd) @ qd` force; and
- actuation- and operational-space transformations repeated Jacobian construction, inverse/factorization work, and underlying system dynamics calls for each transformed term.

These costs are especially visible for multi-segment continuum systems, where
the duplicated work grows with the number of segments and integration points.

## Implementation

### Controller migration

- Route configuration-space `ComputedTorqueTracker` through
  `robot.dynamics_terms(q, qd)` at the current state.
- Route configuration-space `FeedforwardCompensationTracker` through
  `robot.dynamics_terms(q_des, qd_des)` at the desired state.
- Route actuation-space `FeedforwardCompensationTracker` through
  `ActuationSpaceDynamics.dynamics_terms(q_des, qd_des)`.
- Consume the returned contracted Coriolis force directly in each inverse-dynamics expression.

The PID-only, potential-shaping, mixed-state, synergistic, and impedance paths
are intentionally unchanged because they do not request the same complete
`(M, Cqd, G)` tuple.

### Fused coordinate transformations

- `ActuationSpaceDynamics.dynamics_terms` now computes one Jacobian inverse and
  one underlying robot `dynamics_terms` tuple, then transforms all three terms
  with the shared `J^-T`/`J^-1` factors.
- `OperationalSpaceDynamics.dynamics_terms` now computes `J` and `Jd` once,
  obtains one underlying robot dynamics tuple, and solves a single concatenated
  right-hand side for both `M^-1 J^T` and `M^-1 Cqd`. The resulting quantities
  are reused for the operational inertia, Coriolis force, dynamically
  consistent inverse, and gravity transformation.

The algebra and public return values remain unchanged: `dynamics_terms`
continues to return `(M, Cqd, G)` in the selected coordinate space.

### Benchmarking support

- Add `benchmark_model_based_control.py` for the current/default computed-torque,
  configuration-feedforward, actuation-feedforward, and operational-dynamics
  paths on PCS and GVS.
- Keep the persistent benchmark free of a legacy-versus-current switch. Before
  and after revisions are compared by running the same benchmark in clean
  worktrees.
- Keep `benchmark_system_methods.py` limited to actual system methods, including
  the public PCS/GVS `dynamics_terms` method.
- Document the workflow and add benchmark registry/CLI tests.

## Correctness

Regression tests verify that:

- each migrated controller calls `dynamics_terms` exactly once;
- controller output still matches the previous inverse-dynamics expression;
- fused actuation-space terms match the corresponding individual methods; and
- fused operational-space terms match the corresponding individual methods for PCS.

The FP64 equivalence check across the benchmarked configurations found a worst
absolute discrepancy of `6.05e-14` and a worst relative-norm discrepancy of
`3.02e-11` (the four-segment PCS operational-space case).

## Performance

Measurements used JAX 0.11.0 on the CPU backend on arm64 macOS, with FP64
enabled, five Gauss points per segment, and 50 warm executions per measurement.
The table reports the median of five fresh processes for one- and four-segment
PCS/GVS systems. “Before” evaluates the relevant terms through separate public
methods; “after” uses the fused `dynamics_terms` path. Times are steady-state
latencies in microseconds.

| Affected path | System | Segments | Before (us) | After (us) | Runtime reduction |
| --- | --- | ---: | ---: | ---: | ---: |
| Configuration dynamics tuple | PCS | 1 | 70.57 | 50.36 | 28.6% |
| Configuration dynamics tuple | PCS | 4 | 254.05 | 117.17 | 53.9% |
| Configuration dynamics tuple | GVS | 1 | 134.63 | 94.08 | 30.1% |
| Configuration dynamics tuple | GVS | 4 | 542.04 | 281.53 | 48.1% |
| Computed-torque / configuration feedforward inverse dynamics | PCS | 1 | 72.86 | 50.48 | 30.7% |
| Computed-torque / configuration feedforward inverse dynamics | PCS | 4 | 254.71 | 123.00 | 51.7% |
| Computed-torque / configuration feedforward inverse dynamics | GVS | 1 | 137.57 | 98.99 | 28.0% |
| Computed-torque / configuration feedforward inverse dynamics | GVS | 4 | 522.76 | 272.63 | 47.8% |
| Actuation feedforward dynamics tuple | PCS | 1 | 79.87 | 56.63 | 29.1% |
| Actuation feedforward dynamics tuple | PCS | 4 | 279.82 | 123.45 | 55.9% |
| Actuation feedforward dynamics tuple | GVS | 1 | 149.37 | 99.93 | 33.1% |
| Actuation feedforward dynamics tuple | GVS | 4 | 538.52 | 310.87 | 42.3% |
| Operational-space dynamics tuple | PCS | 1 | 96.14 | 72.28 | 24.8% |
| Operational-space dynamics tuple | PCS | 4 | 305.51 | 175.18 | 42.7% |
| Operational-space dynamics tuple | GVS | 1 | 254.03 | 207.43 | 18.3% |
| Operational-space dynamics tuple | GVS | 4 | 971.88 | 672.37 | 30.8% |

Geometric-mean runtime reductions are 41.2% for the configuration dynamics
tuple, 40.5% for the full configuration-space inverse-dynamics controller term,
41.0% for the actuation-space path, and 29.8% for the operational-space path.
Across all 16 PCS/GVS configurations, the geometric-mean reduction is 38.3%
(1.62x speedup), with a maximum reduction of 55.9%.

## Validation

- `uv run ruff check src/soromox/control src/soromox/coordinate_transformations tools/benchmarks tests/control tests/coordinate_transformations tests/tools`
- `uv run pytest -q tests/control tests/coordinate_transformations tests/tools/test_benchmark_common.py tests/tools/test_benchmark_model_based_control.py` (`349 passed`)
- `uv run --extra docs zensical build --clean`
- Controller benchmark CLI smoke test on PCS using the renamed public case selector

