### PR TITLE
Make system-method benchmarks device-aware and reproducible

### DIFF
--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -27,15 +27,17 @@ robot once makes it accessible throughout the benchmarking suite.
 
 The `benchmark_system_methods.py` CLI times a range of core routines for a sweep of
 system sizes. Each measurement captures a cold call (compile + first execution) and
-averages a number of warm calls to estimate steady-state latency.
+reports the median of synchronized warm calls as steady-state latency.
 
 ```bash
 python tools/benchmarks/benchmark_system_methods.py \
+  --device cpu \
   --systems articulated_soft_robot pendulum planar_pcs pcs \
   --segment-counts 1 3 5 7 \
   --duration 2.0 \
   --solver-dt 5e-4 \
-  --execution-repeats 5 \
+  --warmup-duration 1 \
+  --execution-repeats 20 \
   --csv benchmarks/methods.csv \
   --plot benchmarks/methods.png
 ```
@@ -46,7 +48,12 @@ python tools/benchmarks/benchmark_system_methods.py \
 - `--segment-counts`: link/segment sweep; a fresh system instance is created per value.
 - `--duration`, `--solver-dt` (`--dt` alias), `--save-dt`: integration controls when benchmarking
   `rollout_to`.
-- `--execution-repeats`: number of warm calls to average after the cold run.
+- `--device`: select `cpu`, `gpu`, or JAX's default automatic device choice.
+  Explicit choices are applied before JAX is imported.
+- `--warmup-duration`: synchronized, unmeasured execution time used to settle
+  CPU frequency scaling and runtime worker threads before collecting samples.
+- `--execution-repeats`: number of synchronized calls whose median is reported
+  after the cold run and optional warmup.
 - `--json` / `--csv`: export raw results for regression tracking.
 - `--plot` / `--show-plot`: render Matplotlib summaries (compile vs. exec time).
 
@@ -55,13 +62,42 @@ python tools/benchmarks/benchmark_system_methods.py \
 For each system/function pair the script prints:
 
 1. Cold-call latency (compile + execution), synchronised via `block_until_ready()`.
-2. Mean warm-call latency, reflecting the steady-state cost once XLA caches the
-   executable.
+2. Median warm-call latency, reflecting the steady-state cost once XLA caches
+   the executable and rejecting transient scheduler outliers.
 3. Derived compile time = cold − warm. Pure-Python methods show near-zero compile
    time but still track runtime cost.
 
 The plots group results by system, highlighting how complexity evolves with segment
 count for each tracked method.
+
+### Pinning CPU benchmarks
+
+On machines with heterogeneous CPU cores, process migration between performance
+and efficiency cores can distort sub-millisecond measurements. Select the CPU
+backend with `--device cpu` and, where the operating system supports it, pin the
+whole benchmark process to a known core. On Linux, first inspect the topology and
+maximum frequencies:
+
+```bash
+lscpu -e=CPU,CORE,MAXMHZ,ONLINE
+```
+
+Then run the benchmark with `taskset`; CPU 0 is only an example and should be
+replaced with a performance core identified on the benchmark host:
+
+```bash
+taskset -c 0 python tools/benchmarks/benchmark_system_methods.py \
+  --device cpu \
+  --systems pcs \
+  --segment-counts 1 4 8 16 \
+  --warmup-duration 1 \
+  --execution-repeats 20
+```
+
+Affinity applies to the Python process and its JAX worker threads. JSON and CSV
+rows record the resolved `backend`, compact `cpu_affinity`, warmup duration, and
+sample count so the execution context remains auditable. When comparing
+revisions, use the same affinity and warmup settings for every run.
 
 For `articulated_soft_robot`, the method benchmark includes both the default
 articulated-body forward dynamics path and a dense Jacobian-energy forward

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -15,6 +15,11 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Changed
 
+- Made the system-method benchmark device-selectable and reproducible on
+  heterogeneous CPUs by recording the JAX backend and CPU affinity, adding an
+  optional steady-state warmup, and reporting the median of synchronized
+  execution samples.
+
 ### Performance
 
 ### Deprecated

--- a/tests/tools/test_benchmark_system_methods.py
+++ b/tests/tools/test_benchmark_system_methods.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+
+import jax.numpy as jnp
+import pytest
+
+from tools.benchmarks import benchmark_system_methods as benchmark
+
+
+def test_configure_device_before_jax_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JAX_PLATFORMS", raising=False)
+
+    assert benchmark._configure_device_before_jax_import(["--device", "cpu"]) == "cpu"
+    assert os.environ["JAX_PLATFORMS"] == "cpu"
+
+    assert benchmark._configure_device_before_jax_import(["--device", "gpu"]) == "gpu"
+    assert os.environ["JAX_PLATFORMS"] == "cuda"
+
+
+def test_active_cpu_affinity_is_compact(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        benchmark.os,
+        "sched_getaffinity",
+        lambda _pid: {0, 1, 2, 4, 7, 8},
+    )
+
+    assert benchmark._active_cpu_affinity() == "0-2;4;7-8"
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [("--execution-repeats", "0"), ("--warmup-duration", "-0.1")],
+)
+def test_invalid_timing_options_are_rejected(option: str, value: str) -> None:
+    with pytest.raises(SystemExit):
+        benchmark.parse_args([option, value])
+
+
+def test_measure_jitted_call_supports_warmup_duration() -> None:
+    compile_time, execution_time = benchmark._measure_jitted_call(
+        lambda value: value + 1.0,
+        (jnp.array(1.0),),
+        repeats=3,
+        warmup_duration=0.001,
+    )
+
+    assert compile_time >= 0.0
+    assert execution_time > 0.0

--- a/tools/benchmarks/benchmark_system_methods.py
+++ b/tools/benchmarks/benchmark_system_methods.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import statistics
 import sys
 import time
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
@@ -21,6 +23,21 @@ from typing import Any
 
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+def _configure_device_before_jax_import(argv: Sequence[str]) -> str:
+    """Apply an explicit CLI device choice before JAX is imported."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--device", choices=("auto", "cpu", "gpu"), default="auto")
+    args, _ = parser.parse_known_args(argv)
+    if args.device == "cpu":
+        os.environ["JAX_PLATFORMS"] = "cpu"
+    elif args.device == "gpu":
+        os.environ["JAX_PLATFORMS"] = "cuda"
+    return str(args.device)
+
+
+_EARLY_DEVICE_CHOICE = _configure_device_before_jax_import(sys.argv[1:])
 
 try:
     import jax
@@ -53,6 +70,29 @@ Array = jax.Array
 Tree = Any
 
 
+def _active_cpu_affinity() -> str | None:
+    """Return the process CPU affinity as a compact, reproducible string."""
+    if not hasattr(os, "sched_getaffinity"):
+        return None
+    cpus = sorted(os.sched_getaffinity(0))
+    ranges: list[str] = []
+    range_start = range_end = cpus[0]
+    for cpu in cpus[1:]:
+        if cpu == range_end + 1:
+            range_end = cpu
+            continue
+        ranges.append(
+            str(range_start)
+            if range_start == range_end
+            else f"{range_start}-{range_end}"
+        )
+        range_start = range_end = cpu
+    ranges.append(
+        str(range_start) if range_start == range_end else f"{range_start}-{range_end}"
+    )
+    return ";".join(ranges)
+
+
 @dataclass
 class RuntimeConfig:
     """Holds runtime controls shared across benchmark cases."""
@@ -61,6 +101,7 @@ class RuntimeConfig:
     solver_dt: float
     save_dt: float
     execution_repeats: int
+    warmup_duration: float
 
 
 @dataclass
@@ -132,15 +173,21 @@ def _measure_jitted_call(
     fn: Callable[..., Tree],
     args: tuple[Any, ...],
     repeats: int,
+    warmup_duration: float,
 ) -> tuple[float, float]:
-    """Measure compile (first-call) and averaged execution time for a callable.
+    """Measure compile (first-call) and median warm time for a callable.
 
-    The first invocation is treated as "compile + execute" time. Subsequent invocations
-    (``repeats`` of them) are averaged to estimate the steady-state execution cost.
+    The first invocation is treated as "compile + execute" time. Calls made for
+    ``warmup_duration`` seconds are not measured; they let CPU frequency scaling and
+    the runtime thread pool settle. The median of the subsequent ``repeats``
+    synchronized calls estimates the steady-state execution cost while rejecting
+    scheduler outliers.
     """
 
     if repeats < 1:
         raise ValueError("execution repeats must be at least 1")
+    if warmup_duration < 0.0:
+        raise ValueError("warmup duration must be non-negative")
 
     # JIT a closure around the benchmark callable instead of jitting bound
     # methods directly. Bound Equinox methods carry ``self`` as part of the
@@ -160,6 +207,11 @@ def _measure_jitted_call(
     block_until_ready(first)
     first_time = time.perf_counter() - start
 
+    warmup_deadline = time.perf_counter() + warmup_duration
+    while time.perf_counter() < warmup_deadline:
+        warmup_out = jitted_fn(*args)
+        block_until_ready(warmup_out)
+
     exec_times: list[float] = []
     for _ in range(repeats):
         loop_start = time.perf_counter()
@@ -167,7 +219,7 @@ def _measure_jitted_call(
         block_until_ready(out)
         exec_times.append(time.perf_counter() - loop_start)
 
-    exec_time = sum(exec_times) / len(exec_times)
+    exec_time = statistics.median(exec_times)
     compile_time = max(0.0, first_time - exec_time)
     return compile_time, exec_time
 
@@ -662,12 +714,15 @@ def _write_csv(results: Sequence[Mapping[str, Any]], path: Path) -> None:
         "size_value",
         "gauss_points",
         "integration_points",
+        "backend",
+        "cpu_affinity",
         "jit_compile_time_s",
         "jit_execution_time_s",
         "duration",
         "solver_dt",
         "save_dt",
         "execution_repeats",
+        "warmup_duration",
     ]
     with path.open("w", encoding="utf-8") as fp:
         fp.write(",".join(headers) + "\n")
@@ -697,10 +752,25 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--device",
+        choices=("auto", "cpu", "gpu"),
+        default="auto",
+        help="JAX device to select before import (default: automatic selection)",
+    )
+    parser.add_argument(
         "--execution-repeats",
         type=int,
         default=3,
-        help="Number of post-compilation executions to average",
+        help="Number of synchronized post-warmup executions to measure",
+    )
+    parser.add_argument(
+        "--warmup-duration",
+        type=float,
+        default=0.0,
+        help=(
+            "Seconds of synchronized unmeasured execution before timing each "
+            "compiled case (useful for stabilizing CPU frequency)"
+        ),
     )
     parser.add_argument(
         "--json",
@@ -732,6 +802,10 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         args.systems = normalize_system_names(args.systems, registry)
     except ValueError as exc:
         parser.error(str(exc))
+    if args.execution_repeats < 1:
+        parser.error("--execution-repeats must be >= 1.")
+    if args.warmup_duration < 0.0:
+        parser.error("--warmup-duration must be >= 0.")
     if args.gauss_points is not None:
         if any(value < 1 for value in args.gauss_points):
             parser.error("All --gauss-points entries must be >= 1.")
@@ -741,12 +815,27 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.device != _EARLY_DEVICE_CHOICE:
+        raise RuntimeError(
+            "The --device choice must be present on the process command line so it "
+            "can be applied before JAX is imported."
+        )
+    active_backend = jax.default_backend()
+    if args.device == "cpu" and active_backend != "cpu":
+        raise RuntimeError(f"Requested CPU but JAX selected {active_backend!r}.")
+    if args.device == "gpu" and active_backend == "cpu":
+        raise RuntimeError("Requested GPU but JAX selected the CPU backend.")
+    print(f"JAX backend: {active_backend}")
+    active_cpu_affinity = _active_cpu_affinity()
+    if active_cpu_affinity is not None:
+        print(f"CPU affinity: {active_cpu_affinity}")
 
     runtime = RuntimeConfig(
         duration=args.duration,
         solver_dt=args.solver_dt,
         save_dt=max(0.0, args.save_dt),
         execution_repeats=args.execution_repeats,
+        warmup_duration=args.warmup_duration,
     )
 
     registry = _build_system_registry()
@@ -789,7 +878,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                     fn, call_args = case.builder(system, ctx, runtime)
                     print(f"  -> {case.name} ...", end=" ", flush=True)
                     compile_time, exec_time = _measure_jitted_call(
-                        fn, call_args, runtime.execution_repeats
+                        fn,
+                        call_args,
+                        runtime.execution_repeats,
+                        runtime.warmup_duration,
                     )
 
                     per_point_note = ""
@@ -823,12 +915,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                             "size_value": size,
                             "gauss_points": gauss_points,
                             "integration_points": integration_points,
+                            "backend": active_backend,
+                            "cpu_affinity": active_cpu_affinity,
                             "jit_compile_time_s": compile_time,
                             "jit_execution_time_s": exec_time,
                             "duration": runtime.duration,
                             "solver_dt": runtime.solver_dt,
                             "save_dt": runtime.save_dt,
                             "execution_repeats": runtime.execution_repeats,
+                            "warmup_duration": runtime.warmup_duration,
                         }
                     )
 


### PR DESCRIPTION
## Motivation

`benchmark_system_methods.py` previously relied on whichever JAX backend was
selected implicitly at import time and did not retain CPU placement metadata in
its artifacts. This made benchmark provenance incomplete and could materially
distort short CPU measurements on hybrid processors: the process could migrate
between performance and efficiency cores, while early post-compilation calls
were still affected by CPU frequency ramp-up and runtime thread-pool startup.

This PR makes device selection and steady-state timing explicit without changing
the benchmarked system implementations.

## Implementation

### Backend selection and verification

- Add `--device {auto,cpu,gpu}` to `benchmark_system_methods.py`.
- Apply an explicit selection through `JAX_PLATFORMS` before importing JAX, then
  verify the resolved backend before any system is built or benchmarked.
- Keep `--device` as the user-facing selector, but record the resolved value as
  `backend`; `cpu` and `gpu` describe JAX platforms rather than individual
  devices.

### Reproducible CPU placement

- Report the active process affinity at startup when the operating system
  exposes `sched_getaffinity`.
- Store a compact `cpu_affinity` value together with `backend` in JSON and CSV
  rows.
- Document how to inspect Linux CPU topology with `lscpu` and pin the complete
  Python/JAX process with `taskset`.
- Explicitly caution that example core numbers are host-specific and that a
  performance core should be selected from the machine being measured.

Affinity remains an operating-system concern rather than a Python CLI setting:
pinning the parent process with `taskset` also constrains JAX worker threads and
avoids implementing a platform-specific affinity parser in the benchmark.

### Warm execution measurement

- Add `--warmup-duration` for synchronized, unmeasured execution before samples
  are collected. This is useful for settling frequency scaling and runtime
  workers after compilation.
- Validate both `--warmup-duration` and `--execution-repeats` at argument parsing
  time.
- Report the median of the requested synchronized warm samples instead of their
  mean, reducing sensitivity to scheduler outliers.
- Record the warmup duration and sample count in every exported row.

The existing defaults remain conservative: automatic backend selection, no
extra timed warmup interval, and three measured executions. Reproducible
performance comparisons can opt into an explicit backend, affinity, warmup, and
sample count.

## Documentation

The benchmarking guide now includes a complete CPU example using `--device`,
`--warmup-duration`, and `--execution-repeats`, plus a dedicated section on
discovering and pinning a performance core. It also documents the additional
artifact metadata and the change from mean to median warm latency.

## Validation

- `JAX_PLATFORMS=cpu pytest -q tests/tools/test_benchmark_system_methods.py tests/tools/test_benchmark_common.py` — 11 passed.
- Ruff check and format for the changed benchmark and tests — passed.
- `zensical build` — passed.
- `git diff --check` — passed.
- CPU CLI smoke test pinned with `taskset -c 1` — selected the CPU backend,
  reported affinity `1`, and wrote matching `backend`, `cpu_affinity`,
  `warmup_duration`, and `execution_repeats` fields to JSON and CSV.

No GPU backend was initialized during validation.
