### PR TITLE
Optimize contracted SE(3) adjoint actions in PCS and GVS

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -25,11 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Accelerated PlanarPCS, PCS, and GVS forward dynamics. Warm runtime improved
-  in every measured CPU/GPU case: 1.17–2.31x for PlanarPCS, 1.20–7.99x for
-  PCS, and 1.49–2.21x for GVS; representative largest GPU workloads reduced
-  temporary memory from 459 MB to 87 MB, 1.73 GB to 270 MB, and 293 MiB to
-  48 MiB, respectively.
+- Accelerated PlanarPCS, PCS, and GVS forward dynamics through fused dynamics
+  assembly, causal Jacobian propagation, and matrix-free Lie-algebra actions.
+  Compared with v0.2.3 across one-environment CPU and 256-environment GPU
+  benchmarks with 1, 4, 8, and 16 segments, warm runtime improved in every
+  measured case: 1.06–2.21x for PlanarPCS, 1.32–8.28x for PCS, and 1.30–5.36x
+  for GVS. At 16 segments on GPU, temporary memory decreased from 459 MB to
+  95 MB, 1.73 GB to 270 MB, and 3.02 GB to 128 MB, respectively.
 - Routed exact inverse-dynamics controllers through the contracted
   `dynamics_terms` interface and fused actuation- and operational-space term
   transformations to avoid repeated inertia, Coriolis, gravity, Jacobian, and

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -4546,16 +4546,15 @@ class GVS(SoftRobot):
                 link_velocity = local_tangent_basis @ qd_blocks[segment_index, 1]
                 step_velocity = adjoint_inverse @ link_velocity
                 velocity_next = adjoint_inverse @ (velocity_previous + link_velocity)
-                adjoint_inverse_dot = (
-                    -se3.small_adjoint(step_velocity) @ adjoint_inverse
-                )
                 jacobian_next = adjoint_inverse @ (jacobian_previous + tangent_basis)
                 tangent_velocity_dot = (
                     tangent_dot @ magnus_basis + tangent @ magnus_basis_dot
                 ) @ qd_blocks[segment_index, 1]
                 jacobian_dot_qd_next = adjoint_inverse @ (
                     jacobian_dot_qd_previous + tangent_velocity_dot
-                ) + adjoint_inverse_dot @ (jacobian_previous @ qd)
+                ) - se3.small_adjoint_action(
+                    step_velocity, adjoint_inverse @ (jacobian_previous @ qd)
+                )
                 gravity_next = adjoint_inverse @ gravity_previous
                 return (
                     jacobian_next,

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -2939,17 +2939,17 @@ class PCS(SoftRobot):
             J_next = Ad_inv_i @ J_prev + J_segment
 
             eta = Ad_inv_T_i @ xid_i
-            Ad_inv_dot = -se3.small_adjoint(eta) @ Ad_inv_i
 
             if convective_only_jd:
                 Jd_qd_next = (
                     Ad_inv_i @ Jd_or_Jd_qd_prev
-                    + Ad_inv_dot @ (J_prev @ qd)
+                    - se3.small_adjoint_action(eta, Ad_inv_i @ (J_prev @ qd))
                     + Ad_inv_i @ (Td_i @ xid_i)
                 )
                 Jd_or_Jd_qd_next = Jd_qd_next
             else:
                 assert T_tips is not None
+                Ad_inv_dot = -se3.small_adjoint(eta) @ Ad_inv_i
                 T_i = lax.dynamic_index_in_dim(T_tips, i, axis=0, keepdims=False)
                 Jd_segment = (Ad_inv_dot @ T_i + Ad_inv_i @ Td_i) @ B_xi_i
                 Jd_next = Ad_inv_i @ Jd_or_Jd_qd_prev + Ad_inv_dot @ J_prev + Jd_segment
@@ -3213,10 +3213,9 @@ class PCS(SoftRobot):
                 J_next = Ad_inv @ J_base_i + J_segment
 
                 eta = Ad_inv_T @ xid_i
-                Ad_inv_dot = -se3.small_adjoint(eta) @ Ad_inv
                 Jd_qd_next = (
                     Ad_inv @ Jd_qd_base_i
-                    + Ad_inv_dot @ (J_base_i @ qd)
+                    - se3.small_adjoint_action(eta, Ad_inv @ (J_base_i @ qd))
                     + Ad_inv @ (Td @ xid_i)
                 )
                 gravity_local = Ad_inv @ gravity_base_i

--- a/src/soromox/utils/lie_algebra/se3.py
+++ b/src/soromox/utils/lie_algebra/se3.py
@@ -3,6 +3,7 @@ __all__ = [
     "exp",
     "log",
     "small_adjoint",
+    "small_adjoint_action",
     "coadjoint",
     "adjoint",
     "adjoint_inverse",
@@ -405,6 +406,31 @@ def small_adjoint(xi: Array) -> Array:
 
     return jnp.block(
         [[omega_hat, jnp.zeros((3, 3), dtype=xi.dtype)], [v_hat, omega_hat]]
+    )
+
+
+def small_adjoint_action(xi: Array, eta: Array) -> Array:
+    """Apply the Lie algebra adjoint without materializing its matrix.
+
+    Args:
+        xi: Spatial twist with shape ``(6,)`` or ``(6, 1)`` in
+            ``[omega, v]`` order.
+        eta: Spatial twist with shape ``(6,)`` or ``(6, 1)`` in
+            ``[omega, v]`` order.
+
+    Returns:
+        The six-vector ``small_adjoint(xi) @ eta``, equivalently the Lie
+        bracket ``[xi, eta]``.
+    """
+    xi = jnp.asarray(xi).reshape(-1)
+    eta = jnp.asarray(eta).reshape(-1)
+    omega, velocity = xi[:3], xi[3:]
+    eta_omega, eta_velocity = eta[:3], eta[3:]
+    return jnp.concatenate(
+        [
+            jnp.cross(omega, eta_omega),
+            jnp.cross(velocity, eta_omega) + jnp.cross(omega, eta_velocity),
+        ]
     )
 
 

--- a/tests/lie_algebra/test_se3.py
+++ b/tests/lie_algebra/test_se3.py
@@ -537,6 +537,15 @@ def test_coadjoint_action_se3_matches_matrix_product():
     assert_allclose(result, se3.coadjoint(xi) @ dual, rtol=RTOL, atol=ATOL)
 
 
+def test_small_adjoint_action_se3_matches_matrix_product():
+    xi = jnp.array([0.2, -0.4, 0.7, 1.1, -0.3, 0.5])
+    eta = jnp.array([-0.6, 0.8, 0.1, -0.2, 0.9, 0.4])
+
+    result = se3.small_adjoint_action(xi, eta)
+
+    assert_allclose(result, se3.small_adjoint(xi) @ eta, rtol=RTOL, atol=ATOL)
+
+
 def test_adjoint_g_se3_matches_planar_embedding():
     vec2 = jnp.array([jnp.pi / 6.0, 0.4, -0.7])
     g2 = _transform_from_planar_pose(vec2)


### PR DESCRIPTION
## Motivation

PR #163 made the continuum forward-dynamics paths substantially faster by
assembling only the contracted quantities required by the equations of motion.
One remaining hot recurrence still formed a complete 6x6 Lie-algebra adjoint
matrix and multiplied it by a six-vector, even though the result is simply the
SE(3) Lie bracket.

This follow-up investigates whether evaluating Lie-group actions directly can
remove that matrix materialization while preserving the goals of #163:

- improve single-environment CPU and multi-environment GPU forward dynamics;
- retain one implementation without platform or segment-count heuristics;
- avoid material compile-time scaling regressions; and
- keep the full public Jacobian-derivative path unchanged.

## Implementation

### Matrix-free SE(3) Lie bracket

- Add `se3.small_adjoint_action(xi, eta)`, which evaluates
  `se3.small_adjoint(xi) @ eta` through two three-dimensional cross-product
  blocks without materializing the 6x6 matrix.
- Cover the helper with a direct equivalence test against the existing matrix
  representation.

### PCS

- Use the direct action in the contracted `Jdot @ qd` tip and quadrature
  recurrences used by dynamics assembly.
- Continue constructing the complete adjoint derivative when callers request
  the full Jacobian time derivative.

### GVS

- Use the direct action for the repeated link-cell `Jdot @ qd` recurrence.
- Leave the outer/inner scan structure, padding strategy, and joint recurrence
  from #163 unchanged.

No CPU/GPU dispatch or model-size heuristic is introduced.

## Considered alternatives

- **PlanarPCS small-adjoint action:** standalone dynamics assembly improved,
  but eight-segment GPU forward dynamics repeatedly regressed by approximately
  18-22%. The SE(2) variant was therefore removed.
- **Direct rigid-transform adjoint actions:** articulated-soft-robot CPU
  Jacobian operations improved by up to 23%, but 16-link GPU cases regressed by
  up to 32%.
- **Direct inverse-adjoint action:** the compiler produced effectively the same
  executable and no repeatable runtime benefit.
- **Direct left-Jacobian action:** produced isolated dynamics improvements, but
  caused a roughly 9% 16-segment CPU forward-dynamics regression and a large
  small-model GPU compilation increase.
- **Matrix-right-hand-side small-adjoint action:** improved the largest GVS GPU
  case by about 10%, but regressed 16-segment CPU forward dynamics by about 30%.

Only the portable SE(3) vector contraction is retained.

## Correctness

The helper implements the exact identity
`small_adjoint(xi) @ eta == [xi, eta]`. Benchmark outputs match the #163
baseline, and the public equations-of-motion API is unchanged.

The targeted SE(3), PCS, and GVS suites pass (`65 passed`), including:

- public forward dynamics versus manual equation-of-motion assembly;
- contracted dynamics terms versus the public inertia, Coriolis, and gravity
  methods; and
- PCS models with a leading inactive segment.

## Performance against PR #163

All baseline columns measure merged PR #163 at commit `40f3efc`; all new
columns measure this PR. Measurements use JAX FP64 with inputs resident on the
selected device. CPU runtime uses one environment pinned to a performance core
of an Intel Core Ultra 9 285K. GPU runtime uses 256 environments on an RTX
5090. Runtime is the median warm forward-dynamics latency. Compile measurements
disable JAX's persistent compilation cache.

Negative compile deltas are faster. Positive runtime improvements are faster.

### CPU, one environment

| System | Segments | #163 compile (s) | New compile (s) | Compile delta | #163 runtime (ms) | New runtime (ms) | Runtime improvement |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| PCS | 1 | 0.340 | 0.335 | -1.6% | 0.026323 | 0.026033 | +1.1% |
| PCS | 4 | 0.410 | 0.436 | +6.3% | 0.052909 | 0.049024 | +7.9% |
| PCS | 8 | 0.526 | 0.555 | +5.6% | 0.103030 | 0.096940 | +6.3% |
| PCS | 16 | 0.726 | 0.702 | -3.3% | 0.310409 | 0.295743 | +5.0% |
| GVS | 1 | 0.501 | 0.439 | -12.5% | 0.039703 | 0.038614 | +2.8% |
| GVS | 4 | 0.505 | 0.513 | +1.6% | 0.107075 | 0.102247 | +4.7% |
| GVS | 8 | 0.517 | 0.545 | +5.5% | 0.221221 | 0.210230 | +5.2% |
| GVS | 16 | 0.541 | 0.539 | -0.3% | 0.592002 | 0.569166 | +4.0% |

### GPU, 256 environments

| System | Segments | #163 compile (s) | New compile (s) | Compile delta | #163 runtime (ms) | New runtime (ms) | Runtime improvement |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| PCS | 1 | 0.665 | 0.631 | -5.1% | 0.193202 | 0.185005 | +4.4% |
| PCS | 4 | 1.513 | 1.446 | -4.4% | 0.742518 | 0.754564 | -1.6% |
| PCS | 8 | 2.422 | 2.393 | -1.2% | 1.550442 | 1.445380 | +7.3% |
| PCS | 16 | 4.730 | 5.036 | +6.5% | 3.874219 | 3.482673 | +11.2% |
| GVS | 1 | 1.420 | 1.409 | -0.8% | 0.722873 | 0.711818 | +1.6% |
| GVS | 4 | 1.546 | 1.522 | -1.6% | 2.199785 | 2.046533 | +7.5% |
| GVS | 8 | 2.141 | 2.067 | -3.4% | 4.173626 | 4.003934 | +4.2% |
| GVS | 16 | 3.298 | 3.302 | +0.1% | 9.872625 | 9.101456 | +8.5% |

Warm runtime improves in 15 of 16 measured cases. The only regression is 1.6%
for four-segment PCS on GPU, within the 5% portability tolerance. Compile-time
scaling remains effectively unchanged; individual compile measurements range
from 12.5% faster to 6.5% slower.

## Changelog comparison with the last release

The existing #163 changelog item is updated rather than adding a second entry.
A fresh comparison of public `forward_dynamics` against v0.2.3 across one-,
four-, eight-, and sixteen-segment models reports cumulative warm-runtime
speedups of:

- 1.06-2.21x for PlanarPCS;
- 1.32-8.28x for PCS; and
- 1.30-5.36x for GVS.

At 16 segments and 256 GPU environments, temporary memory decreases from
459 MB to 95 MB for PlanarPCS, 1.73 GB to 270 MB for PCS, and 3.02 GB to
128 MB for GVS.

## Validation

- `ruff check` and `ruff format --check` pass for all changed Python files.
- Targeted SE(3), PCS, and GVS tests: `65 passed`.
- Changelog extraction test: `1 passed`.
