### PR TITLE
Add optional Coriolis-free dynamics paths

### DIFF
--- a/docs/api/systems/index.md
+++ b/docs/api/systems/index.md
@@ -32,6 +32,22 @@ The `DynamicalSystem` class is the fundamental base class for all dynamical syst
 
 The `SoftRobot` class extends `DynamicalSystem` with interfaces specific to soft robots, including methods for forward kinematics and Jacobians parameterized by arc-length or position along the robot backbone.
 
+All concrete soft-robot systems accept the static model setting
+`consider_coriolis`, which defaults to `True`. Construct a model with
+`consider_coriolis=False` to omit Coriolis and centrifugal forces from
+`dynamics_terms`, `forward_dynamics`, and rollouts while leaving the explicit
+`coriolis_matrix` diagnostic and all energy methods physically exact. Because
+the setting is static, enabled and disabled models compile to separate optimized
+JAX executables.
+
+```python
+robot = PCS.from_links(links, consider_coriolis=False)
+```
+
+The configured setting is inherited by `rollout_to`, `rollout_closed_loop_to`,
+and `rollout_discrete_closed_loop_to`; the generic rollout signatures do not
+change.
+
 ::: soromox.systems.SoftRobot
     options:
       show_root_heading: true

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -34,6 +34,7 @@ python tools/benchmarks/benchmark_system_methods.py \
   --device cpu \
   --systems articulated_soft_robot pendulum planar_pcs pcs \
   --segment-counts 1 3 5 7 \
+  --coriolis-modes enabled disabled \
   --duration 2.0 \
   --solver-dt 5e-4 \
   --warmup-duration 1 \
@@ -54,6 +55,9 @@ python tools/benchmarks/benchmark_system_methods.py \
   CPU frequency scaling and runtime worker threads before collecting samples.
 - `--execution-repeats`: number of synchronized calls whose median is reported
   after the cold run and optional warmup.
+- `--coriolis-modes`: benchmark enabled and/or disabled static model settings.
+  Each result row records `consider_coriolis`, and plots use distinct lines for
+  both modes.
 - `--json` / `--csv`: export raw results for regression tracking.
 - `--plot` / `--show-plot`: render Matplotlib summaries (compile vs. exec time).
 
@@ -98,6 +102,81 @@ Affinity applies to the Python process and its JAX worker threads. JSON and CSV
 rows record the resolved `backend`, compact `cpu_affinity`, warmup duration, and
 sample count so the execution context remains auditable. When comparing
 revisions, use the same affinity and warmup settings for every run.
+
+When comparing optional Coriolis paths, pass both modes. The exported rows make
+enabled/disabled compile and warm-runtime ratios available for each size, and
+the plots distinguish the two settings.
+
+### Optional Coriolis reference measurement
+
+The reference run used the CPU device, 1, 4, 8, and 16 links or segments, five
+Gauss points for continuum systems, and 20 synchronized measured repetitions
+after a one-second warmup per compiled case. On the benchmark host, CPUs 0-7
+are the performance cores (5.5-5.7 GHz maximum), while CPUs 8-23 are the
+efficiency cores (4.7 GHz maximum). The reference uses CPU 1 exclusively to
+prevent migration both between core classes and among performance cores.
+Determine the appropriate performance-core affinity from the topology of the
+host being measured rather than copying this affinity to other machines. These
+are the commands used to produce the reference:
+
+```bash
+JAX_ENABLE_X64=true taskset -c 1 \
+python tools/benchmarks/benchmark_system_methods.py \
+  --device cpu \
+  --systems articulated_soft_robot \
+  --segment-counts 1 4 8 16 \
+  --methods dynamics_terms forward_dynamics rollout_to \
+  --coriolis-modes enabled disabled \
+  --execution-repeats 20 \
+  --warmup-duration 1 \
+  --duration 0.002 --solver-dt 0.0001 --save-dt 0.002 \
+  --json /tmp/soromox-optional-coriolis-articulated-pcore.json \
+  --csv /tmp/soromox-optional-coriolis-articulated-pcore.csv \
+  --plot /tmp/soromox-optional-coriolis-articulated-pcore.png
+
+JAX_ENABLE_X64=true taskset -c 1 \
+python tools/benchmarks/benchmark_system_methods.py \
+  --device cpu \
+  --systems planar_pcs pcs gvs \
+  --segment-counts 1 4 8 16 --gauss-points 5 \
+  --methods dynamics_terms forward_dynamics rollout_to \
+  --coriolis-modes enabled disabled \
+  --execution-repeats 20 \
+  --warmup-duration 1 \
+  --duration 0.002 --solver-dt 0.0001 --save-dt 0.002 \
+  --json /tmp/soromox-optional-coriolis-continuum-pcore.json \
+  --csv /tmp/soromox-optional-coriolis-continuum-pcore.csv \
+  --plot /tmp/soromox-optional-coriolis-continuum-pcore.png
+```
+
+Each size cell below is the enabled/disabled compile-time ratio followed by the
+enabled/disabled median warm-runtime ratio. Values greater than one favor the
+Coriolis-disabled path.
+
+| System / method | 1 | 4 | 8 | 16 | Warm geometric mean |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| ArticulatedSoftRobot / `dynamics_terms` | 1.53x / 1.12x | 1.86x / 1.57x | 1.76x / 1.84x | 1.76x / 2.62x | 1.71x |
+| ArticulatedSoftRobot / `forward_dynamics` | 1.48x / 1.87x | 1.30x / 1.16x | 1.30x / 1.40x | 1.29x / 1.27x | 1.40x |
+| ArticulatedSoftRobot / `rollout_to` | 1.30x / 1.71x | 1.02x / 1.63x | 1.16x / 1.68x | 1.31x / 1.98x | 1.75x |
+| PlanarPCS / `dynamics_terms` | 2.00x / 1.11x | 1.89x / 1.27x | 1.77x / 1.29x | 1.65x / 1.46x | 1.28x |
+| PlanarPCS / `forward_dynamics` | 2.10x / 1.07x | 1.77x / 1.28x | 1.67x / 1.33x | 1.73x / 1.51x | 1.29x |
+| PlanarPCS / `rollout_to` | 1.27x / 1.37x | 1.55x / 1.77x | 1.54x / 1.67x | 1.58x / 1.57x | 1.59x |
+| PCS / `dynamics_terms` | 1.95x / 1.67x | 1.86x / 1.33x | 1.96x / 1.52x | 1.84x / 1.48x | 1.49x |
+| PCS / `forward_dynamics` | 1.78x / 1.85x | 1.76x / 1.35x | 1.77x / 1.51x | 1.79x / 1.39x | 1.51x |
+| PCS / `rollout_to` | 1.56x / 2.74x | 1.50x / 1.80x | 1.53x / 1.59x | 1.47x / 1.40x | 1.82x |
+| GVS / `dynamics_terms` | 1.77x / 1.28x | 1.79x / 1.53x | 1.75x / 1.50x | 1.73x / 1.37x | 1.42x |
+| GVS / `forward_dynamics` | 1.70x / 1.19x | 1.75x / 1.53x | 1.69x / 1.51x | 1.52x / 1.36x | 1.39x |
+| GVS / `rollout_to` | 1.51x / 1.73x | 1.51x / 1.17x | 1.50x / 1.18x | 1.30x / 1.33x | 1.33x |
+
+Across all requested methods and sizes, the per-system warm-runtime geometric
+means are 1.61x for ArticulatedSoftRobot, 1.38x for PlanarPCS, 1.60x for PCS,
+and 1.38x for GVS.
+
+The per-size compile and warm timings are retained in the JSON and CSV artifacts.
+The exported rows also record `backend`, `cpu_affinity`, the warmup duration,
+and the sample count. Sub-millisecond calls are particularly sensitive to CPU
+frequency scaling and scheduler placement, so performance comparisons should
+retain both the warmup and explicit affinity.
 
 For `articulated_soft_robot`, the method benchmark includes both the default
 articulated-body forward dynamics path and a dense Jacobian-energy forward

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -13,6 +13,12 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Added
 
+- Added a common static `consider_coriolis` model setting to every `SoftRobot`
+  family. It defaults to the existing exact dynamics and can be disabled at
+  construction, including through `from_links` and `from_segments`, to omit
+  Coriolis forces from direct dynamics and all rollout variants while retaining
+  exact explicit Coriolis diagnostics and energy derivatives.
+
 ### Changed
 
 - Made the system-method benchmark device-selectable and reproducible on
@@ -21,6 +27,17 @@ and include benchmark baseline and measurement context for performance claims.
   execution samples.
 
 ### Performance
+
+- Added derivative-free dynamics assembly paths for ArticulatedSoftRobot,
+  McKibben UMArm, PlanarPCS and inheritors, PCS and inheritors, GVS, PlanarHSA,
+  and Pendulum when Coriolis forces are disabled. In a single-performance-core
+  CPU reference sweep (1/4/8/16 links or segments, five Gauss points, a
+  one-second warmup, and 20 measured repetitions), the overall warm-runtime
+  geometric-mean ratios were 1.61x for ArticulatedSoftRobot, 1.38x for
+  PlanarPCS, 1.60x for PCS, and 1.38x for GVS; rollout-only geometric means were
+  1.75x, 1.59x, 1.82x, and 1.33x respectively.
+  See the [benchmarking guide](benchmarking.md#optional-coriolis-reference-measurement)
+  for the exact commands and per-method results.
 
 ### Deprecated
 

--- a/docs/development/extending.md
+++ b/docs/development/extending.md
@@ -334,7 +334,18 @@ Christoffel convention, `C` itself is not generally skew-symmetric; instead
 the mechanical energy balance, passivity arguments, and model-based control. It
 also keeps derivative-based APIs consistent. If you override an optimized
 `dynamics_terms(q, qd)` method, its returned `Cqd` vector must equal the
-convective force `C(q, qd) @ qd` for this same convention.
+convective force `C(q, qd) @ qd` for this same convention when
+`self.consider_coriolis` is true. When it is false, return an exactly zero
+vector and avoid derivative or convective work such as Jacobian time
+derivatives. Explicit `coriolis_matrix` calls and kinetic-energy derivatives
+must remain exact; the setting changes only the forward equations used for
+simulation.
+
+`consider_coriolis` is an Equinox static field. This lets JAX eliminate the
+unused branch instead of executing a runtime conditional, but changing the
+setting therefore produces a separate compiled executable. Keep the setting
+outside physical parameter PyTrees and preserve it in immutable parameter
+updates.
 
 #### 6. Implement Energy Methods (Optional but Recommended)
 

--- a/src/soromox/systems/articulated/articulated_soft_robot.py
+++ b/src/soromox/systems/articulated/articulated_soft_robot.py
@@ -783,11 +783,15 @@ class ArticulatedSoftRobot(SoftRobot):
             pA_i = self._force_cross(v_i) @ inertia_i @ v_i
             return v_i, (v_i, c_i, pA_i)
 
-        _, (_, c, pA_base) = lax.scan(
-            _velocity_step,
-            jnp.zeros((6,), dtype=q.dtype),
-            (Xup, S, spatial_inertias, qd),
-        )
+        if self.consider_coriolis:
+            _, (_, c, pA_base) = lax.scan(
+                _velocity_step,
+                jnp.zeros((6,), dtype=q.dtype),
+                (Xup, S, spatial_inertias, qd),
+            )
+        else:
+            c = jnp.zeros((self.num_links, 6), dtype=q.dtype)
+            pA_base = jnp.zeros_like(c)
 
         def _backward_step(
             carry: tuple[Array, Array],
@@ -834,9 +838,11 @@ class ArticulatedSoftRobot(SoftRobot):
             qdd_i = (u_i - U_i @ a_i) / d_i
             return a_i + S_i * qdd_i, qdd_i
 
+        R_world_base = jnp.asarray(self.base_transform, dtype=q.dtype)[:3, :3]
+        gravity_base = R_world_base.T @ self.g
         _, qdd = lax.scan(
             _acceleration_step,
-            jnp.concatenate([jnp.zeros(3, dtype=q.dtype), -self.g]),
+            jnp.concatenate([jnp.zeros(3, dtype=q.dtype), -gravity_base]),
             (Xup, S, c, U, d, u),
         )
 

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -352,7 +352,8 @@ class GVS(SoftRobot):
             scale_rotational_basis_by_length: Whether to normalize rotational
                 strain-basis rows by link length.
             **kwargs: Additional keyword arguments forwarded to the GVS
-                constructor, such as actuators or passive elements.
+                constructor, such as ``consider_coriolis``, actuators, or
+                passive elements.
 
         Returns:
             A fully initialized GVS model.
@@ -4358,10 +4359,171 @@ class GVS(SoftRobot):
 
         return weights, g_quads, J_quads, Jd_or_Jd_qd_quads
 
+    def _dynamics_terms_without_coriolis(self, q: Array) -> tuple[Array, Array, Array]:
+        """Assemble inertia and gravity without velocity-dependent work."""
+        dtype = q.dtype
+        q_blocks = self._min_size_gathered(q)
+        segment_indices = jnp.arange(self.num_segments)
+        cell_indices = jnp.arange(self.max_num_integration_points - 1)
+
+        def evaluate_joint(segment_index: Array) -> tuple[Array, Array]:
+            _, adjoint_inverse, tangent_basis = self._joint_jacobian_step_terms(
+                self.B_joint[segment_index],
+                self.xi_ref_joint[segment_index],
+                q_blocks[segment_index, 0],
+            )
+            return adjoint_inverse, tangent_basis
+
+        joint_terms = jax.vmap(evaluate_joint)(segment_indices)
+
+        def evaluate_segment_cells(
+            segment_index: Array,
+        ) -> tuple[Array, Array, Array]:
+            def evaluate_cell(cell_index: Array) -> tuple[Array, Array, Array]:
+                cell_width = (
+                    self.integration_points[segment_index, cell_index + 1]
+                    - self.integration_points[segment_index, cell_index]
+                )
+                _, tangent, adjoint_inverse, magnus_basis = (
+                    self._magnus_jacobian_step_terms(
+                        self.segment_lengths[segment_index],
+                        cell_width,
+                        q_blocks[segment_index, 1],
+                        self.B_Z1[segment_index, cell_index],
+                        self.B_Z2[segment_index, cell_index],
+                        self.xi_ref_Z1[segment_index, cell_index],
+                        self.xi_ref_Z2[segment_index, cell_index],
+                    )
+                )
+                return tangent, adjoint_inverse, magnus_basis
+
+            return jax.vmap(evaluate_cell)(cell_indices)
+
+        cell_terms = jax.vmap(evaluate_segment_cells)(segment_indices)
+        interior_cell_terms = jax.tree.map(lambda value: value[:, :-1], cell_terms)
+        tip_cell_terms = jax.tree.map(lambda value: value[:, -1], cell_terms)
+        mass_diagonals = jnp.diagonal(self.inner_mass_matrices, axis1=-2, axis2=-1)
+
+        jacobian_initial = jnp.zeros((6, self.num_dofs), dtype=dtype)
+        gravity_initial = se3.adjoint_inverse(self.g0) @ self.g
+        inertia_initial = jnp.zeros((self.num_dofs, self.num_dofs), dtype=dtype)
+        generalized_vector_initial = jnp.zeros((self.num_dofs,), dtype=dtype)
+
+        def insert_local_basis(
+            local_basis: Array, segment_index: Array, block_index: int
+        ) -> Array:
+            indices = jnp.minimum(
+                self.gather_indices[segment_index, block_index], self.num_dofs - 1
+            )
+            masked_basis = (
+                local_basis * self.gather_mask[segment_index, block_index][None, :]
+            )
+            return jnp.zeros_like(jacobian_initial).at[:, indices].add(masked_basis)
+
+        def body_segment(
+            carry: tuple[Array, Array, Array, Array],
+            segment_input: tuple[
+                Array,
+                tuple[Array, Array],
+                tuple[Array, Array, Array],
+                tuple[Array, Array, Array],
+            ],
+        ) -> tuple[tuple[Array, Array, Array, Array], None]:
+            jacobian_tip, gravity_tip, inertia, gravity_force = carry
+            (
+                segment_index,
+                joint_terms_i,
+                interior_cell_terms_i,
+                tip_cell_terms_i,
+            ) = segment_input
+            joint_adjoint_inverse, joint_tangent_basis = joint_terms_i
+
+            joint_tangent = insert_local_basis(joint_tangent_basis, segment_index, 0)
+            jacobian_joint = joint_adjoint_inverse @ (jacobian_tip + joint_tangent)
+            gravity_joint = joint_adjoint_inverse @ gravity_tip
+
+            def advance_cell(
+                kinematics: tuple[Array, Array],
+                local_terms: tuple[Array, Array, Array],
+            ) -> tuple[Array, Array]:
+                jacobian_previous, gravity_previous = kinematics
+                tangent, adjoint_inverse, magnus_basis = local_terms
+                tangent_basis = insert_local_basis(
+                    tangent @ magnus_basis, segment_index, 1
+                )
+                jacobian_next = adjoint_inverse @ (jacobian_previous + tangent_basis)
+                gravity_next = adjoint_inverse @ gravity_previous
+                return jacobian_next, gravity_next
+
+            def body_cell(
+                kinematics: tuple[Array, Array],
+                local_terms: tuple[Array, Array, Array],
+            ) -> tuple[tuple[Array, Array], tuple[Array, Array]]:
+                kinematics_next = advance_cell(kinematics, local_terms)
+                return kinematics_next, kinematics_next
+
+            kinematics_last_quad, quadrature_kinematics = lax.scan(
+                body_cell,
+                (jacobian_joint, gravity_joint),
+                interior_cell_terms_i,
+            )
+            jacobians, gravities = quadrature_kinematics
+
+            weights = self.inner_integration_weights[segment_index]
+            mass_diagonals_i = mass_diagonals[segment_index]
+            flattened_row_count = (self.max_num_integration_points - 2) * 6
+            jacobians_flat = jacobians.reshape(flattened_row_count, self.num_dofs)
+            inertia_segment = jacobians_flat.T @ (
+                weights[:, None, None] * mass_diagonals_i[:, :, None] * jacobians
+            ).reshape(flattened_row_count, self.num_dofs)
+            gravity_segment = -jacobians_flat.T @ (
+                weights[:, None] * mass_diagonals_i * gravities
+            ).reshape(flattened_row_count)
+
+            jacobian_tip_next, gravity_tip_next = advance_cell(
+                kinematics_last_quad, tip_cell_terms_i
+            )
+            return (
+                jacobian_tip_next,
+                gravity_tip_next,
+                inertia + inertia_segment,
+                gravity_force + gravity_segment,
+            ), None
+
+        (_, _, inertia, gravity_force), _ = lax.scan(
+            body_segment,
+            (
+                jacobian_initial,
+                gravity_initial,
+                inertia_initial,
+                generalized_vector_initial,
+            ),
+            (segment_indices, joint_terms, interior_cell_terms, tip_cell_terms),
+        )
+        return inertia, generalized_vector_initial, gravity_force
+
     @eqx.filter_jit
     def dynamics_terms(self, q: Array, qd: Array) -> tuple[Array, Array, Array]:
+        """Assemble inertia, optional convective force, and gravity.
+
+        Args:
+            q: Active generalized coordinates with shape ``(num_dofs,)``.
+            qd: Active generalized velocities with shape ``(num_dofs,)``.
+
+        Returns:
+            Tuple ``(M, Cqd, G)`` containing the active inertia matrix and the
+            generalized convective and gravity forces. ``Cqd`` is exactly zero
+            when :attr:`consider_coriolis` is false.
         """
-        Assemble forward-dynamics terms with fixed-shape segment recurrences.
+        if self.consider_coriolis:
+            return self._dynamics_terms_with_coriolis(q, qd)
+        return self._dynamics_terms_without_coriolis(q)
+
+    def _dynamics_terms_with_coriolis(
+        self, q: Array, qd: Array
+    ) -> tuple[Array, Array, Array]:
+        """
+        Assemble exact forward-dynamics terms with fixed-shape recurrences.
 
         Joint and cell-local Magnus terms are evaluated in parallel before an
         outer ``lax.scan`` propagates the causal kinematic state between

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -262,7 +262,8 @@ class PCS(SoftRobot):
             base_pose: Optional base translation and unit quaternion with shape
                 ``(7,)``.
             **kwargs: Additional keyword arguments forwarded to the PCS
-                constructor, such as actuators or passive elements.
+                constructor, such as ``consider_coriolis``, actuators, or
+                passive elements.
 
         Returns:
             A fully initialized spatial PCS model.
@@ -3126,6 +3127,79 @@ class PCS(SoftRobot):
         return Ws_inner, g_ps, J_ps, Jd_or_Jd_qd_ps
 
     @eqx.filter_jit
+    def _dynamics_integration_pose_jacobians(
+        self, q: Array
+    ) -> tuple[Array, Array, Array]:
+        """Return derivative-free local gravity and Jacobian quadrature data."""
+        xi = self.strain(q).reshape(self.num_segments, 6)
+        B_xi_segments = self.B_xi.reshape(self.num_segments, 6, self.num_dofs)
+        prepared_powers = vmap(constant_strain_se3._prepare_jacobian_powers)(xi)
+
+        Xs_inner, Ws_inner = vmap(
+            scale_interior_gaussian_quadrature, in_axes=(None, None, 0, 0)
+        )(
+            self.integration_points,
+            self.integration_weights,
+            self.L_cum[:-1],
+            self.L_cum[1:],
+        )
+        s_local = Xs_inner - self.L_cum[:-1, None]
+
+        tip_operators = vmap(
+            lambda prepared_i, L_i: (
+                constant_strain_se3._jacobian_operators_from_prepared(
+                    prepared_i,
+                    L_i,
+                    self.global_eps,
+                    self.tangent_eps,
+                )
+            )
+        )(prepared_powers, self.L)
+        Ad_inv_tips, Ad_inv_T_tips = tip_operators
+        zeros = jnp.zeros((6, self.num_dofs), dtype=xi.dtype)
+        gravity_base_initial = se3.adjoint_inverse(self.g0) @ self.g
+        local_jacobian_tips = vmap(lambda T_i, B_xi_i: T_i @ B_xi_i)(
+            Ad_inv_T_tips, B_xi_segments
+        )
+        J_bases, gravity_bases = self._propagate_body_jacobian_and_gravity(
+            zeros,
+            gravity_base_initial,
+            Ad_inv_tips,
+            local_jacobian_tips,
+        )
+
+        def segment_kinematics(
+            prepared_i: constant_strain_se3._PreparedJacobianPowers,
+            B_xi_i: Array,
+            gravity_base_i: Array,
+            J_base_i: Array,
+            s_local_i: Array,
+        ) -> tuple[Array, Array]:
+            def kinematics_at_s(s_local_ij: Array) -> tuple[Array, Array]:
+                Ad_inv, Ad_inv_T = (
+                    constant_strain_se3._jacobian_operators_from_prepared(
+                        prepared_i,
+                        s_local_ij,
+                        self.global_eps,
+                        self.tangent_eps,
+                    )
+                )
+                J_next = Ad_inv @ J_base_i + Ad_inv_T @ B_xi_i
+                gravity_local = Ad_inv @ gravity_base_i
+                return gravity_local, J_next
+
+            return vmap(kinematics_at_s)(s_local_i)
+
+        gravity_ps, J_ps = vmap(segment_kinematics)(
+            prepared_powers,
+            B_xi_segments,
+            gravity_bases,
+            J_bases,
+            s_local,
+        )
+        return Ws_inner, gravity_ps, J_ps
+
+    @eqx.filter_jit
     def _dynamics_integration_kinematics(
         self, q: Array, qd: Array
     ) -> tuple[Array, Array, Array, Array]:
@@ -3253,9 +3327,13 @@ class PCS(SoftRobot):
             ``(self.num_dofs,)``. ``G`` is the active generalized gravity
             vector with shape ``(self.num_dofs,)``.
         """
-        weights, gravity, jacobians, jacobian_dot_qd = (
-            self._dynamics_integration_kinematics(q, qd)
-        )
+        if self.consider_coriolis:
+            weights, gravity, jacobians, jacobian_dot_qd = (
+                self._dynamics_integration_kinematics(q, qd)
+            )
+        else:
+            weights, gravity, jacobians = self._dynamics_integration_pose_jacobians(q)
+            jacobian_dot_qd = None
         inertia = jnp.zeros((self.num_dofs, self.num_dofs), dtype=jacobians.dtype)
         coriolis_qd = jnp.zeros((self.num_dofs,), dtype=jacobians.dtype)
         gravity_force = jnp.zeros((self.num_dofs,), dtype=jacobians.dtype)
@@ -3278,11 +3356,19 @@ class PCS(SoftRobot):
             ).reshape(flattened_rows, dof_end)
             inertia_segment = jacobian_flat.T @ weighted_mass_jacobian
 
-            eta = jacobian @ qd[:dof_end]
-            momentum = mass_action(eta)
-            coadjoint_momentum = vmap(se3.coadjoint_action)(eta, momentum)
-            wrench = mass_action(jacobian_dot_qd[segment_index]) + coadjoint_momentum
-            coriolis_segment = jacobian_flat.T @ (weight[:, None] * wrench).reshape(-1)
+            if self.consider_coriolis:
+                assert jacobian_dot_qd is not None
+                eta = jacobian @ qd[:dof_end]
+                momentum = mass_action(eta)
+                coadjoint_momentum = vmap(se3.coadjoint_action)(eta, momentum)
+                wrench = (
+                    mass_action(jacobian_dot_qd[segment_index]) + coadjoint_momentum
+                )
+                coriolis_segment = jacobian_flat.T @ (weight[:, None] * wrench).reshape(
+                    -1
+                )
+            else:
+                coriolis_segment = jnp.zeros((dof_end,), dtype=jacobians.dtype)
             gravity_segment = -jacobian_flat.T @ (
                 weight[:, None] * mass_action(gravity[segment_index])
             ).reshape(-1)

--- a/src/soromox/systems/pcs/planar_hsa.py
+++ b/src/soromox/systems/pcs/planar_hsa.py
@@ -1486,6 +1486,60 @@ class PlanarHSA(PlanarPCS):
             payload_mass_matrix,
         )
 
+    def _assemble_dynamics_terms_without_coriolis(
+        self, q: Array
+    ) -> tuple[Array, Array, Array]:
+        """Assemble inertia and gravity from derivative-free mass geometry."""
+        geometry = self._integration_geometry_full(q)
+        (
+            Ws,
+            g_rods,
+            J_rods,
+            rod_mass_matrices,
+            g_cogs,
+            J_cogs,
+            masses,
+            inertias,
+            J_payload,
+            g_payload,
+            payload_mass_matrix,
+        ) = self._mass_geometry_from_integration(geometry, full=False)
+
+        rod_g_inv = vmap(vmap(vmap(se2.adjoint_inverse)))(g_rods)
+        rod_local_gravity = jnp.einsum("sqrab,b->sqra", rod_g_inv, self.g)
+        rod_gravity_wrench = jnp.einsum(
+            "srab,sqrb->sqra", rod_mass_matrices, rod_local_gravity
+        )
+        B_rods = jnp.einsum(
+            "sq,sqrad,srab,sqrbe->de",
+            Ws,
+            J_rods,
+            rod_mass_matrices,
+            J_rods,
+        )
+        G_rods = -jnp.einsum("sq,sqrad,sqra->d", Ws, J_rods, rod_gravity_wrench)
+
+        cog_matrices = jnp.zeros((*masses.shape, 3, 3), dtype=Ws.dtype)
+        cog_matrices = cog_matrices.at[:, 0, 0].set(inertias)
+        cog_matrices = cog_matrices.at[:, 1, 1].set(masses)
+        cog_matrices = cog_matrices.at[:, 2, 2].set(masses)
+        cog_local_gravity = jnp.einsum(
+            "sab,b->sa", vmap(se2.adjoint_inverse)(g_cogs), self.g
+        )
+        cog_gravity_wrench = jnp.einsum("sab,sb->sa", cog_matrices, cog_local_gravity)
+        B_cogs = jnp.einsum("sad,sab,sbe->de", J_cogs, cog_matrices, J_cogs)
+        G_cogs = -jnp.einsum("sad,sa->d", J_cogs, cog_gravity_wrench)
+
+        payload_gravity_wrench = payload_mass_matrix @ (
+            se2.adjoint_inverse(g_payload) @ self.g
+        )
+        B_payload = J_payload.T @ payload_mass_matrix @ J_payload
+        G_payload = -J_payload.T @ payload_gravity_wrench
+
+        inertia = B_rods + B_cogs + B_payload
+        gravity_force = G_rods + G_cogs + G_payload
+        return inertia, jnp.zeros((self.num_dofs,), dtype=q.dtype), gravity_force
+
     def _assemble_dynamics_terms(
         self,
         q: Array,
@@ -1962,6 +2016,8 @@ class PlanarHSA(PlanarPCS):
             A tuple ``(B, Cqd, G)`` with shapes ``(num_dofs, num_dofs)``,
             ``(num_dofs,)``, and ``(num_dofs,)`` respectively.
         """
+        if not self.consider_coriolis:
+            return self._assemble_dynamics_terms_without_coriolis(q)
         return self._assemble_dynamics_terms(q, qd, convective_only_jd=True)
 
     @eqx.filter_jit

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -250,7 +250,8 @@ class PlanarPCS(SoftRobot):
             base_pose: Optional planar base pose ``[theta, x, y]`` with shape
                 ``(3,)``.
             **kwargs: Additional keyword arguments forwarded to the PlanarPCS
-                constructor, such as actuators or passive elements.
+                constructor, such as ``consider_coriolis``, actuators, or
+                passive elements.
 
         Returns:
             A fully initialized planar PCS model.
@@ -2928,6 +2929,77 @@ class PlanarPCS(SoftRobot):
         return Ws_scaled, g_ps, J_ps, Jd_or_Jd_qd_ps
 
     @eqx.filter_jit
+    def _dynamics_integration_pose_jacobians(
+        self, q: Array
+    ) -> tuple[Array, Array, Array]:
+        """Return derivative-free quadrature data for approximate dynamics.
+
+        This path propagates only body Jacobians and local gravity. It is used
+        when Coriolis forces are disabled so strain rates, tangent derivatives,
+        Jacobian time derivatives, and absolute poses are never constructed.
+        """
+        xi = self.strain(q).reshape(self.num_segments, 3)
+        B_xi_segments = self.B_xi.reshape(self.num_segments, 3, self.num_dofs)
+
+        Xs_scaled, Ws_scaled = vmap(
+            scale_interior_gaussian_quadrature, in_axes=(None, None, 0, 0)
+        )(
+            self.integration_points,
+            self.integration_weights,
+            self.L_cum[:-1],
+            self.L_cum[1:],
+        )
+        s_local = Xs_scaled - self.L_cum[:-1, None]
+
+        tip_operators = vmap(
+            lambda xi_i, L_i: constant_strain_se2._operators(
+                xi_i, L_i, self.global_eps, self.tangent_eps
+            )
+        )(xi, self.L)
+        Ad_inv_tips, T_tips = tip_operators
+        zeros = jnp.zeros((3, self.num_dofs), dtype=xi.dtype)
+        g0 = poses.planar_pose_to_transform(jnp.asarray(self.base_pose, dtype=xi.dtype))
+        gravity_base_initial = se2.adjoint_inverse(g0) @ self.g
+        local_jacobian_tips = vmap(
+            lambda Ad_inv_i, T_i, B_xi_i: (Ad_inv_i @ T_i) @ B_xi_i
+        )(Ad_inv_tips, T_tips, B_xi_segments)
+        J_bases, gravity_bases = self._propagate_body_jacobian_and_gravity(
+            zeros,
+            gravity_base_initial,
+            Ad_inv_tips,
+            local_jacobian_tips,
+        )
+
+        def segment_kinematics(
+            xi_i: Array,
+            B_xi_i: Array,
+            gravity_base_i: Array,
+            J_base_i: Array,
+            s_local_i: Array,
+        ) -> tuple[Array, Array]:
+            def kinematics_at_s(s_local_ij: Array) -> tuple[Array, Array]:
+                Ad_inv, T = constant_strain_se2._operators(
+                    xi_i,
+                    s_local_ij,
+                    self.global_eps,
+                    self.tangent_eps,
+                )
+                J_next = Ad_inv @ J_base_i + (Ad_inv @ T) @ B_xi_i
+                gravity_local = Ad_inv @ gravity_base_i
+                return gravity_local, J_next
+
+            return vmap(kinematics_at_s)(s_local_i)
+
+        gravity_ps, J_ps = vmap(segment_kinematics)(
+            xi,
+            B_xi_segments,
+            gravity_bases,
+            J_bases,
+            s_local,
+        )
+        return Ws_scaled, gravity_ps, J_ps
+
+    @eqx.filter_jit
     def _dynamics_integration_kinematics(
         self, q: Array, qd: Array
     ) -> tuple[Array, Array, Array, Array]:
@@ -3050,9 +3122,13 @@ class PlanarPCS(SoftRobot):
             ``(self.num_dofs,)``. ``G`` is the active generalized gravity
             vector with shape ``(self.num_dofs,)``.
         """
-        weights, gravity, jacobians, jacobian_dot_qd = (
-            self._dynamics_integration_kinematics(q, qd)
-        )
+        if self.consider_coriolis:
+            weights, gravity, jacobians, jacobian_dot_qd = (
+                self._dynamics_integration_kinematics(q, qd)
+            )
+        else:
+            weights, gravity, jacobians = self._dynamics_integration_pose_jacobians(q)
+            jacobian_dot_qd = None
         inertia = jnp.zeros((self.num_dofs, self.num_dofs), dtype=jacobians.dtype)
         coriolis_qd = jnp.zeros((self.num_dofs,), dtype=jacobians.dtype)
         gravity_force = jnp.zeros((self.num_dofs,), dtype=jacobians.dtype)
@@ -3075,11 +3151,19 @@ class PlanarPCS(SoftRobot):
             ).reshape(flattened_rows, dof_end)
             inertia_segment = jacobian_flat.T @ weighted_mass_jacobian
 
-            eta = jacobian @ qd[:dof_end]
-            momentum = mass_action(eta)
-            coadjoint_momentum = vmap(se2.coadjoint_action)(eta, momentum)
-            wrench = mass_action(jacobian_dot_qd[segment_index]) + coadjoint_momentum
-            coriolis_segment = jacobian_flat.T @ (weight[:, None] * wrench).reshape(-1)
+            if self.consider_coriolis:
+                assert jacobian_dot_qd is not None
+                eta = jacobian @ qd[:dof_end]
+                momentum = mass_action(eta)
+                coadjoint_momentum = vmap(se2.coadjoint_action)(eta, momentum)
+                wrench = (
+                    mass_action(jacobian_dot_qd[segment_index]) + coadjoint_momentum
+                )
+                coriolis_segment = jacobian_flat.T @ (weight[:, None] * wrench).reshape(
+                    -1
+                )
+            else:
+                coriolis_segment = jnp.zeros((dof_end,), dtype=jacobians.dtype)
             gravity_segment = -jacobian_flat.T @ (
                 weight[:, None] * mass_action(gravity[segment_index])
             ).reshape(-1)

--- a/src/soromox/systems/pendulum/pendulum.py
+++ b/src/soromox/systems/pendulum/pendulum.py
@@ -943,12 +943,15 @@ class Pendulum(SoftRobot):
             tau_ext = jnp.zeros((self.num_links,))
 
         B = self.inertia_matrix(q)
-        C = self.coriolis_matrix(q, qd)
+        if self.consider_coriolis:
+            Cqd = self.coriolis_matrix(q, qd) @ qd
+        else:
+            Cqd = jnp.zeros_like(qd)
         G = self._gravitational_force(q)
         D = self.damping_matrix(q)
         tau_el = self.elastic_force(q)
         tau_u = self.actuation_force(q, u, qd=qd)
-        rhs = tau_u + tau_ext - C @ qd - G - tau_el - D @ qd
+        rhs = tau_u + tau_ext - Cqd - G - tau_el - D @ qd
         qdd = jnp.linalg.solve(B, rhs)
         return jnp.concatenate([qd, qdd])
 

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -74,10 +74,15 @@ class SoftRobot(DynamicalSystem):
             integration, typically on the normalized interval [0, 1].
         integration_weights (Array | None): Quadrature weights corresponding
             to `integration_points`.
+        consider_coriolis (bool): Whether forward-dynamics assembly includes
+            Coriolis and centrifugal forces. This is a static model setting so
+            JAX compiles separate optimized programs for the enabled and
+            disabled cases. Defaults to ``True``.
     """
 
     # global epsilon for numerical computations
     global_eps: float  # Global epsilon for numerical computations
+    consider_coriolis: bool = eqx.field(static=True)
     base_pose: Array
     num_gauss_points: int | Array | None
     num_integration_points: int | Array | None
@@ -99,6 +104,7 @@ class SoftRobot(DynamicalSystem):
         self,
         eps: float | None = None,
         base_pose: Array | None = None,
+        consider_coriolis: bool = True,
         **kwargs: Any,
     ):
         """Initialize the SoftRobot.
@@ -113,11 +119,18 @@ class SoftRobot(DynamicalSystem):
                 normalized before use, and must have nonzero finite norm. If
                 omitted, the upright pose is used: the backbone points along
                 world +y for planar robots and world +z for spatial robots.
+            consider_coriolis: Whether :meth:`dynamics_terms` and
+                :meth:`forward_dynamics` include Coriolis and centrifugal
+                forces. Defaults to ``True``. The explicit
+                :meth:`coriolis_matrix` diagnostic is unaffected.
             **kwargs: Additional keyword arguments (unused, kept for API compatibility).
         """
         # Note: We don't call super().__init__() here because Equinox modules
         # work like dataclasses - fields are set directly rather than through
         # parent __init__ calls. Child classes must set num_dofs and num_actuators.
+        if not isinstance(consider_coriolis, bool):
+            raise TypeError("consider_coriolis must be a bool.")
+        self.consider_coriolis = consider_coriolis
         if base_pose is None:
             if self.is_planar:
                 base_pose = jnp.array([jnp.pi / 2, 0.0, 0.0], dtype=jnp.float64)
@@ -1201,11 +1214,22 @@ class SoftRobot(DynamicalSystem):
         ``d(C(v) @ v)[qd, qd_tangent] / 2 = C(q, qd_tangent) @ qd``
         for the standard Christoffel/energy-consistent Coriolis convention.
         """
-        _, coriolis_cross = jvp(
-            lambda velocity: self.dynamics_terms(q, velocity)[1],
-            (qd,),
-            (qd_tangent,),
-        )
+        if self.consider_coriolis:
+            _, coriolis_cross = jvp(
+                lambda velocity: self.dynamics_terms(q, velocity)[1],
+                (qd,),
+                (qd_tangent,),
+            )
+        else:
+            # ``consider_coriolis`` changes only the equations assembled for
+            # simulation. Energy derivatives remain derivatives of the exact
+            # kinetic energy and therefore use the explicit physical
+            # Coriolis diagnostic when the approximate dynamics path is active.
+            _, coriolis_cross = jvp(
+                lambda velocity: self.coriolis_matrix(q, velocity) @ velocity,
+                (qd,),
+                (qd_tangent,),
+            )
         return 0.5 * coriolis_cross
 
     def gravitational_energy(self, q: Array) -> Array:
@@ -1414,6 +1438,67 @@ class SoftRobot(DynamicalSystem):
     # Dynamics
     # -----------------------------------------
 
+    def _propagate_body_jacobian_and_gravity(
+        self,
+        jacobian_initial: Array,
+        gravity_initial: Array,
+        adjoint_inverse_steps: Array,
+        local_jacobian_steps: Array,
+    ) -> tuple[Array, Array]:
+        """Propagate segment-base Jacobians and gravity through body frames.
+
+        This shared q-only recurrence is useful for serial models whose
+        derivative-free dynamics path has already constructed each step's
+        inverse adjoint and local Jacobian increment. Lie-group-specific
+        operator construction remains with the concrete system.
+
+        Args:
+            jacobian_initial: Body Jacobian at the chain base, with shape
+                ``(twist_dim, num_dofs)``.
+            gravity_initial: Gravity spatial vector in the chain-base frame,
+                with shape ``(twist_dim,)``.
+            adjoint_inverse_steps: Inverse adjoints mapping each segment base
+                to its tip, with shape
+                ``(num_steps, twist_dim, twist_dim)``.
+            local_jacobian_steps: Local Jacobian increments already mapped to
+                the corresponding tip frames, with shape
+                ``(num_steps, twist_dim, num_dofs)``.
+
+        Returns:
+            Tuple ``(jacobian_bases, gravity_bases)``. The first array contains
+            the body Jacobian at every segment base and has shape
+            ``(num_steps, twist_dim, num_dofs)``. The second contains gravity
+            expressed in each segment-base frame and has shape
+            ``(num_steps, twist_dim)``.
+        """
+
+        def scan_jacobian(
+            jacobian_base: Array, inputs: tuple[Array, Array]
+        ) -> tuple[Array, Array]:
+            adjoint_inverse, local_jacobian = inputs
+            jacobian_tip = adjoint_inverse @ jacobian_base + local_jacobian
+            return jacobian_tip, jacobian_tip
+
+        _, jacobian_tips = lax.scan(
+            scan_jacobian,
+            jacobian_initial,
+            (adjoint_inverse_steps, local_jacobian_steps),
+        )
+        jacobian_bases = jnp.concatenate(
+            [jnp.zeros_like(jacobian_tips[:1]), jacobian_tips[:-1]], axis=0
+        )
+
+        def scan_gravity(
+            gravity_base: Array, adjoint_inverse: Array
+        ) -> tuple[Array, Array]:
+            gravity_tip = adjoint_inverse @ gravity_base
+            return gravity_tip, gravity_base
+
+        _, gravity_bases = lax.scan(
+            scan_gravity, gravity_initial, adjoint_inverse_steps
+        )
+        return jacobian_bases, gravity_bases
+
     def dynamics_terms(self, q: Array, qd: Array) -> tuple[Array, Array, Array]:
         """
         Return forward-dynamics terms ``(M, Cqd, G)``.
@@ -1421,10 +1506,15 @@ class SoftRobot(DynamicalSystem):
         ``Cqd`` is the convective force vector ``C(q, qd) @ qd``. The default
         implementation is intentionally unfused and calls the public matrix and
         force APIs separately. Overrides must keep ``M`` and ``Cqd``
-        energy-consistent with ``inertia_matrix`` and ``coriolis_matrix``.
+        energy-consistent with ``inertia_matrix`` and ``coriolis_matrix`` when
+        :attr:`consider_coriolis` is true. When it is false, implementations
+        must return an exact zero vector without evaluating Coriolis-only work.
         """
         M = self.inertia_matrix(q)
-        Cqd = self.coriolis_matrix(q, qd) @ qd
+        if self.consider_coriolis:
+            Cqd = self.coriolis_matrix(q, qd) @ qd
+        else:
+            Cqd = jnp.zeros_like(qd)
         G = self.gravitational_force(q)
         return M, Cqd, G
 

--- a/src/soromox/utils/lie_algebra/constant_strain/se3.py
+++ b/src/soromox/utils/lie_algebra/constant_strain/se3.py
@@ -67,6 +67,25 @@ class _PreparedAdjointPowers(NamedTuple):
     dot_powers: Array
 
 
+class _PreparedJacobianPowers(NamedTuple):
+    """Unscaled adjoint powers for derivative-free Jacobian propagation."""
+
+    angle_sq: Array
+    powers: Array
+
+
+def _prepare_jacobian_powers(xi: Array) -> _PreparedJacobianPowers:
+    """Precompute only the powers needed by position/Jacobian recurrences."""
+    xi = jnp.asarray(xi).reshape(-1)
+    powers = _matrix_polynomials.powers(
+        lie_se3.small_adjoint(xi), _REDUCED_POLYNOMIAL_DEGREE
+    )
+    return _PreparedJacobianPowers(
+        angle_sq=jnp.dot(xi[:3], xi[:3]),
+        powers=jnp.stack(powers),
+    )
+
+
 def _prepare_adjoint_powers(xi: Array, xid: Array) -> _PreparedAdjointPowers:
     r"""Precompute SE(3) powers that do not depend on arclength.
 
@@ -117,6 +136,33 @@ def _scaled_powers_from_prepared(
         dot_powers.append(scale * prepared.dot_powers[order])
         scale = scale * s
     return powers, dot_powers
+
+
+def _jacobian_operators_from_prepared(
+    prepared: _PreparedJacobianPowers,
+    s: Array,
+    adjoint_eps: float | Array,
+    tangent_eps: float | Array,
+) -> tuple[Array, Array]:
+    """Return ``(Ad_inv, Ad_inv @ T)`` without derivative-only work."""
+    s = jnp.asarray(s, dtype=prepared.powers.dtype)
+    scale = jnp.ones((), dtype=prepared.powers.dtype)
+    powers: list[Array] = []
+    for order in range(_REDUCED_POLYNOMIAL_DEGREE + 1):
+        powers.append(scale * prepared.powers[order])
+        scale = scale * s
+
+    adjoint = lie_se3._adjoint_from_powers(
+        powers, _adjoint_coefficients(prepared.angle_sq, s, adjoint_eps)
+    )
+    adjoint_inverse = lie_se3._adjoint_inverse_from_adjoint(adjoint)
+    coefficients, _ = _tangent_coefficients_and_x_derivatives(
+        prepared.angle_sq, s, tangent_eps
+    )
+    transported_tangent = s * lie_se3._transported_left_jacobian_from_powers(
+        powers, coefficients
+    )
+    return adjoint_inverse, transported_tangent
 
 
 def _operators_from_powers(

--- a/tests/systems/test_dynamical_system_rollout.py
+++ b/tests/systems/test_dynamical_system_rollout.py
@@ -174,6 +174,56 @@ def test_rollout_to_keeps_equilibrium():
     assert jnp.allclose(trajectory.y, 0.0, atol=1e-6)
 
 
+def test_all_rollout_variants_inherit_optional_coriolis_setting():
+    default = Pendulum(_pendulum_params())
+    enabled = Pendulum(_pendulum_params(), consider_coriolis=True)
+    disabled = Pendulum(_pendulum_params(), consider_coriolis=False)
+    q0 = jnp.array([0.8, -0.6])
+    qd0 = jnp.array([3.0, -2.0])
+    initial_state = SystemState(
+        t=0.0,
+        y=jnp.concatenate([q0, qd0]),
+        u=jnp.zeros_like(q0),
+    )
+
+    def run(robot: Pendulum):
+        controller = ZeroController(num_actuators=robot.num_actuators)
+        open_loop = robot.rollout_to(
+            initial_state=initial_state,
+            t1=0.02,
+            solver_dt=1e-3,
+            save_dt=0.01,
+        )
+        closed_loop = robot.rollout_closed_loop_to(
+            initial_state=initial_state,
+            controller=controller,
+            t1=0.02,
+            solver_dt=1e-3,
+            save_dt=0.01,
+        )
+        discrete = robot.rollout_discrete_closed_loop_to(
+            initial_state=initial_state,
+            controller=controller,
+            duration=0.02,
+            solver_dt=1e-3,
+            control_dt=0.01,
+            save_dt=0.01,
+        )
+        return open_loop, closed_loop, discrete
+
+    default_rollouts = run(default)
+    enabled_rollouts = run(enabled)
+    disabled_rollouts = run(disabled)
+    for default_trajectory, enabled_trajectory, disabled_trajectory in zip(
+        default_rollouts, enabled_rollouts, disabled_rollouts, strict=True
+    ):
+        assert jnp.allclose(default_trajectory.y, enabled_trajectory.y)
+        assert jnp.all(jnp.isfinite(disabled_trajectory.y))
+        assert not jnp.allclose(
+            disabled_trajectory.y[-1], enabled_trajectory.y[-1], atol=1e-9
+        )
+
+
 def test_rollout_to_environment_model_matches_tau_ext():
     robot = Pendulum(_pendulum_params())
 

--- a/tests/systems/test_mckibben_umarm.py
+++ b/tests/systems/test_mckibben_umarm.py
@@ -46,6 +46,7 @@ def make_zero_actuator_robot() -> McKibbenActuatedUMArm:
     return McKibbenActuatedUMArm(
         params,
         actuator=ArticulatedMcKibbenActuator.empty(),
+        consider_coriolis=False,
     )
 
 
@@ -135,6 +136,7 @@ def test_zero_actuator_umarm_exposes_empty_actuator_interface() -> None:
     y = jnp.concatenate([q, qd])
 
     assert robot.num_actuators == 0
+    assert robot.consider_coriolis is False
     assert robot.num_mckibben_groups == 0
     actuator = robot.actuators[0]
     assert actuator.segments(robot, q).shape == (0, 2, 3)

--- a/tests/systems/test_planar_hsa.py
+++ b/tests/systems/test_planar_hsa.py
@@ -72,6 +72,54 @@ def test_planar_hsa_parameter_updates_are_immutable_and_refresh_eager_caches():
     assert not jnp.allclose(_parameter_runtime_summary(updated), before)
 
 
+def test_planar_hsa_optional_coriolis_dynamics() -> None:
+    enabled = _create_robot()
+    disabled = PlanarHSA(
+        params=typed_params,
+        structure=PlanarHSAStructure(),
+        consider_coriolis=False,
+    )
+    q = jnp.linspace(-0.1, 0.1, enabled.num_dofs)
+    qd = jnp.linspace(0.2, -0.2, enabled.num_dofs)
+
+    M_enabled, _, G_enabled = enabled.dynamics_terms(q, qd)
+    M_disabled, Cqd_disabled, G_disabled = disabled.dynamics_terms(q, qd)
+
+    assert_allclose(M_disabled, M_enabled, rtol=1e-9, atol=1e-11)
+    assert_allclose(G_disabled, G_enabled, rtol=1e-9, atol=1e-11)
+    assert_allclose(Cqd_disabled, jnp.zeros_like(qd), rtol=0.0, atol=0.0)
+    assert_allclose(
+        disabled.coriolis_matrix(q, qd),
+        enabled.coriolis_matrix(q, qd),
+        rtol=1e-8,
+        atol=1e-10,
+    )
+    assert disabled.with_params(disabled.params).consider_coriolis is False
+
+
+def test_planar_hsa_disabled_path_skips_convective_assembly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    robot = PlanarHSA(
+        params=typed_params,
+        structure=PlanarHSAStructure(),
+        consider_coriolis=False,
+    )
+    q = jnp.linspace(-0.1, 0.1, robot.num_dofs)
+    qd = jnp.linspace(0.2, -0.2, robot.num_dofs)
+
+    def fail_if_called(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("disabled dynamics evaluated convective assembly")
+
+    monkeypatch.setattr(PlanarHSA, "_assemble_dynamics_terms", fail_if_called)
+
+    with jax.disable_jit():
+        _, Cqd, _ = robot.dynamics_terms(q, qd)
+
+    assert_allclose(Cqd, jnp.zeros_like(qd), rtol=0.0, atol=0.0)
+
+
 def test_planar_hsa_same_structure_parameter_updates_compile_once():
     robot = _create_robot()
     updated_params = _updated_typed_params()

--- a/tests/systems/test_pressure_actuated_pcs_models.py
+++ b/tests/systems/test_pressure_actuated_pcs_models.py
@@ -141,6 +141,7 @@ def test_isupport_parameter_updates_are_immutable_and_refresh_eager_caches():
     robot = ISupport(
         params=params,
         structure=make_pneumatic_isupport_structure(num_gauss_points=1),
+        consider_coriolis=False,
     )
     updated_params = updated_isupport_params(params)
     before = isupport_runtime_summary(robot)
@@ -149,6 +150,7 @@ def test_isupport_parameter_updates_are_immutable_and_refresh_eager_caches():
 
     assert jnp.allclose(isupport_runtime_summary(robot), before)
     assert not jnp.allclose(isupport_runtime_summary(updated), before)
+    assert updated.consider_coriolis is False
 
 
 def test_isupport_same_structure_parameter_updates_compile_once():

--- a/tests/systems/test_shared_continuum_components.py
+++ b/tests/systems/test_shared_continuum_components.py
@@ -40,7 +40,7 @@ def _poisson_material(*, damping: bool = True) -> IsotropicMaterialParams:
     )
 
 
-def _pcs() -> PCS:
+def _pcs(*, consider_coriolis: bool = True) -> PCS:
     return PCS.from_links(
         [
             LinkSpec.circular(
@@ -52,11 +52,12 @@ def _pcs() -> PCS:
                 material_damping_coefficient=1.0e4,
                 reference_strain=REFERENCE,
             )
-        ]
+        ],
+        consider_coriolis=consider_coriolis,
     )
 
 
-def _planar_pcs() -> PlanarPCS:
+def _planar_pcs(*, consider_coriolis: bool = True) -> PlanarPCS:
     return PlanarPCS.from_links(
         [
             LinkSpec.circular(
@@ -68,11 +69,12 @@ def _planar_pcs() -> PlanarPCS:
                 material_damping_coefficient=1.0e4,
                 reference_strain=[0.0, 0.0, 1.0],
             )
-        ]
+        ],
+        consider_coriolis=consider_coriolis,
     )
 
 
-def _gvs() -> GVS:
+def _gvs(*, consider_coriolis: bool = True) -> GVS:
     return GVS.from_segments(
         [
             GVSSegment(
@@ -98,8 +100,16 @@ def _gvs() -> GVS:
                 ),
                 num_gauss_points=7,
             )
-        ]
+        ],
+        consider_coriolis=consider_coriolis,
     )
+
+
+@pytest.mark.parametrize("factory", [_pcs, _planar_pcs, _gvs])
+def test_construction_helpers_forward_optional_coriolis_setting(factory) -> None:
+    robot = factory(consider_coriolis=False)
+
+    assert robot.consider_coriolis is False
 
 
 def test_shared_params_replace_and_explicit_matrix_bypass() -> None:

--- a/tests/systems/test_soft_robot_defaults.py
+++ b/tests/systems/test_soft_robot_defaults.py
@@ -1,4 +1,6 @@
+import equinox as eqx
 import jax
+import pytest
 from jax import Array
 from jax import numpy as jnp
 from numpy.testing import assert_allclose
@@ -19,8 +21,8 @@ jax.config.update("jax_enable_x64", True)
 class _PlanarDefaultRobot(SoftRobot):
     L: Array
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, consider_coriolis: bool = True):
+        super().__init__(consider_coriolis=consider_coriolis)
         self.num_dofs = 2
         self.num_actuators = 2
         self.L = jnp.array([1.0, 2.0], dtype=jnp.float64)
@@ -143,6 +145,12 @@ class _ToggleSentinelDefaultRobot(_PlanarDefaultRobot):
 
     def _gravitational_force(self, q: Array) -> Array:
         return jnp.array([4.0, -2.0], dtype=q.dtype)
+
+
+class _CoriolisGuardDefaultRobot(_PlanarDefaultRobot):
+    def coriolis_matrix(self, q: Array, qd: Array) -> Array:
+        del q, qd
+        raise AssertionError("disabled dynamics evaluated coriolis_matrix")
 
 
 def test_custom_jvp_global_toggle_context_manager_restores_state() -> None:
@@ -418,6 +426,111 @@ def test_default_gravity_force_and_forward_dynamics() -> None:
     qdd = jnp.linalg.solve(robot.inertia_matrix(q), rhs)
 
     assert_allclose(robot.forward_dynamics(0.0, y, (u, tau_ext)), jnp.r_[qd, qdd])
+
+
+def test_default_dynamics_can_omit_coriolis_without_changing_diagnostics() -> None:
+    enabled = _PlanarDefaultRobot(consider_coriolis=True)
+    disabled = _PlanarDefaultRobot(consider_coriolis=False)
+    q = jnp.array([0.2, -0.3], dtype=jnp.float64)
+    qd = jnp.array([0.7, -0.4], dtype=jnp.float64)
+    u = jnp.array([1.5, -2.0], dtype=jnp.float64)
+    tau_ext = jnp.array([0.25, -0.75], dtype=jnp.float64)
+
+    M_enabled, _, G_enabled = enabled.dynamics_terms(q, qd)
+    M_disabled, Cqd_disabled, G_disabled = disabled.dynamics_terms(q, qd)
+    assert_allclose(M_disabled, M_enabled, rtol=1e-12, atol=1e-12)
+    assert_allclose(G_disabled, G_enabled, rtol=1e-12, atol=1e-12)
+    assert_allclose(Cqd_disabled, jnp.zeros_like(qd), rtol=0.0, atol=0.0)
+    assert_allclose(
+        disabled.coriolis_matrix(q, qd),
+        enabled.coriolis_matrix(q, qd),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+    rhs = (
+        disabled.actuation_force(q, u, qd=qd)
+        + tau_ext
+        - G_disabled
+        - disabled.elastic_force(q)
+        - disabled.damping_matrix(q) @ qd
+    )
+    expected_qdd = jnp.linalg.solve(M_disabled, rhs)
+    actual = disabled.forward_dynamics(0.0, jnp.concatenate([q, qd]), (u, tau_ext))
+    assert_allclose(
+        actual,
+        jnp.concatenate([qd, expected_qdd]),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_disabling_coriolis_preserves_exact_energy_derivatives() -> None:
+    enabled = _PlanarDefaultRobot(consider_coriolis=True)
+    disabled = _PlanarDefaultRobot(consider_coriolis=False)
+    q = jnp.array([0.2, -0.3], dtype=jnp.float64)
+    qd = jnp.array([0.7, -0.4], dtype=jnp.float64)
+    q_tangent = jnp.array([-0.6, 0.25], dtype=jnp.float64)
+    qdd = jnp.array([0.15, -0.35], dtype=jnp.float64)
+
+    def energy_jvp(robot: SoftRobot) -> Array:
+        return jax.jvp(
+            lambda q_, qd_: robot.total_energy(q_, qd_),
+            (q, qd),
+            (q_tangent, qdd),
+        )[1]
+
+    assert_allclose(
+        disabled.total_energy(q, qd),
+        enabled.total_energy(q, qd),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    assert_allclose(
+        jax.grad(disabled.total_energy, argnums=(0, 1))(q, qd),
+        jax.grad(enabled.total_energy, argnums=(0, 1))(q, qd),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    assert_allclose(energy_jvp(disabled), energy_jvp(enabled), rtol=1e-12, atol=1e-12)
+
+
+def test_static_coriolis_modes_compile_separate_executables() -> None:
+    enabled = _PlanarDefaultRobot(consider_coriolis=True)
+    disabled = _PlanarDefaultRobot(consider_coriolis=False)
+    q = jnp.array([0.2, -0.3], dtype=jnp.float64)
+    qd = jnp.array([0.7, -0.4], dtype=jnp.float64)
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_terms(robot: SoftRobot, q: Array, qd: Array):
+        trace_count["value"] += 1
+        return robot.dynamics_terms(q, qd)
+
+    compiled_terms(enabled, q, qd)
+    compiled_terms(enabled, q, qd)
+    compiled_terms(disabled, q, qd)
+    compiled_terms(disabled, q, qd)
+
+    assert trace_count["value"] == 2
+
+
+def test_consider_coriolis_requires_a_boolean() -> None:
+    with pytest.raises(TypeError, match="consider_coriolis must be a bool"):
+        _PlanarDefaultRobot(consider_coriolis=1)  # type: ignore[arg-type]
+
+
+def test_disabled_default_dynamics_never_evaluate_coriolis_matrix() -> None:
+    robot = _CoriolisGuardDefaultRobot(consider_coriolis=False)
+    q = jnp.array([0.2, -0.3], dtype=jnp.float64)
+    qd = jnp.array([0.7, -0.4], dtype=jnp.float64)
+    y = jnp.concatenate([q, qd])
+
+    _, Cqd, _ = robot.dynamics_terms(q, qd)
+    yd = robot.forward_dynamics(jnp.array(0.0), y)
+
+    assert_allclose(Cqd, jnp.zeros_like(qd), rtol=0.0, atol=0.0)
+    assert jnp.all(jnp.isfinite(yd))
 
 
 def test_default_potential_force_sums_conservative_forces() -> None:

--- a/tests/tools/test_benchmark_common.py
+++ b/tests/tools/test_benchmark_common.py
@@ -1,5 +1,7 @@
 import jax
+import jax.numpy as jnp
 import pytest
+from numpy.testing import assert_allclose
 
 from tools.benchmarks._benchmark_common import (
     build_system_with_gauss_points,
@@ -31,3 +33,117 @@ def test_gvs_basis_order_registry_builds_current_system_api() -> None:
 
     assert context["q"].shape == (system.num_dofs,)
     assert context["u"].shape == (system.num_actuators,)
+
+
+@pytest.mark.parametrize("system_name", list(get_system_registry()))
+def test_benchmark_systems_support_optional_coriolis_dynamics(
+    system_name: str,
+) -> None:
+    config = get_system_registry()[system_name]
+    default = build_system_with_gauss_points(config, size=1, gauss_points=None)
+    enabled = build_system_with_gauss_points(
+        config, size=1, gauss_points=None, consider_coriolis=True
+    )
+    disabled = build_system_with_gauss_points(
+        config, size=1, gauss_points=None, consider_coriolis=False
+    )
+    context = config.build_context(enabled)
+    q, qd = context["q"], context["qd"]
+
+    M_enabled, Cqd_enabled, G_enabled = enabled.dynamics_terms(q, qd)
+    M_default, Cqd_default, G_default = default.dynamics_terms(q, qd)
+    M_disabled, Cqd_disabled, G_disabled = disabled.dynamics_terms(q, qd)
+
+    assert default.consider_coriolis is True
+    assert enabled.consider_coriolis is True
+    assert disabled.consider_coriolis is False
+    assert_allclose(M_default, M_enabled, rtol=1e-9, atol=1e-11)
+    assert_allclose(Cqd_default, Cqd_enabled, rtol=1e-9, atol=1e-11)
+    assert_allclose(G_default, G_enabled, rtol=1e-9, atol=1e-11)
+    assert_allclose(M_disabled, M_enabled, rtol=1e-9, atol=1e-11)
+    assert_allclose(G_disabled, G_enabled, rtol=1e-9, atol=1e-11)
+    assert_allclose(Cqd_disabled, jnp.zeros_like(qd), rtol=0.0, atol=0.0)
+    assert jnp.all(jnp.isfinite(Cqd_enabled))
+    assert_allclose(
+        disabled.coriolis_matrix(q, qd),
+        enabled.coriolis_matrix(q, qd),
+        rtol=1e-9,
+        atol=1e-11,
+    )
+
+    tau_u = disabled.actuation_force(q, context["u"], qd=qd)
+    rhs = (
+        tau_u
+        + context["tau_ext"]
+        - G_disabled
+        - disabled.elastic_force(q)
+        - disabled.damping_matrix(q) @ qd
+    )
+    expected_qdd = jnp.linalg.solve(M_disabled, rhs)
+    actual = disabled.forward_dynamics(
+        context["t"],
+        context["y"],
+        (context["u"], context["tau_ext"]),
+    )
+    assert_allclose(actual, jnp.concatenate([qd, expected_qdd]), rtol=1e-8, atol=1e-10)
+    assert_allclose(
+        default.forward_dynamics(
+            context["t"],
+            context["y"],
+            (context["u"], context["tau_ext"]),
+        ),
+        enabled.forward_dynamics(
+            context["t"],
+            context["y"],
+            (context["u"], context["tau_ext"]),
+        ),
+        rtol=1e-9,
+        atol=1e-11,
+    )
+
+    if hasattr(disabled, "with_params"):
+        assert disabled.with_params(disabled.params).consider_coriolis is False
+
+
+@pytest.mark.parametrize(
+    ("system_name", "guarded_helpers", "exercise_forward_dynamics"),
+    [
+        ("pendulum", ("coriolis_matrix",), True),
+        (
+            "articulated_soft_robot",
+            ("_motion_cross", "_force_cross"),
+            True,
+        ),
+        ("planar_pcs", ("_dynamics_integration_kinematics",), False),
+        ("pcs", ("_dynamics_integration_kinematics",), False),
+        ("gvs", ("_joint_jacobian_time_derivative_step_terms",), False),
+    ],
+)
+def test_disabled_paths_do_not_evaluate_derivative_or_convective_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+    system_name: str,
+    guarded_helpers: tuple[str, ...],
+    exercise_forward_dynamics: bool,
+) -> None:
+    config = get_system_registry()[system_name]
+    system = build_system_with_gauss_points(
+        config, size=1, gauss_points=None, consider_coriolis=False
+    )
+    context = config.build_context(system)
+
+    def fail_if_called(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("disabled dynamics evaluated a guarded helper")
+
+    for helper_name in guarded_helpers:
+        monkeypatch.setattr(type(system), helper_name, fail_if_called)
+
+    with jax.disable_jit():
+        if exercise_forward_dynamics:
+            system.forward_dynamics(
+                context["t"],
+                context["y"],
+                (context["u"], context["tau_ext"]),
+            )
+        else:
+            system.dynamics_terms(context["q"], context["qd"])

--- a/tools/benchmarks/_benchmark_common.py
+++ b/tools/benchmarks/_benchmark_common.py
@@ -33,10 +33,10 @@ Array = jax.Array
 class SystemConfig:
     """Factory plus context builder for a Soromox system."""
 
-    factory: Callable[[int], Any]
+    factory: Callable[..., Any]
     size_label: str
     build_context: Callable[[Any], MutableMapping[str, Array]]
-    gauss_factory: Callable[[int, int], Any] | None = None
+    gauss_factory: Callable[..., Any] | None = None
     default_gauss_points: int | None = None
     min_gauss_points: int = 1
 
@@ -45,7 +45,7 @@ class SystemConfig:
         return self.gauss_factory is not None
 
 
-def _pendulum_factory(num_links: int) -> Pendulum:
+def _pendulum_factory(num_links: int, *, consider_coriolis: bool = True) -> Pendulum:
     lengths = jnp.linspace(0.15, 0.25, num_links)
     masses = jnp.linspace(0.8, 1.2, num_links)
     inertias = (1.0 / 12.0) * masses * lengths**2
@@ -61,7 +61,7 @@ def _pendulum_factory(num_links: int) -> Pendulum:
         joint_rest_configuration=jnp.zeros((num_links,)),
         radius=0.05 * lengths,
     )
-    return Pendulum(params=params)
+    return Pendulum(params=params, consider_coriolis=consider_coriolis)
 
 
 def _pendulum_context(system: Pendulum) -> MutableMapping[str, Array]:
@@ -80,7 +80,10 @@ def _pendulum_context(system: Pendulum) -> MutableMapping[str, Array]:
 
 
 def _articulated_soft_robot_factory(
-    num_links: int, gauss_points: int = 5
+    num_links: int,
+    gauss_points: int = 5,
+    *,
+    consider_coriolis: bool = True,
 ) -> ArticulatedSoftRobot:
     axes = jnp.array(
         [
@@ -123,7 +126,7 @@ def _articulated_soft_robot_factory(
         joint_rest_configuration=jnp.zeros((num_links,)),
         radius=0.05 * lengths,
     )
-    return ArticulatedSoftRobot(params=params)
+    return ArticulatedSoftRobot(params=params, consider_coriolis=consider_coriolis)
 
 
 def _articulated_soft_robot_context(
@@ -145,7 +148,12 @@ def _articulated_soft_robot_context(
     return ctx
 
 
-def _planar_pcs_factory(num_segments: int, gauss_points: int = 5) -> PlanarPCS:
+def _planar_pcs_factory(
+    num_segments: int,
+    gauss_points: int = 5,
+    *,
+    consider_coriolis: bool = True,
+) -> PlanarPCS:
     return PlanarPCS.from_links(
         [
             LinkSpec.circular(
@@ -162,6 +170,7 @@ def _planar_pcs_factory(num_segments: int, gauss_points: int = 5) -> PlanarPCS:
         base_pose=jnp.array([jnp.pi / 2, 0.0, 0.0]),
         gravity=jnp.array([0.0, 9.81]),
         structure=PlanarPCSStructure(num_gauss_points=gauss_points),
+        consider_coriolis=consider_coriolis,
     )
 
 
@@ -188,7 +197,12 @@ def _planar_pcs_context(system: PlanarPCS) -> MutableMapping[str, Array]:
     return ctx
 
 
-def _pcs_factory(num_segments: int, gauss_points: int = 5) -> PCS:
+def _pcs_factory(
+    num_segments: int,
+    gauss_points: int = 5,
+    *,
+    consider_coriolis: bool = True,
+) -> PCS:
     return PCS.from_links(
         [
             LinkSpec.circular(
@@ -205,6 +219,7 @@ def _pcs_factory(num_segments: int, gauss_points: int = 5) -> PCS:
         base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
         gravity=jnp.array([0.0, 0.0, -9.81]),
         structure=PCSStructure(num_gauss_points=gauss_points),
+        consider_coriolis=consider_coriolis,
     )
 
 
@@ -256,7 +271,12 @@ def _gvs_segment(strain_basis_order: int, gauss_points: int) -> GVSSegment:
     )
 
 
-def _gvs_factory(num_segments: int, gauss_points: int = 5) -> GVS:
+def _gvs_factory(
+    num_segments: int,
+    gauss_points: int = 5,
+    *,
+    consider_coriolis: bool = True,
+) -> GVS:
     segments: list[GVSSegment] = []
     for _ in range(num_segments):
         segments.append(_gvs_segment(strain_basis_order=0, gauss_points=gauss_points))
@@ -264,10 +284,16 @@ def _gvs_factory(num_segments: int, gauss_points: int = 5) -> GVS:
     return GVS.from_segments(
         segments=segments,
         gravity=jnp.array([0.0, 0.0, 9.81]),
+        consider_coriolis=consider_coriolis,
     )
 
 
-def _gvs_basis_order_factory(strain_basis_order: int, gauss_points: int = 5) -> GVS:
+def _gvs_basis_order_factory(
+    strain_basis_order: int,
+    gauss_points: int = 5,
+    *,
+    consider_coriolis: bool = True,
+) -> GVS:
     return GVS.from_segments(
         segments=[
             _gvs_segment(
@@ -276,6 +302,7 @@ def _gvs_basis_order_factory(strain_basis_order: int, gauss_points: int = 5) -> 
             )
         ],
         gravity=jnp.array([0.0, 0.0, 9.81]),
+        consider_coriolis=consider_coriolis,
     )
 
 
@@ -455,17 +482,18 @@ def build_system_with_gauss_points(
     config: Any,
     size: int,
     gauss_points: int | None,
+    **model_kwargs: Any,
 ) -> Any:
     """Build a configured benchmark system, optionally overriding quadrature."""
 
     if gauss_points is None:
-        return config.factory(size)
+        return config.factory(size, **model_kwargs)
     if not getattr(config, "supports_gauss_points", False):
         raise ValueError(
             f"{getattr(config, 'size_label', 'system')} does not support "
             "Gaussian quadrature point sweeps."
         )
-    return config.gauss_factory(size, gauss_points)
+    return config.gauss_factory(size, gauss_points, **model_kwargs)
 
 
 def system_gauss_point_metadata(system: Any) -> tuple[int | None, int | None]:

--- a/tools/benchmarks/benchmark_system_methods.py
+++ b/tools/benchmarks/benchmark_system_methods.py
@@ -153,14 +153,12 @@ def _dense_forward_dynamics(
     if tau_ext is None:
         tau_ext = jnp.zeros((system.num_dofs,), dtype=y.dtype)
 
-    M = system.inertia_matrix(q)
-    C = system.coriolis_matrix(q, qd)
-    G = system.gravitational_force(q)
+    M, Cqd, G = system.dynamics_terms(q, qd)
     D = system.damping_matrix(q)
     rhs = (
         system.actuation_force(q, u)
         + tau_ext
-        - C @ qd
+        - Cqd
         - G
         - system.elastic_force(q)
         - D @ qd
@@ -301,6 +299,14 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             ),
         ),
         BenchmarkCase(
+            name="dynamics_terms",
+            description="Dense M, C @ qd, and G path",
+            builder=lambda sys, ctx, _: (
+                sys.dynamics_terms,
+                (ctx["q"], ctx["qd"]),
+            ),
+        ),
+        BenchmarkCase(
             name="forward_dynamics",
             description="ABA-backed forward dynamics",
             builder=lambda sys, ctx, _: (
@@ -367,6 +373,14 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             builder=lambda sys, ctx, _: (
                 sys.jacobian_and_time_derivative,
                 (ctx["q"], ctx["qd"], ctx["s_tip"]),
+            ),
+        ),
+        BenchmarkCase(
+            name="dynamics_terms",
+            description="Fused M, C @ qd, and G path",
+            builder=lambda sys, ctx, _: (
+                sys.dynamics_terms,
+                (ctx["q"], ctx["qd"]),
             ),
         ),
         BenchmarkCase(
@@ -631,6 +645,10 @@ def _plot_results(
         subset = [res for res in results if res["system"] == system]
         size_label = subset[0]["size_label"]
         functions = sorted({res["function"] for res in subset})
+        coriolis_modes = sorted(
+            {bool(res.get("consider_coriolis", True)) for res in subset},
+            reverse=True,
+        )
         ax_compile = axes[row, 0]
         ax_exec = axes[row, 1]
         gauss_values = {
@@ -643,39 +661,64 @@ def _plot_results(
         if plot_gauss_axis:
             sizes = sorted({res["size_value"] for res in subset})
             for fn_name in functions:
-                for size in sizes:
+                for consider_coriolis in coriolis_modes:
+                    for size in sizes:
+                        fn_results = sorted(
+                            (
+                                res
+                                for res in subset
+                                if res["function"] == fn_name
+                                and res["size_value"] == size
+                                and bool(res.get("consider_coriolis", True))
+                                is consider_coriolis
+                                and res.get("gauss_points") not in (None, "")
+                            ),
+                            key=lambda item: item["gauss_points"],
+                        )
+                        if not fn_results:
+                            continue
+                        x_values = [item["gauss_points"] for item in fn_results]
+                        compile_times = [
+                            item["jit_compile_time_s"] for item in fn_results
+                        ]
+                        exec_times = [
+                            item["jit_execution_time_s"] for item in fn_results
+                        ]
+                        label_parts = [fn_name]
+                        if len(sizes) > 1:
+                            label_parts.append(f"{size_label}={size}")
+                        if len(coriolis_modes) > 1:
+                            label_parts.append(
+                                "Coriolis on" if consider_coriolis else "Coriolis off"
+                            )
+                        label = ", ".join(label_parts)
+                        ax_compile.plot(
+                            x_values, compile_times, marker="o", label=label
+                        )
+                        ax_exec.plot(x_values, exec_times, marker="o", label=label)
+        else:
+            for fn_name in functions:
+                for consider_coriolis in coriolis_modes:
                     fn_results = sorted(
                         (
                             res
                             for res in subset
                             if res["function"] == fn_name
-                            and res["size_value"] == size
-                            and res.get("gauss_points") not in (None, "")
+                            and bool(res.get("consider_coriolis", True))
+                            is consider_coriolis
                         ),
-                        key=lambda item: item["gauss_points"],
+                        key=lambda item: item["size_value"],
                     )
-                    if not fn_results:
-                        continue
-                    x_values = [item["gauss_points"] for item in fn_results]
+                    sizes = [item["size_value"] for item in fn_results]
                     compile_times = [item["jit_compile_time_s"] for item in fn_results]
                     exec_times = [item["jit_execution_time_s"] for item in fn_results]
-                    label = (
-                        f"{fn_name}, {size_label}={size}" if len(sizes) > 1 else fn_name
-                    )
-                    ax_compile.plot(x_values, compile_times, marker="o", label=label)
-                    ax_exec.plot(x_values, exec_times, marker="o", label=label)
-        else:
-            for fn_name in functions:
-                fn_results = sorted(
-                    (res for res in subset if res["function"] == fn_name),
-                    key=lambda item: item["size_value"],
-                )
-                sizes = [item["size_value"] for item in fn_results]
-                compile_times = [item["jit_compile_time_s"] for item in fn_results]
-                exec_times = [item["jit_execution_time_s"] for item in fn_results]
+                    label = fn_name
+                    if len(coriolis_modes) > 1:
+                        state = "on" if consider_coriolis else "off"
+                        label = f"{fn_name}, Coriolis {state}"
 
-                ax_compile.plot(sizes, compile_times, marker="o", label=fn_name)
-                ax_exec.plot(sizes, exec_times, marker="o", label=fn_name)
+                    ax_compile.plot(sizes, compile_times, marker="o", label=label)
+                    ax_exec.plot(sizes, exec_times, marker="o", label=label)
 
         ax_compile.set_title(f"{system} – compile")
         ax_exec.set_title(f"{system} – execution")
@@ -714,6 +757,7 @@ def _write_csv(results: Sequence[Mapping[str, Any]], path: Path) -> None:
         "size_value",
         "gauss_points",
         "integration_points",
+        "consider_coriolis",
         "backend",
         "cpu_affinity",
         "jit_compile_time_s",
@@ -749,6 +793,16 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         metavar="METHOD",
         help=(
             f"Methods to benchmark (default: all). Available: {', '.join(all_methods)}"
+        ),
+    )
+    parser.add_argument(
+        "--coriolis-modes",
+        nargs="+",
+        choices=("enabled", "disabled"),
+        default=("enabled",),
+        help=(
+            "Coriolis configurations to benchmark. Pass both 'enabled' and "
+            "'disabled' to measure the approximation speedup."
         ),
     )
     parser.add_argument(
@@ -858,74 +912,82 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         for size in args.segment_counts:
             for requested_gauss_points in gauss_values:
-                system = build_system_with_gauss_points(
-                    system_cfg, size, requested_gauss_points
-                )
-                gauss_points, integration_points = system_gauss_point_metadata(system)
-                gauss_note = ""
-                if requested_gauss_points is not None:
-                    gauss_note = (
-                        f", gauss_points={gauss_points}, "
-                        f"integration_points={integration_points}"
+                for coriolis_mode in args.coriolis_modes:
+                    consider_coriolis = coriolis_mode == "enabled"
+                    system = build_system_with_gauss_points(
+                        system_cfg,
+                        size,
+                        requested_gauss_points,
+                        consider_coriolis=consider_coriolis,
                     )
-
-                print(
-                    f"\n=== Benchmarking {system_name} with "
-                    f"{system_cfg.size_label}={size}{gauss_note} ==="
-                )
-                ctx = system_cfg.build_context(system)
-                for case in cases_to_run:
-                    fn, call_args = case.builder(system, ctx, runtime)
-                    print(f"  -> {case.name} ...", end=" ", flush=True)
-                    compile_time, exec_time = _measure_jitted_call(
-                        fn,
-                        call_args,
-                        runtime.execution_repeats,
-                        runtime.warmup_duration,
+                    gauss_points, integration_points = system_gauss_point_metadata(
+                        system
                     )
-
-                    per_point_note = ""
-                    if (
-                        case.name == "forward_kinematics_batched"
-                        and len(call_args) >= 2
-                    ):
-                        s_arg = call_args[1]
-                        num_points = None
-                        if hasattr(s_arg, "shape") and s_arg.shape:
-                            num_points = int(s_arg.shape[0])
-                        else:
-                            try:
-                                num_points = int(len(s_arg))
-                            except TypeError:
-                                num_points = None
-                        if num_points and num_points > 0:
-                            compile_time /= num_points
-                            exec_time /= num_points
-                            per_point_note = f" (per point over {num_points})"
-
+                    gauss_note = ""
+                    if requested_gauss_points is not None:
+                        gauss_note = (
+                            f", gauss_points={gauss_points}, "
+                            f"integration_points={integration_points}"
+                        )
                     print(
-                        f"compile {compile_time:.4f}s | exec {exec_time:.4f}s"
-                        f"{per_point_note}"
+                        f"\n=== Benchmarking {system_name} with "
+                        f"{system_cfg.size_label}={size}{gauss_note}, "
+                        f"Coriolis {coriolis_mode} ==="
                     )
-                    results.append(
-                        {
-                            "system": system_name,
-                            "function": case.name,
-                            "size_label": system_cfg.size_label,
-                            "size_value": size,
-                            "gauss_points": gauss_points,
-                            "integration_points": integration_points,
-                            "backend": active_backend,
-                            "cpu_affinity": active_cpu_affinity,
-                            "jit_compile_time_s": compile_time,
-                            "jit_execution_time_s": exec_time,
-                            "duration": runtime.duration,
-                            "solver_dt": runtime.solver_dt,
-                            "save_dt": runtime.save_dt,
-                            "execution_repeats": runtime.execution_repeats,
-                            "warmup_duration": runtime.warmup_duration,
-                        }
-                    )
+                    ctx = system_cfg.build_context(system)
+                    for case in cases_to_run:
+                        fn, call_args = case.builder(system, ctx, runtime)
+                        print(f"  -> {case.name} ...", end=" ", flush=True)
+                        compile_time, exec_time = _measure_jitted_call(
+                            fn,
+                            call_args,
+                            runtime.execution_repeats,
+                            runtime.warmup_duration,
+                        )
+
+                        per_point_note = ""
+                        if (
+                            case.name == "forward_kinematics_batched"
+                            and len(call_args) >= 2
+                        ):
+                            s_arg = call_args[1]
+                            num_points = None
+                            if hasattr(s_arg, "shape") and s_arg.shape:
+                                num_points = int(s_arg.shape[0])
+                            else:
+                                try:
+                                    num_points = int(len(s_arg))
+                                except TypeError:
+                                    num_points = None
+                            if num_points and num_points > 0:
+                                compile_time /= num_points
+                                exec_time /= num_points
+                                per_point_note = f" (per point over {num_points})"
+
+                        print(
+                            f"compile {compile_time:.4f}s | exec {exec_time:.4f}s"
+                            f"{per_point_note}"
+                        )
+                        results.append(
+                            {
+                                "system": system_name,
+                                "function": case.name,
+                                "size_label": system_cfg.size_label,
+                                "size_value": size,
+                                "gauss_points": gauss_points,
+                                "integration_points": integration_points,
+                                "consider_coriolis": consider_coriolis,
+                                "backend": active_backend,
+                                "cpu_affinity": active_cpu_affinity,
+                                "jit_compile_time_s": compile_time,
+                                "jit_execution_time_s": exec_time,
+                                "duration": runtime.duration,
+                                "solver_dt": runtime.solver_dt,
+                                "save_dt": runtime.save_dt,
+                                "execution_repeats": runtime.execution_repeats,
+                                "warmup_duration": runtime.warmup_duration,
+                            }
+                        )
 
     artifacts: list[str] = []
 


### PR DESCRIPTION
## Motivation

Some simulation and optimization workloads deliberately use a reduced dynamics
model that neglects Coriolis and centrifugal forces. Soromox previously offered
no coherent way to request this approximation: callers could manually modify a
dense equation-of-motion solve, but system-specific `forward_dynamics` paths and
the rollout APIs would still compute the physical velocity-bias terms.

The goal of this PR is therefore to provide one opt-in interface across every
`SoftRobot` family while making the reduced path genuinely cheaper. The existing
physical dynamics remain the default.

This PR builds on the device/affinity/warmup benchmark infrastructure merged in
#170. Its diff against current `main` contains the Coriolis API, optimized
dynamics paths, coverage, and Coriolis-specific benchmark support.

## API

- Add the static Equinox model setting `consider_coriolis: bool` to `SoftRobot`.
- Default it to `True`, preserving current behavior and physical accuracy.
- Accept the setting in direct constructors and shared `from_links` /
  `from_segments` construction helpers:

  ```python
  robot = PCS.from_links(links, consider_coriolis=False)
  ```

- Preserve the setting across immutable `with_params` and parameter-update
  workflows while keeping it outside physical parameter PyTrees.
- Keep the canonical method name `dynamics_terms`; no singular alias is added.
- Let `rollout_to`, `rollout_closed_loop_to`, and
  `rollout_discrete_closed_loop_to` inherit the configured model through their
  existing `forward_dynamics` calls, without changing the generic
  `DynamicalSystem` signatures.

The setting is static rather than a per-call method argument because each mode
has a materially different compiled recurrence. Equinox/JAX can eliminate the
unused branch and produce a smaller executable; changing the setting therefore
creates a separate optimized JIT executable instead of carrying a runtime
conditional through every integration step.

## Dynamics semantics

When `consider_coriolis=False`:

- `dynamics_terms(q, qd)` returns `(M, zeros_like(qd), G)`;
- every `forward_dynamics` implementation omits the Coriolis force; and
- damping, velocity-dependent actuation, gravity, elasticity, and external
  generalized forces continue to use their normal inputs and equations.

An explicit `coriolis_matrix(q, qd)` call remains physically exact for
diagnostics. Kinetic and total energy values and derivatives are also unchanged;
the custom energy JVP uses the explicit physical Coriolis API where the identity
requires it rather than interpreting the dynamics approximation as a change in
kinetic energy.

## Implementation

### Shared and articulated systems

- The base `SoftRobot` and `Pendulum` paths skip `coriolis_matrix` entirely when
  the approximation is selected.
- ArticulatedSoftRobot and McKibben UMArm bypass the ABA velocity-bias,
  motion-cross, and force-cross recurrences, while retaining the real velocity
  for damping and actuation.
- Correct the ABA gravity initialization for non-identity base orientations by
  transforming world gravity into the base frame before the acceleration
  recurrence.

### Continuum systems

- PlanarPCS and PCS use position/Jacobian/gravity-only recurrences and avoid
  strain rates, tangent directional derivatives, `Jdot @ qdot`, spatial
  velocities, and coadjoint momentum assembly.
- GVS uses Jacobian-only joint and Magnus helpers plus a reduced recurrence that
  carries Jacobians, gravity, inertia, and gravity force only.
- PlanarHSA reuses its pose/Jacobian geometry path and skips Jacobian-derivative
  and convective assembly.
- Specialized PCS/GVS systems inherit the same setting and optimized path.

Small assembly differences remain inline. Dedicated private helpers are used
only where removing Coriolis changes the recurrence state and required inputs
substantially; forcing those paths through one scan would retain unnecessary
arrays and derivatives. The serial Jacobian/gravity propagation shared by PCS
and PlanarPCS lives on `SoftRobot`, with independent scans because measurements
showed that combining both carries slightly regressed CPU performance.

## Correctness

Parameterized regression coverage verifies that:

- omitted/default construction matches explicit `consider_coriolis=True`;
- disabled dynamics preserve `M` and `G`, return an exactly zero `Cqd`, and match
  a manual no-Coriolis forward solve;
- explicit Coriolis matrices and energy values, gradients, and JVPs are
  unchanged;
- all three rollout variants honor the configured model;
- derivative and convective helpers are not invoked on reduced paths;
- JIT specialization, immutable parameter updates, damping, actuation, gravity,
  elasticity, and external-force behavior remain valid; and
- inherited McKibben, pressure-actuated PCS, and shared continuum-component
  construction paths preserve the setting.

## Performance

Measurements use JAX FP64 on the CPU backend of an Intel Core Ultra 9 285K.
The process and all JAX worker threads are pinned with `taskset -c 1` to one
5.7 GHz performance core; no efficiency core or GPU backend participates.
Continuum systems use five Gauss points per segment. Each separately compiled
case receives a one-second synchronized warmup followed by 20 synchronized
samples, and the median warm latency is reported. Rollouts integrate 2 ms with
`solver_dt=0.1 ms` and one final saved sample.

Every cell below is `enabled / disabled`: the compile-time ratio followed by the
median warm-runtime ratio. A ratio greater than 1 means the Coriolis-disabled
path is faster. Results are reported separately for every measured link/segment
count.

| System | Links / segments | `dynamics_terms` compile / warm | `forward_dynamics` compile / warm | `rollout_to` compile / warm |
| --- | ---: | ---: | ---: | ---: |
| ArticulatedSoftRobot | 1 | 1.53x / 1.12x | 1.48x / 1.87x | 1.30x / 1.71x |
| ArticulatedSoftRobot | 4 | 1.86x / 1.57x | 1.30x / 1.16x | 1.02x / 1.63x |
| ArticulatedSoftRobot | 8 | 1.76x / 1.84x | 1.30x / 1.40x | 1.16x / 1.68x |
| ArticulatedSoftRobot | 16 | 1.76x / 2.62x | 1.29x / 1.27x | 1.31x / 1.98x |
| PlanarPCS | 1 | 2.00x / 1.11x | 2.10x / 1.07x | 1.27x / 1.37x |
| PlanarPCS | 4 | 1.89x / 1.27x | 1.77x / 1.28x | 1.55x / 1.77x |
| PlanarPCS | 8 | 1.77x / 1.29x | 1.67x / 1.33x | 1.54x / 1.67x |
| PlanarPCS | 16 | 1.65x / 1.46x | 1.73x / 1.51x | 1.58x / 1.57x |
| PCS | 1 | 1.95x / 1.67x | 1.78x / 1.85x | 1.56x / 2.74x |
| PCS | 4 | 1.86x / 1.33x | 1.76x / 1.35x | 1.50x / 1.80x |
| PCS | 8 | 1.96x / 1.52x | 1.77x / 1.51x | 1.53x / 1.59x |
| PCS | 16 | 1.84x / 1.48x | 1.79x / 1.39x | 1.47x / 1.40x |
| GVS | 1 | 1.77x / 1.28x | 1.70x / 1.19x | 1.51x / 1.73x |
| GVS | 4 | 1.79x / 1.53x | 1.75x / 1.53x | 1.51x / 1.17x |
| GVS | 8 | 1.75x / 1.50x | 1.69x / 1.51x | 1.50x / 1.18x |
| GVS | 16 | 1.73x / 1.37x | 1.52x / 1.36x | 1.30x / 1.33x |

Warm-runtime geometric means across the four sizes are:

| System | `dynamics_terms` | `forward_dynamics` | `rollout_to` | All methods |
| --- | ---: | ---: | ---: | ---: |
| ArticulatedSoftRobot | 1.71x | 1.40x | 1.75x | 1.61x |
| PlanarPCS | 1.28x | 1.29x | 1.59x | 1.38x |
| PCS | 1.49x | 1.51x | 1.82x | 1.60x |
| GVS | 1.42x | 1.39x | 1.33x | 1.38x |

An XLA cost audit at 16 segments corroborates the timings. The reduced PlanarPCS
`dynamics_terms` executable uses approximately 17% fewer FLOPs, 25% less memory
traffic, and 37% fewer transcendental operations; GVS uses approximately 13%
fewer FLOPs, 36% less memory traffic, and 38% fewer transcendental operations.

The benchmark command, per-size table, and raw artifact paths are also retained
in the development benchmarking guide.

## Validation

- Ruff check and format — passed for all changed Python files.
- PlanarPCS system suite — 123 passed.
- PCS system suite — 120 passed.
- GVS system suite — 88 passed.
- PlanarHSA system suite — 23 passed.
- ArticulatedSoftRobot and Pendulum suites — 65 passed.
- SoftRobot defaults, pressure-actuated PCS, shared continuum construction, and
  McKibben targeted suites — passed.
- Benchmark registry, benchmark CLI, and all rollout variants — 38 passed after
  rebasing onto the `main` commit containing #170.
- `zensical build` — passed.
- CPU-only Coriolis benchmark smoke test pinned to performance core 1 — passed.

No GPU backend was queried or initialized during the benchmark runs.
