### PR TITLE
Release SoRoMoX 0.3.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,11 +23,11 @@ authors:
   - family-names: "Della Santina"
     given-names: "Cosimo"
 repository-code: "https://github.com/tud-phi/soromox"
-repository-artifact: "https://pypi.org/project/soromox/0.2.3/"
+repository-artifact: "https://pypi.org/project/soromox/0.3.0/"
 url: "https://tud-phi.github.io/soromox"
 license: MIT
-version: "0.2.3"
-date-released: "2026-08-19"
+version: "0.3.0"
+date-released: "2026-08-25"
 keywords:
   - "JAX"
   - "Soft Robotics"

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -35,12 +35,12 @@ If reproducibility depends materially on a particular release, we encourage an
 additional software citation for that release:
 
 ```bibtex
-@software{soromox_v0_2_3,
+@software{soromox_v0_3_0,
   title = {{SoRoMoX}: Soft Robot Models in {JAX}},
   author = {Maximilian St{\"o}lzle and Solange Gribonval and Daniel {Feliu-Talegon} and Vito Daniele Perfetta and Michele Martini and Chuhan Zhang and Kiwan Wong and Daniela Rus and Cosimo {Della Santina}},
   year = {2026},
-  version = {0.2.3},
-  url = {https://github.com/tud-phi/soromox/releases/tag/v0.2.3},
+  version = {0.3.0},
+  url = {https://github.com/tud-phi/soromox/releases/tag/v0.3.0},
 }
 ```
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.3.0] - 2026-08-25
+
+### Added
+
 - Shared continuum-component APIs under `soromox.systems.components` for link,
   joint, cross-section, and isotropic-material parameters and specifications.
 - Common `from_links`, `params_from_links`, `update_link_params`,
@@ -49,6 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   continues after the viewer exits.
 - Made bound-aware finite-difference Jacobians compatible with JAX immutable
   arrays and documented the `numerical_jacobian` utility.
+
+### Contributors
+
+- Thanks to [@matteodv99tn](https://github.com/matteodv99tn) for his
+  contributions to [PR #156](https://github.com/tud-phi/soromox/pull/156).
 
 ## [0.2.3] - 2026-08-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ name = "soromox"  # Required
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "0.2.3"  # Required
+version = "0.3.0"  # Required
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:

--- a/tests/test_citation_metadata.py
+++ b/tests/test_citation_metadata.py
@@ -52,12 +52,14 @@ def test_software_release_and_project_urls_are_version_specific():
     cff = (ROOT / "CITATION.cff").read_text()
     citation_docs = (ROOT / "docs" / "citation.md").read_text()
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+    version = project["version"]
+    citation_key = f"soromox_v{version.replace('.', '_')}"
 
-    assert 'repository-artifact: "https://pypi.org/project/soromox/0.2.3/"' in cff
-    software_bibtex = _extract_bibtex(citation_docs, "software", "soromox_v0_2_3")
-    assert "version = {0.2.3}," in software_bibtex
+    assert f'repository-artifact: "https://pypi.org/project/soromox/{version}/"' in cff
+    software_bibtex = _extract_bibtex(citation_docs, "software", citation_key)
+    assert f"version = {{{version}}}," in software_bibtex
     assert (
-        "url = {https://github.com/tud-phi/soromox/releases/tag/v0.2.3},"
+        f"url = {{https://github.com/tud-phi/soromox/releases/tag/v{version}}},"
         in software_bibtex
     )
     assert project["urls"]["Paper"] == f"https://doi.org/{ARXIV_DOI}"

--- a/uv.lock
+++ b/uv.lock
@@ -4003,7 +4003,7 @@ wheels = [
 
 [[package]]
 name = "soromox"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "diffrax" },


### PR DESCRIPTION
## Summary

- Prepare the SoRoMoX 0.3.0 release from `origin/main`.
- Promote the accumulated unreleased API, performance, documentation, and fix notes into the 0.3.0 changelog entry.
- Thank [@matteodv99tn](https://github.com/matteodv99tn) for his contributions to [PR #156](https://github.com/tud-phi/soromox/pull/156).
- Make the citation metadata regression test follow the package version instead of hard-coding the previous release.

## Validation

- `uv run --extra test pytest tests/test_citation_metadata.py tests/test_bump_version.py tests/test_extract_changelog.py` — 11 passed.
- `uv run --extra docs zensical build --clean` — passed.
- `uv run --extra dev check-manifest` — passed.
- `uv run --extra dev ruff check` — passed.
- `uv lock --check` — passed.
- `uv run --extra dev python -m build .` — built the 0.3.0 sdist and wheel.
- `uv run --extra dev python -m twine check dist/*` — passed.
- Full local test suite: 1,686 passed, with the Section Vd collocated artifact test unable to load the 318 MB Git LFS file because this checkout retains its 134-byte pointer; the citation assertion failure from the pre-release hard-coded version is fixed and covered by the focused tests above. The remote CI checkout has LFS enabled.
