### PR TITLE
docs: expand changelog template

### DIFF
--- a/VERSION_BUMP_README.md
+++ b/VERSION_BUMP_README.md
@@ -50,6 +50,31 @@ unmerged release branch.
 8. Monitor the GitHub Actions release workflow, approve the protected `pypi`
    environment if prompted, and verify the GitHub release and PyPI package.
 
+## Writing changelog entries
+
+Use the `[Unreleased]` sections in `docs/development/changelog.md` for concise,
+user-facing notes:
+
+- `Added`: new capabilities or public APIs.
+- `Changed`: behavior, API, dependency, or architectural changes that are not
+  breaking.
+- `Performance`: measured runtime, memory, compile-time, or scalability
+  improvements. Include the baseline, workload, hardware or backend, and metric.
+- `Deprecated`: still-supported functionality with its replacement and planned
+  removal version when known.
+- `Breaking changes`: incompatible API, behavior, or dependency changes. State
+  the old and new usage and link to migration guidance.
+- `Fixed`: bug fixes, including security fixes when applicable. Add a CVE or
+  advisory link when one exists.
+- `Documentation`: material improvements to user or developer documentation and
+  examples.
+- `Contributors`: meaningful acknowledgements with GitHub handles and pull
+  request links.
+
+Do not add separate `Removed` or `Security` sections. Record removals under
+`Breaking changes` when they affect users, and record security fixes under
+`Fixed`.
+
 ## What the version bump manages
 
 `bump_version.py` updates only release metadata:

--- a/bump_version.py
+++ b/bump_version.py
@@ -28,6 +28,19 @@ RELEASE_FILES = (
     Path("uv.lock"),
 )
 
+CHANGELOG_SECTIONS = (
+    "Added",
+    "Changed",
+    "Performance",
+    "Deprecated",
+    "Breaking changes",
+    "Fixed",
+    "Documentation",
+    "Contributors",
+)
+
+CHANGELOG_SECTION_PATTERN = re.compile(r"^### (?P<title>.+?)\s*$", re.MULTILINE)
+
 
 def parse_version(version_string: str) -> tuple[int, int, int]:
     """Parse a semantic version into major, minor, and patch components."""
@@ -169,21 +182,49 @@ def update_changelog(file_path: Path, new_version: str, release_date: date) -> N
             f"Could not find a bounded [Unreleased] section in {file_path}"
         )
 
-    notes = match.group("body").strip()
+    notes = _remove_empty_changelog_sections(match.group("body"))
     if not re.search(r"(?m)^- ", notes):
         notes = f"### Changed\n\n- Release version {new_version}."
 
     replacement = (
         "## [Unreleased]\n\n"
-        "### Added\n\n"
-        "### Changed\n\n"
-        "### Fixed\n\n"
+        f"{_format_changelog_template()}\n\n"
         f"## [{new_version}] - {release_date.isoformat()}\n\n"
         f"{notes}\n\n"
     )
     file_path.write_text(
         content[: match.start()] + replacement + content[match.end() :]
     )
+
+
+def _format_changelog_template() -> str:
+    """Format the canonical empty changelog template."""
+    return "\n\n".join(f"### {section}" for section in CHANGELOG_SECTIONS)
+
+
+def _remove_empty_changelog_sections(notes: str) -> str:
+    """Remove empty subsection placeholders while preserving populated notes."""
+    notes = notes.strip()
+    matches = list(CHANGELOG_SECTION_PATTERN.finditer(notes))
+    if not matches:
+        return notes
+
+    blocks = []
+    prefix = notes[: matches[0].start()].strip()
+    if prefix:
+        blocks.append(prefix)
+
+    for index, match in enumerate(matches):
+        body_end = (
+            matches[index + 1].start()
+            if index + 1 < len(matches)
+            else len(notes)
+        )
+        body = notes[match.end() : body_end].strip()
+        if body:
+            blocks.append(f"### {match.group('title')}\n\n{body}")
+
+    return "\n\n".join(blocks)
 
 
 def update_uv_lock(file_path: Path, new_version: str) -> None:

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -5,13 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Write user-facing notes under the section that best describes the change. Keep
+entries concise, link to relevant pull requests or documentation when useful,
+and include benchmark baseline and measurement context for performance claims.
+
 ## [Unreleased]
 
 ### Added
 
 ### Changed
 
+### Performance
+
+### Deprecated
+
+### Breaking changes
+
 ### Fixed
+
+### Documentation
+
+### Contributors
 
 ## [0.3.0] - 2026-08-25
 

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,4 +1,6 @@
+import re
 from datetime import date
+from pathlib import Path
 
 import pytest
 
@@ -23,6 +25,18 @@ def test_update_changelog_preserves_history(tmp_path):
         "## [Unreleased]\n\n"
         "### Added\n\n"
         "- New feature.\n\n"
+        "### Changed\n\n"
+        "### Performance\n\n"
+        "- Twice as fast.\n\n"
+        "### Deprecated\n\n"
+        "- Use the replacement API.\n\n"
+        "### Breaking changes\n\n"
+        "- Replace the old API with the new API.\n\n"
+        "### Fixed\n\n"
+        "### Documentation\n\n"
+        "- Added migration guidance.\n\n"
+        "### Contributors\n\n"
+        "- Thanks to the contributors.\n\n"
         "## [0.1.0] - 2025-09-01\n\n"
         "### Added\n\n"
         "- Development milestone.\n"
@@ -35,6 +49,37 @@ def test_update_changelog_preserves_history(tmp_path):
     assert "## [0.2.0] - 2026-07-29" in content
     assert "## [0.1.0] - 2025-09-01" in content
     assert content.index("## [0.2.0]") < content.index("## [0.1.0]")
+
+    release_body = content.split("## [0.2.0] - 2026-07-29\n\n", 1)[1].split(
+        "## [0.1.0]", 1
+    )[0]
+    assert "### Added\n\n- New feature." in release_body
+    assert "### Performance\n\n- Twice as fast." in release_body
+    assert "### Deprecated\n\n- Use the replacement API." in release_body
+    assert "### Breaking changes\n\n- Replace the old API with the new API." in release_body
+    assert "### Documentation\n\n- Added migration guidance." in release_body
+    assert "### Contributors\n\n- Thanks to the contributors." in release_body
+    assert "### Changed" not in release_body
+    assert "### Fixed" not in release_body
+
+    unreleased_body = content.split("## [Unreleased]\n\n", 1)[1].split(
+        "## [0.2.0]", 1
+    )[0]
+    assert re.findall(r"^### (.+)$", unreleased_body, flags=re.MULTILINE) == list(
+        bump_version.CHANGELOG_SECTIONS
+    )
+
+
+def test_changelog_template_matches_release_sections():
+    changelog = Path(__file__).parents[1] / "docs/development/changelog.md"
+    content = changelog.read_text()
+    unreleased_body = content.split("## [Unreleased]\n\n", 1)[1].split(
+        "## [0.3.0]", 1
+    )[0]
+
+    assert re.findall(r"^### (.+)$", unreleased_body, flags=re.MULTILINE) == list(
+        bump_version.CHANGELOG_SECTIONS
+    )
 
 
 def test_update_changelog_rejects_duplicate_version(tmp_path):

--- a/tests/test_extract_changelog.py
+++ b/tests/test_extract_changelog.py
@@ -8,8 +8,10 @@ def test_output_file_ends_with_newline(tmp_path):
     changelog.write_text(
         "# Changelog\n\n"
         "## [0.2.0] - 2026-07-29\n\n"
-        "### Fixed\n\n"
-        "- Preserve the GitHub output delimiter.\n"
+        "### Performance\n\n"
+        "- Preserve the benchmark context.\n\n"
+        "### Breaking changes\n\n"
+        "- Use the new API.\n"
     )
     output = tmp_path / "release-notes.md"
     script = Path(__file__).parents[1] / "extract_changelog.py"
@@ -30,5 +32,6 @@ def test_output_file_ends_with_newline(tmp_path):
     )
 
     assert output.read_text() == (
-        "### Fixed\n\n- Preserve the GitHub output delimiter.\n"
+        "### Performance\n\n- Preserve the benchmark context.\n\n"
+        "### Breaking changes\n\n- Use the new API.\n"
     )


### PR DESCRIPTION
## Summary

- Expand the `[Unreleased]` changelog template with the agreed section order: Added, Changed, Performance, Deprecated, Breaking changes, Fixed, Documentation, and Contributors.
- Keep release promotion and template generation synchronized while omitting empty sections from published release entries.
- Document changelog classification rules and add regression coverage for promotion and extraction.

## Validation

- `uv run pytest tests/test_bump_version.py tests/test_extract_changelog.py` — 7 passed
- `uv run ruff check bump_version.py tests/test_bump_version.py tests/test_extract_changelog.py` — passed
- `git diff --check` — passed
- `uv run --extra docs zensical build --clean` — passed
- `uv run pytest` — 1,688 passed, 1 failed because `paper_results/secVd_control_gain_optimization/data/collocated/optimization_results.npz` is an unhydrated 134-byte Git LFS pointer rather than a valid archive.