### PR TITLE
Codex/jittable parameter updates

### DIFF
--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -843,7 +843,6 @@ class GVS(SoftRobot):
         Raises:
             ValueError: If link params do not contain one entry per segment.
         """
-        link.validate_for_update()
         if link.length.shape != (self.num_segments,):
             raise ValueError(
                 "link params must contain one entry per segment, "

--- a/src/soromox/systems/params.py
+++ b/src/soromox/systems/params.py
@@ -8,12 +8,14 @@ __all__ = [
     "validate_quaternion_base_pose",
 ]
 
+from contextlib import suppress
 from dataclasses import fields
 from typing import Any, ClassVar, Literal, final
 
 import equinox as eqx
 from jax import Array, core, tree_util
 from jax import numpy as jnp
+from jax.errors import ConcretizationTypeError, TracerBoolConversionError
 
 DEFAULT_GRAVITY_MAGNITUDE = 9.81
 
@@ -160,11 +162,17 @@ class BaseSystemParams(eqx.Module):
 
     @final
     def validate_for_update(self) -> None:
-        """Validate fully in eager code and structurally under JAX transforms."""
+        """Validate eagerly when concrete and structurally under JAX transforms.
+
+        A nested parameter object can have concrete leaves while an enclosing
+        parameter update is being traced. In that case, value validation reveals
+        the enclosing trace only when it attempts a Python conversion.
+        """
+        self.validate_structure()
         if _contains_tracer(self):
-            self.validate_structure()
-        else:
-            self.validate()
+            return
+        with suppress(ConcretizationTypeError, TracerBoolConversionError):
+            self.validate_values()
 
     def validate_structure_compatibility(self, structure: Any) -> None:
         """Validate statically observable compatibility with a model structure."""

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -18,6 +18,7 @@ from soromox.actuation.core import (
 from soromox.autodiff import custom_jvp_enabled
 from soromox.systems.dynamical_system import DynamicalSystem
 from soromox.systems.params import (
+    _contains_tracer,
     validate_planar_base_pose,
     validate_quaternion_base_pose,
 )
@@ -200,7 +201,8 @@ class SoftRobot(DynamicalSystem):
             raise IndexError(f"actuator index {index} is out of range.")
         actuators = list(self.actuators)
         actuators[index] = actuators[index].with_params(params)
-        actuators[index].validate_for_robot(self)
+        if not _contains_tracer(actuators[index].params):
+            actuators[index].validate_for_robot(self)
         return eqx.tree_at(lambda robot: robot.actuators, self, tuple(actuators))
 
     def update_actuator_params(self, index: int, **updates: Any) -> Self:
@@ -217,7 +219,8 @@ class SoftRobot(DynamicalSystem):
             raise IndexError(f"passive element index {index} is out of range.")
         elements = list(self.passive_elements)
         elements[index] = elements[index].with_params(params)
-        elements[index].validate_for_robot(self)
+        if not _contains_tracer(elements[index].params):
+            elements[index].validate_for_robot(self)
         return eqx.tree_at(lambda robot: robot.passive_elements, self, tuple(elements))
 
     def update_passive_element_params(self, index: int, **updates: Any) -> Self:

--- a/tests/actuation/test_joint.py
+++ b/tests/actuation/test_joint.py
@@ -125,6 +125,29 @@ def test_articulated_actuator_and_passive_parameter_updates_compile_once():
     assert_allclose(actual, _component_summary(eager, q))
 
 
+def test_articulated_tendon_compiled_partial_component_updates():
+    actuator = _actuator()
+    passive = _passive()
+    robot = Pendulum(_body_params(), actuators=actuator, passive_elements=(passive,))
+    upper_bounds = actuator.params.upper_bounds + 1.0
+    stiffness = 1.1 * passive.params.stiffness
+
+    @eqx.filter_jit
+    def compiled_updates(current_upper_bounds, current_stiffness):
+        updated = robot.update_actuator_params(0, upper_bounds=current_upper_bounds)
+        updated = updated.update_passive_element_params(0, stiffness=current_stiffness)
+        return jnp.concatenate(
+            [
+                updated.actuators[0].params.upper_bounds,
+                updated.passive_elements[0].params.stiffness,
+            ]
+        )
+
+    actual = compiled_updates(upper_bounds, stiffness)
+
+    assert_allclose(actual, jnp.concatenate([upper_bounds, stiffness]))
+
+
 def _spatial_articulated_robot(*, actuators=None):
     params = articulated_params(
         joint_screw=jnp.array([[0.0, 0.0, 1.0, 0.0, 0.0, 0.0]]),

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -190,6 +190,28 @@ def test_threadlike_actuator_and_passive_parameter_updates_compile_once():
     assert_allclose(actual, _threadlike_component_summary(eager, q))
 
 
+def test_threadlike_compiled_partial_component_updates():
+    actuator, passive = _threadlike_components()
+    robot = _spatial_pcs(actuators=actuator, passive_elements=(passive,))
+    lower_bounds = actuator.params.lower_bounds - 1.0
+    stiffness = 1.1 * passive.params.stiffness
+
+    @eqx.filter_jit
+    def compiled_updates(current_lower_bounds, current_stiffness):
+        updated = robot.update_actuator_params(0, lower_bounds=current_lower_bounds)
+        updated = updated.update_passive_element_params(0, stiffness=current_stiffness)
+        return jnp.concatenate(
+            [
+                updated.actuators[0].params.lower_bounds,
+                updated.passive_elements[0].params.stiffness,
+            ]
+        )
+
+    actual = compiled_updates(lower_bounds, stiffness)
+
+    assert_allclose(actual, jnp.concatenate([lower_bounds, stiffness]))
+
+
 class SinusoidalRoutingParams(BaseThreadlikeRoutingParams):
     amplitude: jax.Array
     frequency: jax.Array

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -182,6 +182,20 @@ def test_gvs_same_structure_parameter_updates_compile_once():
     assert_allclose(actual, _gvs_runtime_summary(robot.with_params(updated_params)))
 
 
+def test_gvs_compiled_base_pose_update():
+    robot, _ = build_matched_gvs_pcs()
+    q = jnp.zeros((robot.num_dofs,), dtype=jnp.float64)
+
+    @eqx.filter_jit
+    def compiled_force(base_pose, configuration):
+        return robot.update_params(base_pose=base_pose).potential_force(configuration)
+
+    force = compiled_force(robot.params.base_pose, q)
+
+    assert force.shape == (robot.num_dofs,)
+    assert jnp.all(jnp.isfinite(force))
+
+
 def test_gvs_parameter_gradient_passes_through_compiled_update():
     robot, _ = build_matched_gvs_pcs()
     params = robot.params

--- a/tests/systems/test_mckibben_umarm.py
+++ b/tests/systems/test_mckibben_umarm.py
@@ -421,6 +421,18 @@ def test_umarm_body_and_actuator_parameter_updates_compile_once():
     assert_allclose(actual, _umarm_parameter_summary(eager))
 
 
+def test_umarm_compiled_partial_actuator_update():
+    robot = make_robot()
+    lower_bounds = robot.actuators[0].params.lower_bounds + 1.0
+
+    @eqx.filter_jit
+    def compiled_update(current_lower_bounds):
+        updated = robot.update_actuator_params(0, lower_bounds=current_lower_bounds)
+        return updated.actuators[0].params.lower_bounds
+
+    assert_allclose(compiled_update(lower_bounds), lower_bounds)
+
+
 def test_umarm_parameter_gradient_passes_through_compiled_updates():
     robot = make_robot()
     q = jnp.linspace(-0.1, 0.1, robot.num_dofs)


### PR DESCRIPTION
## Summary

Adds focused regressions for JIT-compiled partial parameter updates and proposes fixes for the discovered failures.

## Problem

Existing compiled-update tests pass a complete parameter PyTree dynamically. They do not cover a closed-over model where only one top-level field is traced, such as `update_params(base_pose=...)`. Unchanged nested parameter arrays can then trigger tracer conversion failures during validation.

## Coverage

- GVS base-pose update followed by `potential_force`
- Threadlike actuator and passive component updates
- McKibben actuator bounds update
- Articulated tendon actuator and passive component updates

This PR contains regression tests and proposed fixes, as anticipated in https://github.com/tud-phi/soromox/pull/156#issuecomment-5393249187.

At minimum, the regression tests should be retained. The accompanying fixes are a proposal and may be taken as-is, revised, or replaced by an implementation that better fits SoRoMoX.

## Bonus content

<details>
<summary>Standalone python script that creates a passive GVS system and evaluates its generalised forces as function of both base pose and Lagrangian coordinates.</summary>

```python
import jax
import jax.numpy as jnp
import equinox as eqx

from soromox.systems.components.joints import JointSpec
from soromox.systems.components.links import LinkSpec
from soromox.systems.gvs.core import GVS
from soromox.systems.gvs.specs import GVSSegment, StrainBasisSpec

link = LinkSpec.circular(
    length=1.0,
    radius=0.05,
    density=1000.0,
    reference_strain=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
    young_modulus=1e8,
    poisson_ratio=0.3,
    # stiffness=10.0*jnp.eye(6),
)
joint = JointSpec.fixed()
strain_basis = StrainBasisSpec(
    type="monomial",
    strain_selector=[True, True, True, False, False, False],
    basis_order=(1, 1, 2, 0, 0, 0),
)
segment = GVSSegment(
    link=link,
    joint=joint,
    basis=strain_basis,
    num_gauss_points=5,
)

system = GVS.from_segments((segment, ),
                           actuators=(),
                           gravity=jnp.array([0.0, -9.81, 0.0]))

@jax.jit
def evaluate(base, q):
    return system.update_params(base_pose=base).potential_force(q)

qs = jnp.zeros((system.num_dofs), )
base1 = jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
base2 = jnp.array([0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0])
assert base1.shape == (7, )
assert base2.shape == (7, )

print(evaluate(base1, qs))
print(evaluate(base2, qs))

```
</details>