### PR TITLE
Add shape-generic Warp backend for batched GVS dynamics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,10 @@ dependencies = [
 cuda13 = [
     "jax[cuda13]>=0.10.0; sys_platform == 'linux'",
     "torch>=2.13.0; sys_platform == 'linux'",
+    "warp-lang>=1.16.0; sys_platform == 'linux'",
+]
+warp = [
+    "warp-lang>=1.16.0",
 ]
 dev = [
     "bump2version",
@@ -245,6 +249,7 @@ all = [
     "tox",
     "trimesh",
     "viser",
+    "warp-lang>=1.16.0",
 ]
 
 # List URLs that are relevant to your project

--- a/src/soromox/systems/__init__.py
+++ b/src/soromox/systems/__init__.py
@@ -53,6 +53,7 @@ from soromox.systems.system_state import EnvironmentState, SystemState
 from .articulated import ArticulatedSoftRobot, McKibbenActuatedUMArm
 from .gvs import (
     GVS,
+    GVSBackend,
     GVSSegment,
     StrainBasisSpec,
 )
@@ -94,6 +95,7 @@ __all__ = [
     "McKibbenActuatedUMArmParams",
     # gvs systems
     "GVS",
+    "GVSBackend",
     "GVSParams",
     "GVSStructure",
     "GVSSegmentStructure",

--- a/src/soromox/systems/__init__.py
+++ b/src/soromox/systems/__init__.py
@@ -53,7 +53,7 @@ from soromox.systems.system_state import EnvironmentState, SystemState
 from .articulated import ArticulatedSoftRobot, McKibbenActuatedUMArm
 from .gvs import (
     GVS,
-    GVSBackend,
+    ExecutionBackend,
     GVSSegment,
     StrainBasisSpec,
 )
@@ -94,8 +94,8 @@ __all__ = [
     "McKibbenActuatedUMArm",
     "McKibbenActuatedUMArmParams",
     # gvs systems
+    "ExecutionBackend",
     "GVS",
-    "GVSBackend",
     "GVSParams",
     "GVSStructure",
     "GVSSegmentStructure",

--- a/src/soromox/systems/gvs/__init__.py
+++ b/src/soromox/systems/gvs/__init__.py
@@ -7,12 +7,12 @@ from soromox.systems.gvs.structures import (
     GVSStructure,
 )
 
-from .core import GVS, GVSBackend
+from .core import GVS, ExecutionBackend
 from .specs import GVSSegment, StrainBasisSpec
 
 __all__ = [
+    "ExecutionBackend",
     "GVS",
-    "GVSBackend",
     "GVSSegment",
     "StrainBasisSpec",
     "GVSParams",

--- a/src/soromox/systems/gvs/__init__.py
+++ b/src/soromox/systems/gvs/__init__.py
@@ -7,11 +7,12 @@ from soromox.systems.gvs.structures import (
     GVSStructure,
 )
 
-from .core import GVS
+from .core import GVS, GVSBackend
 from .specs import GVSSegment, StrainBasisSpec
 
 __all__ = [
     "GVS",
+    "GVSBackend",
     "GVSSegment",
     "StrainBasisSpec",
     "GVSParams",

--- a/src/soromox/systems/gvs/_dynamics.py
+++ b/src/soromox/systems/gvs/_dynamics.py
@@ -1,0 +1,98 @@
+"""Transform-aware execution of GVS dynamics terms."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+DynamicsTerms = tuple[Array, Array, Array]
+
+
+class DynamicsModel(Protocol):
+    """Structural interface required by the backend dispatcher."""
+
+    num_dofs: int
+
+    def _assemble_dynamics_terms(self, q: Array, qd: Array) -> DynamicsTerms: ...
+
+
+@eqx.filter_jit
+def _execute_batch(model: DynamicsModel, q: Array, qd: Array) -> DynamicsTerms:
+    """Execute one shape-generic Warp launch pipeline for a state batch."""
+
+    if q.shape[0] == 0:
+        raise ValueError("The Warp backend requires a non-empty batch.")
+    if q.dtype != jnp.float64 or qd.dtype != jnp.float64:
+        raise TypeError(
+            "The Warp GVS backend currently requires float64 q and qd; "
+            f"got {q.dtype} and {qd.dtype}."
+        )
+
+    try:
+        from soromox.systems.gvs._warp.backend import dynamics_terms
+    except ModuleNotFoundError as error:
+        if error.name == "warp":
+            raise ImportError(
+                "The Warp GVS backend requires the optional 'warp-lang' "
+                "dependency. Install it with `pip install soromox[warp]`."
+            ) from error
+        raise
+
+    if jax.default_backend() == "gpu":
+        lanes_per_block = 192 if model.num_dofs > 64 else 128
+    else:
+        lanes_per_block = 1
+    return dynamics_terms(model, q, qd, lanes_per_block=lanes_per_block)
+
+
+@jax.custom_batching.custom_vmap
+def _execute_primal(model: DynamicsModel, q: Array, qd: Array) -> DynamicsTerms:
+    """Give the batched Warp implementation scalar-call semantics."""
+
+    batched = _execute_batch(model, q[None, :], qd[None, :])
+    return jax.tree.map(lambda value: value[0], batched)
+
+
+@_execute_primal.def_vmap
+def _vmap_rule(
+    axis_size: int,
+    in_batched: tuple[Any, bool, bool],
+    model: DynamicsModel,
+    q: Array,
+    qd: Array,
+) -> tuple[DynamicsTerms, tuple[bool, bool, bool]]:
+    """Map independent environments to one batched Warp execution."""
+
+    model_batched, q_batched, qd_batched = in_batched
+    if any(jax.tree.leaves(model_batched)):
+        raise ValueError("Batching over GVS model parameters is not supported.")
+    if not q_batched:
+        q = jnp.broadcast_to(q, (axis_size, *q.shape))
+    if not qd_batched:
+        qd = jnp.broadcast_to(qd, (axis_size, *qd.shape))
+    return _execute_batch(model, q, qd), (True, True, True)
+
+
+@eqx.filter_custom_jvp
+def evaluate_terms(model: DynamicsModel, q: Array, qd: Array) -> DynamicsTerms:
+    """Evaluate Warp dynamics while retaining differentiable JAX semantics."""
+
+    return _execute_primal(model, q, qd)
+
+
+@evaluate_terms.def_jvp
+def _jvp_rule(
+    primals: tuple[DynamicsModel, Array, Array],
+    tangents: tuple[Any, Array | None, Array | None],
+) -> tuple[DynamicsTerms, DynamicsTerms]:
+    """Use the JAX assembly for both forward- and reverse-mode derivatives."""
+
+    return eqx.filter_jvp(
+        lambda model, q, qd: model._assemble_dynamics_terms(q, qd),
+        primals,
+        tangents,
+    )

--- a/src/soromox/systems/gvs/_warp/__init__.py
+++ b/src/soromox/systems/gvs/_warp/__init__.py
@@ -1,0 +1,1 @@
+"""Optional forward-only Warp backend for batched GVS dynamics."""

--- a/src/soromox/systems/gvs/_warp/backend.py
+++ b/src/soromox/systems/gvs/_warp/backend.py
@@ -10,7 +10,6 @@ from jax import Array
 from soromox.systems.gvs._warp.joint import scalable_joint_terms
 from soromox.systems.gvs._warp.persistent import scalable_persistent_chain
 from soromox.systems.gvs._warp.scalable import scalable_cell_terms
-from soromox.utils.lie_algebra import se3
 
 if TYPE_CHECKING:
     from soromox.systems.gvs.core import GVS
@@ -81,22 +80,16 @@ def _cell_terms(
     max_dof = model.max_dof
     work_items = batch_size * num_segments * num_cells
     matrix_rows = work_items * SPATIAL_DIM
-    basis_z1 = model.B_Z1
-    basis_z2 = model.B_Z2
-    if model.scale_rotational_basis_by_length:
-        scales = model.segment_lengths[:, None, None]
-        basis_z1 = basis_z1.at[:, :, :3].divide(scales)
-        basis_z2 = basis_z2.at[:, :, :3].divide(scales)
-    cell_widths = model.integration_points[:, 1:] - model.integration_points[:, :-1]
     outputs = scalable_cell_terms(
         q_link.reshape(batch_size * num_segments, max_dof),
         qd_link.reshape(batch_size * num_segments, max_dof),
-        basis_z1.reshape(num_segments * num_cells * SPATIAL_DIM, max_dof),
-        basis_z2.reshape(num_segments * num_cells * SPATIAL_DIM, max_dof),
+        model.scaled_B_Z1_values.reshape(num_segments * num_cells, max_dof),
+        model.scaled_B_Z2_values.reshape(num_segments * num_cells, max_dof),
+        model.link_basis_rows,
         model.xi_ref_Z1.reshape(num_segments * num_cells, SPATIAL_DIM),
         model.xi_ref_Z2.reshape(num_segments * num_cells, SPATIAL_DIM),
         model.segment_lengths,
-        cell_widths.reshape(num_segments * num_cells),
+        model.cell_widths.reshape(num_segments * num_cells),
         jnp.asarray([num_cells], dtype=jnp.int32),
         jnp.asarray([0], dtype=jnp.int32),
         output_dims={
@@ -148,8 +141,6 @@ def dynamics_terms(
     state_rows = batch_size * SPATIAL_DIM
     joint_rows = batch_size * num_segments * SPATIAL_DIM
     cell_rows = batch_size * num_segments * num_cells * SPATIAL_DIM
-    gravity_base = se3.adjoint_inverse(model.g0) @ model.g
-    masses = jnp.diagonal(model.inner_mass_matrices, axis1=-2, axis2=-1)
     outputs = scalable_persistent_chain(
         joint_adjoint.reshape(joint_rows, SPATIAL_DIM),
         joint_adjoint_dot.reshape(joint_rows, SPATIAL_DIM),
@@ -165,8 +156,8 @@ def dynamics_terms(
         model.active_dofs_per_segment,
         qd,
         model.inner_integration_weights.reshape(num_segments * num_quadrature),
-        masses.reshape(num_segments * num_quadrature, SPATIAL_DIM),
-        gravity_base,
+        model.inner_mass_diagonals.reshape(num_segments * num_quadrature, SPATIAL_DIM),
+        model.gravity_base,
         jnp.asarray([num_cells], dtype=jnp.int32),
         jnp.asarray([num_quadrature], dtype=jnp.int32),
         jnp.asarray([lanes_per_block], dtype=jnp.int32),

--- a/src/soromox/systems/gvs/_warp/backend.py
+++ b/src/soromox/systems/gvs/_warp/backend.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import jax.numpy as jnp
 from jax import Array
 
+from soromox.systems.gvs._warp.cooperative import cooperative_joint_terms
 from soromox.systems.gvs._warp.joint import scalable_joint_terms
 from soromox.systems.gvs._warp.persistent import scalable_persistent_chain
 from soromox.systems.gvs._warp.scalable import scalable_cell_terms
@@ -27,7 +28,7 @@ def _gather_local(values: Array, local_to_global: Array) -> Array:
 
 
 def _joint_terms(
-    model: GVS, q: Array, qd: Array
+    model: GVS, q: Array, qd: Array, *, cooperative: bool
 ) -> tuple[Array, Array, Array, Array, Array]:
     """Evaluate all general-joint Lie terms in one runtime-shaped launch."""
 
@@ -37,7 +38,8 @@ def _joint_terms(
     num_dofs = model.num_dofs
     work_items = batch_size * num_segments
     matrix_rows = work_items * SPATIAL_DIM
-    outputs = scalable_joint_terms(
+    joint_terms = cooperative_joint_terms if cooperative else scalable_joint_terms
+    outputs = joint_terms(
         q,
         qd,
         model.B_joint.reshape(num_segments * SPATIAL_DIM, max_dof),
@@ -121,7 +123,7 @@ def dynamics_terms(
         joint_tangent,
         joint_tangent_dot_qd,
         joint_velocity,
-    ) = _joint_terms(model, q, qd)
+    ) = _joint_terms(model, q, qd, cooperative=lanes_per_block > 1)
     q_link = _gather_local(q, model.link_local_to_global)
     qd_link = _gather_local(qd, model.link_local_to_global)
     (
@@ -155,8 +157,11 @@ def dynamics_terms(
         model.link_global_to_local,
         model.active_dofs_per_segment,
         qd,
-        model.inner_integration_weights.reshape(num_segments * num_quadrature),
-        model.inner_mass_diagonals.reshape(num_segments * num_quadrature, SPATIAL_DIM),
+        model.inertia_upper_rows,
+        model.inertia_upper_columns,
+        model.inner_weighted_mass_diagonals.reshape(
+            num_segments * num_quadrature, SPATIAL_DIM
+        ),
         model.gravity_base,
         jnp.asarray([num_cells], dtype=jnp.int32),
         jnp.asarray([num_quadrature], dtype=jnp.int32),

--- a/src/soromox/systems/gvs/_warp/backend.py
+++ b/src/soromox/systems/gvs/_warp/backend.py
@@ -1,0 +1,187 @@
+"""JAX-facing orchestration for persistent batched GVS dynamics in Warp."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import jax.numpy as jnp
+from jax import Array
+
+from soromox.systems.gvs._warp.joint import scalable_joint_terms
+from soromox.systems.gvs._warp.persistent import scalable_persistent_chain
+from soromox.systems.gvs._warp.scalable import scalable_cell_terms
+from soromox.utils.lie_algebra import se3
+
+if TYPE_CHECKING:
+    from soromox.systems.gvs.core import GVS
+
+
+SPATIAL_DIM = 6
+
+
+def _gather_local(values: Array, local_to_global: Array) -> Array:
+    """Gather padded segment-local coordinates from a batched active state."""
+
+    safe_indices = jnp.maximum(local_to_global, 0)
+    gathered = jnp.take(values, safe_indices, axis=1)
+    return gathered * (local_to_global >= 0)[None, :, :]
+
+
+def _joint_terms(
+    model: GVS, q: Array, qd: Array
+) -> tuple[Array, Array, Array, Array, Array]:
+    """Evaluate all general-joint Lie terms in one runtime-shaped launch."""
+
+    batch_size = q.shape[0]
+    num_segments = model.num_segments
+    max_dof = model.max_dof
+    num_dofs = model.num_dofs
+    work_items = batch_size * num_segments
+    matrix_rows = work_items * SPATIAL_DIM
+    outputs = scalable_joint_terms(
+        q,
+        qd,
+        model.B_joint.reshape(num_segments * SPATIAL_DIM, max_dof),
+        model.xi_ref_joint,
+        model.joint_local_to_global,
+        output_dims={
+            "adjoint": (matrix_rows, SPATIAL_DIM),
+            "adjoint_dot": (matrix_rows, SPATIAL_DIM),
+            "tangent_local": (matrix_rows, max_dof),
+            "tangent_dot_qd": (matrix_rows, 1),
+            "joint_velocity": (matrix_rows, 1),
+        },
+    )
+    leading = (batch_size, num_segments, SPATIAL_DIM)
+    tangent_local = outputs[2].reshape(*leading, max_dof)
+    local_columns = jnp.maximum(model.joint_global_to_local, 0)
+    local_columns = jnp.broadcast_to(
+        local_columns[None, :, None, :],
+        (batch_size, num_segments, SPATIAL_DIM, num_dofs),
+    )
+    tangent_active = jnp.take_along_axis(tangent_local, local_columns, axis=-1)
+    tangent_active *= (model.joint_global_to_local >= 0)[None, :, None, :]
+    return (
+        outputs[0].reshape(*leading, SPATIAL_DIM),
+        outputs[1].reshape(*leading, SPATIAL_DIM),
+        tangent_active,
+        outputs[3].reshape(*leading),
+        outputs[4].reshape(*leading),
+    )
+
+
+def _cell_terms(
+    model: GVS, q_link: Array, qd_link: Array
+) -> tuple[Array, Array, Array, Array, Array]:
+    """Evaluate spatially varying link-cell Lie terms in local coordinates."""
+
+    batch_size = q_link.shape[0]
+    num_segments = model.num_segments
+    num_cells = model.max_num_integration_points - 1
+    max_dof = model.max_dof
+    work_items = batch_size * num_segments * num_cells
+    matrix_rows = work_items * SPATIAL_DIM
+    basis_z1 = model.B_Z1
+    basis_z2 = model.B_Z2
+    if model.scale_rotational_basis_by_length:
+        scales = model.segment_lengths[:, None, None]
+        basis_z1 = basis_z1.at[:, :, :3].divide(scales)
+        basis_z2 = basis_z2.at[:, :, :3].divide(scales)
+    cell_widths = model.integration_points[:, 1:] - model.integration_points[:, :-1]
+    outputs = scalable_cell_terms(
+        q_link.reshape(batch_size * num_segments, max_dof),
+        qd_link.reshape(batch_size * num_segments, max_dof),
+        basis_z1.reshape(num_segments * num_cells * SPATIAL_DIM, max_dof),
+        basis_z2.reshape(num_segments * num_cells * SPATIAL_DIM, max_dof),
+        model.xi_ref_Z1.reshape(num_segments * num_cells, SPATIAL_DIM),
+        model.xi_ref_Z2.reshape(num_segments * num_cells, SPATIAL_DIM),
+        model.segment_lengths,
+        cell_widths.reshape(num_segments * num_cells),
+        jnp.asarray([num_cells], dtype=jnp.int32),
+        jnp.asarray([0], dtype=jnp.int32),
+        output_dims={
+            "adjoint": (matrix_rows, SPATIAL_DIM),
+            "tangent_local": (matrix_rows, max_dof),
+            "link_velocity": (matrix_rows, 1),
+            "step_velocity": (matrix_rows, 1),
+            "tangent_velocity_dot": (matrix_rows, 1),
+        },
+    )
+    leading = (batch_size, num_segments, num_cells, SPATIAL_DIM)
+    return (
+        outputs[0].reshape(*leading, SPATIAL_DIM),
+        outputs[1].reshape(*leading, max_dof),
+        outputs[2].reshape(*leading),
+        outputs[3].reshape(*leading),
+        outputs[4].reshape(*leading),
+    )
+
+
+def dynamics_terms(
+    model: GVS, q: Array, qd: Array, *, lanes_per_block: int
+) -> tuple[Array, Array, Array]:
+    """Assemble batched ``(B, C @ qd, G)`` with the persistent Warp pipeline."""
+
+    (
+        joint_adjoint,
+        joint_adjoint_dot,
+        joint_tangent,
+        joint_tangent_dot_qd,
+        joint_velocity,
+    ) = _joint_terms(model, q, qd)
+    q_link = _gather_local(q, model.link_local_to_global)
+    qd_link = _gather_local(qd, model.link_local_to_global)
+    (
+        cell_adjoint,
+        cell_tangent_local,
+        cell_link_velocity,
+        cell_step_velocity,
+        cell_tangent_velocity_dot,
+    ) = _cell_terms(model, q_link, qd_link)
+
+    batch_size = q.shape[0]
+    num_segments = model.num_segments
+    num_cells = model.max_num_integration_points - 1
+    num_quadrature = model.max_num_integration_points - 2
+    num_dofs = model.num_dofs
+    max_dof = model.max_dof
+    state_rows = batch_size * SPATIAL_DIM
+    joint_rows = batch_size * num_segments * SPATIAL_DIM
+    cell_rows = batch_size * num_segments * num_cells * SPATIAL_DIM
+    gravity_base = se3.adjoint_inverse(model.g0) @ model.g
+    masses = jnp.diagonal(model.inner_mass_matrices, axis1=-2, axis2=-1)
+    outputs = scalable_persistent_chain(
+        joint_adjoint.reshape(joint_rows, SPATIAL_DIM),
+        joint_adjoint_dot.reshape(joint_rows, SPATIAL_DIM),
+        joint_tangent.reshape(joint_rows, num_dofs),
+        joint_tangent_dot_qd.reshape(joint_rows, 1),
+        joint_velocity.reshape(joint_rows, 1),
+        cell_adjoint.reshape(cell_rows, SPATIAL_DIM),
+        cell_tangent_local.reshape(cell_rows, max_dof),
+        cell_link_velocity.reshape(cell_rows, 1),
+        cell_step_velocity.reshape(cell_rows, 1),
+        cell_tangent_velocity_dot.reshape(cell_rows, 1),
+        model.link_global_to_local,
+        model.active_dofs_per_segment,
+        qd,
+        model.inner_integration_weights.reshape(num_segments * num_quadrature),
+        masses.reshape(num_segments * num_quadrature, SPATIAL_DIM),
+        gravity_base,
+        jnp.asarray([num_cells], dtype=jnp.int32),
+        jnp.asarray([num_quadrature], dtype=jnp.int32),
+        jnp.asarray([lanes_per_block], dtype=jnp.int32),
+        output_dims={
+            "jacobian_first": (state_rows, num_dofs),
+            "jacobian_dot_qd_first": (state_rows, 1),
+            "velocity_first": (state_rows, 1),
+            "gravity_first": (state_rows, 1),
+            "jacobian_second": (state_rows, num_dofs),
+            "jacobian_dot_qd_second": (state_rows, 1),
+            "velocity_second": (state_rows, 1),
+            "gravity_second": (state_rows, 1),
+            "inertia": (batch_size, num_dofs, num_dofs),
+            "coriolis_qd": (batch_size, num_dofs),
+            "gravity_force": (batch_size, num_dofs),
+        },
+    )
+    return outputs[-3], outputs[-2], outputs[-1]

--- a/src/soromox/systems/gvs/_warp/cooperative.py
+++ b/src/soromox/systems/gvs/_warp/cooperative.py
@@ -1,0 +1,285 @@
+# ruff: noqa: I001, UP018
+"""Cooperative shape-generic preparation kernels for GVS dynamics."""
+
+from __future__ import annotations
+
+import warp as wp
+
+from soromox.systems.gvs._warp.joint import _joint_basis_column
+from soromox.systems.gvs._warp.lie import (
+    Vec6d,
+    _ad_action,
+    _adjoint_inverse_action,
+    _adjoint_inverse_entry,
+    _forward_coefficients,
+    _left_action,
+    _left_coefficient_x_derivatives,
+    _left_coefficients,
+    _left_total_derivative_action,
+    _translation,
+)
+
+wp.set_module_options({"enable_backward": False})
+
+
+SPATIAL_DIM = 6
+JOINT_BLOCK_DIM = 32
+
+
+@wp.kernel(enable_backward=False)
+def cooperative_joint_terms_kernel(
+    q: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    local_to_global: wp.array2d(dtype=wp.int32),
+    adjoint: wp.array2d(dtype=wp.float64),
+    adjoint_dot: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+):
+    """Evaluate one general joint cooperatively per warp-sized block."""
+
+    work_item, lane = wp.tid()
+    num_segments = reference.shape[0]
+    environment = work_item // num_segments
+    segment = work_item - environment * num_segments
+    output_base_row = work_item * SPATIAL_DIM
+
+    xi_shared = wp.tile_zeros(shape=(SPATIAL_DIM,), dtype=wp.float64, storage="shared")
+    xid_shared = wp.tile_zeros(shape=(SPATIAL_DIM,), dtype=wp.float64, storage="shared")
+    coefficients_shared = wp.tile_zeros(shape=(4,), dtype=wp.float64, storage="shared")
+    forward_shared = wp.tile_zeros(shape=(3,), dtype=wp.float64, storage="shared")
+    translation_shared = wp.tile_zeros(shape=(3,), dtype=wp.float64, storage="shared")
+    eta_shared = wp.tile_zeros(shape=(SPATIAL_DIM,), dtype=wp.float64, storage="shared")
+    angle_sq_shared = wp.tile_zeros(shape=(1,), dtype=wp.float64, storage="shared")
+    barrier = wp.tile_zeros(shape=(1,), dtype=wp.int32, storage="shared")
+
+    component = lane
+    xi_value = wp.float64(0.0)
+    xid_value = wp.float64(0.0)
+    if component < SPATIAL_DIM:
+        xi_value = reference[segment, component]
+        local_column = int(0)
+        while local_column < local_to_global.shape[1]:
+            global_column = local_to_global[segment, local_column]
+            if global_column >= 0:
+                xi_value += (
+                    basis[segment * SPATIAL_DIM + component, local_column]
+                    * q[environment, global_column]
+                )
+                xid_value += (
+                    basis[segment * SPATIAL_DIM + component, local_column]
+                    * qd[environment, global_column]
+                )
+            local_column += 1
+    wp.tile_scatter_masked(xi_shared, component, xi_value, component < SPATIAL_DIM)
+    wp.tile_scatter_masked(xid_shared, component, xid_value, component < SPATIAL_DIM)
+
+    angle_sq_value = wp.float64(0.0)
+    if lane == 0:
+        angle_sq_value = (
+            xi_shared[0] * xi_shared[0]
+            + xi_shared[1] * xi_shared[1]
+            + xi_shared[2] * xi_shared[2]
+        )
+    wp.tile_scatter_masked(angle_sq_shared, 0, angle_sq_value, lane == 0)
+
+    coefficient_index = lane
+    coefficient_value = wp.float64(0.0)
+    if coefficient_index < 4:
+        coefficient_value = _left_coefficients(angle_sq_shared[0])[coefficient_index]
+    wp.tile_scatter_masked(
+        coefficients_shared,
+        coefficient_index,
+        coefficient_value,
+        coefficient_index < 4,
+    )
+
+    forward_index = lane
+    forward_value = wp.float64(0.0)
+    if forward_index < 3:
+        forward_value = _forward_coefficients(angle_sq_shared[0])[forward_index]
+    wp.tile_scatter_masked(
+        forward_shared,
+        forward_index,
+        forward_value,
+        forward_index < 3,
+    )
+
+    translation_index = lane
+    translation_value = wp.float64(0.0)
+    if translation_index < 3:
+        translation_value = _translation(
+            wp.vec3d(xi_shared[0], xi_shared[1], xi_shared[2]),
+            wp.vec3d(xi_shared[3], xi_shared[4], xi_shared[5]),
+            wp.vec3d(forward_shared[0], forward_shared[1], forward_shared[2]),
+        )[translation_index]
+    wp.tile_scatter_masked(
+        translation_shared,
+        translation_index,
+        translation_value,
+        translation_index < 3,
+    )
+
+    xi = Vec6d(
+        xi_shared[0],
+        xi_shared[1],
+        xi_shared[2],
+        xi_shared[3],
+        xi_shared[4],
+        xi_shared[5],
+    )
+    xid = Vec6d(
+        xid_shared[0],
+        xid_shared[1],
+        xid_shared[2],
+        xid_shared[3],
+        xid_shared[4],
+        xid_shared[5],
+    )
+    coefficients = wp.vec4d(
+        coefficients_shared[0],
+        coefficients_shared[1],
+        coefficients_shared[2],
+        coefficients_shared[3],
+    )
+    if lane == 0:
+        velocity = _left_action(xi, xid, coefficients)
+        coefficient_derivatives = _left_coefficient_x_derivatives(angle_sq_shared[0])
+        angle_sq_dot = wp.float64(2.0) * (
+            xi[0] * xid[0] + xi[1] * xid[1] + xi[2] * xid[2]
+        )
+        derivative_velocity = _left_total_derivative_action(
+            xi,
+            xid,
+            xid,
+            Vec6d(),
+            coefficients,
+            coefficient_derivatives * angle_sq_dot,
+        )
+        row = int(0)
+        while row < SPATIAL_DIM:
+            tangent_dot_qd[output_base_row + row, 0] = derivative_velocity[row]
+            joint_velocity[output_base_row + row, 0] = velocity[row]
+            row += 1
+    wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+
+    eta_component = lane
+    eta_value = wp.float64(0.0)
+    if eta_component < SPATIAL_DIM:
+        velocity = Vec6d(
+            joint_velocity[output_base_row + 0, 0],
+            joint_velocity[output_base_row + 1, 0],
+            joint_velocity[output_base_row + 2, 0],
+            joint_velocity[output_base_row + 3, 0],
+            joint_velocity[output_base_row + 4, 0],
+            joint_velocity[output_base_row + 5, 0],
+        )
+        eta = _adjoint_inverse_action(
+            wp.vec3d(xi[0], xi[1], xi[2]),
+            wp.vec3d(
+                translation_shared[0],
+                translation_shared[1],
+                translation_shared[2],
+            ),
+            angle_sq_shared[0],
+            wp.vec3d(forward_shared[0], forward_shared[1], forward_shared[2]),
+            velocity,
+        )
+        eta_value = eta[eta_component]
+    wp.tile_scatter_masked(
+        eta_shared,
+        eta_component,
+        eta_value,
+        eta_component < SPATIAL_DIM,
+    )
+
+    entry = lane
+    while entry < SPATIAL_DIM * SPATIAL_DIM:
+        row = entry // SPATIAL_DIM
+        column = entry - row * SPATIAL_DIM
+        adjoint[output_base_row + row, column] = _adjoint_inverse_entry(
+            wp.vec3d(xi[0], xi[1], xi[2]),
+            wp.vec3d(
+                translation_shared[0],
+                translation_shared[1],
+                translation_shared[2],
+            ),
+            angle_sq_shared[0],
+            wp.vec3d(forward_shared[0], forward_shared[1], forward_shared[2]),
+            row,
+            column,
+        )
+        entry += JOINT_BLOCK_DIM
+    wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+
+    column = lane
+    if column < SPATIAL_DIM:
+        adjoint_column = Vec6d(
+            adjoint[output_base_row + 0, column],
+            adjoint[output_base_row + 1, column],
+            adjoint[output_base_row + 2, column],
+            adjoint[output_base_row + 3, column],
+            adjoint[output_base_row + 4, column],
+            adjoint[output_base_row + 5, column],
+        )
+        derivative_column = -_ad_action(
+            Vec6d(
+                eta_shared[0],
+                eta_shared[1],
+                eta_shared[2],
+                eta_shared[3],
+                eta_shared[4],
+                eta_shared[5],
+            ),
+            adjoint_column,
+        )
+        row = int(0)
+        while row < SPATIAL_DIM:
+            adjoint_dot[output_base_row + row, column] = derivative_column[row]
+            row += 1
+
+    local_column = lane
+    while local_column < local_to_global.shape[1]:
+        tangent = _left_action(
+            xi,
+            _joint_basis_column(basis, segment, local_column),
+            coefficients,
+        )
+        row = int(0)
+        while row < SPATIAL_DIM:
+            tangent_local[output_base_row + row, local_column] = tangent[row]
+            row += 1
+        local_column += JOINT_BLOCK_DIM
+
+
+def _cooperative_joint_terms(
+    q: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    local_to_global: wp.array2d(dtype=wp.int32),
+    adjoint: wp.array2d(dtype=wp.float64),
+    adjoint_dot: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+):
+    wp.launch_tiled(
+        cooperative_joint_terms_kernel,
+        dim=q.shape[0] * reference.shape[0],
+        inputs=[q, qd, basis, reference, local_to_global],
+        outputs=[
+            adjoint,
+            adjoint_dot,
+            tangent_local,
+            tangent_dot_qd,
+            joint_velocity,
+        ],
+        block_dim=JOINT_BLOCK_DIM,
+    )
+
+
+cooperative_joint_terms = wp.jax_callable(_cooperative_joint_terms, num_outputs=5)

--- a/src/soromox/systems/gvs/_warp/joint.py
+++ b/src/soromox/systems/gvs/_warp/joint.py
@@ -1,0 +1,227 @@
+# ruff: noqa: I001, UP018
+"""Shape-generic forward-only GVS joint kernels.
+
+The GVS joint basis already encodes the concrete joint type.  This module
+therefore evaluates every supported joint through the same runtime-sized
+SE(3) path instead of generating a kernel for each joint type or model shape.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+from soromox.systems.gvs._warp.lie import (
+    Vec6d,
+    _ad_action,
+    _adjoint_inverse_action,
+    _adjoint_inverse_entry,
+    _forward_coefficients,
+    _left_action,
+    _left_coefficient_x_derivatives,
+    _left_coefficients,
+    _left_total_derivative_action,
+    _translation,
+)
+
+wp.set_module_options({"enable_backward": False})
+
+
+SPATIAL_DIM = 6
+
+
+@wp.func
+def _joint_strain(
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    coordinates: wp.array2d(dtype=wp.float64),
+    local_to_global: wp.array2d(dtype=wp.int32),
+    environment: int,
+    segment: int,
+) -> Vec6d:
+    value = Vec6d(
+        reference[segment, 0],
+        reference[segment, 1],
+        reference[segment, 2],
+        reference[segment, 3],
+        reference[segment, 4],
+        reference[segment, 5],
+    )
+    base_row = segment * SPATIAL_DIM
+    local_column = int(0)
+    while local_column < local_to_global.shape[1]:
+        global_column = local_to_global[segment, local_column]
+        if global_column >= 0:
+            coordinate = coordinates[environment, global_column]
+            row = int(0)
+            while row < SPATIAL_DIM:
+                value[row] += basis[base_row + row, local_column] * coordinate
+                row += 1
+        local_column += 1
+    return value
+
+
+@wp.func
+def _joint_strain_rate(
+    basis: wp.array2d(dtype=wp.float64),
+    velocities: wp.array2d(dtype=wp.float64),
+    local_to_global: wp.array2d(dtype=wp.int32),
+    environment: int,
+    segment: int,
+) -> Vec6d:
+    value = Vec6d()
+    base_row = segment * SPATIAL_DIM
+    local_column = int(0)
+    while local_column < local_to_global.shape[1]:
+        global_column = local_to_global[segment, local_column]
+        if global_column >= 0:
+            velocity = velocities[environment, global_column]
+            row = int(0)
+            while row < SPATIAL_DIM:
+                value[row] += basis[base_row + row, local_column] * velocity
+                row += 1
+        local_column += 1
+    return value
+
+
+@wp.func
+def _joint_basis_column(
+    basis: wp.array2d(dtype=wp.float64), segment: int, column: int
+) -> Vec6d:
+    base_row = segment * SPATIAL_DIM
+    return Vec6d(
+        basis[base_row + 0, column],
+        basis[base_row + 1, column],
+        basis[base_row + 2, column],
+        basis[base_row + 3, column],
+        basis[base_row + 4, column],
+        basis[base_row + 5, column],
+    )
+
+
+@wp.kernel(enable_backward=False)
+def scalable_joint_terms_kernel(
+    q: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    local_to_global: wp.array2d(dtype=wp.int32),
+    adjoint: wp.array2d(dtype=wp.float64),
+    adjoint_dot: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+):
+    """Evaluate one joint per ``(environment, segment)`` work item."""
+
+    work_item = wp.tid()
+    num_segments = reference.shape[0]
+    environment = work_item // num_segments
+    segment = work_item - environment * num_segments
+    output_base_row = work_item * SPATIAL_DIM
+
+    xi = _joint_strain(
+        basis, reference, q, local_to_global, environment, segment
+    )
+    xid = _joint_strain_rate(
+        basis, qd, local_to_global, environment, segment
+    )
+    angle_sq = xi[0] * xi[0] + xi[1] * xi[1] + xi[2] * xi[2]
+    coefficients = _left_coefficients(angle_sq)
+    coefficient_derivatives = _left_coefficient_x_derivatives(angle_sq)
+    angle_sq_dot = wp.float64(2.0) * (
+        xi[0] * xid[0] + xi[1] * xid[1] + xi[2] * xid[2]
+    )
+    omega = wp.vec3d(xi[0], xi[1], xi[2])
+    linear = wp.vec3d(xi[3], xi[4], xi[5])
+    forward = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, forward)
+
+    velocity = _left_action(xi, xid, coefficients)
+    eta = _adjoint_inverse_action(
+        omega, translation, angle_sq, forward, velocity
+    )
+    derivative_velocity = _left_total_derivative_action(
+        xi,
+        xid,
+        xid,
+        Vec6d(),
+        coefficients,
+        coefficient_derivatives * angle_sq_dot,
+    )
+
+    row = int(0)
+    while row < SPATIAL_DIM:
+        tangent_dot_qd[output_base_row + row, 0] = derivative_velocity[row]
+        joint_velocity[output_base_row + row, 0] = velocity[row]
+        column = int(0)
+        while column < SPATIAL_DIM:
+            adjoint_value = _adjoint_inverse_entry(
+                omega,
+                translation,
+                angle_sq,
+                forward,
+                row,
+                column,
+            )
+            adjoint[output_base_row + row, column] = adjoint_value
+            column += 1
+        row += 1
+
+    # Ad_inv_dot = -ad(Ad_inv * joint_velocity) * Ad_inv.  Applying ad to
+    # each already-computed adjoint column avoids materializing a dense ad.
+    column = int(0)
+    while column < SPATIAL_DIM:
+        adjoint_column = Vec6d()
+        row = int(0)
+        while row < SPATIAL_DIM:
+            adjoint_column[row] = adjoint[output_base_row + row, column]
+            row += 1
+        derivative_column = -_ad_action(eta, adjoint_column)
+        row = int(0)
+        while row < SPATIAL_DIM:
+            adjoint_dot[output_base_row + row, column] = derivative_column[row]
+            row += 1
+        column += 1
+
+    local_column = int(0)
+    while local_column < local_to_global.shape[1]:
+        tangent = _left_action(
+            xi,
+            _joint_basis_column(basis, segment, local_column),
+            coefficients,
+        )
+        row = int(0)
+        while row < SPATIAL_DIM:
+            tangent_local[output_base_row + row, local_column] = tangent[row]
+            row += 1
+        local_column += 1
+
+
+def _scalable_joint_terms(
+    q: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    local_to_global: wp.array2d(dtype=wp.int32),
+    adjoint: wp.array2d(dtype=wp.float64),
+    adjoint_dot: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+):
+    wp.launch(
+        scalable_joint_terms_kernel,
+        dim=q.shape[0] * reference.shape[0],
+        inputs=[q, qd, basis, reference, local_to_global],
+        outputs=[
+            adjoint,
+            adjoint_dot,
+            tangent_local,
+            tangent_dot_qd,
+            joint_velocity,
+        ],
+        block_dim=128,
+    )
+
+
+scalable_joint_terms = wp.jax_callable(_scalable_joint_terms, num_outputs=5)

--- a/src/soromox/systems/gvs/_warp/lie.py
+++ b/src/soromox/systems/gvs/_warp/lie.py
@@ -1,0 +1,362 @@
+# ruff: noqa: I001, UP018
+"""Forward-only Warp Lie-algebra preparation kernels for GVS dynamics.
+
+The implementation applies ``ad`` polynomials directly to spatial vectors
+instead of materializing dense ``ad``, tangent, or tangent-derivative
+matrices.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+
+Vec6d = wp.types.vector(length=6, dtype=wp.float64)
+SPATIAL_DIM = 6
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.func
+def _ad_action(left: Vec6d, right: Vec6d) -> Vec6d:
+    left_omega = wp.vec3d(left[0], left[1], left[2])
+    left_linear = wp.vec3d(left[3], left[4], left[5])
+    right_omega = wp.vec3d(right[0], right[1], right[2])
+    right_linear = wp.vec3d(right[3], right[4], right[5])
+    angular = wp.cross(left_omega, right_omega)
+    linear = wp.cross(left_linear, right_omega) + wp.cross(
+        left_omega, right_linear
+    )
+    return Vec6d(
+        angular[0],
+        angular[1],
+        angular[2],
+        linear[0],
+        linear[1],
+        linear[2],
+    )
+
+
+@wp.func
+def _left_coefficients(angle_sq: wp.float64) -> wp.vec4d:
+    c1 = wp.float64(0.0)
+    c2 = wp.float64(0.0)
+    c3 = wp.float64(0.0)
+    c4 = wp.float64(0.0)
+    if angle_sq <= wp.float64(0.00580466633864119):
+        x = angle_sq
+        c1 = wp.float64(0.5) + x * x * (
+            -wp.float64(1.0 / 720.0)
+            + x
+            * (
+                wp.float64(1.0 / 20160.0)
+                - x * wp.float64(1.0 / 1209600.0)
+            )
+        )
+        c2 = wp.float64(1.0 / 6.0) + x * x * (
+            -wp.float64(1.0 / 5040.0)
+            + x
+            * (
+                wp.float64(1.0 / 181440.0)
+                - x * wp.float64(1.0 / 13305600.0)
+            )
+        )
+        c3 = wp.float64(1.0 / 24.0) + x * (
+            -wp.float64(1.0 / 360.0)
+            + x
+            * (
+                wp.float64(1.0 / 13440.0)
+                + x
+                * (
+                    -wp.float64(1.0 / 907200.0)
+                    + x * wp.float64(1.0 / 95800320.0)
+                )
+            )
+        )
+        c4 = wp.float64(1.0 / 120.0) + x * (
+            -wp.float64(1.0 / 2520.0)
+            + x
+            * (
+                wp.float64(1.0 / 120960.0)
+                + x
+                * (
+                    -wp.float64(1.0 / 9979200.0)
+                    + x * wp.float64(1.0 / 1245404160.0)
+                )
+            )
+        )
+    else:
+        theta = wp.sqrt(angle_sq)
+        sine = wp.sin(theta)
+        cosine = wp.cos(theta)
+        theta2 = theta * theta
+        theta3 = theta2 * theta
+        theta4 = theta2 * theta2
+        theta5 = theta4 * theta
+        c1 = (wp.float64(4.0) - wp.float64(4.0) * cosine - theta * sine) / (
+            wp.float64(2.0) * theta2
+        )
+        c2 = (
+            wp.float64(4.0) * theta
+            - wp.float64(5.0) * sine
+            + theta * cosine
+        ) / (wp.float64(2.0) * theta3)
+        c3 = (wp.float64(2.0) - wp.float64(2.0) * cosine - theta * sine) / (
+            wp.float64(2.0) * theta4
+        )
+        c4 = (
+            wp.float64(2.0) * theta
+            - wp.float64(3.0) * sine
+            + theta * cosine
+        ) / (wp.float64(2.0) * theta5)
+    return wp.vec4d(c1, c2, c3, c4)
+
+
+@wp.func
+def _left_coefficient_x_derivatives(angle_sq: wp.float64) -> wp.vec4d:
+    d1 = wp.float64(0.0)
+    d2 = wp.float64(0.0)
+    d3 = wp.float64(0.0)
+    d4 = wp.float64(0.0)
+    if angle_sq <= wp.float64(0.00580466633864119):
+        x = angle_sq
+        d1 = x * (
+            -wp.float64(1.0 / 360.0)
+            + x
+            * (
+                wp.float64(1.0 / 6720.0)
+                - x * wp.float64(1.0 / 302400.0)
+            )
+        )
+        d2 = x * (
+            -wp.float64(1.0 / 2520.0)
+            + x
+            * (
+                wp.float64(1.0 / 60480.0)
+                - x * wp.float64(1.0 / 3326400.0)
+            )
+        )
+        d3 = -wp.float64(1.0 / 360.0) + x * (
+            wp.float64(1.0 / 6720.0)
+            + x
+            * (
+                -wp.float64(1.0 / 302400.0)
+                + x * wp.float64(1.0 / 23950080.0)
+            )
+        )
+        d4 = -wp.float64(1.0 / 2520.0) + x * (
+            wp.float64(1.0 / 60480.0)
+            + x
+            * (
+                -wp.float64(1.0 / 3326400.0)
+                + x * wp.float64(1.0 / 311351040.0)
+            )
+        )
+    else:
+        theta = wp.sqrt(angle_sq)
+        sine = wp.sin(theta)
+        cosine = wp.cos(theta)
+        theta2 = theta * theta
+        theta3 = theta2 * theta
+        theta4 = theta2 * theta2
+        theta5 = theta4 * theta
+        theta6 = theta3 * theta3
+        theta7 = theta6 * theta
+        common = (
+            -wp.float64(8.0)
+            + (wp.float64(8.0) - theta2) * cosine
+            + wp.float64(5.0) * theta * sine
+        )
+        alternate = (
+            -wp.float64(8.0) * theta
+            + (wp.float64(15.0) - theta2) * sine
+            - wp.float64(7.0) * theta * cosine
+        )
+        d1 = common / (wp.float64(4.0) * theta4)
+        d2 = alternate / (wp.float64(4.0) * theta5)
+        d3 = common / (wp.float64(4.0) * theta6)
+        d4 = alternate / (wp.float64(4.0) * theta7)
+    return wp.vec4d(d1, d2, d3, d4)
+
+
+@wp.func
+def _left_action(xi: Vec6d, value: Vec6d, coefficients: wp.vec4d) -> Vec6d:
+    result = value
+    power = value
+    for order in range(4):
+        power = _ad_action(xi, power)
+        result += coefficients[order] * power
+    return result
+
+
+@wp.func
+def _left_total_derivative_action(
+    xi: Vec6d,
+    xi_dot: Vec6d,
+    value: Vec6d,
+    value_dot: Vec6d,
+    coefficients: wp.vec4d,
+    coefficient_directions: wp.vec4d,
+) -> Vec6d:
+    result = value_dot
+    power = value
+    power_dot = value_dot
+    for order in range(4):
+        power_previous = power
+        power = _ad_action(xi, power_previous)
+        power_dot = _ad_action(xi_dot, power_previous) + _ad_action(
+            xi, power_dot
+        )
+        result += coefficient_directions[order] * power
+        result += coefficients[order] * power_dot
+    return result
+
+
+@wp.func
+def _forward_coefficients(angle_sq: wp.float64) -> wp.vec3d:
+    sinc = wp.float64(0.0)
+    cosc = wp.float64(0.0)
+    tanc = wp.float64(0.0)
+    if angle_sq <= wp.float64(0.0024607823917256556):
+        x = angle_sq
+        sinc = wp.float64(1.0) + x * (
+            -wp.float64(1.0 / 6.0)
+            + x
+            * (
+                wp.float64(1.0 / 120.0)
+                + x
+                * (
+                    -wp.float64(1.0 / 5040.0)
+                    + x * wp.float64(1.0 / 362880.0)
+                )
+            )
+        )
+        cosc = wp.float64(0.5) + x * (
+            -wp.float64(1.0 / 24.0)
+            + x
+            * (
+                wp.float64(1.0 / 720.0)
+                + x
+                * (
+                    -wp.float64(1.0 / 40320.0)
+                    + x * wp.float64(1.0 / 3628800.0)
+                )
+            )
+        )
+        tanc = wp.float64(1.0 / 6.0) + x * (
+            -wp.float64(1.0 / 120.0)
+            + x
+            * (
+                wp.float64(1.0 / 5040.0)
+                + x
+                * (
+                    -wp.float64(1.0 / 362880.0)
+                    + x * wp.float64(1.0 / 39916800.0)
+                )
+            )
+        )
+    else:
+        theta = wp.sqrt(angle_sq)
+        sinc = wp.sin(theta) / theta
+        cosc = (wp.float64(1.0) - wp.cos(theta)) / angle_sq
+        tanc = (theta - wp.sin(theta)) / (angle_sq * theta)
+    return wp.vec3d(sinc, cosc, tanc)
+
+
+@wp.func
+def _rotation_entry(
+    omega: wp.vec3d,
+    angle_sq: wp.float64,
+    forward: wp.vec3d,
+    row: int,
+    column: int,
+) -> wp.float64:
+    delta = wp.float64(0.0)
+    if row == column:
+        delta = wp.float64(1.0)
+    skew = wp.float64(0.0)
+    if row == 0 and column == 1:
+        skew = -omega[2]
+    elif row == 0 and column == 2:
+        skew = omega[1]
+    elif row == 1 and column == 0:
+        skew = omega[2]
+    elif row == 1 and column == 2:
+        skew = -omega[0]
+    elif row == 2 and column == 0:
+        skew = -omega[1]
+    elif row == 2 and column == 1:
+        skew = omega[0]
+    square = omega[row] * omega[column] - angle_sq * delta
+    return delta + forward[0] * skew + forward[1] * square
+
+
+@wp.func
+def _translation(
+    omega: wp.vec3d, linear: wp.vec3d, forward: wp.vec3d
+) -> wp.vec3d:
+    first = wp.cross(omega, linear)
+    second = wp.cross(omega, first)
+    return linear + forward[1] * first + forward[2] * second
+
+
+@wp.func
+def _adjoint_inverse_entry(
+    omega: wp.vec3d,
+    translation: wp.vec3d,
+    angle_sq: wp.float64,
+    forward: wp.vec3d,
+    row: int,
+    column: int,
+) -> wp.float64:
+    value = wp.float64(0.0)
+    if row < 3 and column < 3:
+        value = _rotation_entry(omega, angle_sq, forward, column, row)
+    elif row >= 3 and column >= 3:
+        value = _rotation_entry(
+            omega, angle_sq, forward, column - 3, row - 3
+        )
+    elif row >= 3 and column < 3:
+        local_row = row - 3
+        for k in range(3):
+            skew = wp.float64(0.0)
+            if k == 0 and column == 1:
+                skew = -translation[2]
+            elif k == 0 and column == 2:
+                skew = translation[1]
+            elif k == 1 and column == 0:
+                skew = translation[2]
+            elif k == 1 and column == 2:
+                skew = -translation[0]
+            elif k == 2 and column == 0:
+                skew = -translation[1]
+            elif k == 2 and column == 1:
+                skew = translation[0]
+            value -= _rotation_entry(
+                omega, angle_sq, forward, k, local_row
+            ) * skew
+    return value
+
+
+@wp.func
+def _adjoint_inverse_action(
+    omega: wp.vec3d,
+    translation: wp.vec3d,
+    angle_sq: wp.float64,
+    forward: wp.vec3d,
+    value: Vec6d,
+) -> Vec6d:
+    result = Vec6d()
+    for row in range(SPATIAL_DIM):
+        row_value = wp.float64(0.0)
+        for column in range(SPATIAL_DIM):
+            row_value += _adjoint_inverse_entry(
+                omega,
+                translation,
+                angle_sq,
+                forward,
+                row,
+                column,
+            ) * value[column]
+        result[row] = row_value
+    return result

--- a/src/soromox/systems/gvs/_warp/persistent.py
+++ b/src/soromox/systems/gvs/_warp/persistent.py
@@ -36,8 +36,9 @@ def scalable_persistent_chain_kernel(
     global_to_local: wp.array2d(dtype=wp.int32),
     active_dofs: wp.array(dtype=wp.int32),
     qd: wp.array2d(dtype=wp.float64),
-    weights: wp.array(dtype=wp.float64),
-    masses: wp.array2d(dtype=wp.float64),
+    inertia_upper_rows: wp.array(dtype=wp.int32),
+    inertia_upper_columns: wp.array(dtype=wp.int32),
+    weighted_masses: wp.array2d(dtype=wp.float64),
     gravity_base: wp.array(dtype=wp.float64),
     num_cells_array: wp.array(dtype=wp.int32),
     num_quadrature_array: wp.array(dtype=wp.int32),
@@ -64,6 +65,12 @@ def scalable_persistent_chain_kernel(
     lane_stride = lanes_per_block[0]
     state_base_row = environment * SPATIAL_DIM
     barrier = wp.tile_zeros(shape=(1,), dtype=wp.int32, storage="shared")
+    source_jacobian_velocity_shared = wp.tile_zeros(
+        shape=(SPATIAL_DIM,), dtype=wp.float64, storage="shared"
+    )
+    transported_source_velocity_shared = wp.tile_zeros(
+        shape=(SPATIAL_DIM,), dtype=wp.float64, storage="shared"
+    )
 
     entry = lane
     while entry < SPATIAL_DIM * num_dofs:
@@ -95,9 +102,7 @@ def scalable_persistent_chain_kernel(
     segment = int(0)
     while segment < num_segments:
         segment_dofs = active_dofs[segment]
-        joint_base_row = (
-            (environment * num_segments + segment) * SPATIAL_DIM
-        )
+        joint_base_row = (environment * num_segments + segment) * SPATIAL_DIM
         destination_is_first = not current_is_first
 
         entry = lane
@@ -130,23 +135,53 @@ def scalable_persistent_chain_kernel(
             )
             entry += lane_stride
 
-        state_row = lane
-        while state_row < SPATIAL_DIM:
-            source_jacobian_velocity = Vec6d()
-            k = int(0)
-            while k < SPATIAL_DIM:
+        if lane_stride == 1:
+            source_row = int(0)
+            while source_row < SPATIAL_DIM:
+                source_velocity_value = wp.float64(0.0)
                 source_column = int(0)
                 while source_column < segment_dofs:
-                    source_jacobian_velocity[k] += _matrix_value(
-                        jacobian_first,
-                        jacobian_second,
-                        current_is_first,
-                        state_base_row,
-                        k,
-                        source_column,
-                    ) * qd[environment, source_column]
+                    source_velocity_value += (
+                        _matrix_value(
+                            jacobian_first,
+                            jacobian_second,
+                            current_is_first,
+                            state_base_row,
+                            source_row,
+                            source_column,
+                        )
+                        * qd[environment, source_column]
+                    )
                     source_column += 1
-                k += 1
+                source_jacobian_velocity_shared[source_row] = source_velocity_value
+                source_row += 1
+        else:
+            source_row = lane
+            source_velocity_value = wp.float64(0.0)
+            if source_row < SPATIAL_DIM:
+                source_column = int(0)
+                while source_column < segment_dofs:
+                    source_velocity_value += (
+                        _matrix_value(
+                            jacobian_first,
+                            jacobian_second,
+                            current_is_first,
+                            state_base_row,
+                            source_row,
+                            source_column,
+                        )
+                        * qd[environment, source_column]
+                    )
+                    source_column += 1
+            wp.tile_scatter_masked(
+                source_jacobian_velocity_shared,
+                source_row,
+                source_velocity_value,
+                source_row < SPATIAL_DIM,
+            )
+
+        state_row = lane
+        while state_row < SPATIAL_DIM:
             derivative_value = wp.float64(0.0)
             velocity_value = wp.float64(0.0)
             gravity_value = wp.float64(0.0)
@@ -165,11 +200,9 @@ def scalable_persistent_chain_kernel(
                         + joint_tangent_dot_qd[joint_base_row + k, 0]
                     )
                     + joint_adjoint_dot[joint_base_row + state_row, k]
-                    * source_jacobian_velocity[k]
+                    * source_jacobian_velocity_shared[k]
                 )
-                velocity_value += joint_adjoint[
-                    joint_base_row + state_row, k
-                ] * (
+                velocity_value += joint_adjoint[joint_base_row + state_row, k] * (
                     _vector_value(
                         velocity_first,
                         velocity_second,
@@ -221,12 +254,8 @@ def scalable_persistent_chain_kernel(
         while cell < num_cells:
             destination_is_first = not current_is_first
             cell_base_row = (
-                (
-                    (environment * num_segments + segment) * num_cells
-                    + cell
-                )
-                * SPATIAL_DIM
-            )
+                (environment * num_segments + segment) * num_cells + cell
+            ) * SPATIAL_DIM
 
             entry = lane
             while entry < SPATIAL_DIM * segment_dofs:
@@ -264,42 +293,98 @@ def scalable_persistent_chain_kernel(
                 )
                 entry += lane_stride
 
-            state_row = lane
-            while state_row < SPATIAL_DIM:
-                source_jacobian_velocity = Vec6d()
-                k = int(0)
-                while k < SPATIAL_DIM:
+            if lane_stride == 1:
+                source_row = int(0)
+                while source_row < SPATIAL_DIM:
+                    source_velocity_value = wp.float64(0.0)
                     source_column = int(0)
                     while source_column < segment_dofs:
-                        source_jacobian_velocity[k] += _matrix_value(
-                            jacobian_first,
-                            jacobian_second,
-                            current_is_first,
-                            state_base_row,
-                            k,
-                            source_column,
-                        ) * qd[environment, source_column]
+                        source_velocity_value += (
+                            _matrix_value(
+                                jacobian_first,
+                                jacobian_second,
+                                current_is_first,
+                                state_base_row,
+                                source_row,
+                                source_column,
+                            )
+                            * qd[environment, source_column]
+                        )
                         source_column += 1
-                    k += 1
-                transported_source_velocity = Vec6d()
+                    source_jacobian_velocity_shared[source_row] = source_velocity_value
+                    source_row += 1
+            else:
+                source_row = lane
+                source_velocity_value = wp.float64(0.0)
+                if source_row < SPATIAL_DIM:
+                    source_column = int(0)
+                    while source_column < segment_dofs:
+                        source_velocity_value += (
+                            _matrix_value(
+                                jacobian_first,
+                                jacobian_second,
+                                current_is_first,
+                                state_base_row,
+                                source_row,
+                                source_column,
+                            )
+                            * qd[environment, source_column]
+                        )
+                        source_column += 1
+                wp.tile_scatter_masked(
+                    source_jacobian_velocity_shared,
+                    source_row,
+                    source_velocity_value,
+                    source_row < SPATIAL_DIM,
+                )
+
+            if lane_stride == 1:
                 target = int(0)
                 while target < SPATIAL_DIM:
+                    transported_value = wp.float64(0.0)
                     k = int(0)
                     while k < SPATIAL_DIM:
-                        transported_source_velocity[target] += (
+                        transported_value += (
                             cell_adjoint[cell_base_row + target, k]
-                            * source_jacobian_velocity[k]
+                            * source_jacobian_velocity_shared[k]
                         )
                         k += 1
+                    transported_source_velocity_shared[target] = transported_value
                     target += 1
+            else:
+                target = lane
+                transported_value = wp.float64(0.0)
+                if target < SPATIAL_DIM:
+                    k = int(0)
+                    while k < SPATIAL_DIM:
+                        transported_value += (
+                            cell_adjoint[cell_base_row + target, k]
+                            * source_jacobian_velocity_shared[k]
+                        )
+                        k += 1
+                wp.tile_scatter_masked(
+                    transported_source_velocity_shared,
+                    target,
+                    transported_value,
+                    target < SPATIAL_DIM,
+                )
+
+            state_row = lane
+            while state_row < SPATIAL_DIM:
+                transported_source_velocity = Vec6d(
+                    transported_source_velocity_shared[0],
+                    transported_source_velocity_shared[1],
+                    transported_source_velocity_shared[2],
+                    transported_source_velocity_shared[3],
+                    transported_source_velocity_shared[4],
+                    transported_source_velocity_shared[5],
+                )
                 derivative_value = wp.float64(0.0)
                 velocity_value = wp.float64(0.0)
                 gravity_value = wp.float64(0.0)
                 k = int(0)
                 while k < SPATIAL_DIM:
-                    adjoint_value = cell_adjoint[
-                        cell_base_row + state_row, k
-                    ]
+                    adjoint_value = cell_adjoint[cell_base_row + state_row, k]
                     derivative_value += adjoint_value * (
                         _vector_value(
                             jacobian_dot_qd_first,
@@ -367,11 +452,11 @@ def scalable_persistent_chain_kernel(
 
             if cell < num_quadrature:
                 quadrature_item = segment * num_quadrature + cell
-                weight = weights[quadrature_item]
+                num_inertia_pairs = segment_dofs * (segment_dofs + 1) // 2
                 entry = lane
-                while entry < segment_dofs * segment_dofs:
-                    output_row = entry // segment_dofs
-                    output_column = entry - output_row * segment_dofs
+                while entry < num_inertia_pairs:
+                    output_row = inertia_upper_rows[entry]
+                    output_column = inertia_upper_columns[entry]
                     value = wp.float64(0.0)
                     row = int(0)
                     while row < SPATIAL_DIM:
@@ -384,8 +469,7 @@ def scalable_persistent_chain_kernel(
                                 row,
                                 output_row,
                             )
-                            * weight
-                            * masses[quadrature_item, row]
+                            * weighted_masses[quadrature_item, row]
                             * _matrix_value(
                                 jacobian_first,
                                 jacobian_second,
@@ -397,6 +481,8 @@ def scalable_persistent_chain_kernel(
                         )
                         row += 1
                     inertia[environment, output_row, output_column] += value
+                    if output_row != output_column:
+                        inertia[environment, output_column, output_row] += value
                     entry += lane_stride
 
                 column = lane
@@ -408,7 +494,7 @@ def scalable_persistent_chain_kernel(
                         jacobian_dot_qd_second,
                         current_is_first,
                         state_base_row,
-                        masses,
+                        weighted_masses,
                         quadrature_item,
                     )
                     coriolis_value = wp.float64(0.0)
@@ -423,13 +509,10 @@ def scalable_persistent_chain_kernel(
                             row,
                             column,
                         )
-                        coriolis_value += (
-                            weight * jacobian_value * wrench[row]
-                        )
+                        coriolis_value += jacobian_value * wrench[row]
                         gravity_value -= (
-                            weight
-                            * jacobian_value
-                            * masses[quadrature_item, row]
+                            jacobian_value
+                            * weighted_masses[quadrature_item, row]
                             * _vector_value(
                                 gravity_first,
                                 gravity_second,
@@ -461,8 +544,9 @@ def _scalable_persistent_chain(
     global_to_local: wp.array2d(dtype=wp.int32),
     active_dofs: wp.array(dtype=wp.int32),
     qd: wp.array2d(dtype=wp.float64),
-    weights: wp.array(dtype=wp.float64),
-    masses: wp.array2d(dtype=wp.float64),
+    inertia_upper_rows: wp.array(dtype=wp.int32),
+    inertia_upper_columns: wp.array(dtype=wp.int32),
+    weighted_masses: wp.array2d(dtype=wp.float64),
     gravity_base: wp.array(dtype=wp.float64),
     num_cells: wp.array(dtype=wp.int32),
     num_quadrature: wp.array(dtype=wp.int32),
@@ -496,8 +580,9 @@ def _scalable_persistent_chain(
             global_to_local,
             active_dofs,
             qd,
-            weights,
-            masses,
+            inertia_upper_rows,
+            inertia_upper_columns,
+            weighted_masses,
             gravity_base,
             num_cells,
             num_quadrature,
@@ -516,10 +601,8 @@ def _scalable_persistent_chain(
             coriolis_qd,
             gravity_force,
         ],
-        block_dim=BLOCK_DIM,
+        block_dim=192 if qd.shape[1] > 64 else BLOCK_DIM,
     )
 
 
-scalable_persistent_chain = wp.jax_callable(
-    _scalable_persistent_chain, num_outputs=11
-)
+scalable_persistent_chain = wp.jax_callable(_scalable_persistent_chain, num_outputs=11)

--- a/src/soromox/systems/gvs/_warp/persistent.py
+++ b/src/soromox/systems/gvs/_warp/persistent.py
@@ -1,0 +1,525 @@
+# ruff: noqa: I001, UP018
+"""Runtime-sized persistent whole-chain GVS dynamics kernel."""
+
+from __future__ import annotations
+
+import warp as wp
+
+from soromox.systems.gvs._warp.lie import Vec6d, _ad_action
+from soromox.systems.gvs._warp.segment import (
+    _coadjoint_wrench,
+    _matrix_value,
+    _vector_value,
+    _write_matrix_value,
+    _write_vector_value,
+)
+
+wp.set_module_options({"enable_backward": False})
+
+
+SPATIAL_DIM = 6
+BLOCK_DIM = 128
+
+
+@wp.kernel(enable_backward=False)
+def scalable_persistent_chain_kernel(
+    joint_adjoint: wp.array2d(dtype=wp.float64),
+    joint_adjoint_dot: wp.array2d(dtype=wp.float64),
+    joint_tangent: wp.array2d(dtype=wp.float64),
+    joint_tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+    cell_adjoint: wp.array2d(dtype=wp.float64),
+    cell_tangent_local: wp.array2d(dtype=wp.float64),
+    cell_link_velocity: wp.array2d(dtype=wp.float64),
+    cell_step_velocity: wp.array2d(dtype=wp.float64),
+    cell_tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    global_to_local: wp.array2d(dtype=wp.int32),
+    active_dofs: wp.array(dtype=wp.int32),
+    qd: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    masses: wp.array2d(dtype=wp.float64),
+    gravity_base: wp.array(dtype=wp.float64),
+    num_cells_array: wp.array(dtype=wp.int32),
+    num_quadrature_array: wp.array(dtype=wp.int32),
+    lanes_per_block: wp.array(dtype=wp.int32),
+    jacobian_first: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_first: wp.array2d(dtype=wp.float64),
+    velocity_first: wp.array2d(dtype=wp.float64),
+    gravity_first: wp.array2d(dtype=wp.float64),
+    jacobian_second: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_second: wp.array2d(dtype=wp.float64),
+    velocity_second: wp.array2d(dtype=wp.float64),
+    gravity_second: wp.array2d(dtype=wp.float64),
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    """Traverse one full serial GVS chain per cooperative block."""
+
+    environment, lane = wp.tid()
+    num_dofs = qd.shape[1]
+    num_cells = num_cells_array[0]
+    num_quadrature = num_quadrature_array[0]
+    num_segments = joint_adjoint.shape[0] // (qd.shape[0] * SPATIAL_DIM)
+    lane_stride = lanes_per_block[0]
+    state_base_row = environment * SPATIAL_DIM
+    barrier = wp.tile_zeros(shape=(1,), dtype=wp.int32, storage="shared")
+
+    entry = lane
+    while entry < SPATIAL_DIM * num_dofs:
+        row = entry // num_dofs
+        column = entry - row * num_dofs
+        jacobian_first[state_base_row + row, column] = wp.float64(0.0)
+        jacobian_second[state_base_row + row, column] = wp.float64(0.0)
+        entry += lane_stride
+    row = lane
+    while row < SPATIAL_DIM:
+        jacobian_dot_qd_first[state_base_row + row, 0] = wp.float64(0.0)
+        velocity_first[state_base_row + row, 0] = wp.float64(0.0)
+        gravity_first[state_base_row + row, 0] = gravity_base[row]
+        row += lane_stride
+    entry = lane
+    while entry < num_dofs * num_dofs:
+        output_row = entry // num_dofs
+        output_column = entry - output_row * num_dofs
+        inertia[environment, output_row, output_column] = wp.float64(0.0)
+        entry += lane_stride
+    column = lane
+    while column < num_dofs:
+        coriolis_qd[environment, column] = wp.float64(0.0)
+        gravity_force[environment, column] = wp.float64(0.0)
+        column += lane_stride
+    wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+
+    current_is_first = bool(True)
+    segment = int(0)
+    while segment < num_segments:
+        segment_dofs = active_dofs[segment]
+        joint_base_row = (
+            (environment * num_segments + segment) * SPATIAL_DIM
+        )
+        destination_is_first = not current_is_first
+
+        entry = lane
+        while entry < SPATIAL_DIM * segment_dofs:
+            row = entry // segment_dofs
+            column = entry - row * segment_dofs
+            value = wp.float64(0.0)
+            k = int(0)
+            while k < SPATIAL_DIM:
+                value += joint_adjoint[joint_base_row + row, k] * (
+                    _matrix_value(
+                        jacobian_first,
+                        jacobian_second,
+                        current_is_first,
+                        state_base_row,
+                        k,
+                        column,
+                    )
+                    + joint_tangent[joint_base_row + k, column]
+                )
+                k += 1
+            _write_matrix_value(
+                jacobian_first,
+                jacobian_second,
+                destination_is_first,
+                state_base_row,
+                row,
+                column,
+                value,
+            )
+            entry += lane_stride
+
+        state_row = lane
+        while state_row < SPATIAL_DIM:
+            source_jacobian_velocity = Vec6d()
+            k = int(0)
+            while k < SPATIAL_DIM:
+                source_column = int(0)
+                while source_column < segment_dofs:
+                    source_jacobian_velocity[k] += _matrix_value(
+                        jacobian_first,
+                        jacobian_second,
+                        current_is_first,
+                        state_base_row,
+                        k,
+                        source_column,
+                    ) * qd[environment, source_column]
+                    source_column += 1
+                k += 1
+            derivative_value = wp.float64(0.0)
+            velocity_value = wp.float64(0.0)
+            gravity_value = wp.float64(0.0)
+            k = int(0)
+            while k < SPATIAL_DIM:
+                derivative_value += (
+                    joint_adjoint[joint_base_row + state_row, k]
+                    * (
+                        _vector_value(
+                            jacobian_dot_qd_first,
+                            jacobian_dot_qd_second,
+                            current_is_first,
+                            state_base_row,
+                            k,
+                        )
+                        + joint_tangent_dot_qd[joint_base_row + k, 0]
+                    )
+                    + joint_adjoint_dot[joint_base_row + state_row, k]
+                    * source_jacobian_velocity[k]
+                )
+                velocity_value += joint_adjoint[
+                    joint_base_row + state_row, k
+                ] * (
+                    _vector_value(
+                        velocity_first,
+                        velocity_second,
+                        current_is_first,
+                        state_base_row,
+                        k,
+                    )
+                    + joint_velocity[joint_base_row + k, 0]
+                )
+                gravity_value += joint_adjoint[
+                    joint_base_row + state_row, k
+                ] * _vector_value(
+                    gravity_first,
+                    gravity_second,
+                    current_is_first,
+                    state_base_row,
+                    k,
+                )
+                k += 1
+            _write_vector_value(
+                jacobian_dot_qd_first,
+                jacobian_dot_qd_second,
+                destination_is_first,
+                state_base_row,
+                state_row,
+                derivative_value,
+            )
+            _write_vector_value(
+                velocity_first,
+                velocity_second,
+                destination_is_first,
+                state_base_row,
+                state_row,
+                velocity_value,
+            )
+            _write_vector_value(
+                gravity_first,
+                gravity_second,
+                destination_is_first,
+                state_base_row,
+                state_row,
+                gravity_value,
+            )
+            state_row += lane_stride
+        wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+        current_is_first = destination_is_first
+
+        cell = int(0)
+        while cell < num_cells:
+            destination_is_first = not current_is_first
+            cell_base_row = (
+                (
+                    (environment * num_segments + segment) * num_cells
+                    + cell
+                )
+                * SPATIAL_DIM
+            )
+
+            entry = lane
+            while entry < SPATIAL_DIM * segment_dofs:
+                row = entry // segment_dofs
+                column = entry - row * segment_dofs
+                local_column = global_to_local[segment, column]
+                value = wp.float64(0.0)
+                k = int(0)
+                while k < SPATIAL_DIM:
+                    tangent_value = wp.float64(0.0)
+                    if local_column >= 0:
+                        tangent_value = cell_tangent_local[
+                            cell_base_row + k, local_column
+                        ]
+                    value += cell_adjoint[cell_base_row + row, k] * (
+                        _matrix_value(
+                            jacobian_first,
+                            jacobian_second,
+                            current_is_first,
+                            state_base_row,
+                            k,
+                            column,
+                        )
+                        + tangent_value
+                    )
+                    k += 1
+                _write_matrix_value(
+                    jacobian_first,
+                    jacobian_second,
+                    destination_is_first,
+                    state_base_row,
+                    row,
+                    column,
+                    value,
+                )
+                entry += lane_stride
+
+            state_row = lane
+            while state_row < SPATIAL_DIM:
+                source_jacobian_velocity = Vec6d()
+                k = int(0)
+                while k < SPATIAL_DIM:
+                    source_column = int(0)
+                    while source_column < segment_dofs:
+                        source_jacobian_velocity[k] += _matrix_value(
+                            jacobian_first,
+                            jacobian_second,
+                            current_is_first,
+                            state_base_row,
+                            k,
+                            source_column,
+                        ) * qd[environment, source_column]
+                        source_column += 1
+                    k += 1
+                transported_source_velocity = Vec6d()
+                target = int(0)
+                while target < SPATIAL_DIM:
+                    k = int(0)
+                    while k < SPATIAL_DIM:
+                        transported_source_velocity[target] += (
+                            cell_adjoint[cell_base_row + target, k]
+                            * source_jacobian_velocity[k]
+                        )
+                        k += 1
+                    target += 1
+                derivative_value = wp.float64(0.0)
+                velocity_value = wp.float64(0.0)
+                gravity_value = wp.float64(0.0)
+                k = int(0)
+                while k < SPATIAL_DIM:
+                    adjoint_value = cell_adjoint[
+                        cell_base_row + state_row, k
+                    ]
+                    derivative_value += adjoint_value * (
+                        _vector_value(
+                            jacobian_dot_qd_first,
+                            jacobian_dot_qd_second,
+                            current_is_first,
+                            state_base_row,
+                            k,
+                        )
+                        + cell_tangent_velocity_dot[cell_base_row + k, 0]
+                    )
+                    velocity_value += adjoint_value * (
+                        _vector_value(
+                            velocity_first,
+                            velocity_second,
+                            current_is_first,
+                            state_base_row,
+                            k,
+                        )
+                        + cell_link_velocity[cell_base_row + k, 0]
+                    )
+                    gravity_value += adjoint_value * _vector_value(
+                        gravity_first,
+                        gravity_second,
+                        current_is_first,
+                        state_base_row,
+                        k,
+                    )
+                    k += 1
+                step = Vec6d(
+                    cell_step_velocity[cell_base_row + 0, 0],
+                    cell_step_velocity[cell_base_row + 1, 0],
+                    cell_step_velocity[cell_base_row + 2, 0],
+                    cell_step_velocity[cell_base_row + 3, 0],
+                    cell_step_velocity[cell_base_row + 4, 0],
+                    cell_step_velocity[cell_base_row + 5, 0],
+                )
+                bracket = _ad_action(step, transported_source_velocity)
+                _write_vector_value(
+                    jacobian_dot_qd_first,
+                    jacobian_dot_qd_second,
+                    destination_is_first,
+                    state_base_row,
+                    state_row,
+                    derivative_value - bracket[state_row],
+                )
+                _write_vector_value(
+                    velocity_first,
+                    velocity_second,
+                    destination_is_first,
+                    state_base_row,
+                    state_row,
+                    velocity_value,
+                )
+                _write_vector_value(
+                    gravity_first,
+                    gravity_second,
+                    destination_is_first,
+                    state_base_row,
+                    state_row,
+                    gravity_value,
+                )
+                state_row += lane_stride
+            wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+            current_is_first = destination_is_first
+
+            if cell < num_quadrature:
+                quadrature_item = segment * num_quadrature + cell
+                weight = weights[quadrature_item]
+                entry = lane
+                while entry < segment_dofs * segment_dofs:
+                    output_row = entry // segment_dofs
+                    output_column = entry - output_row * segment_dofs
+                    value = wp.float64(0.0)
+                    row = int(0)
+                    while row < SPATIAL_DIM:
+                        value += (
+                            _matrix_value(
+                                jacobian_first,
+                                jacobian_second,
+                                current_is_first,
+                                state_base_row,
+                                row,
+                                output_row,
+                            )
+                            * weight
+                            * masses[quadrature_item, row]
+                            * _matrix_value(
+                                jacobian_first,
+                                jacobian_second,
+                                current_is_first,
+                                state_base_row,
+                                row,
+                                output_column,
+                            )
+                        )
+                        row += 1
+                    inertia[environment, output_row, output_column] += value
+                    entry += lane_stride
+
+                column = lane
+                while column < segment_dofs:
+                    wrench = _coadjoint_wrench(
+                        velocity_first,
+                        velocity_second,
+                        jacobian_dot_qd_first,
+                        jacobian_dot_qd_second,
+                        current_is_first,
+                        state_base_row,
+                        masses,
+                        quadrature_item,
+                    )
+                    coriolis_value = wp.float64(0.0)
+                    gravity_value = wp.float64(0.0)
+                    row = int(0)
+                    while row < SPATIAL_DIM:
+                        jacobian_value = _matrix_value(
+                            jacobian_first,
+                            jacobian_second,
+                            current_is_first,
+                            state_base_row,
+                            row,
+                            column,
+                        )
+                        coriolis_value += (
+                            weight * jacobian_value * wrench[row]
+                        )
+                        gravity_value -= (
+                            weight
+                            * jacobian_value
+                            * masses[quadrature_item, row]
+                            * _vector_value(
+                                gravity_first,
+                                gravity_second,
+                                current_is_first,
+                                state_base_row,
+                                row,
+                            )
+                        )
+                        row += 1
+                    coriolis_qd[environment, column] += coriolis_value
+                    gravity_force[environment, column] += gravity_value
+                    column += lane_stride
+            wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+            cell += 1
+        segment += 1
+
+
+def _scalable_persistent_chain(
+    joint_adjoint: wp.array2d(dtype=wp.float64),
+    joint_adjoint_dot: wp.array2d(dtype=wp.float64),
+    joint_tangent: wp.array2d(dtype=wp.float64),
+    joint_tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+    cell_adjoint: wp.array2d(dtype=wp.float64),
+    cell_tangent_local: wp.array2d(dtype=wp.float64),
+    cell_link_velocity: wp.array2d(dtype=wp.float64),
+    cell_step_velocity: wp.array2d(dtype=wp.float64),
+    cell_tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    global_to_local: wp.array2d(dtype=wp.int32),
+    active_dofs: wp.array(dtype=wp.int32),
+    qd: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    masses: wp.array2d(dtype=wp.float64),
+    gravity_base: wp.array(dtype=wp.float64),
+    num_cells: wp.array(dtype=wp.int32),
+    num_quadrature: wp.array(dtype=wp.int32),
+    lanes_per_block: wp.array(dtype=wp.int32),
+    jacobian_first: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_first: wp.array2d(dtype=wp.float64),
+    velocity_first: wp.array2d(dtype=wp.float64),
+    gravity_first: wp.array2d(dtype=wp.float64),
+    jacobian_second: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_second: wp.array2d(dtype=wp.float64),
+    velocity_second: wp.array2d(dtype=wp.float64),
+    gravity_second: wp.array2d(dtype=wp.float64),
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    wp.launch_tiled(
+        scalable_persistent_chain_kernel,
+        dim=qd.shape[0],
+        inputs=[
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            cell_adjoint,
+            cell_tangent_local,
+            cell_link_velocity,
+            cell_step_velocity,
+            cell_tangent_velocity_dot,
+            global_to_local,
+            active_dofs,
+            qd,
+            weights,
+            masses,
+            gravity_base,
+            num_cells,
+            num_quadrature,
+            lanes_per_block,
+        ],
+        outputs=[
+            jacobian_first,
+            jacobian_dot_qd_first,
+            velocity_first,
+            gravity_first,
+            jacobian_second,
+            jacobian_dot_qd_second,
+            velocity_second,
+            gravity_second,
+            inertia,
+            coriolis_qd,
+            gravity_force,
+        ],
+        block_dim=BLOCK_DIM,
+    )
+
+
+scalable_persistent_chain = wp.jax_callable(
+    _scalable_persistent_chain, num_outputs=11
+)

--- a/src/soromox/systems/gvs/_warp/scalable.py
+++ b/src/soromox/systems/gvs/_warp/scalable.py
@@ -31,28 +31,30 @@ SPATIAL_DIM = 6
 
 
 @wp.func
-def _load_dynamic_column(
-    matrix: wp.array2d(dtype=wp.float64), base_row: int, column: int
+def _load_sparse_column(
+    values: wp.array2d(dtype=wp.float64),
+    rows: wp.array2d(dtype=wp.int32),
+    cell_item: int,
+    segment: int,
+    column: int,
 ) -> Vec6d:
-    return Vec6d(
-        matrix[base_row + 0, column],
-        matrix[base_row + 1, column],
-        matrix[base_row + 2, column],
-        matrix[base_row + 3, column],
-        matrix[base_row + 4, column],
-        matrix[base_row + 5, column],
-    )
+    result = Vec6d()
+    row = rows[segment, column]
+    if row >= 0:
+        result[row] = values[cell_item, column]
+    return result
 
 
 @wp.func
 def _dynamic_strain(
-    basis: wp.array2d(dtype=wp.float64),
+    basis_values: wp.array2d(dtype=wp.float64),
+    basis_rows: wp.array2d(dtype=wp.int32),
     reference: wp.array2d(dtype=wp.float64),
     coordinates: wp.array2d(dtype=wp.float64),
     cell_item: int,
+    segment: int,
     coordinate_item: int,
 ) -> Vec6d:
-    base_row = cell_item * SPATIAL_DIM
     value = Vec6d(
         reference[cell_item, 0],
         reference[cell_item, 1],
@@ -64,30 +66,29 @@ def _dynamic_strain(
     column = int(0)
     while column < coordinates.shape[1]:
         coordinate = coordinates[coordinate_item, column]
-        row = int(0)
-        while row < SPATIAL_DIM:
-            value[row] += basis[base_row + row, column] * coordinate
-            row += 1
+        row = basis_rows[segment, column]
+        if row >= 0:
+            value[row] += basis_values[cell_item, column] * coordinate
         column += 1
     return value
 
 
 @wp.func
 def _dynamic_strain_rate(
-    basis: wp.array2d(dtype=wp.float64),
+    basis_values: wp.array2d(dtype=wp.float64),
+    basis_rows: wp.array2d(dtype=wp.int32),
     velocities: wp.array2d(dtype=wp.float64),
     cell_item: int,
+    segment: int,
     coordinate_item: int,
 ) -> Vec6d:
-    base_row = cell_item * SPATIAL_DIM
     value = Vec6d()
     column = int(0)
     while column < velocities.shape[1]:
         velocity = velocities[coordinate_item, column]
-        row = int(0)
-        while row < SPATIAL_DIM:
-            value[row] += basis[base_row + row, column] * velocity
-            row += 1
+        row = basis_rows[segment, column]
+        if row >= 0:
+            value[row] += basis_values[cell_item, column] * velocity
         column += 1
     return value
 
@@ -98,6 +99,7 @@ def scalable_cell_terms_kernel(
     qd_link: wp.array2d(dtype=wp.float64),
     basis_z1: wp.array2d(dtype=wp.float64),
     basis_z2: wp.array2d(dtype=wp.float64),
+    basis_rows: wp.array2d(dtype=wp.int32),
     reference_z1: wp.array2d(dtype=wp.float64),
     reference_z2: wp.array2d(dtype=wp.float64),
     segment_lengths: wp.array(dtype=wp.float64),
@@ -121,14 +123,19 @@ def scalable_cell_terms_kernel(
     cell = environment_cell - segment * cells_per_segment
     cell_item = segment * cells_per_segment + cell
     coordinate_item = environment * segment_lengths.shape[0] + segment
-    base_row = cell_item * SPATIAL_DIM
     output_base_row = work_item * SPATIAL_DIM
 
     xi1 = _dynamic_strain(
-        basis_z1, reference_z1, q_link, cell_item, coordinate_item
+        basis_z1,
+        basis_rows,
+        reference_z1,
+        q_link,
+        cell_item,
+        segment,
+        coordinate_item,
     )
     xid1 = _dynamic_strain_rate(
-        basis_z1, qd_link, cell_item, coordinate_item
+        basis_z1, basis_rows, qd_link, cell_item, segment, coordinate_item
     )
     length = segment_lengths[segment]
     width = cell_widths[cell_item]
@@ -148,10 +155,16 @@ def scalable_cell_terms_kernel(
     magnus_dot = length * width * xid1
     if order_zero[0] == 0:
         xi2 = _dynamic_strain(
-            basis_z2, reference_z2, q_link, cell_item, coordinate_item
+            basis_z2,
+            basis_rows,
+            reference_z2,
+            q_link,
+            cell_item,
+            segment,
+            coordinate_item,
         )
         xid2 = _dynamic_strain_rate(
-            basis_z2, qd_link, cell_item, coordinate_item
+            basis_z2, basis_rows, qd_link, cell_item, segment, coordinate_item
         )
         magnus = alpha * (xi1 + xi2) + commutator_coefficient * _ad_action(
             xi1, xi2
@@ -188,10 +201,14 @@ def scalable_cell_terms_kernel(
 
     local_column = int(0)
     while local_column < q_link.shape[1]:
-        basis1 = _load_dynamic_column(basis_z1, base_row, local_column)
+        basis1 = _load_sparse_column(
+            basis_z1, basis_rows, cell_item, segment, local_column
+        )
         magnus_basis = length * width * basis1
         if order_zero[0] == 0:
-            basis2 = _load_dynamic_column(basis_z2, base_row, local_column)
+            basis2 = _load_sparse_column(
+                basis_z2, basis_rows, cell_item, segment, local_column
+            )
             magnus_basis = alpha * (
                 basis1 + basis2
             ) + commutator_coefficient * (
@@ -244,6 +261,7 @@ def _scalable_cell_terms(
     qd_link: wp.array2d(dtype=wp.float64),
     basis_z1: wp.array2d(dtype=wp.float64),
     basis_z2: wp.array2d(dtype=wp.float64),
+    basis_rows: wp.array2d(dtype=wp.int32),
     reference_z1: wp.array2d(dtype=wp.float64),
     reference_z2: wp.array2d(dtype=wp.float64),
     segment_lengths: wp.array(dtype=wp.float64),
@@ -267,6 +285,7 @@ def _scalable_cell_terms(
             qd_link,
             basis_z1,
             basis_z2,
+            basis_rows,
             reference_z1,
             reference_z2,
             segment_lengths,

--- a/src/soromox/systems/gvs/_warp/scalable.py
+++ b/src/soromox/systems/gvs/_warp/scalable.py
@@ -1,0 +1,288 @@
+# ruff: noqa: I001, UP018
+"""Shape-generic Warp kernels for GVS link-cell dynamics.
+
+The kernels keep spatial dimension six, but obtain the number of generalized
+coordinates and local strain coordinates from array shapes. Runtime ``while``
+loops prevent Warp from expanding work proportional to the number of segments
+into the generated CUDA source.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+from soromox.systems.gvs._warp.lie import (
+    Vec6d,
+    _ad_action,
+    _adjoint_inverse_action,
+    _adjoint_inverse_entry,
+    _forward_coefficients,
+    _left_action,
+    _left_coefficient_x_derivatives,
+    _left_coefficients,
+    _left_total_derivative_action,
+    _translation,
+)
+
+wp.set_module_options({"enable_backward": False})
+
+
+SPATIAL_DIM = 6
+
+
+@wp.func
+def _load_dynamic_column(
+    matrix: wp.array2d(dtype=wp.float64), base_row: int, column: int
+) -> Vec6d:
+    return Vec6d(
+        matrix[base_row + 0, column],
+        matrix[base_row + 1, column],
+        matrix[base_row + 2, column],
+        matrix[base_row + 3, column],
+        matrix[base_row + 4, column],
+        matrix[base_row + 5, column],
+    )
+
+
+@wp.func
+def _dynamic_strain(
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    coordinates: wp.array2d(dtype=wp.float64),
+    cell_item: int,
+    coordinate_item: int,
+) -> Vec6d:
+    base_row = cell_item * SPATIAL_DIM
+    value = Vec6d(
+        reference[cell_item, 0],
+        reference[cell_item, 1],
+        reference[cell_item, 2],
+        reference[cell_item, 3],
+        reference[cell_item, 4],
+        reference[cell_item, 5],
+    )
+    column = int(0)
+    while column < coordinates.shape[1]:
+        coordinate = coordinates[coordinate_item, column]
+        row = int(0)
+        while row < SPATIAL_DIM:
+            value[row] += basis[base_row + row, column] * coordinate
+            row += 1
+        column += 1
+    return value
+
+
+@wp.func
+def _dynamic_strain_rate(
+    basis: wp.array2d(dtype=wp.float64),
+    velocities: wp.array2d(dtype=wp.float64),
+    cell_item: int,
+    coordinate_item: int,
+) -> Vec6d:
+    base_row = cell_item * SPATIAL_DIM
+    value = Vec6d()
+    column = int(0)
+    while column < velocities.shape[1]:
+        velocity = velocities[coordinate_item, column]
+        row = int(0)
+        while row < SPATIAL_DIM:
+            value[row] += basis[base_row + row, column] * velocity
+            row += 1
+        column += 1
+    return value
+
+
+@wp.kernel(enable_backward=False)
+def scalable_cell_terms_kernel(
+    q_link: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array2d(dtype=wp.float64),
+    basis_z1: wp.array2d(dtype=wp.float64),
+    basis_z2: wp.array2d(dtype=wp.float64),
+    reference_z1: wp.array2d(dtype=wp.float64),
+    reference_z2: wp.array2d(dtype=wp.float64),
+    segment_lengths: wp.array(dtype=wp.float64),
+    cell_widths: wp.array(dtype=wp.float64),
+    num_cells: wp.array(dtype=wp.int32),
+    order_zero: wp.array(dtype=wp.int32),
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    """Compute general cell-local Lie data with an optional order-zero branch."""
+
+    work_item = wp.tid()
+    cells_per_segment = num_cells[0]
+    cells_per_environment = segment_lengths.shape[0] * cells_per_segment
+    environment = work_item // cells_per_environment
+    environment_cell = work_item - environment * cells_per_environment
+    segment = environment_cell // cells_per_segment
+    cell = environment_cell - segment * cells_per_segment
+    cell_item = segment * cells_per_segment + cell
+    coordinate_item = environment * segment_lengths.shape[0] + segment
+    base_row = cell_item * SPATIAL_DIM
+    output_base_row = work_item * SPATIAL_DIM
+
+    xi1 = _dynamic_strain(
+        basis_z1, reference_z1, q_link, cell_item, coordinate_item
+    )
+    xid1 = _dynamic_strain_rate(
+        basis_z1, qd_link, cell_item, coordinate_item
+    )
+    length = segment_lengths[segment]
+    width = cell_widths[cell_item]
+    alpha = length * width * wp.float64(0.5)
+    commutator_coefficient = (
+        wp.sqrt(wp.float64(3.0))
+        * length
+        * length
+        * width
+        * width
+        / wp.float64(12.0)
+    )
+
+    xi2 = xi1
+    xid2 = xid1
+    magnus = length * width * xi1
+    magnus_dot = length * width * xid1
+    if order_zero[0] == 0:
+        xi2 = _dynamic_strain(
+            basis_z2, reference_z2, q_link, cell_item, coordinate_item
+        )
+        xid2 = _dynamic_strain_rate(
+            basis_z2, qd_link, cell_item, coordinate_item
+        )
+        magnus = alpha * (xi1 + xi2) + commutator_coefficient * _ad_action(
+            xi1, xi2
+        )
+        magnus_dot = alpha * (xid1 + xid2) + commutator_coefficient * (
+            _ad_action(xid1, xi2) + _ad_action(xi1, xid2)
+        )
+
+    angle_sq = (
+        magnus[0] * magnus[0]
+        + magnus[1] * magnus[1]
+        + magnus[2] * magnus[2]
+    )
+    coefficients = _left_coefficients(angle_sq)
+    omega = wp.vec3d(magnus[0], magnus[1], magnus[2])
+    linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
+    forward = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, forward)
+
+    row = int(0)
+    while row < SPATIAL_DIM:
+        column = int(0)
+        while column < SPATIAL_DIM:
+            adjoint[output_base_row + row, column] = _adjoint_inverse_entry(
+                omega,
+                translation,
+                angle_sq,
+                forward,
+                row,
+                column,
+            )
+            column += 1
+        row += 1
+
+    local_column = int(0)
+    while local_column < q_link.shape[1]:
+        basis1 = _load_dynamic_column(basis_z1, base_row, local_column)
+        magnus_basis = length * width * basis1
+        if order_zero[0] == 0:
+            basis2 = _load_dynamic_column(basis_z2, base_row, local_column)
+            magnus_basis = alpha * (
+                basis1 + basis2
+            ) + commutator_coefficient * (
+                _ad_action(xi1, basis2) - _ad_action(xi2, basis1)
+            )
+        local_tangent = _left_action(magnus, magnus_basis, coefficients)
+        row = int(0)
+        while row < SPATIAL_DIM:
+            tangent_local[output_base_row + row, local_column] = local_tangent[row]
+            row += 1
+        local_column += 1
+
+    link = _left_action(magnus, magnus_dot, coefficients)
+    step = _adjoint_inverse_action(
+        omega, translation, angle_sq, forward, link
+    )
+    magnus_basis_dot_qd = Vec6d()
+    if order_zero[0] == 0:
+        magnus_basis_dot_qd = (
+            wp.float64(2.0)
+            * commutator_coefficient
+            * _ad_action(xid1, xid2)
+        )
+    coefficient_derivatives = _left_coefficient_x_derivatives(angle_sq)
+    angle_sq_dot = wp.float64(2.0) * (
+        magnus[0] * magnus_dot[0]
+        + magnus[1] * magnus_dot[1]
+        + magnus[2] * magnus_dot[2]
+    )
+    tangent_dot_velocity_value = _left_total_derivative_action(
+        magnus,
+        magnus_dot,
+        magnus_dot,
+        magnus_basis_dot_qd,
+        coefficients,
+        coefficient_derivatives * angle_sq_dot,
+    )
+    row = int(0)
+    while row < SPATIAL_DIM:
+        link_velocity[output_base_row + row, 0] = link[row]
+        step_velocity[output_base_row + row, 0] = step[row]
+        tangent_velocity_dot[output_base_row + row, 0] = (
+            tangent_dot_velocity_value[row]
+        )
+        row += 1
+
+
+def _scalable_cell_terms(
+    q_link: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array2d(dtype=wp.float64),
+    basis_z1: wp.array2d(dtype=wp.float64),
+    basis_z2: wp.array2d(dtype=wp.float64),
+    reference_z1: wp.array2d(dtype=wp.float64),
+    reference_z2: wp.array2d(dtype=wp.float64),
+    segment_lengths: wp.array(dtype=wp.float64),
+    cell_widths: wp.array(dtype=wp.float64),
+    num_cells: wp.array(dtype=wp.int32),
+    order_zero: wp.array(dtype=wp.int32),
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    # ``num_cells`` has one entry whose value is not available to Python here.
+    # Derive the work count from the reference-strain rows instead.
+    work_items = (q_link.shape[0] * reference_z1.shape[0]) // segment_lengths.shape[0]
+    wp.launch(
+        scalable_cell_terms_kernel,
+        dim=work_items,
+        inputs=[
+            q_link,
+            qd_link,
+            basis_z1,
+            basis_z2,
+            reference_z1,
+            reference_z2,
+            segment_lengths,
+            cell_widths,
+            num_cells,
+            order_zero,
+        ],
+        outputs=[
+            adjoint,
+            tangent_local,
+            link_velocity,
+            step_velocity,
+            tangent_velocity_dot,
+        ],
+        block_dim=128,
+    )
+
+
+scalable_cell_terms = wp.jax_callable(_scalable_cell_terms, num_outputs=5)

--- a/src/soromox/systems/gvs/_warp/segment.py
+++ b/src/soromox/systems/gvs/_warp/segment.py
@@ -1,0 +1,151 @@
+# ruff: noqa: I001, UP018
+"""Runtime-sized cooperative GVS segment recurrence and assembly."""
+
+from __future__ import annotations
+
+import warp as wp
+
+from soromox.systems.gvs._warp.lie import Vec6d
+
+wp.set_module_options({"enable_backward": False})
+
+
+SPATIAL_DIM = 6
+BLOCK_DIM = 128
+
+
+@wp.func
+def _matrix_value(
+    first: wp.array2d(dtype=wp.float64),
+    second: wp.array2d(dtype=wp.float64),
+    use_first: bool,
+    base_row: int,
+    row: int,
+    column: int,
+) -> wp.float64:
+    if use_first:
+        return first[base_row + row, column]
+    return second[base_row + row, column]
+
+
+@wp.func
+def _vector_value(
+    first: wp.array2d(dtype=wp.float64),
+    second: wp.array2d(dtype=wp.float64),
+    use_first: bool,
+    base_row: int,
+    row: int,
+) -> wp.float64:
+    if use_first:
+        return first[base_row + row, 0]
+    return second[base_row + row, 0]
+
+
+@wp.func
+def _write_matrix_value(
+    first: wp.array2d(dtype=wp.float64),
+    second: wp.array2d(dtype=wp.float64),
+    use_first: bool,
+    base_row: int,
+    row: int,
+    column: int,
+    value: wp.float64,
+):
+    if use_first:
+        first[base_row + row, column] = value
+    else:
+        second[base_row + row, column] = value
+
+
+@wp.func
+def _write_vector_value(
+    first: wp.array2d(dtype=wp.float64),
+    second: wp.array2d(dtype=wp.float64),
+    use_first: bool,
+    base_row: int,
+    row: int,
+    value: wp.float64,
+):
+    if use_first:
+        first[base_row + row, 0] = value
+    else:
+        second[base_row + row, 0] = value
+
+
+@wp.func
+def _coadjoint_wrench(
+    velocity_first: wp.array2d(dtype=wp.float64),
+    velocity_second: wp.array2d(dtype=wp.float64),
+    derivative_first: wp.array2d(dtype=wp.float64),
+    derivative_second: wp.array2d(dtype=wp.float64),
+    use_first: bool,
+    base_row: int,
+    masses: wp.array2d(dtype=wp.float64),
+    quadrature: int,
+) -> Vec6d:
+    omega = wp.vec3d(
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 0
+        ),
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 1
+        ),
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 2
+        ),
+    )
+    linear_velocity = wp.vec3d(
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 3
+        ),
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 4
+        ),
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 5
+        ),
+    )
+    moment = wp.vec3d(
+        masses[quadrature, 0] * omega[0],
+        masses[quadrature, 1] * omega[1],
+        masses[quadrature, 2] * omega[2],
+    )
+    force = wp.vec3d(
+        masses[quadrature, 3] * linear_velocity[0],
+        masses[quadrature, 4] * linear_velocity[1],
+        masses[quadrature, 5] * linear_velocity[2],
+    )
+    angular = wp.cross(omega, moment) + wp.cross(linear_velocity, force)
+    linear = wp.cross(omega, force)
+    return Vec6d(
+        masses[quadrature, 0]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 0
+        )
+        + angular[0],
+        masses[quadrature, 1]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 1
+        )
+        + angular[1],
+        masses[quadrature, 2]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 2
+        )
+        + angular[2],
+        masses[quadrature, 3]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 3
+        )
+        + linear[0],
+        masses[quadrature, 4]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 4
+        )
+        + linear[1],
+        masses[quadrature, 5]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 5
+        )
+        + linear[2],
+    )

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -181,6 +181,13 @@ class GVS(SoftRobot):
     inner_integration_weights: Array
     mass_matrices: Array
     inner_mass_matrices: Array
+    # Model-invariant operands reused by the batched Warp dynamics backend.
+    cell_widths: Array
+    link_basis_rows: Array
+    scaled_B_Z1_values: Array
+    scaled_B_Z2_values: Array
+    inner_mass_diagonals: Array
+    gravity_base: Array
 
     B_joint: Array
     B_Xs: Array
@@ -750,6 +757,45 @@ class GVS(SoftRobot):
             joint_stiffness=K_joint_full,
         )
 
+    def _compact_link_basis_operands(
+        self, segment_lengths: Array
+    ) -> tuple[Array, Array, Array]:
+        """Pack each structurally one-row link-basis column for Warp."""
+
+        active = self.basis_active_params.astype(jnp.int32)
+        orders = self.basis_order_params.astype(jnp.int32)
+        standard_widths = active * (orders + 1)
+        fourier_widths = active * (2 * orders + 1)
+        widths = jnp.where(
+            (self.basis_type_index == Basis.BASISTYPE_MAP["fourier"])[:, None],
+            fourier_widths,
+            standard_widths,
+        )
+        offsets = jnp.concatenate(
+            [
+                jnp.zeros((self.num_segments, 1), dtype=jnp.int32),
+                jnp.cumsum(widths[:, :-1], axis=1),
+            ],
+            axis=1,
+        )
+        columns = jnp.arange(self.max_dof, dtype=jnp.int32)[None, None, :]
+        row_numbers = jnp.arange(6, dtype=jnp.int32)[None, :, None]
+        active_columns = (columns >= offsets[:, :, None]) & (
+            columns < (offsets + widths)[:, :, None]
+        )
+        rows = jnp.max(jnp.where(active_columns, row_numbers, -1), axis=1)
+
+        B_Z1 = self.B_Z1
+        B_Z2 = self.B_Z2
+        if self.scale_rotational_basis_by_length:
+            scales = segment_lengths[:, None, None, None]
+            B_Z1 = B_Z1.at[:, :, :3].divide(scales)
+            B_Z2 = B_Z2.at[:, :, :3].divide(scales)
+        gather_rows = jnp.maximum(rows, 0)[:, None, None, :]
+        values_Z1 = jnp.take_along_axis(B_Z1, gather_rows, axis=2).squeeze(2)
+        values_Z2 = jnp.take_along_axis(B_Z2, gather_rows, axis=2).squeeze(2)
+        return rows.astype(jnp.int32), values_Z1, values_Z2
+
     def precompute(self) -> None:
         """Precompute padded gathers and canonical system matrices.
 
@@ -803,6 +849,23 @@ class GVS(SoftRobot):
             "inner_mass_matrices",
             self.mass_matrices[:, 1 : self.max_num_integration_points - 1],
         )
+        object.__setattr__(
+            self,
+            "cell_widths",
+            self.integration_points[:, 1:] - self.integration_points[:, :-1],
+        )
+        link_basis_rows, scaled_B_Z1_values, scaled_B_Z2_values = (
+            self._compact_link_basis_operands(self.segment_lengths)
+        )
+        object.__setattr__(self, "link_basis_rows", link_basis_rows)
+        object.__setattr__(self, "scaled_B_Z1_values", scaled_B_Z1_values)
+        object.__setattr__(self, "scaled_B_Z2_values", scaled_B_Z2_values)
+        object.__setattr__(
+            self,
+            "inner_mass_diagonals",
+            jnp.diagonal(self.inner_mass_matrices, axis1=-2, axis2=-1),
+        )
+        object.__setattr__(self, "gravity_base", se3.adjoint_inverse(self.g0) @ self.g)
         object.__setattr__(self, "gather_indices", gather_indices)
         object.__setattr__(self, "gather_mask", gather_mask)
         object.__setattr__(self, "joint_local_to_global", joint_local_to_global)
@@ -813,9 +876,7 @@ class GVS(SoftRobot):
         object.__setattr__(
             self, "link_global_to_local", invert_local_map(link_local_to_global)
         )
-        object.__setattr__(
-            self, "active_dofs_per_segment", active_dofs_per_segment
-        )
+        object.__setattr__(self, "active_dofs_per_segment", active_dofs_per_segment)
         object.__setattr__(self, "young_stiffness_operator", young_operator)
         object.__setattr__(self, "shear_stiffness_operator", shear_operator)
         object.__setattr__(self, "material_damping_operator", damping_operator)
@@ -1073,10 +1134,18 @@ class GVS(SoftRobot):
         young_operator, shear_operator, damping_operator = (
             material_operators_from_params(params, self.structure)
         )
+        link_basis_rows, scaled_B_Z1_values, scaled_B_Z2_values = (
+            updated_self._compact_link_basis_operands(updated_self.segment_lengths)
+        )
         return eqx.tree_at(
             lambda model: (
                 model.inner_integration_weights,
                 model.inner_mass_matrices,
+                model.link_basis_rows,
+                model.scaled_B_Z1_values,
+                model.scaled_B_Z2_values,
+                model.inner_mass_diagonals,
+                model.gravity_base,
                 model.young_stiffness_operator,
                 model.shear_stiffness_operator,
                 model.material_damping_operator,
@@ -1094,6 +1163,17 @@ class GVS(SoftRobot):
                 updated_self.mass_matrices[
                     :, 1 : updated_self.max_num_integration_points - 1
                 ],
+                link_basis_rows,
+                scaled_B_Z1_values,
+                scaled_B_Z2_values,
+                jnp.diagonal(
+                    updated_self.mass_matrices[
+                        :, 1 : updated_self.max_num_integration_points - 1
+                    ],
+                    axis1=-2,
+                    axis2=-1,
+                ),
+                se3.adjoint_inverse(updated_self.g0) @ updated_self.g,
                 young_operator,
                 shear_operator,
                 damping_operator,
@@ -4446,8 +4526,7 @@ class GVS(SoftRobot):
             raise ValueError(f"qd must have shape {q.shape}, got {qd.shape}.")
         if backend not in ("auto", "jax", "warp"):
             raise ValueError(
-                "backend must be one of 'auto', 'jax', or 'warp', "
-                f"got {backend!r}."
+                f"backend must be one of 'auto', 'jax', or 'warp', got {backend!r}."
             )
 
         selected_backend = backend

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 import equinox as eqx
 import jax
@@ -63,7 +63,9 @@ from soromox.utils.integration import gauss_quadrature
 from soromox.utils.lie_algebra import se3, so3
 from soromox.utils.numerics import safe_divide, safe_norm, safe_normalize
 
-__all__ = ["GVS"]
+GVSBackend = Literal["auto", "jax", "warp"]
+
+__all__ = ["GVS", "GVSBackend"]
 
 
 class GVS(SoftRobot):
@@ -201,6 +203,12 @@ class GVS(SoftRobot):
     material_damping_operator: Array
     gather_indices: Array  # Indices for active-to-padded coordinate gather
     gather_mask: Array  # Valid-entry mask for active-to-padded coordinate gather
+    # Runtime-shaped maps consumed by the optional Warp dynamics backend.
+    joint_local_to_global: Array
+    joint_global_to_local: Array
+    link_local_to_global: Array
+    link_global_to_local: Array
+    active_dofs_per_segment: Array
 
     g0: Array  # Initial base pose (4,4)
     g: Array  # Gravity vector (6,)
@@ -758,6 +766,19 @@ class GVS(SoftRobot):
         start_indices = start_indices_flat.reshape(self.num_segments, 2)
         gather_indices = start_indices[..., None] + jnp.arange(self.max_dof)
         gather_mask = jnp.arange(self.max_dof) < self.dofs_per_segment[..., None]
+        local_to_global = jnp.where(gather_mask, gather_indices, -1).astype(jnp.int32)
+        global_columns = jnp.arange(self.num_dofs, dtype=jnp.int32)[None, None, :]
+        local_columns = jnp.arange(self.max_dof, dtype=jnp.int32)[None, :, None]
+
+        def invert_local_map(local_map: Array) -> Array:
+            matches = local_map[:, :, None] == global_columns
+            return jnp.max(jnp.where(matches, local_columns, -1), axis=1)
+
+        joint_local_to_global = local_to_global[:, 0]
+        link_local_to_global = local_to_global[:, 1]
+        active_dofs_per_segment = jnp.cumsum(
+            jnp.sum(self.dofs_per_segment, axis=1), dtype=jnp.int32
+        )
 
         young_operator, shear_operator, damping_operator = (
             material_operators_from_params(self.params, self.structure)
@@ -784,6 +805,17 @@ class GVS(SoftRobot):
         )
         object.__setattr__(self, "gather_indices", gather_indices)
         object.__setattr__(self, "gather_mask", gather_mask)
+        object.__setattr__(self, "joint_local_to_global", joint_local_to_global)
+        object.__setattr__(
+            self, "joint_global_to_local", invert_local_map(joint_local_to_global)
+        )
+        object.__setattr__(self, "link_local_to_global", link_local_to_global)
+        object.__setattr__(
+            self, "link_global_to_local", invert_local_map(link_local_to_global)
+        )
+        object.__setattr__(
+            self, "active_dofs_per_segment", active_dofs_per_segment
+        )
         object.__setattr__(self, "young_stiffness_operator", young_operator)
         object.__setattr__(self, "shear_stiffness_operator", shear_operator)
         object.__setattr__(self, "material_damping_operator", damping_operator)
@@ -4357,6 +4389,93 @@ class GVS(SoftRobot):
         )
 
         return weights, g_quads, J_quads, Jd_or_Jd_qd_quads
+
+    @eqx.filter_jit
+    def dynamics_terms_batched(
+        self,
+        q: Array,
+        qd: Array,
+        *,
+        backend: GVSBackend = "auto",
+    ) -> tuple[Array, Array, Array]:
+        """Assemble dynamics terms for a batch of independent environments.
+
+        With ``"warp"``, all general-joint and spatially varying link Lie terms
+        are prepared by runtime-shaped kernels. One persistent cooperative block
+        per environment then traverses the serial chain and assembles ``B``,
+        ``C @ qd``, and ``G`` using each segment's active coordinate prefix.
+        Generated Warp source is independent of the batch size, number of
+        segments, basis order, quadrature count, and supported joint family.
+
+        ``"auto"`` selects Warp on GPU and JAX on CPU, without a model-order or
+        batch-size crossover policy. Use ``"jax"`` explicitly when GPU
+        differentiability is required. ``"jax"`` is fully differentiable;
+        ``"warp"`` is forward-only and must not be used through JAX transforms
+        that request derivatives.
+
+        Warp is an optional dependency. Install ``soromox[warp]`` before
+        explicitly requesting that backend. The current kernels use FP64 to
+        preserve the numerical behavior of GVS dynamics.
+
+        Args:
+            q: Batched active generalized coordinates with shape
+                ``(batch_size, self.num_dofs)``.
+            qd: Batched active generalized velocities with the same shape.
+            backend: ``"auto"``, ``"jax"``, or ``"warp"``.
+
+        Returns:
+            Batched ``(B, Cqd, G)`` with shapes
+            ``(batch_size, num_dofs, num_dofs)``,
+            ``(batch_size, num_dofs)``, and ``(batch_size, num_dofs)``.
+
+        Raises:
+            ValueError: If the backend or input shapes are invalid, or an empty
+                batch is explicitly sent to Warp.
+            TypeError: If Warp is requested for non-FP64 inputs.
+            ImportError: If Warp is requested but not installed.
+        """
+        q = jnp.asarray(q)
+        qd = jnp.asarray(qd)
+        expected_suffix = (self.num_dofs,)
+        if q.ndim != 2 or q.shape[1:] != expected_suffix:
+            raise ValueError(
+                "q must have shape (batch_size, num_dofs); "
+                f"expected (*, {self.num_dofs}), got {q.shape}."
+            )
+        if qd.shape != q.shape:
+            raise ValueError(f"qd must have shape {q.shape}, got {qd.shape}.")
+        if backend not in ("auto", "jax", "warp"):
+            raise ValueError(
+                "backend must be one of 'auto', 'jax', or 'warp', "
+                f"got {backend!r}."
+            )
+
+        selected_backend = backend
+        if selected_backend == "auto":
+            selected_backend = "warp" if jax.default_backend() == "gpu" else "jax"
+
+        if selected_backend == "jax":
+            return jax.vmap(self.dynamics_terms)(q, qd)
+
+        if q.shape[0] == 0:
+            raise ValueError("The Warp backend requires a non-empty batch.")
+        if q.dtype != jnp.float64 or qd.dtype != jnp.float64:
+            raise TypeError(
+                "The Warp GVS backend currently requires float64 q and qd; "
+                f"got {q.dtype} and {qd.dtype}."
+            )
+        try:
+            from soromox.systems.gvs._warp.backend import dynamics_terms
+        except ModuleNotFoundError as error:
+            if error.name == "warp":
+                raise ImportError(
+                    "The Warp GVS backend requires the optional 'warp-lang' "
+                    "dependency. Install it with `pip install soromox[warp]`."
+                ) from error
+            raise
+
+        lanes_per_block = 128 if jax.default_backend() == "gpu" else 1
+        return dynamics_terms(self, q, qd, lanes_per_block=lanes_per_block)
 
     @eqx.filter_jit
     def dynamics_terms(self, q: Array, qd: Array) -> tuple[Array, Array, Array]:

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -17,6 +17,7 @@ from soromox.systems.components import (
     IsotropicMaterialParams,
 )
 from soromox.systems.gvs._assembly import assign_gvs_runtime_arrays
+from soromox.systems.gvs._dynamics import evaluate_terms
 from soromox.systems.gvs._runtime import SegmentRuntimeData
 from soromox.systems.gvs.construction import (
     _resolve_structure,
@@ -63,9 +64,9 @@ from soromox.utils.integration import gauss_quadrature
 from soromox.utils.lie_algebra import se3, so3
 from soromox.utils.numerics import safe_divide, safe_norm, safe_normalize
 
-GVSBackend = Literal["auto", "jax", "warp"]
+ExecutionBackend = Literal["auto", "jax", "warp"]
 
-__all__ = ["GVS", "GVSBackend"]
+__all__ = ["ExecutionBackend", "GVS"]
 
 
 class GVS(SoftRobot):
@@ -158,6 +159,8 @@ class GVS(SoftRobot):
         static=True
     )  # Total number of DOFs for the robot, considering the maximum DOFs per link: num_segments * 2 * max_dof
 
+    backend: ExecutionBackend = eqx.field(static=True, default="auto")
+
     Z1: float = eqx.field(static=True, default=0.5 - math.sqrt(3) / 6)
     Z2: float = eqx.field(static=True, default=0.5 + math.sqrt(3) / 6)
 
@@ -244,6 +247,7 @@ class GVS(SoftRobot):
         structure: GVSStructure,
         actuators: Actuator | tuple[Actuator, ...] | None = None,
         passive_elements: PassiveElement | tuple[PassiveElement, ...] | None = (),
+        backend: ExecutionBackend = "auto",
         **kwargs: Any,
     ) -> None:
         """Initialize a GVS robot from typed parameters and static structure.
@@ -257,6 +261,10 @@ class GVS(SoftRobot):
                 model.
             passive_elements: Optional passive element or tuple of passive
                 elements. Pass ``None`` or an empty tuple to disable them.
+            backend: Preferred execution backend for accelerated GVS methods.
+                ``"auto"`` selects Warp on GPU and JAX on CPU. Currently the
+                Warp implementation covers dynamics; other methods remain in
+                JAX. Transformations that request derivatives always use JAX.
             **kwargs: Additional keyword arguments forwarded to
                 :class:`BaseContinuumSoftRobot`.
 
@@ -269,10 +277,16 @@ class GVS(SoftRobot):
             raise TypeError("params must be a GVSParams instance.")
         if not isinstance(structure, GVSStructure):
             raise TypeError("structure must be a GVSStructure instance.")
+        if backend not in ("auto", "jax", "warp"):
+            raise ValueError(
+                "backend must be one of 'auto', 'jax', or 'warp', "
+                f"got {backend!r}."
+            )
         structure = _resolve_structure(params, structure)
         super().__init__(base_pose=params.base_pose, **kwargs)
         self.params = params
         self.structure = structure
+        self.backend = backend
         self.scale_rotational_basis_by_length = bool(
             structure.scale_rotational_basis_by_length
         )
@@ -4501,15 +4515,17 @@ class GVS(SoftRobot):
 
         return weights, g_quads, J_quads, Jd_or_Jd_qd_quads
 
-    @eqx.filter_jit
-    def dynamics_terms_batched(
+    # The selected implementations own their JIT boundaries. Keeping this
+    # transform-aware dispatcher outside ``filter_jit`` lets JVP and transpose
+    # rules select JAX before a forward-only Warp primal is staged.
+    def dynamics_terms(
         self,
         q: Array,
         qd: Array,
         *,
-        backend: GVSBackend = "auto",
+        backend: ExecutionBackend | None = None,
     ) -> tuple[Array, Array, Array]:
-        """Assemble dynamics terms for a batch of independent environments.
+        """Assemble single- or multi-environment forward-dynamics terms.
 
         With ``"warp"``, all general-joint and spatially varying link Lie terms
         are prepared by runtime-shaped kernels. One persistent cooperative block
@@ -4518,80 +4534,66 @@ class GVS(SoftRobot):
         Generated Warp source is independent of the batch size, number of
         segments, basis order, quadrature count, and supported joint family.
 
+        ``backend=None`` uses the model's configured ``backend``.
         ``"auto"`` selects Warp on GPU and JAX on CPU, without a model-order or
-        batch-size crossover policy. Use ``"jax"`` explicitly when GPU
-        differentiability is required. ``"jax"`` is fully differentiable;
-        ``"warp"`` is forward-only and must not be used through JAX transforms
-        that request derivatives.
+        batch-size crossover policy. Forward- and reverse-mode differentiation
+        always use the JAX assembly, including when primal execution selects
+        Warp. Applying :func:`jax.vmap` to scalar calls invokes the batch-shaped
+        Warp pipeline once rather than mapping batch-one kernel launches.
 
         Warp is an optional dependency. Install ``soromox[warp]`` before
         explicitly requesting that backend. The current kernels use FP64 to
         preserve the numerical behavior of GVS dynamics.
 
         Args:
-            q: Batched active generalized coordinates with shape
-                ``(batch_size, self.num_dofs)``.
-            qd: Batched active generalized velocities with the same shape.
-            backend: ``"auto"``, ``"jax"``, or ``"warp"``.
+            q: Active generalized coordinates with shape ``(num_dofs,)`` or
+                ``(batch_size, num_dofs)``.
+            qd: Generalized velocities with the same shape as ``q``.
+            backend: Optional per-call override: ``"auto"``, ``"jax"``, or
+                ``"warp"``.
 
         Returns:
-            Batched ``(B, Cqd, G)`` with shapes
-            ``(batch_size, num_dofs, num_dofs)``,
-            ``(batch_size, num_dofs)``, and ``(batch_size, num_dofs)``.
+            ``(B, Cqd, G)`` with the same optional leading batch dimension as
+            the inputs.
 
         Raises:
             ValueError: If the backend or input shapes are invalid, or an empty
-                batch is explicitly sent to Warp.
+                batch is sent to Warp.
             TypeError: If Warp is requested for non-FP64 inputs.
             ImportError: If Warp is requested but not installed.
         """
         q = jnp.asarray(q)
         qd = jnp.asarray(qd)
-        expected_suffix = (self.num_dofs,)
-        if q.ndim != 2 or q.shape[1:] != expected_suffix:
+        if q.ndim not in (1, 2) or q.shape[-1:] != (self.num_dofs,):
             raise ValueError(
-                "q must have shape (batch_size, num_dofs); "
-                f"expected (*, {self.num_dofs}), got {q.shape}."
+                "q must have shape (num_dofs,) or (batch_size, num_dofs); "
+                f"expected (..., {self.num_dofs}), got {q.shape}."
             )
         if qd.shape != q.shape:
             raise ValueError(f"qd must have shape {q.shape}, got {qd.shape}.")
-        if backend not in ("auto", "jax", "warp"):
+        configured_backend = self.backend if backend is None else backend
+        if configured_backend not in ("auto", "jax", "warp"):
             raise ValueError(
                 f"backend must be one of 'auto', 'jax', or 'warp', got {backend!r}."
             )
 
-        selected_backend = backend
+        selected_backend = configured_backend
         if selected_backend == "auto":
             selected_backend = "warp" if jax.default_backend() == "gpu" else "jax"
 
         if selected_backend == "jax":
-            return jax.vmap(self.dynamics_terms)(q, qd)
+            if q.ndim == 1:
+                return self._assemble_dynamics_terms(q, qd)
+            return jax.vmap(self._assemble_dynamics_terms)(q, qd)
 
-        if q.shape[0] == 0:
-            raise ValueError("The Warp backend requires a non-empty batch.")
-        if q.dtype != jnp.float64 or qd.dtype != jnp.float64:
-            raise TypeError(
-                "The Warp GVS backend currently requires float64 q and qd; "
-                f"got {q.dtype} and {qd.dtype}."
-            )
-        try:
-            from soromox.systems.gvs._warp.backend import dynamics_terms
-        except ModuleNotFoundError as error:
-            if error.name == "warp":
-                raise ImportError(
-                    "The Warp GVS backend requires the optional 'warp-lang' "
-                    "dependency. Install it with `pip install soromox[warp]`."
-                ) from error
-            raise
-
-        if jax.default_backend() == "gpu":
-            lanes_per_block = 192 if self.num_dofs > 64 else 128
-        else:
-            lanes_per_block = 1
-        return dynamics_terms(self, q, qd, lanes_per_block=lanes_per_block)
+        if q.ndim == 1:
+            return evaluate_terms(self, q, qd)
+        return jax.vmap(evaluate_terms, in_axes=(None, 0, 0))(self, q, qd)
 
     @eqx.filter_jit
-    def dynamics_terms(self, q: Array, qd: Array) -> tuple[Array, Array, Array]:
+    def _assemble_dynamics_terms(
+        self, q: Array, qd: Array
+    ) -> tuple[Array, Array, Array]:
         """
         Assemble forward-dynamics terms with fixed-shape segment recurrences.
 
@@ -5370,7 +5372,8 @@ class GVS(SoftRobot):
             params.end_segment_index_array,
         )
 
-    @eqx.filter_jit
+    # As with ``dynamics_terms``, the compiled implementation lives behind the
+    # transform-aware wrapper so differentiation can select JAX before staging.
     def forward_dynamics(
         self, t: Array, y: Array, actuation_args: tuple | None = None
     ) -> Array:
@@ -5387,6 +5390,44 @@ class GVS(SoftRobot):
         Returns:
             yd (Array): Time derivative of the state vector.
         """
+        return GVS._forward_dynamics_custom_jvp(self, t, y, actuation_args)
+
+    @eqx.filter_custom_jvp
+    @staticmethod
+    def _forward_dynamics_custom_jvp(
+        model: "GVS", t: Array, y: Array, actuation_args: tuple | None
+    ) -> Array:
+        """Custom-JVP entry point for the public forward-dynamics wrapper."""
+
+        return model._evaluate_forward_dynamics(t, y, actuation_args, backend=None)
+
+    @_forward_dynamics_custom_jvp.def_jvp
+    def _forward_dynamics_custom_jvp_jvp(
+        primals: tuple["GVS", Array, Array, tuple | None],
+        tangents: tuple[Any, Any, Any, Any],
+    ) -> tuple[Array, Array]:
+        """Differentiate the complete forward-dynamics calculation with JAX."""
+
+        return eqx.filter_jvp(
+            lambda model, t, y, actuation_args: model._evaluate_forward_dynamics(
+                t, y, actuation_args, backend="jax"
+            ),
+            primals,
+            tangents,
+        )
+
+    @eqx.filter_jit
+    def _evaluate_forward_dynamics(
+        self,
+        t: Array,
+        y: Array,
+        actuation_args: tuple | None,
+        *,
+        backend: ExecutionBackend | None,
+    ) -> Array:
+        """Evaluate forward dynamics with an explicitly selected terms backend."""
+
+        del t
         # Split the state vector into configuration and velocity
         q, qd = jnp.split(y, 2)
 
@@ -5406,7 +5447,7 @@ class GVS(SoftRobot):
         if tau_ext is None:
             tau_ext = jnp.zeros((q.shape[-1],))
 
-        B, Cqd, G = self.dynamics_terms(q, qd)
+        B, Cqd, G = self.dynamics_terms(q, qd, backend=backend)
         tau_el = self.elastic_force(q)
         tau_u = self.actuation_force(q, u, qd=qd)
 

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -187,7 +187,10 @@ class GVS(SoftRobot):
     scaled_B_Z1_values: Array
     scaled_B_Z2_values: Array
     inner_mass_diagonals: Array
+    inner_weighted_mass_diagonals: Array
     gravity_base: Array
+    inertia_upper_rows: Array
+    inertia_upper_columns: Array
 
     B_joint: Array
     B_Xs: Array
@@ -838,17 +841,16 @@ class GVS(SoftRobot):
                 self.num_segments, 2, self.max_dof, self.num_dofs
             ),
         )
-        object.__setattr__(
-            self,
-            "inner_integration_weights",
+        inner_integration_weights = (
             self.integration_weights[:, 1 : self.max_num_integration_points - 1]
-            * self.segment_lengths[:, None],
+            * self.segment_lengths[:, None]
         )
-        object.__setattr__(
-            self,
-            "inner_mass_matrices",
-            self.mass_matrices[:, 1 : self.max_num_integration_points - 1],
-        )
+        inner_mass_matrices = self.mass_matrices[
+            :, 1 : self.max_num_integration_points - 1
+        ]
+        inner_mass_diagonals = jnp.diagonal(inner_mass_matrices, axis1=-2, axis2=-1)
+        object.__setattr__(self, "inner_integration_weights", inner_integration_weights)
+        object.__setattr__(self, "inner_mass_matrices", inner_mass_matrices)
         object.__setattr__(
             self,
             "cell_widths",
@@ -860,12 +862,27 @@ class GVS(SoftRobot):
         object.__setattr__(self, "link_basis_rows", link_basis_rows)
         object.__setattr__(self, "scaled_B_Z1_values", scaled_B_Z1_values)
         object.__setattr__(self, "scaled_B_Z2_values", scaled_B_Z2_values)
+        object.__setattr__(self, "inner_mass_diagonals", inner_mass_diagonals)
         object.__setattr__(
             self,
-            "inner_mass_diagonals",
-            jnp.diagonal(self.inner_mass_matrices, axis1=-2, axis2=-1),
+            "inner_weighted_mass_diagonals",
+            inner_integration_weights[..., None] * inner_mass_diagonals,
         )
         object.__setattr__(self, "gravity_base", se3.adjoint_inverse(self.g0) @ self.g)
+        upper_rows = tuple(
+            row for column in range(self.num_dofs) for row in range(column + 1)
+        )
+        upper_columns = tuple(
+            column for column in range(self.num_dofs) for _ in range(column + 1)
+        )
+        object.__setattr__(
+            self, "inertia_upper_rows", jnp.asarray(upper_rows, dtype=jnp.int32)
+        )
+        object.__setattr__(
+            self,
+            "inertia_upper_columns",
+            jnp.asarray(upper_columns, dtype=jnp.int32),
+        )
         object.__setattr__(self, "gather_indices", gather_indices)
         object.__setattr__(self, "gather_mask", gather_mask)
         object.__setattr__(self, "joint_local_to_global", joint_local_to_global)
@@ -1145,6 +1162,7 @@ class GVS(SoftRobot):
                 model.scaled_B_Z1_values,
                 model.scaled_B_Z2_values,
                 model.inner_mass_diagonals,
+                model.inner_weighted_mass_diagonals,
                 model.gravity_base,
                 model.young_stiffness_operator,
                 model.shear_stiffness_operator,
@@ -1167,6 +1185,19 @@ class GVS(SoftRobot):
                 scaled_B_Z1_values,
                 scaled_B_Z2_values,
                 jnp.diagonal(
+                    updated_self.mass_matrices[
+                        :, 1 : updated_self.max_num_integration_points - 1
+                    ],
+                    axis1=-2,
+                    axis2=-1,
+                ),
+                (
+                    updated_self.integration_weights[
+                        :, 1 : updated_self.max_num_integration_points - 1
+                    ]
+                    * updated_self.segment_lengths[:, None]
+                )[..., None]
+                * jnp.diagonal(
                     updated_self.mass_matrices[
                         :, 1 : updated_self.max_num_integration_points - 1
                     ],
@@ -4553,7 +4584,10 @@ class GVS(SoftRobot):
                 ) from error
             raise
 
-        lanes_per_block = 128 if jax.default_backend() == "gpu" else 1
+        if jax.default_backend() == "gpu":
+            lanes_per_block = 192 if self.num_dofs > 64 else 128
+        else:
+            lanes_per_block = 1
         return dynamics_terms(self, q, qd, lanes_per_block=lanes_per_block)
 
     @eqx.filter_jit

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -34,6 +34,21 @@ ATOL = Tolerance.atol()
 NUM_RANDOM_SAMPLES = 5
 
 
+class _DynamicsDispatchProbe(eqx.Module):
+    """Small differentiable model used to test transform routing in isolation."""
+
+    scale: Array
+    num_dofs: int = eqx.field(static=True)
+
+    def _assemble_dynamics_terms(
+        self, q: Array, qd: Array
+    ) -> tuple[Array, Array, Array]:
+        inertia = self.scale * jnp.eye(self.num_dofs, dtype=q.dtype) + jnp.outer(q, q)
+        coriolis_qd = self.scale * q * qd
+        gravity = q + self.scale
+        return inertia, coriolis_qd, gravity
+
+
 def _updated_gvs_params(robot: GVS):
     params = robot.params
     return params.replace(
@@ -1762,17 +1777,169 @@ def test_dynamics_terms_match_public_matrices(
         assert_allclose(G, robot.gravitational_force(q), rtol=RTOL, atol=ATOL)
 
 
-def test_dynamics_terms_batched_jax_matches_single_environment_api() -> None:
+def test_dynamics_terms_accepts_batched_inputs() -> None:
     robot = build_varied_basis_gvs(num_segments=3)
     key_q, key_qd = jax.random.split(jax.random.PRNGKey(6125))
     q = jax.random.normal(key_q, (3, robot.num_dofs), dtype=jnp.float64) * 0.02
     qd = jax.random.normal(key_qd, (3, robot.num_dofs), dtype=jnp.float64) * 0.04
 
     expected = jax.vmap(robot.dynamics_terms)(q, qd)
-    actual = robot.dynamics_terms_batched(q, qd, backend="jax")
+    actual = robot.dynamics_terms(q, qd, backend="jax")
 
     for actual_term, expected_term in zip(actual, expected, strict=True):
         assert_allclose(actual_term, expected_term, rtol=RTOL, atol=ATOL)
+
+
+def test_warp_dispatch_batches_primals_and_differentiates_with_jax(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from soromox.systems.gvs import _dynamics
+
+    model = _DynamicsDispatchProbe(
+        scale=jnp.asarray(2.0, dtype=jnp.float64),
+        num_dofs=3,
+    )
+    q = jnp.asarray([0.1, -0.2, 0.3], dtype=jnp.float64)
+    qd = jnp.asarray([-0.4, 0.5, 0.6], dtype=jnp.float64)
+
+    def fake_batch(model, q, qd):
+        del qd
+        batch_size = q.shape[0]
+        value = jnp.asarray(batch_size, dtype=q.dtype)
+        return (
+            jnp.full((batch_size, model.num_dofs, model.num_dofs), value),
+            jnp.full((batch_size, model.num_dofs), value + 1.0),
+            jnp.full((batch_size, model.num_dofs), value + 2.0),
+        )
+
+    monkeypatch.setattr(_dynamics, "_execute_batch", fake_batch)
+
+    primal = _dynamics.evaluate_terms(model, q, qd)
+    assert_allclose(primal[0], jnp.ones((3, 3)), rtol=0.0, atol=0.0)
+
+    q_batch = jnp.stack((q, 2.0 * q, 3.0 * q))
+    qd_batch = jnp.stack((qd, 2.0 * qd, 3.0 * qd))
+    batched = jax.vmap(_dynamics.evaluate_terms, in_axes=(None, 0, 0))(
+        model, q_batch, qd_batch
+    )
+    assert_allclose(batched[0], jnp.full((3, 3, 3), 3.0), rtol=0.0, atol=0.0)
+
+    tangent = jnp.asarray([0.7, -0.8, 0.9], dtype=jnp.float64)
+    expected_jvp = jax.jvp(
+        lambda q_: model._assemble_dynamics_terms(q_, qd),
+        (q,),
+        (tangent,),
+    )
+    actual_jvp = jax.jvp(
+        lambda q_: _dynamics.evaluate_terms(model, q_, qd),
+        (q,),
+        (tangent,),
+    )
+    for actual_tree, expected_tree in zip(actual_jvp, expected_jvp, strict=True):
+        for actual, expected in zip(actual_tree, expected_tree, strict=True):
+            assert_allclose(actual, expected, rtol=RTOL, atol=ATOL)
+
+    def objective(evaluate, q):
+        return sum(jnp.sum(term) for term in evaluate(model, q, qd))
+
+    expected_gradient = jax.grad(
+        lambda q_: objective(
+            lambda model_, q__, qd_: model_._assemble_dynamics_terms(q__, qd_),
+            q_,
+        )
+    )(q)
+    actual_gradient = jax.grad(lambda q_: objective(_dynamics.evaluate_terms, q_))(q)
+    assert_allclose(actual_gradient, expected_gradient, rtol=RTOL, atol=ATOL)
+
+    def batched_objective(evaluate, q):
+        terms = jax.vmap(evaluate, in_axes=(None, 0, 0))(model, q, qd_batch)
+        return sum(jnp.sum(term) for term in terms)
+
+    expected_batched_gradient = jax.grad(
+        lambda q_: batched_objective(
+            lambda model_, q__, qd_: model_._assemble_dynamics_terms(q__, qd_),
+            q_,
+        )
+    )(q_batch)
+    actual_batched_gradient = jax.grad(
+        lambda q_: batched_objective(_dynamics.evaluate_terms, q_)
+    )(q_batch)
+    assert_allclose(
+        actual_batched_gradient,
+        expected_batched_gradient,
+        rtol=RTOL,
+        atol=ATOL,
+    )
+
+
+def test_configured_warp_backend_routes_autodiff_to_jax(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from soromox.systems.gvs import _dynamics
+
+    reference = build_constant_strain_gvs(
+        num_segments=1,
+        selector_per_segment=(True, True, False, False, False, False),
+    )
+    robot = GVS(
+        params=reference.params,
+        structure=reference.structure,
+        backend="warp",
+    )
+    q = jnp.asarray([0.01, -0.02], dtype=jnp.float64)
+    qd = jnp.asarray([0.03, -0.04], dtype=jnp.float64)
+    tangent = jnp.asarray([0.2, -0.3], dtype=jnp.float64)
+
+    def fail_if_warp_is_staged(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("autodiff staged the forward-only Warp backend")
+
+    monkeypatch.setattr(_dynamics, "_execute_batch", fail_if_warp_is_staged)
+
+    expected_jvp = jax.jvp(
+        lambda q_: reference.dynamics_terms(q_, qd, backend="jax"),
+        (q,),
+        (tangent,),
+    )
+    actual_jvp = jax.jvp(lambda q_: robot.dynamics_terms(q_, qd), (q,), (tangent,))
+    for actual_tree, expected_tree in zip(actual_jvp, expected_jvp, strict=True):
+        for actual, expected in zip(actual_tree, expected_tree, strict=True):
+            assert_allclose(actual, expected, rtol=RTOL, atol=ATOL)
+
+    def objective(model, q):
+        return sum(jnp.sum(term) for term in model.dynamics_terms(q, qd))
+
+    expected_gradient = jax.grad(lambda q_: objective(reference, q_))(q)
+    actual_gradient = jax.grad(lambda q_: objective(robot, q_))(q)
+    assert_allclose(actual_gradient, expected_gradient, rtol=RTOL, atol=ATOL)
+
+    y = jnp.concatenate((q, qd))
+    y_tangent = jnp.concatenate((tangent, -tangent))
+    expected_forward_jvp = jax.jvp(
+        lambda y_: reference.forward_dynamics(jnp.asarray(0.0), y_),
+        (y,),
+        (y_tangent,),
+    )
+    actual_forward_jvp = jax.jvp(
+        lambda y_: robot.forward_dynamics(jnp.asarray(0.0), y_),
+        (y,),
+        (y_tangent,),
+    )
+    for actual, expected in zip(actual_forward_jvp, expected_forward_jvp, strict=True):
+        assert_allclose(actual, expected, rtol=RTOL, atol=ATOL)
+
+    expected_forward_gradient = jax.grad(
+        lambda y_: jnp.sum(reference.forward_dynamics(jnp.asarray(0.0), y_))
+    )(y)
+    actual_forward_gradient = jax.grad(
+        lambda y_: jnp.sum(robot.forward_dynamics(jnp.asarray(0.0), y_))
+    )(y)
+    assert_allclose(
+        actual_forward_gradient,
+        expected_forward_gradient,
+        rtol=RTOL,
+        atol=ATOL,
+    )
 
 
 def test_warp_runtime_maps_follow_serial_active_coordinate_prefixes() -> None:
@@ -1887,13 +2054,19 @@ def test_dynamics_terms_batched_warp_matches_heterogeneous_jax(
     )
     qd = 0.5 * q
 
-    expected = robot.dynamics_terms_batched(q, qd, backend="jax")
-    actual = robot.dynamics_terms_batched(q, qd, backend="warp")
-    automatic = robot.dynamics_terms_batched(q, qd, backend="auto")
+    expected = robot.dynamics_terms(q, qd, backend="jax")
+    actual = robot.dynamics_terms(q, qd, backend="warp")
+    automatic = robot.dynamics_terms(q, qd, backend="auto")
+    mapped = jax.vmap(
+        lambda q_i, qd_i: robot.dynamics_terms(q_i, qd_i, backend="warp")
+    )(q, qd)
+    scalar = robot.dynamics_terms(q[0], qd[0], backend="warp")
 
-    for result in (actual, automatic):
+    for result in (actual, automatic, mapped):
         for actual_term, expected_term in zip(result, expected, strict=True):
             assert_allclose(actual_term, expected_term, rtol=2e-8, atol=2e-10)
+    for actual_term, expected_term in zip(scalar, expected, strict=True):
+        assert_allclose(actual_term, expected_term[0], rtol=2e-8, atol=2e-10)
 
 
 def test_dynamics_terms_batched_warp_matches_length_scaled_basis(
@@ -1914,8 +2087,8 @@ def test_dynamics_terms_batched_warp_matches_length_scaled_basis(
     )
     qd = -0.4 * q
 
-    expected = robot.dynamics_terms_batched(q, qd, backend="jax")
-    actual = robot.dynamics_terms_batched(q, qd, backend="warp")
+    expected = robot.dynamics_terms(q, qd, backend="jax")
+    actual = robot.dynamics_terms(q, qd, backend="warp")
 
     for actual_term, expected_term in zip(actual, expected, strict=True):
         assert_allclose(actual_term, expected_term, rtol=2e-8, atol=2e-10)

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1765,12 +1765,8 @@ def test_dynamics_terms_match_public_matrices(
 def test_dynamics_terms_batched_jax_matches_single_environment_api() -> None:
     robot = build_varied_basis_gvs(num_segments=3)
     key_q, key_qd = jax.random.split(jax.random.PRNGKey(6125))
-    q = jax.random.normal(
-        key_q, (3, robot.num_dofs), dtype=jnp.float64
-    ) * 0.02
-    qd = jax.random.normal(
-        key_qd, (3, robot.num_dofs), dtype=jnp.float64
-    ) * 0.04
+    q = jax.random.normal(key_q, (3, robot.num_dofs), dtype=jnp.float64) * 0.02
+    qd = jax.random.normal(key_qd, (3, robot.num_dofs), dtype=jnp.float64) * 0.04
 
     expected = jax.vmap(robot.dynamics_terms)(q, qd)
     actual = robot.dynamics_terms_batched(q, qd, backend="jax")
@@ -1796,9 +1792,7 @@ def test_warp_runtime_maps_follow_serial_active_coordinate_prefixes() -> None:
                 global_column = int(local_to_global[segment, local_column])
                 if local_column < dofs:
                     assert global_column >= 0
-                    assert (
-                        int(global_to_local[segment, global_column]) == local_column
-                    )
+                    assert int(global_to_local[segment, global_column]) == local_column
                 else:
                     assert global_column == -1
 
@@ -1842,6 +1836,32 @@ def test_warp_cached_operands_reconstruct_dense_model_data() -> None:
         assert_allclose(
             robot.inner_mass_diagonals,
             jnp.diagonal(robot.inner_mass_matrices, axis1=-2, axis2=-1),
+            rtol=0.0,
+            atol=0.0,
+        )
+        assert_allclose(
+            robot.inner_weighted_mass_diagonals,
+            robot.inner_integration_weights[..., None] * robot.inner_mass_diagonals,
+            rtol=0.0,
+            atol=0.0,
+        )
+        expected_upper_rows = onp.asarray(
+            [row for column in range(robot.num_dofs) for row in range(column + 1)],
+            dtype=onp.int32,
+        )
+        expected_upper_columns = onp.asarray(
+            [column for column in range(robot.num_dofs) for _ in range(column + 1)],
+            dtype=onp.int32,
+        )
+        assert_allclose(
+            robot.inertia_upper_rows,
+            expected_upper_rows,
+            rtol=0.0,
+            atol=0.0,
+        )
+        assert_allclose(
+            robot.inertia_upper_columns,
+            expected_upper_columns,
             rtol=0.0,
             atol=0.0,
         )

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1803,6 +1803,56 @@ def test_warp_runtime_maps_follow_serial_active_coordinate_prefixes() -> None:
                     assert global_column == -1
 
 
+def test_warp_cached_operands_reconstruct_dense_model_data() -> None:
+    robots = (
+        build_varied_basis_gvs(num_segments=3),
+        build_constant_strain_gvs(
+            num_segments=2,
+            max_dof=8,
+            scale_rotational_basis_by_length=True,
+        ),
+    )
+
+    for robot in robots:
+        expected_z1 = robot.B_Z1
+        expected_z2 = robot.B_Z2
+        if robot.scale_rotational_basis_by_length:
+            scales = robot.segment_lengths[:, None, None, None]
+            expected_z1 = expected_z1.at[:, :, :3].divide(scales)
+            expected_z2 = expected_z2.at[:, :, :3].divide(scales)
+
+        row_selectors = jax.nn.one_hot(
+            robot.link_basis_rows, 6, dtype=robot.B_Z1.dtype
+        ).transpose(0, 2, 1)
+        reconstructed_z1 = (
+            robot.scaled_B_Z1_values[:, :, None, :] * row_selectors[:, None, :, :]
+        )
+        reconstructed_z2 = (
+            robot.scaled_B_Z2_values[:, :, None, :] * row_selectors[:, None, :, :]
+        )
+
+        assert_allclose(reconstructed_z1, expected_z1, rtol=0.0, atol=0.0)
+        assert_allclose(reconstructed_z2, expected_z2, rtol=0.0, atol=0.0)
+        assert_allclose(
+            robot.cell_widths,
+            robot.integration_points[:, 1:] - robot.integration_points[:, :-1],
+            rtol=0.0,
+            atol=0.0,
+        )
+        assert_allclose(
+            robot.inner_mass_diagonals,
+            jnp.diagonal(robot.inner_mass_matrices, axis1=-2, axis2=-1),
+            rtol=0.0,
+            atol=0.0,
+        )
+        assert_allclose(
+            robot.gravity_base,
+            se3.adjoint_inverse(robot.g0) @ robot.g,
+            rtol=RTOL,
+            atol=ATOL,
+        )
+
+
 def test_dynamics_terms_batched_warp_matches_heterogeneous_jax(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
@@ -1824,6 +1874,31 @@ def test_dynamics_terms_batched_warp_matches_heterogeneous_jax(
     for result in (actual, automatic):
         for actual_term, expected_term in zip(result, expected, strict=True):
             assert_allclose(actual_term, expected_term, rtol=2e-8, atol=2e-10)
+
+
+def test_dynamics_terms_batched_warp_matches_length_scaled_basis(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("WARP_CACHE_PATH", str(tmp_path / "warp-cache-scaled"))
+    pytest.importorskip("warp")
+    robot = build_constant_strain_gvs(
+        num_segments=2,
+        max_dof=8,
+        scale_rotational_basis_by_length=True,
+    )
+    q = jnp.stack(
+        (
+            jnp.linspace(-0.025, 0.02, robot.num_dofs, dtype=jnp.float64),
+            jnp.linspace(0.015, -0.01, robot.num_dofs, dtype=jnp.float64),
+        )
+    )
+    qd = -0.4 * q
+
+    expected = robot.dynamics_terms_batched(q, qd, backend="jax")
+    actual = robot.dynamics_terms_batched(q, qd, backend="warp")
+
+    for actual_term, expected_term in zip(actual, expected, strict=True):
+        assert_allclose(actual_term, expected_term, rtol=2e-8, atol=2e-10)
 
 
 def test_cached_constant_matrices_refresh_after_update_params() -> None:
@@ -1875,6 +1950,18 @@ def test_cached_constant_matrices_refresh_after_update_params() -> None:
     assert_allclose(
         updated.inner_mass_matrices,
         updated.mass_matrices[:, 1 : updated.max_num_integration_points - 1],
+        rtol=RTOL,
+        atol=ATOL,
+    )
+    assert_allclose(
+        updated.inner_mass_diagonals,
+        jnp.diagonal(updated.inner_mass_matrices, axis1=-2, axis2=-1),
+        rtol=RTOL,
+        atol=ATOL,
+    )
+    assert_allclose(
+        updated.gravity_base,
+        se3.adjoint_inverse(updated.g0) @ updated.g,
         rtol=RTOL,
         atol=ATOL,
     )

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1762,6 +1762,70 @@ def test_dynamics_terms_match_public_matrices(
         assert_allclose(G, robot.gravitational_force(q), rtol=RTOL, atol=ATOL)
 
 
+def test_dynamics_terms_batched_jax_matches_single_environment_api() -> None:
+    robot = build_varied_basis_gvs(num_segments=3)
+    key_q, key_qd = jax.random.split(jax.random.PRNGKey(6125))
+    q = jax.random.normal(
+        key_q, (3, robot.num_dofs), dtype=jnp.float64
+    ) * 0.02
+    qd = jax.random.normal(
+        key_qd, (3, robot.num_dofs), dtype=jnp.float64
+    ) * 0.04
+
+    expected = jax.vmap(robot.dynamics_terms)(q, qd)
+    actual = robot.dynamics_terms_batched(q, qd, backend="jax")
+
+    for actual_term, expected_term in zip(actual, expected, strict=True):
+        assert_allclose(actual_term, expected_term, rtol=RTOL, atol=ATOL)
+
+
+def test_warp_runtime_maps_follow_serial_active_coordinate_prefixes() -> None:
+    robot = build_varied_basis_gvs(num_segments=3)
+    expected_prefixes = jnp.cumsum(jnp.sum(robot.dofs_per_segment, axis=1))
+
+    assert_allclose(robot.active_dofs_per_segment, expected_prefixes)
+    for segment in range(robot.num_segments):
+        for block, (local_to_global, global_to_local) in enumerate(
+            (
+                (robot.joint_local_to_global, robot.joint_global_to_local),
+                (robot.link_local_to_global, robot.link_global_to_local),
+            )
+        ):
+            dofs = int(robot.dofs_per_segment[segment, block])
+            for local_column in range(robot.max_dof):
+                global_column = int(local_to_global[segment, local_column])
+                if local_column < dofs:
+                    assert global_column >= 0
+                    assert (
+                        int(global_to_local[segment, global_column]) == local_column
+                    )
+                else:
+                    assert global_column == -1
+
+
+def test_dynamics_terms_batched_warp_matches_heterogeneous_jax(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("WARP_CACHE_PATH", str(tmp_path / "warp-cache"))
+    pytest.importorskip("warp")
+    robot = build_varied_basis_gvs(num_segments=3)
+    q = jnp.stack(
+        (
+            jnp.linspace(-0.02, 0.03, robot.num_dofs, dtype=jnp.float64),
+            jnp.linspace(0.01, -0.015, robot.num_dofs, dtype=jnp.float64),
+        )
+    )
+    qd = 0.5 * q
+
+    expected = robot.dynamics_terms_batched(q, qd, backend="jax")
+    actual = robot.dynamics_terms_batched(q, qd, backend="warp")
+    automatic = robot.dynamics_terms_batched(q, qd, backend="auto")
+
+    for result in (actual, automatic):
+        for actual_term, expected_term in zip(result, expected, strict=True):
+            assert_allclose(actual_term, expected_term, rtol=2e-8, atol=2e-10)
+
+
 def test_cached_constant_matrices_refresh_after_update_params() -> None:
     selector_per_segment = (False, False, True, True, False, False)
     robot = build_constant_strain_gvs(

--- a/tools/benchmarks/GVS_WARP_RESULTS.md
+++ b/tools/benchmarks/GVS_WARP_RESULTS.md
@@ -422,11 +422,18 @@ Four basis-order-one revolute-jointed segments (52 DoFs):
 | 256 | 2.266 ms | 1.481 ms | **0.968 ms** | **2.34x** |
 | 1024 | 6.211 ms | 4.336 ms | **2.771 ms** | **2.24x** |
 
+Single-environment CPU medians from 100 synchronized, interleaved repetitions:
+
+| Basis order | DoFs | JAX CPU | Option 17 CPU | Option 23 CPU | Best Warp regression |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 52 | **0.339 ms** | 1.131 ms | 0.424 ms | Option 23 is 25.1% slower |
+| 5 | 148 | **0.703 ms** | 1.636 ms | 1.523 ms | Option 23 is 116.6% slower (2.17x runtime) |
+
 Four basis-order-five revolute-jointed segments (148 DoFs):
 
-| Environments | JAX | Option 17 | Option 23 | Winner |
-|---:|---:|---:|---:|---|
-| 64 | **2.011 ms** | 2.162 ms | 2.326 ms | JAX |
+| Environments | JAX | Option 17 | Option 23 | Best Warp regression |
+|---:|---:|---:|---:|---:|
+| 64 | **2.011 ms** | 2.162 ms | 2.326 ms | Option 17 is 7.5% slower |
 | 256 | 3.612 ms | 4.189 ms | **3.021 ms** | Option 23, 1.20x |
 
 Eight basis-order-one segments cycling through revolute, prismatic, helical,

--- a/tools/benchmarks/GVS_WARP_RESULTS.md
+++ b/tools/benchmarks/GVS_WARP_RESULTS.md
@@ -1,0 +1,664 @@
+# GVS Warp kernel investigation
+
+## Scope and setup
+
+This experiment is based on commit `60185cb6802a73117ed22c5eae8cdb0ee3d71b8e`
+from `codex/lie-action-performance` and lives on `codex/gvs-warp-kernels`.
+It uses Warp 1.16.0, JAX 0.11.0, FP64, and an RTX 5090. The legacy
+Options 1--14 target four constant-strain, fixed-joint GVS segments, five Gauss
+points and six recurrence cells per segment, and 24 active DoFs. Options
+15--23 remove the compile-time segment/DoF dimensions and are tested with
+higher-order strain bases and general joints. Autodifferentiation is
+intentionally out of scope. `GVS` is currently a serial segment chain, so the
+persistent kernels preserve that topology rather than introducing a rigid-body
+tree algorithm.
+
+All timings are synchronized wall times. The harness interleaves the tested
+implementations and reports medians, which reduces clock, thermal, and ordering
+bias. CUDA compilation and steady-state execution are reported separately.
+
+## Implementations
+
+| Option | Description |
+|---|---|
+| Baseline | `jax.jit(jax.vmap(robot.dynamics_terms))` |
+| 1 | One parallel Warp launch per cell; JAX Lie terms and assembly |
+| 2 | Six dependent cell launches captured in each segment graph |
+| 3 | Warp contraction of JAX Lie arrays, then Option 2 |
+| 4 | One persistent serial Warp thread per environment |
+| 5 | One cooperative recurrence block plus one parallel assembly kernel per segment |
+| 6 | General matrix-free Lie algebra, redundantly computed per output entry, then Option 2 |
+| 7 | Option 6 Lie mapping plus Option 5 |
+| 8 | General matrix-free Lie algebra with one owning thread per cell, then Option 2 |
+| 9 | Option 8 Lie mapping plus Option 5 |
+| 10 | Exact constant-strain Lie specialization, then Option 2 |
+| 11 | Constant-strain specialization plus Option 5 |
+| 12 | Option 8 plus exact fixed-joint elimination |
+| 13 | Constant-strain and fixed-joint specializations, then Option 2 |
+| 14 | Constant-strain and fixed-joint specializations plus Option 5 |
+| 15 | Shape-generic two-point Magnus Lie terms and runtime-sized segment recurrence; general JAX joint propagation and JAX assembly |
+| 16 | Option 15 with guarded order-zero and fixed-joint fast paths |
+| 17 | Option 15 with persistent flattened model maps and shape-generic Warp joint Lie terms |
+| 18 | Option 17 with one unique Warp owner per global `M`, `C qd`, and `G` output entry |
+| 19 | Option 17 with one cooperative block per environment/segment, double-buffered recurrence, and online quadrature assembly |
+| 20 | Option 19 with general joint-to-link state propagation fused into the segment block |
+| 21 | One persistent runtime-looped block per environment for the complete serial chain |
+| 22 | Option 21 plus a shape-generic Warp dense Cholesky solve for zero-input forward dynamics |
+| 23 | Option 21 with model-map-guarded active-prefix recurrence and assembly |
+
+## Phase-by-phase evaluation
+
+### Phase 1: revalidate the existing segment graph
+
+The previous conclusion survived the branch/worktree change. Option 2 remained
+faster through batch 256 and reached parity at 1024.
+
+| Environments | JAX | Option 2 |
+|---:|---:|---:|
+| 1 | 1.410 ms | 0.887 ms |
+| 64 | 1.612 ms | 1.086 ms |
+| 256 | 2.132 ms | 1.770 ms |
+| 1024 | 5.169 ms | 5.269 ms |
+
+Single-environment CPU: JAX 0.261 ms, Option 2 1.165 ms.
+
+Decision: keep the segment graph as the reference Warp topology, but not as the
+final implementation.
+
+### Phase 2: cooperative segment recurrence and assembly
+
+Option 5 keeps the current `6 x 24` Jacobian in a shared tile, advances all six
+cells inside one cooperative block, writes the six recurrence states, and uses
+a second parallel kernel to assemble the five quadrature contributions.
+
+| Environments | JAX | Option 2 | Option 5 |
+|---:|---:|---:|---:|
+| 1 | 1.103 ms | 0.678 ms | **0.592 ms** |
+| 64 | 1.273 ms | 0.884 ms | **0.795 ms** |
+| 256 | 1.950 ms | **1.680 ms** | 1.687 ms |
+| 1024 | **4.929 ms** | 5.167 ms | 5.296 ms |
+
+At batch 64, Nsight Systems measured about 0.199 ms/evaluation for the four
+recurrence plus four assembly kernels and 0.569 ms total GPU kernel time, down
+from 0.630 ms for Option 2. The launch-saving topology helps small batches, but
+block synchronization and the assembly layout lose throughput after saturation.
+
+CPU: JAX 0.271 ms, Option 5 0.776 ms.
+
+Decision: retain the cooperative topology for small and medium batches.
+
+### Phase 3: matrix-free Lie algebra
+
+The first mapping (Option 6) assigned one thread to each `6 x 24` output entry.
+It recomputed the same strain, Magnus expansion, coefficients, and SE(3)
+exponential 144 times per cell and became slower as the batch grew.
+
+Option 8 instead assigns one thread to each cell. That thread computes shared
+cell data once, applies the `ad` polynomial directly to the six active basis
+columns, constructs the compact SE(3) exponential/adjoint, and emits the data
+consumed by the recurrence.
+
+| Environments | JAX | Option 2 | Option 8 |
+|---:|---:|---:|---:|
+| 1 | 1.141 ms | 0.756 ms | **0.683 ms** |
+| 64 | 1.321 ms | 0.939 ms | **0.699 ms** |
+| 256 | 1.969 ms | 1.819 ms | **1.075 ms** |
+| 1024 | 5.260 ms | 5.407 ms | **2.553 ms** |
+
+At batch 64, the winning Lie kernel costs about 0.071 ms/evaluation while the
+24 segment-cell recurrence kernels cost about 0.221 ms. The bad Option 6 Lie
+mapping alone cost about 0.525 ms/evaluation.
+
+CPU: JAX 0.238 ms, Option 8 1.186 ms.
+
+Decision: one cell owner is the correct general Lie mapping. Keep JAX on CPU.
+
+### Phase 4: combine Phase 2 and Phase 3
+
+Option 9 combines the one-cell-owner Lie kernel with cooperative segment
+recurrence/assembly. It improves launch-bound cases but not saturated ones.
+
+| Environments | Option 8 | Option 9 | Winner |
+|---:|---:|---:|---|
+| 1 | 0.685 ms | **0.613 ms** | Cooperative |
+| 64 | 0.704 ms | **0.646 ms** | Cooperative |
+| 256 | **1.133 ms** | 1.140 ms | Tie |
+| 1024 | **2.360 ms** | 2.559 ms | Throughput |
+
+Decision: use a batch-dependent mapping; fusion is not monotonically beneficial.
+
+### Phase 5: fully fused Lie, recurrence, and quadrature
+
+This phase failed the compile-feasibility gate. The strictly smaller monolithic
+cooperative kernel containing only recurrence and quadrature did not finish Warp
+CUDA compilation within a six-minute bound. Inlining the full Lie expansion
+would make that same tile AST larger, so it was not meaningful to spend runtime
+benchmark effort on an even less tractable version.
+
+The practical split kernel from Phase 2 compiled and exposed the same on-chip
+recurrence structure without the pathological monolithic code-generation path.
+
+Decision: reject the monolithic Warp tile implementation with Warp 1.16.0.
+Revisit only after decomposing it into smaller device functions/modules or after
+Warp compiler improvements.
+
+### Phase 6: exact model specializations
+
+Two exact facts of this benchmark configuration are guarded at construction
+time. They are not general properties of the `GVS` class: `_gvs_factory`
+explicitly creates Legendre basis-order-zero links and `JointSpec(type="fixed")`
+for every segment.
+
+The benchmark-specific facts are:
+
+- Order-zero constant strain gives `B_Z1 == B_Z2` and matching reference
+  strains. Therefore the Magnus commutator and its derivative vanish,
+  `Magnus = length * width * xi`, and `Magnus_basis = length * width * B`.
+- All inter-segment joints are fixed: their adjoints are identity and all joint
+  tangent, derivative, and velocity terms are zero. The link coordinates are
+  contiguous six-DoF slices of `q` and `qd`.
+
+For GVS basis order greater than zero, the strain varies spatially and the
+general two-point Magnus terms must be retained. Likewise, articulated GVS
+models with non-fixed joints must retain the general joint propagation. Those
+models should use the general Option 8/9 path, not Options 13/14.
+
+The Lie specialization lives in its own Warp module. This matters because Warp
+compiles all kernels in a module together. A true empty-cache build showed that
+the specialized Lie module itself took only 0.35--0.71 seconds; the original
+static recurrence module was the real bottleneck at 102--106 seconds per FFI
+variant. Cached module loading is about 1--4 ms.
+
+The fixed-joint specialization was the larger win because it removed a
+surprisingly expensive JAX joint path and its launches. Final focused results
+are below.
+
+### Phase 7: full-environment persistence
+
+The existing one-thread-per-environment implementation was retested against the
+Phase 6 winners.
+
+| Environments | Persistent full environment | Best Phase 6 |
+|---:|---:|---:|
+| 1 | 19.093 ms | 0.533 ms |
+| 64 | 28.234 ms | 0.639 ms |
+| 256 | 33.156 ms | 0.885 ms |
+| 1024 | 35.603 ms | 1.981 ms |
+
+It serializes the complete recurrence and 24-DoF assembly while launching only
+one thread per environment. The saved launches do not compensate for lost
+parallelism and register/local-memory pressure.
+
+Decision: reject full-environment persistence.
+
+### Phase 8: shape-generic, forward-only production candidate
+
+Option 15 retains the Phase 3 one-cell-owner idea, but changes the generated
+program in four important ways:
+
+- the two-point Magnus expansion remains active, so spatially varying GVS
+  strains are supported;
+- joints are evaluated through the general JAX joint path, so the Warp kernels
+  do not assume fixed joints;
+- each cell emits only its compact `6 x max_dof` tangent, and a runtime
+  global-to-local lookup maps it into the system Jacobian;
+- segment count, global DoF count, and local DoF count are runtime loop bounds
+  rather than Python/Warp-unrolled constants.
+
+Option 16 uses the same small module but enables the order-zero and fixed-joint
+shortcuts only after construction-time guards prove they are valid. Both
+options set `enable_backward=False`, which is appropriate for this explicitly
+primal-only experiment. The old kernels received the same setting for a fair
+compilation comparison.
+
+This is the key compilation result. With a genuinely empty Warp and JAX cache,
+Option 15 for four basis-order-one segments with revolute joints and batch 64
+took:
+
+| Stage | Time |
+|---|---:|
+| First Warp FFI variant, included in lowering | 0.761 s |
+| JAX lowering total | 0.886 s |
+| XLA executable compilation | 0.820 s |
+| Second Warp FFI variant, first execution | 0.712 s |
+| Lower + XLA compile | 1.706 s |
+| Lower + XLA compile + first execution | **2.424 s** |
+
+Once that shape-independent Warp module is cached, changing the link count or
+basis order does not regenerate CUDA code. Every experiment below loaded the
+same module hashes (`24c987e` and `5ac4abf`). Each JAX measurement used a fresh
+persistent-cache directory.
+
+| Segments | Basis order | Joint | DoFs | JAX lower + compile |
+|---:|---:|---|---:|---:|
+| 1 | 1 | revolute | 13 | 0.591 s |
+| 2 | 1 | revolute | 26 | 0.715 s |
+| 4 | 1 | revolute | 52 | 0.933 s |
+| 8 | 1 | revolute | 104 | 1.210 s |
+| 16 | 1 | revolute | 208 | 1.388 s |
+
+The remaining growth is JAX/XLA compilation of progressively larger joint and
+assembly graphs, not Warp CUDA source generation. At four revolute-jointed
+segments, the basis-order sweep was similarly bounded:
+
+| Basis order | DoFs | JAX lower + compile |
+|---:|---:|---:|
+| 0 | 28 | 0.795 s |
+| 1 | 52 | 0.933 s |
+| 2 | 76 | 1.077 s |
+| 3 | 100 | 1.115 s |
+| 5 | 148 | 1.158 s |
+
+The guarded Option 16 path also compiled a 16-segment, 96-DoF fixed-joint model
+in 1.103 seconds with the Warp module cached.
+
+Disabling unused backward generation helped the old static module, but did not
+make it suitable for runtime specialization. A fresh Option 13 build fell from
+102--106 seconds to 14.84--15.00 seconds per FFI variant; reaching the first
+completed call still took about 31.6 seconds. Options 13/14 should therefore be
+ahead-of-time/cached peak-performance choices, not compiled per model shape.
+
+### Phase 9: shape-generic Warp joint terms
+
+Option 17 moves the general joint SE(3) exponential, left-Jacobian terms,
+directional derivative, inverse adjoint, and inverse-adjoint derivative from
+JAX into one runtime-sized Warp launch. Joint types are not compile-time
+branches: the existing padded GVS joint basis encodes fixed, revolute,
+prismatic, helical, cylindrical, planar, spherical, and free joints. Static
+joint/link local-to-global maps and the varying-strain cell data are flattened
+once into persistent arrays captured by the benchmark closure.
+
+An empty-cache four-segment, basis-order-one, revolute-joint batch-64 build took
+0.409 s to lower, 0.460 s to compile with XLA, and 0.344 s for the first
+synchronized call, or **1.214 s** through the first completed result. A
+16-segment mixed-joint model used the identical Warp module hashes and completed
+in **1.662 s**. The extra size-dependent time remains in the JAX recurrence and
+assembly graph rather than Warp CUDA generation.
+
+Fifty cached, synchronized, interleaved GPU measurements for the four-segment,
+basis-order-one revolute model were:
+
+| Environments | JAX | Option 15 | Option 17 | Option 17 vs JAX |
+|---:|---:|---:|---:|---:|
+| 1 | 1.072 ms | 0.798 ms | 0.802 ms | 1.34x |
+| 64 | 1.681 ms | 1.059 ms | **1.031 ms** | **1.63x** |
+| 256 | 2.228 ms | 1.579 ms | **1.406 ms** | **1.58x** |
+| 1024 | 6.041 ms | 4.727 ms | **4.121 ms** | **1.47x** |
+
+The primary batch-64 improvement over Option 15 is modest (3%), but batch 256
+improves 11% and the new joint/data path is required to fuse propagation in the
+next phase. A mixed eight-segment model containing every non-fixed joint family
+matched JAX within `9.17e-12`.
+
+High-order basis evaluation remains unresolved. At basis order 5, Option 17
+took 2.143 ms versus 2.000 ms for JAX at batch 64, and 4.087 ms versus 3.612 ms
+at batch 256. Joint offload does not address the scalar link-coordinate loops
+that dominate this case.
+
+Decision: accept Option 17 as the new general-path foundation. Keep JAX on CPU,
+and address high-order link evaluation in the later tiled/matrix-free phase.
+
+### Phase 10: runtime-sized unique-owner assembly
+
+Option 18 replaces only the JAX `M`, `C qd`, and `G` contractions with two
+runtime-sized Warp kernels. Every output element has one owner, so no atomics
+or nondeterministic reductions are used. Correctness remained at the Option 17
+FP64 tolerance, but rereading the complete chain state for every output entry
+was slower at every GPU batch.
+
+| Environments | JAX | Option 17 | Option 18 |
+|---:|---:|---:|---:|
+| 1 | 1.233 ms | **0.978 ms** | 1.018 ms |
+| 64 | 1.500 ms | **0.903 ms** | 0.953 ms |
+| 256 | 2.240 ms | **1.405 ms** | 1.547 ms |
+| 1024 | 6.126 ms | **4.205 ms** | 4.959 ms |
+
+Single-environment CPU was 0.424 ms for JAX, 1.536 ms for Option 17, and
+1.796 ms for Option 18.
+
+Decision: reject the whole-chain owner-per-output assembly layout. Unique
+ownership is useful, but the recurrence and quadrature must share live state.
+
+### Phase 11: cooperative runtime-sized segment engine
+
+Option 19 assigns one cooperative block to an environment/segment. It uses two
+alternating global recurrence buffers, synchronizes cells inside the block,
+assembles each quadrature contribution while its state is live, and returns
+only the segment tip plus accumulated `M`, `C qd`, and `G`. Loop bounds remain
+runtime values, so this does not regenerate source for a new model shape.
+
+| Environments | JAX | Option 17 | Option 19 |
+|---:|---:|---:|---:|
+| 1 | 1.217 ms | **0.934 ms** | 1.248 ms |
+| 64 | 1.526 ms | **0.861 ms** | 0.932 ms |
+| 256 | 2.214 ms | 1.470 ms | **1.350 ms** |
+| 1024 | 6.204 ms | 4.264 ms | **3.883 ms** |
+
+It is a throughput mapping, not a small-batch mapping. At basis order 5 its
+owner-per-mass-entry work becomes too large: 3.580 ms versus 1.895 ms for JAX
+at batch 64, and 5.376 versus 3.589 ms at batch 256.
+
+Decision: retain Option 19 for moderate DoF counts from roughly batch 256, but
+continue using Option 17 for batch 1/64 and high-order links.
+
+### Phase 12: joint propagation fused into each segment
+
+Option 20 moves the general joint adjoint propagation into the Option 19 block.
+It supports the same padded joint bases and does not branch on joint type in
+generated source. The fusion boundary did not pay for its redundant block-local
+joint work.
+
+| Environments | JAX | Option 19 | Option 20 |
+|---:|---:|---:|---:|
+| 1 | 1.101 ms | **1.026 ms** | 1.084 ms |
+| 64 | 1.518 ms | **0.954 ms** | 0.972 ms |
+| 256 | 2.304 ms | 1.362 ms | **1.351 ms** |
+| 1024 | 6.186 ms | **3.756 ms** | 3.924 ms |
+
+Decision: reject Option 20 as a dispatch target. Keep the separate parallel
+joint Lie kernel and fuse across segment boundaries instead.
+
+### Phase 13: persistent complete-chain dynamics
+
+Option 21 consumes the precomputed joint/cell Lie terms and traverses every
+segment and cell in one runtime-looped cooperative kernel. It eliminates the
+per-segment JAX additions and kernel boundaries while keeping general joints
+and spatially varying strain.
+
+| Environments | JAX | Option 17 | Option 19 | Option 21 |
+|---:|---:|---:|---:|---:|
+| 1 | 0.962 ms | **0.683 ms** | 0.906 ms | 0.925 ms |
+| 64 | 1.649 ms | **1.071 ms** | 1.157 ms | 1.177 ms |
+| 256 | 2.349 ms | 1.507 ms | 1.356 ms | **1.323 ms** |
+| 1024 | 6.190 ms | 4.319 ms | 3.869 ms | **3.842 ms** |
+
+The whole-chain launch is mildly better only after enough environments are
+available. At batch 64, one block per environment cannot occupy all 170 SMs on
+the RTX 5090.
+
+Decision: retain Option 21 as infrastructure for the model-map sparsity phase,
+not as the final unguarded implementation.
+
+### Phase 14: forward solve
+
+Option 22 adds a forward-only, runtime-sized dense Cholesky kernel and measures
+complete zero-input forward dynamics,
+`qdd = solve(M, -(C qd + G))`. The comparison uses JAX's compiled dense solve
+after every other terms implementation.
+
+| Environments | JAX end-to-end | Option 17 + JAX solve | Option 21 + JAX solve | Option 21 + Warp solve |
+|---:|---:|---:|---:|---:|
+| 1 | 1.381 ms | **1.055 ms** | 1.308 ms | 1.428 ms |
+| 64 | 2.004 ms | **1.416 ms** | 1.509 ms | 1.525 ms |
+| 256 | 2.645 ms | 1.710 ms | **1.598 ms** | 1.621 ms |
+| 1024 | 6.930 ms | 4.905 ms | 4.360 ms | **4.186 ms** |
+
+Forward acceleration differs from the JAX reference by about `1e-7`, because
+the approximately `1e-12` term-ordering differences are amplified by the dense
+mass solve. Both JAX and Warp solve the same well-formed SPD systems.
+
+Decision: keep the JAX solve at the priority batch sizes. The Warp solve is
+useful only at the non-priority batch-1024 end of this experiment.
+
+### Phase 15: active-prefix persistent dynamics
+
+For a serial GVS chain, segment `s` can depend only on coordinates introduced
+at or before `s`. Option 23 derives the active prefix from the actual joint/link
+gather maps. It enables the shortcut only when the active indices are exactly
+`0..N_s-1`; otherwise that segment falls back to the full global DoF count.
+The persistent buffers are initialized once, so newly introduced columns are
+zero until their joint or link tangent becomes active.
+
+This changes the dominant assembly work from `S * N^2` to
+`sum_s(N_s^2)` without assuming fixed joints, order-zero strain, or a specific
+joint family.
+
+Four basis-order-one revolute-jointed segments (52 DoFs):
+
+| Environments | JAX | Option 17 | Option 23 | Option 23 vs JAX |
+|---:|---:|---:|---:|---:|
+| 1 | 1.104 ms | **0.803 ms** | 0.875 ms | 1.26x |
+| 64 | 1.481 ms | 0.853 ms | **0.699 ms** | **2.12x** |
+| 256 | 2.266 ms | 1.481 ms | **0.968 ms** | **2.34x** |
+| 1024 | 6.211 ms | 4.336 ms | **2.771 ms** | **2.24x** |
+
+Four basis-order-five revolute-jointed segments (148 DoFs):
+
+| Environments | JAX | Option 17 | Option 23 | Winner |
+|---:|---:|---:|---:|---|
+| 64 | **2.011 ms** | 2.162 ms | 2.326 ms | JAX |
+| 256 | 3.612 ms | 4.189 ms | **3.021 ms** | Option 23, 1.20x |
+
+Eight basis-order-one segments cycling through revolute, prismatic, helical,
+cylindrical, planar, spherical, and free joints:
+
+| Environments | JAX | Option 17 | Option 23 | Option 23 vs JAX |
+|---:|---:|---:|---:|---:|
+| 1 | **1.788 ms** | 1.847 ms | 2.350 ms | 0.76x |
+| 64 | 3.224 ms | 2.980 ms | **2.471 ms** | 1.30x |
+| 256 | 5.329 ms | 5.984 ms | **3.111 ms** | 1.71x |
+| 1024 | 17.893 ms | 18.206 ms | **10.744 ms** | 1.67x |
+
+All joint-family and term correctness checks remain below `9.17e-12`.
+
+True empty-cache compilation is both comfortably below ten seconds and flat
+with segment count. Times include compilation of both Warp FFI variants across
+lowering and first execution.
+
+| Model | Option 23 lower | XLA compile | First call | Through first result | JAX lower + compile |
+|---|---:|---:|---:|---:|---:|
+| 4 segments, order 1, revolute | 0.456 s | 0.037 s | 0.408 s | **0.901 s** | 1.635 s |
+| 16 segments, order 1, mixed | 0.476 s | 0.045 s | 0.421 s | **0.942 s** | 1.626 s |
+
+Both shapes compile identical Warp module hashes (`15724be`/`5072bdb`,
+`24c987e`/`5ac4abf`, and `a9298da`/`a6f1840`). The larger model changes runtime
+array sizes but not CUDA source. This is the desired compilation scaling law.
+
+Decision: accept Option 23 as the primary serial-chain GPU candidate. Dispatch
+Option 17 at very small batches, use JAX for high-order batch 64, and retain JAX
+on CPU. The next optimization target for large mixed-joint models is avoiding
+the full global joint-tangent materialization and fusing cell Lie preprocessing
+with active-prefix recurrence, while keeping these runtime loops.
+
+## Fixed-model steady-state results
+
+These are medians of 50 cached, synchronized, interleaved measurements from the
+latest lookup implementation. Option 14 is the cooperative mapping; Option 13
+is the throughput mapping.
+
+| Environments | JAX | Option 13 | Option 14 | Option 15 | Option 16 | Best |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 0.928 ms | 0.353 ms | **0.290 ms** | 0.499 ms | 0.381 ms | Option 14, 3.20x |
+| 64 | 1.228 ms | 0.556 ms | **0.448 ms** | 0.663 ms | 0.546 ms | Option 14, 2.74x |
+| 256 | 1.969 ms | 0.805 ms | **0.740 ms** | 0.952 ms | 0.782 ms | Option 14, 2.66x |
+| 1024 | 4.990 ms | **1.771 ms** | 1.942 ms | 2.449 ms | 1.849 ms | Option 13, 2.82x |
+
+Option 16 is the practical runtime-compiled substitute for the old specialized
+options. It is 2% faster than Option 13 at batch 64 and 4% slower at batch 1024,
+while avoiding shape-specific Warp compilation. Option 14 retains a meaningful
+small-batch advantage and is worth distributing as a prebuilt/cached kernel for
+the exact supported shape.
+
+The dispatch crossover should be measured on each target GPU; for this RTX 5090
+and fixed shape, use Option 14 through 256 environments and Option 13 at 1024.
+
+Single-environment CPU, 100 measurements:
+
+| Implementation | Runtime | Relative to JAX |
+|---|---:|---:|
+| JAX | **0.241 ms** | 1.00x |
+| Option 14 | 0.520 ms | 0.46x |
+| Option 13 | 1.051 ms | 0.23x |
+
+Keep the compiled JAX path for CPU.
+
+## General GVS results
+
+Option 15 was evaluated on four segments with basis order 1 and a revolute
+joint at every segment. This case has 52 DoFs and violates both assumptions
+behind Options 13/14.
+
+| Environments | JAX | Option 15 | Speedup |
+|---:|---:|---:|---:|
+| 1 | 1.352 ms | **1.034 ms** | 1.31x |
+| 64 | 1.755 ms | **1.227 ms** | 1.43x |
+| 256 | 2.082 ms | **1.452 ms** | 1.43x |
+| 1024 | 6.204 ms | **4.769 ms** | 1.30x |
+
+Single-environment CPU is still a JAX case: 0.377 ms for JAX versus 1.289 ms
+for Option 15. At basis order 5 and batch 64, Option 15 remained correct but
+was slower than JAX (2.936 versus 2.091 ms); runtime-sized scalar loops lose to
+XLA's dense contractions as local strain dimension grows. The scalable path
+solves compilation scaling, but does not make Warp universally faster.
+
+## Correctness
+
+Every implemented option is compared with the JAX baseline before timing. For
+the final specialized options, the largest observed absolute errors were:
+
+- inertia: `2.13e-13`;
+- `C(q, qd) qd`: `5.06e-14`;
+- gravity: `3.72e-12`.
+
+For the general basis-order-one/revolute model, the largest observed error was
+`3.44e-12`; at basis order 5 it was `2.97e-12`. A 16-segment Option 16 check was
+within `2.09e-11`.
+
+The harness rejects errors above `2e-9`. The larger difference compared with
+the earlier recurrence-only kernels comes from changed FP64 evaluation order in
+the direct matrix-free Lie polynomials, not from a changed model.
+
+## Final profiler evidence
+
+Nsight Systems 2025.5.2 captured 20 warm CUDA-graph evaluations with node
+tracing enabled.
+
+At batch 64, Option 14 uses about 0.285 ms GPU kernel time/evaluation:
+
+- cooperative recurrence: 0.096 ms;
+- cooperative assembly: 0.104 ms;
+- constant-strain Lie terms: 0.051 ms;
+- remaining JAX/XLA kernels: about 0.034 ms.
+
+At batch 1024, Option 13 uses about 1.51 ms GPU kernel time/evaluation. Its 24
+cell-recurrence kernels consume about 1.01 ms (67%), constant-strain Lie terms
+consume 0.113 ms, and the remaining contractions/assembly consume the rest.
+This explains both the remaining fusion opportunity and why the serial
+full-environment response is the wrong way to pursue it.
+
+Nsight Compute requires privileged performance counters on this host. An
+unprivileged capture returns `ERR_NVGPUCTRPERM`; the Codex sandbox cannot invoke
+`sudo`, so a user-run `sudo ncu` command is included below.
+
+## Reproduction
+
+From this worktree:
+
+```bash
+cd /home/mstolzle/src/soromox/.worktrees/gvs-warp-kernels
+env WARP_CACHE_PATH=/tmp/soromox-warp-cache \
+  PYTHONPATH="$PWD/src:$PWD" \
+  /home/mstolzle/src/soromox/.venv/bin/python \
+  tools/benchmarks/benchmark_gvs_warp.py \
+  --device gpu --batch-sizes 1 64 256 1024 --repeats 50 \
+  --options option_13 option_14 option_15 option_16 \
+  --output /tmp/soromox-gvs-warp-final-gpu.json
+```
+
+Use `JAX_PLATFORMS=cpu --device cpu --batch-sizes 1` for CPU timing.
+
+General higher-order/revolute runtime and compilation:
+
+```bash
+env WARP_CACHE_PATH=/tmp/soromox-warp-cache \
+  PYTHONPATH="$PWD/src:$PWD" \
+  /home/mstolzle/src/soromox/.venv/bin/python \
+  tools/benchmarks/benchmark_gvs_warp.py \
+  --device gpu --segment-count 4 --basis-order 1 --joint-type revolute \
+  --batch-sizes 1 64 256 1024 --repeats 50 \
+  --options option_17 option_23 \
+  --output /tmp/soromox-gvs-warp-option23-gpu.json
+
+env WARP_CACHE_PATH=/tmp/soromox-warp-cache-cold \
+  JAX_COMPILATION_CACHE_DIR=/tmp/soromox-jax-cache-cold \
+  PYTHONPATH="$PWD/src:$PWD" \
+  /home/mstolzle/src/soromox/.venv/bin/python \
+  tools/benchmarks/benchmark_gvs_warp.py \
+  --device gpu --segment-count 4 --basis-order 1 --joint-type revolute \
+  --batch-sizes 64 --compile-option option_23 --compile-repeats 1 \
+  --output /tmp/soromox-gvs-warp-option23-compile.json
+```
+
+Measure uncached JAX/XLA GPU compilation with:
+
+```bash
+env JAX_ENABLE_COMPILATION_CACHE=false \
+  WARP_CACHE_PATH=/tmp/soromox-warp-cache \
+  PYTHONPATH="$PWD/src:$PWD" \
+  /home/mstolzle/src/soromox/.venv/bin/python \
+  tools/benchmarks/benchmark_gvs_warp.py \
+  --device gpu --batch-sizes 1 64 256 1024 \
+  --compile-option baseline --compile-repeats 3 \
+  --output /tmp/soromox-gvs-jax-cold-compile-gpu.json
+```
+
+Nsight Systems example:
+
+```bash
+nsys profile --force-overwrite=true --trace=cuda,nvtx \
+  --cuda-graph-trace=node \
+  --capture-range=cudaProfilerApi --capture-range-end=stop \
+  --output=/tmp/soromox-gvs-warp-option14-b64 \
+  /usr/bin/env WARP_CACHE_PATH=/tmp/soromox-warp-cache \
+  PYTHONPATH="$PWD/src:$PWD" \
+  /home/mstolzle/src/soromox/.venv/bin/python \
+  tools/benchmarks/benchmark_gvs_warp.py \
+  --device gpu --batch-sizes 64 \
+  --profile-option option_14 --profile-iterations 20
+```
+
+Nsight Compute example for the batch-1024 winning Lie kernel:
+
+```bash
+sudo env WARP_CACHE_PATH=/tmp/soromox-warp-cache \
+  PYTHONPATH="$PWD/src:$PWD" \
+  /opt/nvidia/nsight-compute/2025.4.1/ncu \
+  --force-overwrite --profile-from-start off --graph-profiling node \
+  --section LaunchStats --section Occupancy --section SpeedOfLight \
+  --section MemoryWorkloadAnalysis --section SourceCounters \
+  --launch-count 1 \
+  --kernel-name 'regex:^constant_strain_cell_terms_kernel.*$' \
+  --export /tmp/soromox-gvs-warp-option13-b1024-lie \
+  /home/mstolzle/src/soromox/.venv/bin/python \
+  tools/benchmarks/benchmark_gvs_warp.py \
+  --device gpu --batch-sizes 1024 \
+  --profile-option option_13 --profile-iterations 1
+```
+
+## Recommendation
+
+Use the following forward-only dispatch on the measured RTX 5090:
+
+- CPU: compiled JAX.
+- General serial-chain GVS, very small GPU batches: Option 17.
+- General serial-chain GVS, order 1, batch 64 and above: Option 23.
+- High strain-basis order at batch 64: JAX; remeasure the Option 17/23 crossover
+  from batch 256 on each target GPU.
+- Zero-input/applied-force forward solve at batch 64/256: keep the JAX dense
+  solve after the selected Warp terms path. Use the Warp Cholesky experiment
+  only after a target-specific large-batch crossover measurement.
+- Exact order-zero/fixed-joint models reused many times: the prebuilt Option 14
+  small/medium-batch kernel remains fastest for that narrower model class.
+
+Option 23 is the main result: it supports spatially varying GVS strain and all
+current joint families, exceeds 2x JAX for the four-segment order-one priority
+batches, and reaches the first result in under one second on both the measured
+four- and 16-segment shapes. It does not generate source proportional to the
+number of segments or DoFs.
+
+The remaining general-path opportunities are narrower and evidence-based:
+retain joint tangents in local coordinates instead of materializing a
+`6 x global_DoFs` tensor, combine active-prefix propagation with cell Lie
+preprocessing, and introduce a multi-block assembly mapping for high-order
+batch 64. These should preserve the runtime-looped modules; the rejected static
+monolithic tile must not return to the first-use compilation path.

--- a/tools/benchmarks/benchmark_gvs_warp.py
+++ b/tools/benchmarks/benchmark_gvs_warp.py
@@ -1,0 +1,2253 @@
+#!/usr/bin/env python3
+"""Correctness and runtime harness for experimental GVS Warp kernels."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import statistics
+import sys
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    repository_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(repository_root / "src"))
+    sys.path.insert(1, str(repository_root))
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import warp as wp
+
+jax.config.update("jax_enable_x64", True)
+
+from soromox.systems import GVS, JointSpec
+from soromox.utils.lie_algebra import se3
+from tools.benchmarks._benchmark_common import (
+    _gvs_context,
+    _gvs_factory,
+    _gvs_segment,
+)
+from tools.benchmarks.gvs_warp_assembly_kernels import (
+    scalable_assemble_dynamics,
+)
+from tools.benchmarks.gvs_warp_joint_kernels import scalable_joint_terms
+from tools.benchmarks.gvs_warp_kernels import (
+    MAX_DOF,
+    NUM_CELLS,
+    NUM_DOFS,
+    NUM_QUADRATURE_CELLS,
+    NUM_SEGMENTS,
+    SPATIAL_DIM,
+    contract_cell_terms,
+    cooperative_segment_dynamics,
+    fused_cell_advance,
+    persistent_raw_dynamics,
+    segment_recurrence,
+)
+from tools.benchmarks.gvs_warp_lie_kernels import (
+    matrix_free_cell_terms,
+    matrix_free_cell_terms_serial,
+)
+from tools.benchmarks.gvs_warp_persistent_kernels import (
+    scalable_persistent_chain,
+)
+from tools.benchmarks.gvs_warp_scalable_kernels import (
+    scalable_cell_terms,
+    scalable_segment_recurrence,
+)
+from tools.benchmarks.gvs_warp_segment_kernels import (
+    scalable_cooperative_segment,
+)
+from tools.benchmarks.gvs_warp_solve_kernels import scalable_cholesky_solve
+from tools.benchmarks.gvs_warp_specialized_kernels import (
+    constant_strain_cell_terms,
+)
+
+Array = jax.Array
+Tree = Any
+JOINT_TYPES = (
+    "fixed",
+    "revolute",
+    "prismatic",
+    "helical",
+    "cylindrical",
+    "planar",
+    "spherical",
+    "free",
+    "mixed",
+)
+
+
+@dataclass(frozen=True)
+class ScalableWarpModelData:
+    """Persistent shape-generic arrays captured by the experimental kernels."""
+
+    joint_basis: Array
+    joint_reference: Array
+    joint_local_to_global: Array
+    joint_global_to_local: Array
+    link_local_to_global: Array
+    basis_z1: Array
+    basis_z2: Array
+    reference_z1: Array
+    reference_z2: Array
+    segment_lengths: Array
+    cell_widths: Array
+
+
+def _build_scalable_model_data(robot: Any) -> ScalableWarpModelData:
+    """Flatten static model data without specializing generated Warp source."""
+
+    num_segments = int(robot.B_joint.shape[0])
+    num_dofs = int(robot.num_dofs)
+    max_dof = int(robot.B_joint.shape[-1])
+    gather_indices = np.asarray(robot.gather_indices)
+    gather_mask = np.asarray(robot.gather_mask)
+
+    local_to_global = np.where(gather_mask, gather_indices, -1).astype(np.int32)
+    joint_global_to_local = np.full(
+        (num_segments, num_dofs), -1, dtype=np.int32
+    )
+    for segment in range(num_segments):
+        for local_column in range(max_dof):
+            global_column = local_to_global[segment, 0, local_column]
+            if global_column >= 0:
+                joint_global_to_local[segment, global_column] = local_column
+
+    basis_z1 = robot.B_Z1
+    basis_z2 = robot.B_Z2
+    if robot.scale_rotational_basis_by_length:
+        scales = robot.segment_lengths[:, None, None]
+        basis_z1 = basis_z1.at[:, :, :3].divide(scales)
+        basis_z2 = basis_z2.at[:, :, :3].divide(scales)
+
+    return ScalableWarpModelData(
+        joint_basis=robot.B_joint,
+        joint_reference=robot.xi_ref_joint,
+        joint_local_to_global=jnp.asarray(local_to_global[:, 0]),
+        joint_global_to_local=jnp.asarray(joint_global_to_local),
+        link_local_to_global=jnp.asarray(local_to_global[:, 1]),
+        basis_z1=basis_z1,
+        basis_z2=basis_z2,
+        reference_z1=robot.xi_ref_Z1,
+        reference_z2=robot.xi_ref_Z2,
+        segment_lengths=robot.segment_lengths,
+        cell_widths=(
+            robot.integration_points[:, 1:] - robot.integration_points[:, :-1]
+        ),
+    )
+
+
+def _joint_spec(joint_type: str) -> JointSpec:
+    """Construct a nondegenerate representative of one supported joint."""
+
+    if joint_type == "helical":
+        return JointSpec(type="helical", axis="z", pitch=0.05)
+    if joint_type == "planar":
+        return JointSpec(type="planar", plane="xy")
+    if joint_type in {"revolute", "prismatic", "cylindrical"}:
+        return JointSpec(type=joint_type, axis="z")
+    return JointSpec(type=joint_type)
+
+
+def _block(tree: Tree) -> None:
+    jax.tree.map(lambda value: value.block_until_ready(), tree)
+
+
+def _coadjoint_action(velocity: Array, momentum: Array) -> Array:
+    omega = velocity[..., :3]
+    linear_velocity = velocity[..., 3:]
+    moment = momentum[..., :3]
+    force = momentum[..., 3:]
+    return jnp.concatenate(
+        [
+            jnp.cross(omega, moment) + jnp.cross(linear_velocity, force),
+            jnp.cross(omega, force),
+        ],
+        axis=-1,
+    )
+
+
+def _build_precompute(robot: Any) -> Callable[[Array, Array], tuple[Array, ...]]:
+    segment_indices = jnp.arange(NUM_SEGMENTS)
+    cell_indices = jnp.arange(NUM_CELLS)
+
+    def precompute_one(q: Array, qd: Array) -> tuple[Array, ...]:
+        q_blocks = robot._min_size_gathered(q)
+        qd_blocks = robot._min_size_gathered(qd)
+
+        def insert_basis(local_basis: Array, segment: Array, block: int) -> Array:
+            indices = jnp.minimum(robot.gather_indices[segment, block], NUM_DOFS - 1)
+            masked = local_basis * robot.gather_mask[segment, block][None, :]
+            return (
+                jnp.zeros((SPATIAL_DIM, NUM_DOFS), dtype=q.dtype)
+                .at[:, indices]
+                .add(masked)
+            )
+
+        def evaluate_joint(segment: Array) -> tuple[Array, ...]:
+            (
+                _,
+                adjoint,
+                adjoint_dot,
+                tangent_basis,
+                tangent_basis_dot,
+                velocity,
+            ) = robot._joint_jacobian_time_derivative_step_terms(
+                robot.B_joint[segment],
+                robot.xi_ref_joint[segment],
+                q_blocks[segment, 0],
+                qd_blocks[segment, 0],
+            )
+            tangent_active = insert_basis(tangent_basis, segment, 0)
+            tangent_dot_qd = tangent_basis_dot @ qd_blocks[segment, 0]
+            return (
+                adjoint,
+                adjoint_dot,
+                tangent_active,
+                tangent_dot_qd,
+                velocity,
+            )
+
+        def evaluate_segment(segment: Array) -> tuple[Array, ...]:
+            def evaluate_cell(cell: Array) -> tuple[Array, ...]:
+                width = (
+                    robot.integration_points[segment, cell + 1]
+                    - robot.integration_points[segment, cell]
+                )
+                (
+                    _,
+                    tangent,
+                    tangent_dot,
+                    adjoint,
+                    magnus_basis,
+                    magnus_basis_dot,
+                ) = robot._magnus_jacobian_time_derivative_step_terms(
+                    robot.segment_lengths[segment],
+                    width,
+                    q_blocks[segment, 1],
+                    qd_blocks[segment, 1],
+                    robot.B_Z1[segment, cell],
+                    robot.B_Z2[segment, cell],
+                    robot.xi_ref_Z1[segment, cell],
+                    robot.xi_ref_Z2[segment, cell],
+                )
+                local_tangent = tangent @ magnus_basis
+                tangent_active = insert_basis(local_tangent, segment, 1)
+                link_velocity = local_tangent @ qd_blocks[segment, 1]
+                step_velocity = adjoint @ link_velocity
+                tangent_velocity_dot = (
+                    tangent_dot @ magnus_basis + tangent @ magnus_basis_dot
+                ) @ qd_blocks[segment, 1]
+                return (
+                    adjoint,
+                    tangent_active,
+                    link_velocity,
+                    step_velocity,
+                    tangent_velocity_dot,
+                    tangent,
+                    tangent_dot,
+                    magnus_basis,
+                    magnus_basis_dot,
+                )
+
+            return jax.vmap(evaluate_cell)(cell_indices)
+
+        return (
+            *jax.vmap(evaluate_joint)(segment_indices),
+            *jax.vmap(evaluate_segment)(segment_indices),
+            qd_blocks[:, 1],
+        )
+
+    return jax.vmap(precompute_one)
+
+
+def _build_joint_precompute(robot: Any) -> Callable[[Array, Array], tuple[Array, ...]]:
+    """Evaluate only joint terms and gather link coordinates and velocities."""
+
+    num_segments = int(robot.B_joint.shape[0])
+    num_dofs = int(robot.num_dofs)
+    segment_indices = jnp.arange(num_segments)
+
+    def precompute_one(q: Array, qd: Array) -> tuple[Array, ...]:
+        q_blocks = robot._min_size_gathered(q)
+        qd_blocks = robot._min_size_gathered(qd)
+
+        def insert_basis(local_basis: Array, segment: Array) -> Array:
+            indices = jnp.minimum(robot.gather_indices[segment, 0], num_dofs - 1)
+            masked = local_basis * robot.gather_mask[segment, 0][None, :]
+            return (
+                jnp.zeros((SPATIAL_DIM, num_dofs), dtype=q.dtype)
+                .at[:, indices]
+                .add(masked)
+            )
+
+        def evaluate_joint(segment: Array) -> tuple[Array, ...]:
+            (
+                _,
+                adjoint,
+                adjoint_dot,
+                tangent_basis,
+                tangent_basis_dot,
+                velocity,
+            ) = robot._joint_jacobian_time_derivative_step_terms(
+                robot.B_joint[segment],
+                robot.xi_ref_joint[segment],
+                q_blocks[segment, 0],
+                qd_blocks[segment, 0],
+            )
+            return (
+                adjoint,
+                adjoint_dot,
+                insert_basis(tangent_basis, segment),
+                tangent_basis_dot @ qd_blocks[segment, 0],
+                velocity,
+            )
+
+        return (*jax.vmap(evaluate_joint)(segment_indices), q_blocks[:, 1], qd_blocks[:, 1])
+
+    return jax.vmap(precompute_one)
+
+
+def _build_fixed_joint_precompute(
+    robot: Any,
+) -> Callable[[Array, Array], tuple[Array, ...]]:
+    """Return exact identity/zero joint terms for this fixed-joint benchmark."""
+
+    num_segments = int(robot.B_joint.shape[0])
+    num_dofs = int(robot.num_dofs)
+    if (
+        np.any(np.asarray(robot.B_joint))
+        or np.any(np.asarray(robot.xi_ref_joint))
+        or np.any(np.asarray(robot.gather_mask[:, 0]))
+    ):
+        raise ValueError(
+            "Fixed-joint specialization requires zero joint bases, reference "
+            "strains, and active joint gather masks."
+        )
+
+    def precompute(q: Array, qd: Array) -> tuple[Array, ...]:
+        batch_size = q.shape[0]
+        q_blocks = jax.vmap(robot._min_size_gathered)(q)
+        qd_blocks = jax.vmap(robot._min_size_gathered)(qd)
+        identity = jnp.broadcast_to(
+            jnp.eye(SPATIAL_DIM, dtype=q.dtype),
+            (batch_size, num_segments, SPATIAL_DIM, SPATIAL_DIM),
+        )
+        matrix_zeros = jnp.zeros_like(identity)
+        tangent_zeros = jnp.zeros(
+            (batch_size, num_segments, SPATIAL_DIM, num_dofs), dtype=q.dtype
+        )
+        vector_zeros = jnp.zeros(
+            (batch_size, num_segments, SPATIAL_DIM), dtype=q.dtype
+        )
+        return (
+            identity,
+            matrix_zeros,
+            tangent_zeros,
+            vector_zeros,
+            vector_zeros,
+            q_blocks[:, :, 1],
+            qd_blocks[:, :, 1],
+        )
+
+    return precompute
+
+
+def _warp_scalable_joint_terms(
+    q: Array,
+    qd: Array,
+    model_data: ScalableWarpModelData,
+) -> tuple[Array, Array, Array, Array, Array]:
+    """Evaluate general GVS joint terms in one shape-generic Warp launch."""
+
+    batch_size = q.shape[0]
+    num_segments, max_dof = model_data.joint_local_to_global.shape
+    num_dofs = q.shape[1]
+    work_items = batch_size * num_segments
+    matrix_rows = work_items * SPATIAL_DIM
+    outputs = scalable_joint_terms(
+        q,
+        qd,
+        model_data.joint_basis.reshape(num_segments * SPATIAL_DIM, max_dof),
+        model_data.joint_reference,
+        model_data.joint_local_to_global,
+        output_dims={
+            "adjoint": (matrix_rows, SPATIAL_DIM),
+            "adjoint_dot": (matrix_rows, SPATIAL_DIM),
+            "tangent_local": (matrix_rows, max_dof),
+            "tangent_dot_qd": (matrix_rows, 1),
+            "joint_velocity": (matrix_rows, 1),
+        },
+    )
+    leading = (batch_size, num_segments, SPATIAL_DIM)
+    tangent_local = outputs[2].reshape(*leading, max_dof)
+    local_columns = jnp.maximum(model_data.joint_global_to_local, 0)
+    local_columns = jnp.broadcast_to(
+        local_columns[None, :, None, :],
+        (batch_size, num_segments, SPATIAL_DIM, num_dofs),
+    )
+    tangent_active = jnp.take_along_axis(
+        tangent_local, local_columns, axis=-1
+    )
+    tangent_active *= (
+        model_data.joint_global_to_local >= 0
+    )[None, :, None, :]
+    return (
+        outputs[0].reshape(*leading, SPATIAL_DIM),
+        outputs[1].reshape(*leading, SPATIAL_DIM),
+        tangent_active,
+        outputs[3].reshape(*leading),
+        outputs[4].reshape(*leading),
+    )
+
+
+def _gather_link_coordinates(
+    values: Array, model_data: ScalableWarpModelData
+) -> Array:
+    """Gather padded link coordinates from one batched global state array."""
+
+    local_to_global = model_data.link_local_to_global
+    gathered = jnp.take(values, jnp.maximum(local_to_global, 0), axis=1)
+    return gathered * (local_to_global >= 0)[None, :, :]
+
+
+def _build_warp_joint_precompute(
+    model_data: ScalableWarpModelData,
+) -> Callable[[Array, Array], tuple[Array, ...]]:
+    """Return Warp joint terms and directly gathered link coordinates."""
+
+    def precompute(q: Array, qd: Array) -> tuple[Array, ...]:
+        return (
+            *_warp_scalable_joint_terms(q, qd, model_data),
+            _gather_link_coordinates(q, model_data),
+            _gather_link_coordinates(qd, model_data),
+        )
+
+    return precompute
+
+
+def _warp_matrix_free_cell_terms(
+    q_link: Array,
+    qd_link: Array,
+    basis_z1: Array,
+    basis_z2: Array,
+    reference_z1: Array,
+    reference_z2: Array,
+    segment_lengths: Array,
+    cell_widths: Array,
+    gather_indices: Array,
+    gather_mask: Array,
+    *,
+    serial_cell: bool = False,
+    constant_strain: bool = False,
+) -> tuple[Array, ...]:
+    batch_size = q_link.shape[0]
+    work_items = batch_size * NUM_SEGMENTS * NUM_CELLS
+    matrix_rows = work_items * SPATIAL_DIM
+    output_dims = {
+        "adjoint": (matrix_rows, SPATIAL_DIM),
+        "tangent_active": (matrix_rows, NUM_DOFS),
+        "link_velocity": (matrix_rows, 1),
+        "step_velocity": (matrix_rows, 1),
+        "tangent_velocity_dot": (matrix_rows, 1),
+    }
+    common_inputs = (
+        q_link.reshape(batch_size * NUM_SEGMENTS, MAX_DOF),
+        qd_link.reshape(batch_size * NUM_SEGMENTS, MAX_DOF),
+    )
+    if constant_strain:
+        outputs = constant_strain_cell_terms(
+            *common_inputs,
+            basis_z1.reshape(NUM_SEGMENTS * NUM_CELLS * SPATIAL_DIM, MAX_DOF),
+            reference_z1.reshape(NUM_SEGMENTS * NUM_CELLS, SPATIAL_DIM),
+            segment_lengths,
+            cell_widths.reshape(NUM_SEGMENTS * NUM_CELLS),
+            output_dims=output_dims,
+        )
+    else:
+        callable_kernel = (
+            matrix_free_cell_terms_serial if serial_cell else matrix_free_cell_terms
+        )
+        outputs = callable_kernel(
+            *common_inputs,
+            basis_z1.reshape(NUM_SEGMENTS * NUM_CELLS * SPATIAL_DIM, MAX_DOF),
+            basis_z2.reshape(NUM_SEGMENTS * NUM_CELLS * SPATIAL_DIM, MAX_DOF),
+            reference_z1.reshape(NUM_SEGMENTS * NUM_CELLS, SPATIAL_DIM),
+            reference_z2.reshape(NUM_SEGMENTS * NUM_CELLS, SPATIAL_DIM),
+            segment_lengths,
+            cell_widths.reshape(NUM_SEGMENTS * NUM_CELLS),
+            gather_indices,
+            gather_mask,
+            output_dims=output_dims,
+        )
+    leading = (batch_size, NUM_SEGMENTS, NUM_CELLS, SPATIAL_DIM)
+    return (
+        outputs[0].reshape(*leading, SPATIAL_DIM),
+        outputs[1].reshape(*leading, NUM_DOFS),
+        outputs[2].reshape(*leading),
+        outputs[3].reshape(*leading),
+        outputs[4].reshape(*leading),
+    )
+
+
+def _build_matrix_free_precompute(
+    robot: Any,
+    *,
+    serial_cell: bool = False,
+    constant_strain: bool = False,
+    fixed_joints: bool = False,
+) -> Callable[[Array, Array], tuple[Array, ...]]:
+    """Replace JAX cell-local Lie preparation with one matrix-free Warp kernel."""
+
+    if constant_strain:
+        expected_indices = np.arange(NUM_DOFS, dtype=np.int32).reshape(
+            NUM_SEGMENTS, MAX_DOF
+        )
+        if (
+            robot.scale_rotational_basis_by_length
+            or not np.array_equal(np.asarray(robot.B_Z1), np.asarray(robot.B_Z2))
+            or not np.array_equal(
+                np.asarray(robot.xi_ref_Z1), np.asarray(robot.xi_ref_Z2)
+            )
+            or not np.array_equal(
+                np.asarray(robot.gather_indices[:, 1]), expected_indices
+            )
+            or not np.all(np.asarray(robot.gather_mask[:, 1]))
+        ):
+            raise ValueError(
+                "Constant-strain specialization requires identical Z1/Z2 data, "
+                "unscaled rotational bases, and six contiguous active DoFs per segment."
+            )
+
+    joint_precompute = (
+        _build_fixed_joint_precompute(robot)
+        if fixed_joints
+        else _build_joint_precompute(robot)
+    )
+    basis_z1 = robot.B_Z1
+    basis_z2 = robot.B_Z2
+    if robot.scale_rotational_basis_by_length:
+        scales = robot.segment_lengths[:, None, None]
+        basis_z1 = basis_z1.at[:, :, :3].divide(scales)
+        basis_z2 = basis_z2.at[:, :, :3].divide(scales)
+    cell_widths = robot.integration_points[:, 1:] - robot.integration_points[:, :-1]
+    gather_indices = jnp.asarray(robot.gather_indices[:, 1], dtype=jnp.int32)
+    gather_mask = jnp.asarray(robot.gather_mask[:, 1], dtype=robot.B_Z1.dtype)
+
+    def precompute(q: Array, qd: Array) -> tuple[Array, ...]:
+        (
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            q_link,
+            qd_link,
+        ) = joint_precompute(q, qd)
+        (
+            cell_adjoint,
+            cell_tangent,
+            cell_link_velocity,
+            cell_step_velocity,
+            cell_tangent_velocity_dot,
+        ) = _warp_matrix_free_cell_terms(
+            q_link,
+            qd_link,
+            basis_z1,
+            basis_z2,
+            robot.xi_ref_Z1,
+            robot.xi_ref_Z2,
+            robot.segment_lengths,
+            cell_widths,
+            gather_indices,
+            gather_mask,
+            serial_cell=serial_cell,
+            constant_strain=constant_strain,
+        )
+        # The four raw arrays are unused by the matrix-free Option 6 path. They
+        # retain compatible positions in the shared precompute interface.
+        return (
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            cell_adjoint,
+            cell_tangent,
+            cell_link_velocity,
+            cell_step_velocity,
+            cell_tangent_velocity_dot,
+            cell_adjoint,
+            cell_adjoint,
+            cell_adjoint,
+            cell_adjoint,
+            qd_link,
+        )
+
+    return precompute
+
+
+def _warp_scalable_cell_terms(
+    q_link: Array,
+    qd_link: Array,
+    basis_z1: Array,
+    basis_z2: Array,
+    reference_z1: Array,
+    reference_z2: Array,
+    segment_lengths: Array,
+    cell_widths: Array,
+    *,
+    order_zero: bool,
+) -> tuple[Array, ...]:
+    """Call the compact local-coordinate Lie kernel."""
+
+    batch_size, num_segments, max_dof = q_link.shape
+    num_cells = reference_z1.shape[1]
+    work_items = batch_size * num_segments * num_cells
+    matrix_rows = work_items * SPATIAL_DIM
+    outputs = scalable_cell_terms(
+        q_link.reshape(batch_size * num_segments, max_dof),
+        qd_link.reshape(batch_size * num_segments, max_dof),
+        basis_z1.reshape(num_segments * num_cells * SPATIAL_DIM, max_dof),
+        basis_z2.reshape(num_segments * num_cells * SPATIAL_DIM, max_dof),
+        reference_z1.reshape(num_segments * num_cells, SPATIAL_DIM),
+        reference_z2.reshape(num_segments * num_cells, SPATIAL_DIM),
+        segment_lengths,
+        cell_widths.reshape(num_segments * num_cells),
+        jnp.asarray([num_cells], dtype=jnp.int32),
+        jnp.asarray([int(order_zero)], dtype=jnp.int32),
+        output_dims={
+            "adjoint": (matrix_rows, SPATIAL_DIM),
+            "tangent_local": (matrix_rows, max_dof),
+            "link_velocity": (matrix_rows, 1),
+            "step_velocity": (matrix_rows, 1),
+            "tangent_velocity_dot": (matrix_rows, 1),
+        },
+    )
+    leading = (batch_size, num_segments, num_cells, SPATIAL_DIM)
+    return (
+        outputs[0].reshape(*leading, SPATIAL_DIM),
+        outputs[1].reshape(*leading, max_dof),
+        outputs[2].reshape(*leading),
+        outputs[3].reshape(*leading),
+        outputs[4].reshape(*leading),
+    )
+
+
+def _build_scalable_precompute(
+    robot: Any,
+    *,
+    order_zero: bool,
+    fixed_joints: bool,
+    warp_joints: bool = False,
+) -> Callable[[Array, Array], tuple[Array, ...]]:
+    """Prepare general joints and compact cell-local Lie terms."""
+
+    if order_zero and (
+        robot.scale_rotational_basis_by_length
+        or not np.array_equal(np.asarray(robot.B_Z1), np.asarray(robot.B_Z2))
+        or not np.array_equal(
+            np.asarray(robot.xi_ref_Z1), np.asarray(robot.xi_ref_Z2)
+        )
+    ):
+        raise ValueError(
+            "Order-zero specialization requires identical Z1/Z2 bases and "
+            "reference strains without rotational basis rescaling."
+        )
+    model_data = _build_scalable_model_data(robot)
+    if fixed_joints and warp_joints:
+        raise ValueError("Fixed-joint and general Warp-joint paths are exclusive")
+    joint_precompute = (
+        _build_fixed_joint_precompute(robot)
+        if fixed_joints
+        else (
+            _build_warp_joint_precompute(model_data)
+            if warp_joints
+            else _build_joint_precompute(robot)
+        )
+    )
+
+    def precompute(q: Array, qd: Array) -> tuple[Array, ...]:
+        (
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            q_link,
+            qd_link,
+        ) = joint_precompute(q, qd)
+        cell_terms = _warp_scalable_cell_terms(
+            q_link,
+            qd_link,
+            model_data.basis_z1,
+            model_data.basis_z2,
+            model_data.reference_z1,
+            model_data.reference_z2,
+            model_data.segment_lengths,
+            model_data.cell_widths,
+            order_zero=order_zero,
+        )
+        return (
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            *cell_terms,
+        )
+
+    return precompute
+
+
+def _warp_cell(
+    adjoint: Array,
+    tangent_active: Array,
+    link_velocity: Array,
+    step_velocity: Array,
+    tangent_velocity_dot: Array,
+    qd: Array,
+    jacobian: Array,
+    jacobian_dot_qd: Array,
+    velocity: Array,
+    gravity: Array,
+) -> tuple[Array, Array, Array, Array]:
+    return fused_cell_advance(
+        adjoint,
+        tangent_active,
+        link_velocity,
+        step_velocity,
+        tangent_velocity_dot,
+        qd,
+        jacobian,
+        jacobian_dot_qd,
+        velocity,
+        gravity,
+        output_dims={
+            "jacobian_next": jacobian.shape,
+            "jacobian_dot_qd_next": jacobian_dot_qd.shape,
+            "velocity_next": velocity.shape,
+            "gravity_next": gravity.shape,
+        },
+    )
+
+
+def _build_option_1(robot: Any) -> Callable[[Array, Array], tuple[Array, ...]]:
+    precompute = _build_precompute(robot)
+    mass_diagonals = jnp.diagonal(robot.inner_mass_matrices, axis1=-2, axis2=-1)
+    gravity_initial = se3.adjoint_inverse(robot.g0) @ robot.g
+
+    def dynamics(q: Array, qd: Array) -> tuple[Array, Array, Array]:
+        (
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            cell_adjoint,
+            cell_tangent,
+            cell_link_velocity,
+            cell_step_velocity,
+            cell_tangent_velocity_dot,
+            _cell_tangent_raw,
+            _cell_tangent_dot_raw,
+            _cell_magnus_basis_raw,
+            _cell_magnus_basis_dot_raw,
+            _qd_link,
+        ) = precompute(q, qd)
+        batch_size = q.shape[0]
+        jacobian = jnp.zeros((batch_size, SPATIAL_DIM, NUM_DOFS), dtype=q.dtype)
+        vector = jnp.zeros((batch_size, SPATIAL_DIM), dtype=q.dtype)
+        jacobian_dot_qd = vector
+        velocity = vector
+        gravity = jnp.broadcast_to(gravity_initial, (batch_size, SPATIAL_DIM))
+        inertia = jnp.zeros((batch_size, NUM_DOFS, NUM_DOFS), dtype=q.dtype)
+        coriolis_qd = jnp.zeros((batch_size, NUM_DOFS), dtype=q.dtype)
+        gravity_force = jnp.zeros((batch_size, NUM_DOFS), dtype=q.dtype)
+
+        for segment in range(NUM_SEGMENTS):
+            adjoint = joint_adjoint[:, segment]
+            jacobian_tip_qd = jnp.einsum("bij,bj->bi", jacobian, qd)
+            jacobian = jnp.einsum(
+                "bij,bjk->bik", adjoint, jacobian + joint_tangent[:, segment]
+            )
+            jacobian_dot_qd = jnp.einsum(
+                "bij,bj->bi",
+                adjoint,
+                jacobian_dot_qd + joint_tangent_dot_qd[:, segment],
+            ) + jnp.einsum("bij,bj->bi", joint_adjoint_dot[:, segment], jacobian_tip_qd)
+            velocity = jnp.einsum(
+                "bij,bj->bi", adjoint, velocity + joint_velocity[:, segment]
+            )
+            gravity = jnp.einsum("bij,bj->bi", adjoint, gravity)
+
+            quadrature_states: list[tuple[Array, Array, Array, Array]] = []
+            for cell in range(NUM_CELLS):
+                jacobian, jacobian_dot_qd, velocity, gravity = _warp_cell(
+                    cell_adjoint[:, segment, cell],
+                    cell_tangent[:, segment, cell],
+                    cell_link_velocity[:, segment, cell],
+                    cell_step_velocity[:, segment, cell],
+                    cell_tangent_velocity_dot[:, segment, cell],
+                    qd,
+                    jacobian,
+                    jacobian_dot_qd,
+                    velocity,
+                    gravity,
+                )
+                if cell < NUM_QUADRATURE_CELLS:
+                    quadrature_states.append(
+                        (jacobian, jacobian_dot_qd, velocity, gravity)
+                    )
+
+            jacobians = jnp.stack([state[0] for state in quadrature_states], axis=1)
+            jacobians_dot_qd = jnp.stack(
+                [state[1] for state in quadrature_states], axis=1
+            )
+            velocities = jnp.stack([state[2] for state in quadrature_states], axis=1)
+            gravities = jnp.stack([state[3] for state in quadrature_states], axis=1)
+            weights = robot.inner_integration_weights[segment]
+            masses = mass_diagonals[segment]
+            weighted_masses = weights[:, None] * masses
+            inertia += jnp.einsum(
+                "bqri,qr,bqrj->bij", jacobians, weighted_masses, jacobians
+            )
+            momentum = masses[None, :, :] * velocities
+            wrench = masses[None, :, :] * jacobians_dot_qd + _coadjoint_action(
+                velocities, momentum
+            )
+            coriolis_qd += jnp.einsum(
+                "bqri,bqr->bi", jacobians, weights[None, :, None] * wrench
+            )
+            gravity_force -= jnp.einsum(
+                "bqri,bqr->bi",
+                jacobians,
+                weighted_masses[None, :, :] * gravities,
+            )
+
+        return inertia, coriolis_qd, gravity_force
+
+    return dynamics
+
+
+def _warp_segment(
+    adjoint: Array,
+    tangent_active: Array,
+    link_velocity: Array,
+    step_velocity: Array,
+    tangent_velocity_dot: Array,
+    qd: Array,
+    jacobian: Array,
+    jacobian_dot_qd: Array,
+    velocity: Array,
+    gravity: Array,
+) -> tuple[Array, Array, Array, Array]:
+    batch_size = jacobian.shape[0]
+    return segment_recurrence(
+        adjoint,
+        tangent_active,
+        link_velocity,
+        step_velocity,
+        tangent_velocity_dot,
+        qd,
+        jacobian,
+        jacobian_dot_qd,
+        velocity,
+        gravity,
+        output_dims={
+            "jacobian_states": (
+                batch_size,
+                NUM_CELLS,
+                SPATIAL_DIM,
+                NUM_DOFS,
+            ),
+            "jacobian_dot_qd_states": (
+                batch_size,
+                NUM_CELLS,
+                SPATIAL_DIM,
+            ),
+            "velocity_states": (batch_size, NUM_CELLS, SPATIAL_DIM),
+            "gravity_states": (batch_size, NUM_CELLS, SPATIAL_DIM),
+        },
+    )
+
+
+def _warp_scalable_segment(
+    adjoint: Array,
+    tangent_local: Array,
+    link_velocity: Array,
+    step_velocity: Array,
+    tangent_velocity_dot: Array,
+    global_to_local: Array,
+    qd: Array,
+    jacobian: Array,
+    jacobian_dot_qd: Array,
+    velocity: Array,
+    gravity: Array,
+) -> tuple[Array, Array, Array, Array]:
+    batch_size, num_cells = adjoint.shape[:2]
+    num_dofs = qd.shape[1]
+    max_dof = tangent_local.shape[-1]
+    matrix_rows = batch_size * num_cells * SPATIAL_DIM
+    outputs = scalable_segment_recurrence(
+        adjoint.reshape(matrix_rows, SPATIAL_DIM),
+        tangent_local.reshape(matrix_rows, max_dof),
+        link_velocity.reshape(matrix_rows, 1),
+        step_velocity.reshape(matrix_rows, 1),
+        tangent_velocity_dot.reshape(matrix_rows, 1),
+        global_to_local,
+        qd,
+        jacobian.reshape(batch_size * SPATIAL_DIM, num_dofs),
+        jacobian_dot_qd.reshape(batch_size * SPATIAL_DIM, 1),
+        velocity.reshape(batch_size * SPATIAL_DIM, 1),
+        gravity.reshape(batch_size * SPATIAL_DIM, 1),
+        output_dims={
+            "jacobian_states": (matrix_rows, num_dofs),
+            "jacobian_dot_qd_states": (matrix_rows, 1),
+            "velocity_states": (matrix_rows, 1),
+            "gravity_states": (matrix_rows, 1),
+        },
+    )
+    return (
+        outputs[0].reshape(
+            batch_size, num_cells, SPATIAL_DIM, num_dofs
+        ),
+        outputs[1].reshape(batch_size, num_cells, SPATIAL_DIM),
+        outputs[2].reshape(batch_size, num_cells, SPATIAL_DIM),
+        outputs[3].reshape(batch_size, num_cells, SPATIAL_DIM),
+    )
+
+
+def _warp_scalable_assembly(
+    jacobians: Array,
+    jacobians_dot_qd: Array,
+    velocities: Array,
+    gravities: Array,
+    weights: Array,
+    mass_diagonals: Array,
+) -> tuple[Array, Array, Array]:
+    """Assemble batched GVS terms with one Warp owner per output entry."""
+
+    batch_size, num_segments, num_quadrature, _, num_dofs = jacobians.shape
+    state_rows = batch_size * num_segments * num_quadrature * SPATIAL_DIM
+    outputs = scalable_assemble_dynamics(
+        jacobians.reshape(state_rows, num_dofs),
+        jacobians_dot_qd.reshape(state_rows, 1),
+        velocities.reshape(state_rows, 1),
+        gravities.reshape(state_rows, 1),
+        weights.reshape(num_segments * num_quadrature),
+        mass_diagonals.reshape(num_segments * num_quadrature, SPATIAL_DIM),
+        jnp.asarray([num_quadrature], dtype=jnp.int32),
+        output_dims={
+            "inertia": (batch_size, num_dofs, num_dofs),
+            "coriolis_qd": (batch_size, num_dofs),
+            "gravity_force": (batch_size, num_dofs),
+        },
+    )
+    return outputs[0], outputs[1], outputs[2]
+
+
+def _warp_scalable_cooperative_segment(
+    adjoint: Array,
+    tangent_local: Array,
+    link_velocity: Array,
+    step_velocity: Array,
+    tangent_velocity_dot: Array,
+    global_to_local: Array,
+    qd: Array,
+    jacobian: Array,
+    jacobian_dot_qd: Array,
+    velocity: Array,
+    gravity: Array,
+    joint_adjoint: Array,
+    joint_adjoint_dot: Array,
+    joint_tangent: Array,
+    joint_tangent_dot_qd: Array,
+    joint_velocity: Array,
+    apply_joint: bool,
+    weights: Array,
+    masses: Array,
+    lanes_per_block: int,
+) -> tuple[Array, ...]:
+    """Advance and assemble one runtime-shaped segment per environment."""
+
+    batch_size, num_cells = adjoint.shape[:2]
+    num_dofs = qd.shape[1]
+    max_dof = tangent_local.shape[-1]
+    state_rows = batch_size * SPATIAL_DIM
+    cell_rows = batch_size * num_cells * SPATIAL_DIM
+    outputs = scalable_cooperative_segment(
+        adjoint.reshape(cell_rows, SPATIAL_DIM),
+        tangent_local.reshape(cell_rows, max_dof),
+        link_velocity.reshape(cell_rows, 1),
+        step_velocity.reshape(cell_rows, 1),
+        tangent_velocity_dot.reshape(cell_rows, 1),
+        global_to_local,
+        qd,
+        jacobian.reshape(state_rows, num_dofs),
+        jacobian_dot_qd.reshape(state_rows, 1),
+        velocity.reshape(state_rows, 1),
+        gravity.reshape(state_rows, 1),
+        joint_adjoint.reshape(state_rows, SPATIAL_DIM),
+        joint_adjoint_dot.reshape(state_rows, SPATIAL_DIM),
+        joint_tangent.reshape(state_rows, num_dofs),
+        joint_tangent_dot_qd.reshape(state_rows, 1),
+        joint_velocity.reshape(state_rows, 1),
+        jnp.asarray([int(apply_joint)], dtype=jnp.int32),
+        weights,
+        masses,
+        jnp.asarray([lanes_per_block], dtype=jnp.int32),
+        output_dims={
+            "jacobian_tip": (state_rows, num_dofs),
+            "jacobian_dot_qd_tip": (state_rows, 1),
+            "velocity_tip": (state_rows, 1),
+            "gravity_tip": (state_rows, 1),
+            "inertia": (batch_size, num_dofs, num_dofs),
+            "coriolis_qd": (batch_size, num_dofs),
+            "gravity_force": (batch_size, num_dofs),
+            "jacobian_scratch": (state_rows, num_dofs),
+            "jacobian_dot_qd_scratch": (state_rows, 1),
+            "velocity_scratch": (state_rows, 1),
+            "gravity_scratch": (state_rows, 1),
+        },
+    )
+    return (
+        outputs[0].reshape(batch_size, SPATIAL_DIM, num_dofs),
+        outputs[1].reshape(batch_size, SPATIAL_DIM),
+        outputs[2].reshape(batch_size, SPATIAL_DIM),
+        outputs[3].reshape(batch_size, SPATIAL_DIM),
+        outputs[4],
+        outputs[5],
+        outputs[6],
+    )
+
+
+def _warp_scalable_persistent_chain(
+    joint_adjoint: Array,
+    joint_adjoint_dot: Array,
+    joint_tangent: Array,
+    joint_tangent_dot_qd: Array,
+    joint_velocity: Array,
+    cell_adjoint: Array,
+    cell_tangent_local: Array,
+    cell_link_velocity: Array,
+    cell_step_velocity: Array,
+    cell_tangent_velocity_dot: Array,
+    global_to_local: Array,
+    active_dofs: Array,
+    qd: Array,
+    weights: Array,
+    masses: Array,
+    gravity_base: Array,
+    lanes_per_block: int,
+) -> tuple[Array, Array, Array]:
+    """Evaluate a complete runtime-shaped serial GVS chain in one kernel."""
+
+    batch_size, num_segments = joint_adjoint.shape[:2]
+    num_cells = cell_adjoint.shape[2]
+    num_quadrature = weights.shape[1]
+    num_dofs = qd.shape[1]
+    max_dof = cell_tangent_local.shape[-1]
+    state_rows = batch_size * SPATIAL_DIM
+    joint_rows = batch_size * num_segments * SPATIAL_DIM
+    cell_rows = batch_size * num_segments * num_cells * SPATIAL_DIM
+    state_output_dims = {
+        "jacobian_first": (state_rows, num_dofs),
+        "jacobian_dot_qd_first": (state_rows, 1),
+        "velocity_first": (state_rows, 1),
+        "gravity_first": (state_rows, 1),
+        "jacobian_second": (state_rows, num_dofs),
+        "jacobian_dot_qd_second": (state_rows, 1),
+        "velocity_second": (state_rows, 1),
+        "gravity_second": (state_rows, 1),
+    }
+    outputs = scalable_persistent_chain(
+        joint_adjoint.reshape(joint_rows, SPATIAL_DIM),
+        joint_adjoint_dot.reshape(joint_rows, SPATIAL_DIM),
+        joint_tangent.reshape(joint_rows, num_dofs),
+        joint_tangent_dot_qd.reshape(joint_rows, 1),
+        joint_velocity.reshape(joint_rows, 1),
+        cell_adjoint.reshape(cell_rows, SPATIAL_DIM),
+        cell_tangent_local.reshape(cell_rows, max_dof),
+        cell_link_velocity.reshape(cell_rows, 1),
+        cell_step_velocity.reshape(cell_rows, 1),
+        cell_tangent_velocity_dot.reshape(cell_rows, 1),
+        global_to_local,
+        active_dofs,
+        qd,
+        weights.reshape(num_segments * num_quadrature),
+        masses.reshape(num_segments * num_quadrature, SPATIAL_DIM),
+        gravity_base,
+        jnp.asarray([num_cells], dtype=jnp.int32),
+        jnp.asarray([num_quadrature], dtype=jnp.int32),
+        jnp.asarray([lanes_per_block], dtype=jnp.int32),
+        output_dims={
+            **state_output_dims,
+            "inertia": (batch_size, num_dofs, num_dofs),
+            "coriolis_qd": (batch_size, num_dofs),
+            "gravity_force": (batch_size, num_dofs),
+        },
+    )
+    return outputs[-3], outputs[-2], outputs[-1]
+
+
+def _build_jax_forward_dynamics(
+    terms: Callable[[Array, Array], tuple[Array, Array, Array]],
+) -> Callable[[Array, Array], tuple[Array]]:
+    """Add a zero-applied-force JAX dense solve to a dynamics-terms path."""
+
+    def forward(q: Array, qd: Array) -> tuple[Array]:
+        inertia, coriolis_qd, gravity_force = terms(q, qd)
+        right_hand_side = -(coriolis_qd + gravity_force)
+        return (
+            jnp.linalg.solve(inertia, right_hand_side[..., None]).squeeze(-1),
+        )
+
+    return forward
+
+
+def _build_warp_forward_dynamics(
+    terms: Callable[[Array, Array], tuple[Array, Array, Array]],
+    *,
+    lanes_per_block: int,
+) -> Callable[[Array, Array], tuple[Array]]:
+    """Add the runtime-sized Warp Cholesky solve to a terms path."""
+
+    def forward(q: Array, qd: Array) -> tuple[Array]:
+        inertia, coriolis_qd, gravity_force = terms(q, qd)
+        batch_size, num_dofs = coriolis_qd.shape
+        outputs = scalable_cholesky_solve(
+            inertia,
+            coriolis_qd,
+            gravity_force,
+            jnp.asarray([lanes_per_block], dtype=jnp.int32),
+            output_dims={
+                "factor": (batch_size, num_dofs, num_dofs),
+                "intermediate": (batch_size, num_dofs),
+                "acceleration": (batch_size, num_dofs),
+            },
+        )
+        return (outputs[-1],)
+
+    return forward
+
+
+def _warp_contract(
+    tangent: Array,
+    tangent_dot: Array,
+    adjoint: Array,
+    magnus_basis: Array,
+    magnus_basis_dot: Array,
+    qd_link: Array,
+    gather_indices: Array,
+    gather_mask: Array,
+) -> tuple[Array, Array, Array, Array]:
+    batch_size = tangent.shape[0]
+    work_items = batch_size * NUM_SEGMENTS * NUM_CELLS
+    contracted = contract_cell_terms(
+        tangent.reshape(work_items, SPATIAL_DIM, SPATIAL_DIM),
+        tangent_dot.reshape(work_items, SPATIAL_DIM, SPATIAL_DIM),
+        adjoint.reshape(work_items, SPATIAL_DIM, SPATIAL_DIM),
+        magnus_basis.reshape(work_items, SPATIAL_DIM, MAX_DOF),
+        magnus_basis_dot.reshape(work_items, SPATIAL_DIM, MAX_DOF),
+        qd_link,
+        gather_indices,
+        gather_mask,
+        output_dims={
+            "tangent_active": (
+                work_items,
+                SPATIAL_DIM,
+                NUM_DOFS,
+            ),
+            "link_velocity": (work_items, SPATIAL_DIM),
+            "step_velocity": (work_items, SPATIAL_DIM),
+            "tangent_velocity_dot": (work_items, SPATIAL_DIM),
+        },
+    )
+    return (
+        contracted[0].reshape(
+            batch_size,
+            NUM_SEGMENTS,
+            NUM_CELLS,
+            SPATIAL_DIM,
+            NUM_DOFS,
+        ),
+        *(
+            value.reshape(batch_size, NUM_SEGMENTS, NUM_CELLS, SPATIAL_DIM)
+            for value in contracted[1:]
+        ),
+    )
+
+
+def _build_option_2(
+    robot: Any,
+    *,
+    warp_contraction: bool = False,
+    matrix_free_lie: bool = False,
+    serial_lie: bool = False,
+    constant_strain: bool = False,
+    fixed_joints: bool = False,
+) -> Callable[[Array, Array], tuple[Array, ...]]:
+    if warp_contraction and matrix_free_lie:
+        raise ValueError("Warp contraction and matrix-free Lie prep are exclusive")
+    precompute = (
+        _build_matrix_free_precompute(
+            robot,
+            serial_cell=serial_lie,
+            constant_strain=constant_strain,
+            fixed_joints=fixed_joints,
+        )
+        if matrix_free_lie
+        else _build_precompute(robot)
+    )
+    mass_diagonals = jnp.diagonal(robot.inner_mass_matrices, axis1=-2, axis2=-1)
+    gravity_initial = se3.adjoint_inverse(robot.g0) @ robot.g
+
+    def dynamics(q: Array, qd: Array) -> tuple[Array, Array, Array]:
+        (
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            cell_adjoint,
+            cell_tangent,
+            cell_link_velocity,
+            cell_step_velocity,
+            cell_tangent_velocity_dot,
+            cell_tangent_raw,
+            cell_tangent_dot_raw,
+            cell_magnus_basis_raw,
+            cell_magnus_basis_dot_raw,
+            qd_link,
+        ) = precompute(q, qd)
+        if warp_contraction:
+            (
+                cell_tangent,
+                cell_link_velocity,
+                cell_step_velocity,
+                cell_tangent_velocity_dot,
+            ) = _warp_contract(
+                cell_tangent_raw,
+                cell_tangent_dot_raw,
+                cell_adjoint,
+                cell_magnus_basis_raw,
+                cell_magnus_basis_dot_raw,
+                qd_link,
+                jnp.asarray(robot.gather_indices[:, 1], dtype=jnp.int32),
+                jnp.asarray(robot.gather_mask[:, 1], dtype=q.dtype),
+            )
+        batch_size = q.shape[0]
+        jacobian = jnp.zeros((batch_size, SPATIAL_DIM, NUM_DOFS), dtype=q.dtype)
+        vector = jnp.zeros((batch_size, SPATIAL_DIM), dtype=q.dtype)
+        jacobian_dot_qd = vector
+        velocity = vector
+        gravity = jnp.broadcast_to(gravity_initial, (batch_size, SPATIAL_DIM))
+        inertia = jnp.zeros((batch_size, NUM_DOFS, NUM_DOFS), dtype=q.dtype)
+        coriolis_qd = jnp.zeros((batch_size, NUM_DOFS), dtype=q.dtype)
+        gravity_force = jnp.zeros((batch_size, NUM_DOFS), dtype=q.dtype)
+
+        for segment in range(NUM_SEGMENTS):
+            adjoint = joint_adjoint[:, segment]
+            jacobian_tip_qd = jnp.einsum("bij,bj->bi", jacobian, qd)
+            jacobian = jnp.einsum(
+                "bij,bjk->bik", adjoint, jacobian + joint_tangent[:, segment]
+            )
+            jacobian_dot_qd = jnp.einsum(
+                "bij,bj->bi",
+                adjoint,
+                jacobian_dot_qd + joint_tangent_dot_qd[:, segment],
+            ) + jnp.einsum("bij,bj->bi", joint_adjoint_dot[:, segment], jacobian_tip_qd)
+            velocity = jnp.einsum(
+                "bij,bj->bi", adjoint, velocity + joint_velocity[:, segment]
+            )
+            gravity = jnp.einsum("bij,bj->bi", adjoint, gravity)
+
+            (
+                jacobian_states,
+                jacobian_dot_qd_states,
+                velocity_states,
+                gravity_states,
+            ) = _warp_segment(
+                cell_adjoint[:, segment],
+                cell_tangent[:, segment],
+                cell_link_velocity[:, segment],
+                cell_step_velocity[:, segment],
+                cell_tangent_velocity_dot[:, segment],
+                qd,
+                jacobian,
+                jacobian_dot_qd,
+                velocity,
+                gravity,
+            )
+            jacobian = jacobian_states[:, -1]
+            jacobian_dot_qd = jacobian_dot_qd_states[:, -1]
+            velocity = velocity_states[:, -1]
+            gravity = gravity_states[:, -1]
+
+            jacobians = jacobian_states[:, :NUM_QUADRATURE_CELLS]
+            jacobians_dot_qd = jacobian_dot_qd_states[:, :NUM_QUADRATURE_CELLS]
+            velocities = velocity_states[:, :NUM_QUADRATURE_CELLS]
+            gravities = gravity_states[:, :NUM_QUADRATURE_CELLS]
+            weights = robot.inner_integration_weights[segment]
+            masses = mass_diagonals[segment]
+            weighted_masses = weights[:, None] * masses
+            inertia += jnp.einsum(
+                "bqri,qr,bqrj->bij", jacobians, weighted_masses, jacobians
+            )
+            momentum = masses[None, :, :] * velocities
+            wrench = masses[None, :, :] * jacobians_dot_qd + _coadjoint_action(
+                velocities, momentum
+            )
+            coriolis_qd += jnp.einsum(
+                "bqri,bqr->bi", jacobians, weights[None, :, None] * wrench
+            )
+            gravity_force -= jnp.einsum(
+                "bqri,bqr->bi",
+                jacobians,
+                weighted_masses[None, :, :] * gravities,
+            )
+
+        return inertia, coriolis_qd, gravity_force
+
+    return dynamics
+
+
+def _build_scalable_option(
+    robot: Any,
+    *,
+    order_zero: bool = False,
+    fixed_joints: bool = False,
+    warp_joints: bool = False,
+    warp_assembly: bool = False,
+    cooperative_segment: bool = False,
+    cooperative_lanes: int = 128,
+    integrated_joint_segment: bool = False,
+    persistent_chain: bool = False,
+    active_prefix: bool = False,
+) -> Callable[[Array, Array], tuple[Array, ...]]:
+    """Runtime-shaped general GVS Lie and segment recurrence path."""
+
+    precompute = _build_scalable_precompute(
+        robot,
+        order_zero=order_zero,
+        fixed_joints=fixed_joints,
+        warp_joints=warp_joints,
+    )
+    num_segments = int(robot.B_Z1.shape[0])
+    num_cells = int(robot.B_Z1.shape[1])
+    num_dofs = int(robot.num_dofs)
+    mass_diagonals = jnp.diagonal(robot.inner_mass_matrices, axis1=-2, axis2=-1)
+    gravity_initial = se3.adjoint_inverse(robot.g0) @ robot.g
+    global_to_local_numpy = np.full(
+        (num_segments, num_dofs), -1, dtype=np.int32
+    )
+    gather_indices_numpy = np.asarray(robot.gather_indices[:, 1])
+    gather_mask_numpy = np.asarray(robot.gather_mask[:, 1])
+    for segment in range(num_segments):
+        for local_column in range(gather_indices_numpy.shape[1]):
+            if gather_mask_numpy[segment, local_column]:
+                global_column = gather_indices_numpy[segment, local_column]
+                global_to_local_numpy[segment, global_column] = local_column
+    global_to_local = jnp.asarray(global_to_local_numpy)
+    active_dofs_numpy = np.full(num_segments, num_dofs, dtype=np.int32)
+    if active_prefix:
+        active_indices: set[int] = set()
+        full_gather_indices = np.asarray(robot.gather_indices)
+        full_gather_mask = np.asarray(robot.gather_mask)
+        for segment in range(num_segments):
+            for item in range(full_gather_indices.shape[1]):
+                for local_column in range(full_gather_indices.shape[2]):
+                    if full_gather_mask[segment, item, local_column]:
+                        active_indices.add(
+                            int(
+                                full_gather_indices[
+                                    segment, item, local_column
+                                ]
+                            )
+                        )
+            prefix_size = len(active_indices)
+            if active_indices == set(range(prefix_size)):
+                active_dofs_numpy[segment] = prefix_size
+    active_dofs = jnp.asarray(active_dofs_numpy)
+    if warp_assembly and cooperative_segment:
+        raise ValueError(
+            "Separate Warp assembly and cooperative segment paths are exclusive"
+        )
+    if integrated_joint_segment and not cooperative_segment:
+        raise ValueError(
+            "Integrated joint propagation requires the cooperative segment path"
+        )
+    if persistent_chain and (warp_assembly or cooperative_segment):
+        raise ValueError(
+            "Persistent-chain and per-segment assembly paths are exclusive"
+        )
+
+    def dynamics(q: Array, qd: Array) -> tuple[Array, Array, Array]:
+        (
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            cell_adjoint,
+            cell_tangent_local,
+            cell_link_velocity,
+            cell_step_velocity,
+            cell_tangent_velocity_dot,
+        ) = precompute(q, qd)
+        batch_size = q.shape[0]
+        jacobian = jnp.zeros(
+            (batch_size, SPATIAL_DIM, num_dofs), dtype=q.dtype
+        )
+        vector = jnp.zeros((batch_size, SPATIAL_DIM), dtype=q.dtype)
+        jacobian_dot_qd = vector
+        velocity = vector
+        gravity = jnp.broadcast_to(gravity_initial, (batch_size, SPATIAL_DIM))
+        inertia = jnp.zeros((batch_size, num_dofs, num_dofs), dtype=q.dtype)
+        coriolis_qd = jnp.zeros((batch_size, num_dofs), dtype=q.dtype)
+        gravity_force = jnp.zeros((batch_size, num_dofs), dtype=q.dtype)
+        jacobian_quadrature = []
+        jacobian_dot_qd_quadrature = []
+        velocity_quadrature = []
+        gravity_quadrature = []
+
+        if persistent_chain:
+            return _warp_scalable_persistent_chain(
+                joint_adjoint,
+                joint_adjoint_dot,
+                joint_tangent,
+                joint_tangent_dot_qd,
+                joint_velocity,
+                cell_adjoint,
+                cell_tangent_local,
+                cell_link_velocity,
+                cell_step_velocity,
+                cell_tangent_velocity_dot,
+                global_to_local,
+                active_dofs,
+                qd,
+                robot.inner_integration_weights,
+                mass_diagonals,
+                gravity_initial,
+                cooperative_lanes,
+            )
+
+        for segment in range(num_segments):
+            adjoint = joint_adjoint[:, segment]
+            if integrated_joint_segment:
+                (
+                    jacobian,
+                    jacobian_dot_qd,
+                    velocity,
+                    gravity,
+                    segment_inertia,
+                    segment_coriolis_qd,
+                    segment_gravity_force,
+                ) = _warp_scalable_cooperative_segment(
+                    cell_adjoint[:, segment],
+                    cell_tangent_local[:, segment],
+                    cell_link_velocity[:, segment],
+                    cell_step_velocity[:, segment],
+                    cell_tangent_velocity_dot[:, segment],
+                    global_to_local[segment],
+                    qd,
+                    jacobian,
+                    jacobian_dot_qd,
+                    velocity,
+                    gravity,
+                    joint_adjoint[:, segment],
+                    joint_adjoint_dot[:, segment],
+                    joint_tangent[:, segment],
+                    joint_tangent_dot_qd[:, segment],
+                    joint_velocity[:, segment],
+                    True,
+                    robot.inner_integration_weights[segment],
+                    mass_diagonals[segment],
+                    cooperative_lanes,
+                )
+                inertia += segment_inertia
+                coriolis_qd += segment_coriolis_qd
+                gravity_force += segment_gravity_force
+                continue
+            jacobian_tip_qd = jnp.einsum("bij,bj->bi", jacobian, qd)
+            jacobian = jnp.einsum(
+                "bij,bjk->bik", adjoint, jacobian + joint_tangent[:, segment]
+            )
+            jacobian_dot_qd = jnp.einsum(
+                "bij,bj->bi",
+                adjoint,
+                jacobian_dot_qd + joint_tangent_dot_qd[:, segment],
+            ) + jnp.einsum(
+                "bij,bj->bi", joint_adjoint_dot[:, segment], jacobian_tip_qd
+            )
+            velocity = jnp.einsum(
+                "bij,bj->bi", adjoint, velocity + joint_velocity[:, segment]
+            )
+            gravity = jnp.einsum("bij,bj->bi", adjoint, gravity)
+
+            if cooperative_segment:
+                (
+                    jacobian,
+                    jacobian_dot_qd,
+                    velocity,
+                    gravity,
+                    segment_inertia,
+                    segment_coriolis_qd,
+                    segment_gravity_force,
+                ) = _warp_scalable_cooperative_segment(
+                    cell_adjoint[:, segment],
+                    cell_tangent_local[:, segment],
+                    cell_link_velocity[:, segment],
+                    cell_step_velocity[:, segment],
+                    cell_tangent_velocity_dot[:, segment],
+                    global_to_local[segment],
+                    qd,
+                    jacobian,
+                    jacobian_dot_qd,
+                    velocity,
+                    gravity,
+                    adjoint,
+                    adjoint,
+                    jacobian,
+                    jacobian_dot_qd,
+                    velocity,
+                    False,
+                    robot.inner_integration_weights[segment],
+                    mass_diagonals[segment],
+                    cooperative_lanes,
+                )
+                inertia += segment_inertia
+                coriolis_qd += segment_coriolis_qd
+                gravity_force += segment_gravity_force
+                continue
+
+            (
+                jacobian_states,
+                jacobian_dot_qd_states,
+                velocity_states,
+                gravity_states,
+            ) = _warp_scalable_segment(
+                cell_adjoint[:, segment],
+                cell_tangent_local[:, segment],
+                cell_link_velocity[:, segment],
+                cell_step_velocity[:, segment],
+                cell_tangent_velocity_dot[:, segment],
+                global_to_local[segment],
+                qd,
+                jacobian,
+                jacobian_dot_qd,
+                velocity,
+                gravity,
+            )
+            jacobian = jacobian_states[:, -1]
+            jacobian_dot_qd = jacobian_dot_qd_states[:, -1]
+            velocity = velocity_states[:, -1]
+            gravity = gravity_states[:, -1]
+
+            jacobians = jacobian_states[:, : num_cells - 1]
+            jacobians_dot_qd = jacobian_dot_qd_states[:, : num_cells - 1]
+            velocities = velocity_states[:, : num_cells - 1]
+            gravities = gravity_states[:, : num_cells - 1]
+            if warp_assembly:
+                jacobian_quadrature.append(jacobians)
+                jacobian_dot_qd_quadrature.append(jacobians_dot_qd)
+                velocity_quadrature.append(velocities)
+                gravity_quadrature.append(gravities)
+                continue
+            weights = robot.inner_integration_weights[segment]
+            masses = mass_diagonals[segment]
+            weighted_masses = weights[:, None] * masses
+            inertia += jnp.einsum(
+                "bqri,qr,bqrj->bij", jacobians, weighted_masses, jacobians
+            )
+            momentum = masses[None, :, :] * velocities
+            wrench = masses[None, :, :] * jacobians_dot_qd + _coadjoint_action(
+                velocities, momentum
+            )
+            coriolis_qd += jnp.einsum(
+                "bqri,bqr->bi", jacobians, weights[None, :, None] * wrench
+            )
+            gravity_force -= jnp.einsum(
+                "bqri,bqr->bi",
+                jacobians,
+                weighted_masses[None, :, :] * gravities,
+            )
+
+        if warp_assembly:
+            return _warp_scalable_assembly(
+                jnp.stack(jacobian_quadrature, axis=1),
+                jnp.stack(jacobian_dot_qd_quadrature, axis=1),
+                jnp.stack(velocity_quadrature, axis=1),
+                jnp.stack(gravity_quadrature, axis=1),
+                robot.inner_integration_weights,
+                mass_diagonals,
+            )
+        return inertia, coriolis_qd, gravity_force
+
+    return dynamics
+
+
+def _warp_cooperative_segment(
+    adjoint: Array,
+    tangent_active: Array,
+    link_velocity: Array,
+    step_velocity: Array,
+    tangent_velocity_dot: Array,
+    qd: Array,
+    jacobian: Array,
+    jacobian_dot_qd: Array,
+    velocity: Array,
+    gravity: Array,
+    weights: Array,
+    masses: Array,
+) -> tuple[Array, ...]:
+    batch_size = qd.shape[0]
+    matrix_rows = batch_size * NUM_CELLS * SPATIAL_DIM
+    vector_rows = batch_size * NUM_CELLS * SPATIAL_DIM
+    state_rows = batch_size * NUM_CELLS * SPATIAL_DIM
+    outputs = cooperative_segment_dynamics(
+        adjoint.reshape(matrix_rows, SPATIAL_DIM),
+        tangent_active.reshape(matrix_rows, NUM_DOFS),
+        link_velocity.reshape(vector_rows, 1),
+        step_velocity.reshape(vector_rows, 1),
+        tangent_velocity_dot.reshape(vector_rows, 1),
+        qd.reshape(batch_size * NUM_DOFS, 1),
+        jacobian.reshape(batch_size * SPATIAL_DIM, NUM_DOFS),
+        jacobian_dot_qd.reshape(batch_size * SPATIAL_DIM, 1),
+        velocity.reshape(batch_size * SPATIAL_DIM, 1),
+        gravity.reshape(batch_size * SPATIAL_DIM, 1),
+        weights,
+        masses.reshape(NUM_QUADRATURE_CELLS * SPATIAL_DIM, 1),
+        output_dims={
+            "jacobian_states": (state_rows, NUM_DOFS),
+            "jacobian_dot_qd_states": (state_rows, 1),
+            "velocity_states": (state_rows, 1),
+            "gravity_states": (state_rows, 1),
+            "inertia": (batch_size * NUM_DOFS, NUM_DOFS),
+            "coriolis_qd": (batch_size * NUM_DOFS, 1),
+            "gravity_force": (batch_size * NUM_DOFS, 1),
+        },
+    )
+    jacobian_states = outputs[0].reshape(batch_size, NUM_CELLS, SPATIAL_DIM, NUM_DOFS)
+    jacobian_dot_qd_states = outputs[1].reshape(batch_size, NUM_CELLS, SPATIAL_DIM)
+    velocity_states = outputs[2].reshape(batch_size, NUM_CELLS, SPATIAL_DIM)
+    gravity_states = outputs[3].reshape(batch_size, NUM_CELLS, SPATIAL_DIM)
+    return (
+        jacobian_states[:, -1],
+        jacobian_dot_qd_states[:, -1],
+        velocity_states[:, -1],
+        gravity_states[:, -1],
+        outputs[4].reshape(batch_size, NUM_DOFS, NUM_DOFS),
+        outputs[5].reshape(batch_size, NUM_DOFS),
+        outputs[6].reshape(batch_size, NUM_DOFS),
+    )
+
+
+def _build_option_5(
+    robot: Any,
+    *,
+    matrix_free_lie: bool = False,
+    serial_lie: bool = False,
+    constant_strain: bool = False,
+    fixed_joints: bool = False,
+) -> Callable[[Array, Array], tuple[Array, ...]]:
+    """Cooperative one-block-per-environment segment recurrence and assembly."""
+
+    precompute = (
+        _build_matrix_free_precompute(
+            robot,
+            serial_cell=serial_lie,
+            constant_strain=constant_strain,
+            fixed_joints=fixed_joints,
+        )
+        if matrix_free_lie
+        else _build_precompute(robot)
+    )
+    mass_diagonals = jnp.diagonal(robot.inner_mass_matrices, axis1=-2, axis2=-1)
+    gravity_initial = se3.adjoint_inverse(robot.g0) @ robot.g
+
+    def dynamics(q: Array, qd: Array) -> tuple[Array, Array, Array]:
+        (
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            cell_adjoint,
+            cell_tangent,
+            cell_link_velocity,
+            cell_step_velocity,
+            cell_tangent_velocity_dot,
+            _cell_tangent_raw,
+            _cell_tangent_dot_raw,
+            _cell_magnus_basis_raw,
+            _cell_magnus_basis_dot_raw,
+            _qd_link,
+        ) = precompute(q, qd)
+        batch_size = q.shape[0]
+        jacobian = jnp.zeros((batch_size, SPATIAL_DIM, NUM_DOFS), dtype=q.dtype)
+        vector = jnp.zeros((batch_size, SPATIAL_DIM), dtype=q.dtype)
+        jacobian_dot_qd = vector
+        velocity = vector
+        gravity = jnp.broadcast_to(gravity_initial, (batch_size, SPATIAL_DIM))
+        inertia = jnp.zeros((batch_size, NUM_DOFS, NUM_DOFS), dtype=q.dtype)
+        coriolis_qd = jnp.zeros((batch_size, NUM_DOFS), dtype=q.dtype)
+        gravity_force = jnp.zeros((batch_size, NUM_DOFS), dtype=q.dtype)
+
+        for segment in range(NUM_SEGMENTS):
+            adjoint = joint_adjoint[:, segment]
+            jacobian_tip_qd = jnp.einsum("bij,bj->bi", jacobian, qd)
+            jacobian = jnp.einsum(
+                "bij,bjk->bik", adjoint, jacobian + joint_tangent[:, segment]
+            )
+            jacobian_dot_qd = jnp.einsum(
+                "bij,bj->bi",
+                adjoint,
+                jacobian_dot_qd + joint_tangent_dot_qd[:, segment],
+            ) + jnp.einsum("bij,bj->bi", joint_adjoint_dot[:, segment], jacobian_tip_qd)
+            velocity = jnp.einsum(
+                "bij,bj->bi", adjoint, velocity + joint_velocity[:, segment]
+            )
+            gravity = jnp.einsum("bij,bj->bi", adjoint, gravity)
+
+            (
+                jacobian,
+                jacobian_dot_qd,
+                velocity,
+                gravity,
+                inertia_segment,
+                coriolis_segment,
+                gravity_segment,
+            ) = _warp_cooperative_segment(
+                cell_adjoint[:, segment],
+                cell_tangent[:, segment],
+                cell_link_velocity[:, segment],
+                cell_step_velocity[:, segment],
+                cell_tangent_velocity_dot[:, segment],
+                qd,
+                jacobian,
+                jacobian_dot_qd,
+                velocity,
+                gravity,
+                robot.inner_integration_weights[segment],
+                mass_diagonals[segment],
+            )
+            inertia += inertia_segment
+            coriolis_qd += coriolis_segment
+            gravity_force += gravity_segment
+
+        return inertia, coriolis_qd, gravity_force
+
+    return dynamics
+
+
+def _build_option_4(robot: Any) -> Callable[[Array, Array], tuple[Array, ...]]:
+    precompute = _build_precompute(robot)
+    mass_diagonals = jnp.diagonal(robot.inner_mass_matrices, axis1=-2, axis2=-1)
+    gravity_initial = se3.adjoint_inverse(robot.g0) @ robot.g
+    total_states = NUM_SEGMENTS * (NUM_CELLS + 1)
+
+    def dynamics(q: Array, qd: Array) -> tuple[Array, Array, Array]:
+        (
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            cell_adjoint,
+            _cell_tangent_active,
+            _cell_link_velocity,
+            _cell_step_velocity,
+            _cell_tangent_velocity_dot,
+            cell_tangent_raw,
+            cell_tangent_dot_raw,
+            cell_magnus_basis_raw,
+            cell_magnus_basis_dot_raw,
+            qd_link,
+        ) = precompute(q, qd)
+        batch_size = q.shape[0]
+        joint_items = batch_size * NUM_SEGMENTS
+        cell_items = batch_size * NUM_SEGMENTS * NUM_CELLS
+        outputs = persistent_raw_dynamics(
+            joint_adjoint.reshape(joint_items, SPATIAL_DIM, SPATIAL_DIM),
+            joint_adjoint_dot.reshape(joint_items, SPATIAL_DIM, SPATIAL_DIM),
+            joint_tangent.reshape(joint_items, SPATIAL_DIM, NUM_DOFS),
+            joint_tangent_dot_qd.reshape(joint_items, SPATIAL_DIM),
+            joint_velocity.reshape(joint_items, SPATIAL_DIM),
+            cell_adjoint.reshape(cell_items, SPATIAL_DIM, SPATIAL_DIM),
+            cell_tangent_raw.reshape(cell_items, SPATIAL_DIM, SPATIAL_DIM),
+            cell_tangent_dot_raw.reshape(cell_items, SPATIAL_DIM, SPATIAL_DIM),
+            cell_magnus_basis_raw.reshape(cell_items, SPATIAL_DIM, MAX_DOF),
+            cell_magnus_basis_dot_raw.reshape(cell_items, SPATIAL_DIM, MAX_DOF),
+            qd,
+            qd_link,
+            jnp.asarray(robot.gather_indices[:, 1], dtype=jnp.int32),
+            jnp.asarray(robot.gather_mask[:, 1], dtype=q.dtype),
+            robot.inner_integration_weights,
+            mass_diagonals,
+            gravity_initial,
+            output_dims={
+                "jacobian_states": (
+                    batch_size,
+                    total_states,
+                    SPATIAL_DIM,
+                    NUM_DOFS,
+                ),
+                "jacobian_dot_qd_states": (
+                    batch_size,
+                    total_states,
+                    SPATIAL_DIM,
+                ),
+                "velocity_states": (batch_size, total_states, SPATIAL_DIM),
+                "gravity_states": (batch_size, total_states, SPATIAL_DIM),
+                "inertia": (batch_size, NUM_DOFS, NUM_DOFS),
+                "coriolis_qd": (batch_size, NUM_DOFS),
+                "gravity_force": (batch_size, NUM_DOFS),
+            },
+        )
+        return outputs[-3:]
+
+    return dynamics
+
+
+def _make_inputs(
+    robot: Any, batch_size: int, device: jax.Device
+) -> tuple[Array, Array]:
+    context = _gvs_context(robot)
+    phase = jnp.linspace(0.0, 1.0, batch_size, dtype=jnp.float64)[:, None]
+    q = context["q"][None, :] + 1.0e-3 * jnp.sin(phase)
+    qd = context["qd"][None, :] + 1.0e-3 * jnp.cos(phase)
+    return jax.device_put(q, device), jax.device_put(qd, device)
+
+
+def _timed_many_ms(
+    functions: dict[str, Callable[..., Tree]],
+    args: tuple[Array, ...],
+    repeats: int,
+) -> dict[str, dict[str, float]]:
+    compiled = {name: jax.jit(function) for name, function in functions.items()}
+    for function in compiled.values():
+        _block(function(*args))
+
+    samples: dict[str, list[float]] = {name: [] for name in functions}
+    names = list(functions)
+    for repeat in range(repeats):
+        offset = repeat % len(names)
+        for name in names[offset:] + names[:offset]:
+            start = time.perf_counter()
+            result = compiled[name](*args)
+            _block(result)
+            samples[name].append((time.perf_counter() - start) * 1.0e3)
+
+    return {
+        name: {
+            "median_ms": statistics.median(values),
+            "p25_ms": float(np.quantile(values, 0.25)),
+            "p75_ms": float(np.quantile(values, 0.75)),
+        }
+        for name, values in samples.items()
+    }
+
+
+def _cuda_profiler_library() -> ctypes.CDLL:
+    candidates = [Path("libcudart.so.13"), Path("libcudart.so")]
+    candidates.extend(
+        sorted(
+            Path(sys.prefix).glob(
+                "lib/python*/site-packages/nvidia/cu*/lib/libcudart.so*"
+            ),
+            reverse=True,
+        )
+    )
+    errors: list[str] = []
+    for candidate in candidates:
+        try:
+            library = ctypes.CDLL(str(candidate))
+        except OSError as error:
+            errors.append(f"{candidate}: {error}")
+            continue
+        for function_name in ("cudaProfilerStart", "cudaProfilerStop"):
+            function = getattr(library, function_name)
+            function.argtypes = []
+            function.restype = ctypes.c_int
+        return library
+    raise RuntimeError("Could not load libcudart:\n" + "\n".join(errors))
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    option_names = (
+        "baseline",
+        "option_1",
+        "option_2",
+        "option_3",
+        "option_4",
+        "option_5",
+        "option_6",
+        "option_7",
+        "option_8",
+        "option_9",
+        "option_10",
+        "option_11",
+        "option_12",
+        "option_13",
+        "option_14",
+        "option_15",
+        "option_16",
+        "option_17",
+        "option_18",
+        "option_19",
+        "option_20",
+        "option_21",
+        "option_22",
+        "option_23",
+    )
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", choices=("cpu", "gpu"), default="gpu")
+    parser.add_argument(
+        "--operation",
+        choices=("terms", "forward"),
+        default="terms",
+        help="Benchmark M/C/G terms or zero-input forward dynamics.",
+    )
+    parser.add_argument("--segment-count", type=int, default=NUM_SEGMENTS)
+    parser.add_argument("--basis-order", type=int, default=0)
+    parser.add_argument("--joint-type", choices=JOINT_TYPES, default="fixed")
+    parser.add_argument("--batch-sizes", type=int, nargs="+", default=[1])
+    parser.add_argument("--repeats", type=int, default=10)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--options",
+        choices=option_names,
+        nargs="+",
+        default=tuple(name for name in option_names if name != "option_22"),
+        help="Implementations included in the interleaved timing comparison.",
+    )
+    parser.add_argument(
+        "--profile-option",
+        choices=option_names,
+        help="Run only this compiled option inside a CUDA profiler API range.",
+    )
+    parser.add_argument("--profile-iterations", type=int, default=10)
+    parser.add_argument(
+        "--compile-option",
+        choices=option_names,
+        help="Measure uncached lowering and compilation time without benchmarking.",
+    )
+    parser.add_argument("--compile-repeats", type=int, default=3)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = _parse_args(argv)
+    wp.init()
+    device = jax.devices(args.device)[0]
+    if args.segment_count < 1 or args.basis_order < 0:
+        raise ValueError("Segment count must be positive and basis order non-negative")
+    if args.basis_order == 0 and args.joint_type == "fixed":
+        robot = _gvs_factory(
+            args.segment_count, gauss_points=NUM_QUADRATURE_CELLS
+        )
+    else:
+        segments = [
+            _gvs_segment(
+                strain_basis_order=args.basis_order,
+                gauss_points=NUM_QUADRATURE_CELLS,
+            )
+            for _ in range(args.segment_count)
+        ]
+        if args.joint_type == "mixed":
+            mixed_types = JOINT_TYPES[1:-1]
+            for index, segment in enumerate(segments):
+                segment.joint = _joint_spec(
+                    mixed_types[index % len(mixed_types)]
+                )
+        elif args.joint_type != "fixed":
+            for segment in segments:
+                segment.joint = _joint_spec(args.joint_type)
+        robot = GVS.from_segments(
+            segments=segments,
+            gravity=jnp.array([0.0, 0.0, 9.81]),
+        )
+
+    if args.compile_option is not None:
+        requested_names = {"baseline", args.compile_option}
+    elif args.profile_option is not None:
+        requested_names = {"baseline", args.profile_option}
+    else:
+        requested_names = {"baseline", *args.options}
+    shape_generic_names = {
+        "baseline",
+        "option_15",
+        "option_16",
+        "option_17",
+        "option_18",
+        "option_19",
+        "option_20",
+        "option_21",
+        "option_22",
+        "option_23",
+    }
+    fixed_shape_names = requested_names - shape_generic_names
+    if fixed_shape_names and (
+        robot.num_dofs != NUM_DOFS or robot.max_dof != MAX_DOF
+    ):
+        raise ValueError(
+            f"Options {sorted(fixed_shape_names)} require the original "
+            f"{NUM_SEGMENTS}-segment/order-zero shape; use option_15 or "
+            "option_17 for "
+            "shape-generic GVS experiments."
+        )
+    baseline = jax.vmap(robot.dynamics_terms)
+    builders: dict[str, Callable[[], Callable[[Array, Array], tuple[Array, ...]]]] = {
+        "option_1": lambda: _build_option_1(robot),
+        "option_2": lambda: _build_option_2(robot),
+        "option_3": lambda: _build_option_2(robot, warp_contraction=True),
+        "option_4": lambda: _build_option_4(robot),
+        "option_5": lambda: _build_option_5(robot),
+        "option_6": lambda: _build_option_2(robot, matrix_free_lie=True),
+        "option_7": lambda: _build_option_5(robot, matrix_free_lie=True),
+        "option_8": lambda: _build_option_2(
+            robot, matrix_free_lie=True, serial_lie=True
+        ),
+        "option_9": lambda: _build_option_5(
+            robot, matrix_free_lie=True, serial_lie=True
+        ),
+        "option_10": lambda: _build_option_2(
+            robot, matrix_free_lie=True, constant_strain=True
+        ),
+        "option_11": lambda: _build_option_5(
+            robot, matrix_free_lie=True, constant_strain=True
+        ),
+        "option_12": lambda: _build_option_2(
+            robot,
+            matrix_free_lie=True,
+            serial_lie=True,
+            fixed_joints=True,
+        ),
+        "option_13": lambda: _build_option_2(
+            robot,
+            matrix_free_lie=True,
+            constant_strain=True,
+            fixed_joints=True,
+        ),
+        "option_14": lambda: _build_option_5(
+            robot,
+            matrix_free_lie=True,
+            constant_strain=True,
+            fixed_joints=True,
+        ),
+        "option_15": lambda: _build_scalable_option(robot),
+        "option_16": lambda: _build_scalable_option(
+            robot,
+            order_zero=True,
+            fixed_joints=True,
+        ),
+        "option_17": lambda: _build_scalable_option(
+            robot,
+            warp_joints=True,
+        ),
+        "option_18": lambda: _build_scalable_option(
+            robot,
+            warp_joints=True,
+            warp_assembly=True,
+        ),
+        "option_19": lambda: _build_scalable_option(
+            robot,
+            warp_joints=True,
+            cooperative_segment=True,
+            cooperative_lanes=1 if args.device == "cpu" else 128,
+        ),
+        "option_20": lambda: _build_scalable_option(
+            robot,
+            warp_joints=True,
+            cooperative_segment=True,
+            cooperative_lanes=1 if args.device == "cpu" else 128,
+            integrated_joint_segment=True,
+        ),
+        "option_21": lambda: _build_scalable_option(
+            robot,
+            warp_joints=True,
+            cooperative_lanes=1 if args.device == "cpu" else 128,
+            persistent_chain=True,
+        ),
+        "option_23": lambda: _build_scalable_option(
+            robot,
+            warp_joints=True,
+            cooperative_lanes=1 if args.device == "cpu" else 128,
+            persistent_chain=True,
+            active_prefix=True,
+        ),
+    }
+    if "option_22" in requested_names and args.operation != "forward":
+        raise ValueError("option_22 requires --operation forward")
+    if args.operation == "forward":
+        baseline = _build_jax_forward_dynamics(baseline)
+        builders = {
+            name: (
+                lambda builder=builder: _build_jax_forward_dynamics(builder())
+            )
+            for name, builder in builders.items()
+        }
+        builders["option_22"] = lambda: _build_warp_forward_dynamics(
+            _build_scalable_option(
+                robot,
+                warp_joints=True,
+                cooperative_lanes=1 if args.device == "cpu" else 128,
+                persistent_chain=True,
+            ),
+            lanes_per_block=1 if args.device == "cpu" else 128,
+        )
+    all_functions = {"baseline": baseline}
+    all_functions.update(
+        {name: builders[name]() for name in requested_names - {"baseline"}}
+    )
+    selected_names = [
+        name
+        for name in dict.fromkeys(("baseline", *args.options))
+        if name in all_functions
+    ]
+    functions = {name: all_functions[name] for name in selected_names}
+
+    if args.compile_option is not None:
+        if args.compile_repeats < 1:
+            raise ValueError("--compile-repeats must be positive")
+        compile_records: list[dict[str, Any]] = []
+        function = all_functions[args.compile_option]
+        for batch_size in args.batch_sizes:
+            q, qd = _make_inputs(robot, batch_size, device)
+            lower_samples: list[float] = []
+            compile_samples: list[float] = []
+            first_call_samples: list[float] = []
+            for _ in range(args.compile_repeats):
+                jax.clear_caches()
+                jitted = jax.jit(function)
+
+                start = time.perf_counter()
+                lowered = jitted.lower(q, qd)
+                lower_samples.append((time.perf_counter() - start) * 1.0e3)
+
+                start = time.perf_counter()
+                compiled = lowered.compile()
+                compile_samples.append((time.perf_counter() - start) * 1.0e3)
+
+                start = time.perf_counter()
+                _block(compiled(q, qd))
+                first_call_samples.append((time.perf_counter() - start) * 1.0e3)
+
+            record = {
+                "device": str(device),
+                "batch_size": batch_size,
+                "compile_option": args.compile_option,
+                "repeats": args.compile_repeats,
+                "lower_ms": statistics.median(lower_samples),
+                "compile_ms": statistics.median(compile_samples),
+                "total_lower_compile_ms": statistics.median(
+                    [
+                        lower + compile_time
+                        for lower, compile_time in zip(
+                            lower_samples, compile_samples, strict=True
+                        )
+                    ]
+                ),
+                "first_call_ms": statistics.median(first_call_samples),
+                "samples": {
+                    "lower_ms": lower_samples,
+                    "compile_ms": compile_samples,
+                    "first_call_ms": first_call_samples,
+                },
+            }
+            compile_records.append(record)
+            print(json.dumps(record, sort_keys=True))
+        if args.output is not None:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(json.dumps(compile_records, indent=2) + "\n")
+        return
+
+    if args.profile_option is not None:
+        if args.device != "gpu":
+            raise ValueError("--profile-option requires --device gpu")
+        batch_size = args.batch_sizes[0]
+        q, qd = _make_inputs(robot, batch_size, device)
+        compiled = jax.jit(all_functions[args.profile_option]).lower(q, qd).compile()
+        _block(compiled(q, qd))
+        cuda_runtime = _cuda_profiler_library()
+        if cuda_runtime.cudaProfilerStart() != 0:
+            raise RuntimeError("cudaProfilerStart failed")
+        result = None
+        for _ in range(args.profile_iterations):
+            result = compiled(q, qd)
+        assert result is not None
+        _block(result)
+        if cuda_runtime.cudaProfilerStop() != 0:
+            raise RuntimeError("cudaProfilerStop failed")
+        print(
+            json.dumps(
+                {
+                    "profile_option": args.profile_option,
+                    "batch_size": batch_size,
+                    "iterations": args.profile_iterations,
+                    "device": str(device),
+                },
+                sort_keys=True,
+            )
+        )
+        return
+    records: list[dict[str, Any]] = []
+
+    for batch_size in args.batch_sizes:
+        q, qd = _make_inputs(robot, batch_size, device)
+        with jax.default_device(device):
+            results = {
+                name: jax.jit(function)(q, qd) for name, function in functions.items()
+            }
+            _block(results)
+            baseline_result = results["baseline"]
+            errors = {}
+            for name, actual_result in results.items():
+                if name == "baseline":
+                    continue
+                errors[name] = [
+                    float(np.max(np.abs(np.asarray(actual) - np.asarray(expected))))
+                    for actual, expected in zip(
+                        actual_result, baseline_result, strict=True
+                    )
+                ]
+                tolerance = 2.0e-6 if args.operation == "forward" else 2.0e-9
+                if max(errors[name]) > tolerance:
+                    raise AssertionError(
+                        f"{name} correctness failure: max errors {errors[name]}"
+                    )
+            timings = _timed_many_ms(functions, (q, qd), args.repeats)
+        baseline_ms = timings["baseline"]["median_ms"]
+        record = {
+            "device": str(device),
+            "operation": args.operation,
+            "batch_size": batch_size,
+            "baseline_ms": baseline_ms,
+            "timing_distributions": timings,
+            "max_abs_errors": errors,
+        }
+        for name, distribution in timings.items():
+            if name == "baseline":
+                continue
+            option_ms = distribution["median_ms"]
+            record[f"{name}_ms"] = option_ms
+            record[f"{name}_speedup"] = baseline_ms / option_ms
+        records.append(record)
+        print(json.dumps(record, sort_keys=True))
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(records, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmarks/gvs_warp_assembly_kernels.py
+++ b/tools/benchmarks/gvs_warp_assembly_kernels.py
@@ -1,0 +1,235 @@
+# ruff: noqa: I001, UP018
+"""Runtime-sized forward-only GVS dynamics assembly kernels."""
+
+from __future__ import annotations
+
+import warp as wp
+
+from tools.benchmarks.gvs_warp_lie_kernels import Vec6d
+
+wp.set_module_options({"enable_backward": False})
+
+
+SPATIAL_DIM = 6
+
+
+@wp.func
+def _state_row(
+    environment: int,
+    segment: int,
+    quadrature: int,
+    row: int,
+    num_segments: int,
+    num_quadrature: int,
+) -> int:
+    return (
+        ((environment * num_segments + segment) * num_quadrature + quadrature)
+        * SPATIAL_DIM
+        + row
+    )
+
+
+@wp.kernel(enable_backward=False)
+def scalable_inertia_assembly_kernel(
+    jacobians: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    mass_diagonals: wp.array2d(dtype=wp.float64),
+    num_quadrature_array: wp.array(dtype=wp.int32),
+    inertia: wp.array3d(dtype=wp.float64),
+):
+    """Assign one unique thread to each batched mass-matrix entry."""
+
+    linear_index = wp.tid()
+    num_dofs = inertia.shape[1]
+    entries_per_environment = num_dofs * num_dofs
+    environment = linear_index // entries_per_environment
+    entry = linear_index - environment * entries_per_environment
+    output_row = entry // num_dofs
+    output_column = entry - output_row * num_dofs
+    num_quadrature = num_quadrature_array[0]
+    num_segments = weights.shape[0] // num_quadrature
+
+    value = wp.float64(0.0)
+    segment = int(0)
+    while segment < num_segments:
+        quadrature = int(0)
+        while quadrature < num_quadrature:
+            quadrature_item = segment * num_quadrature + quadrature
+            weight = weights[quadrature_item]
+            row = int(0)
+            while row < SPATIAL_DIM:
+                state_row = _state_row(
+                    environment,
+                    segment,
+                    quadrature,
+                    row,
+                    num_segments,
+                    num_quadrature,
+                )
+                value += (
+                    jacobians[state_row, output_row]
+                    * weight
+                    * mass_diagonals[quadrature_item, row]
+                    * jacobians[state_row, output_column]
+                )
+                row += 1
+            quadrature += 1
+        segment += 1
+    inertia[environment, output_row, output_column] = value
+
+
+@wp.func
+def _coadjoint_wrench(
+    velocity: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd: wp.array2d(dtype=wp.float64),
+    mass_diagonals: wp.array2d(dtype=wp.float64),
+    state_base_row: int,
+    quadrature_item: int,
+) -> Vec6d:
+    omega = wp.vec3d(
+        velocity[state_base_row + 0, 0],
+        velocity[state_base_row + 1, 0],
+        velocity[state_base_row + 2, 0],
+    )
+    linear_velocity = wp.vec3d(
+        velocity[state_base_row + 3, 0],
+        velocity[state_base_row + 4, 0],
+        velocity[state_base_row + 5, 0],
+    )
+    moment = wp.vec3d(
+        mass_diagonals[quadrature_item, 0] * omega[0],
+        mass_diagonals[quadrature_item, 1] * omega[1],
+        mass_diagonals[quadrature_item, 2] * omega[2],
+    )
+    force = wp.vec3d(
+        mass_diagonals[quadrature_item, 3] * linear_velocity[0],
+        mass_diagonals[quadrature_item, 4] * linear_velocity[1],
+        mass_diagonals[quadrature_item, 5] * linear_velocity[2],
+    )
+    angular = wp.cross(omega, moment) + wp.cross(linear_velocity, force)
+    linear = wp.cross(omega, force)
+    return Vec6d(
+        mass_diagonals[quadrature_item, 0]
+        * jacobian_dot_qd[state_base_row + 0, 0]
+        + angular[0],
+        mass_diagonals[quadrature_item, 1]
+        * jacobian_dot_qd[state_base_row + 1, 0]
+        + angular[1],
+        mass_diagonals[quadrature_item, 2]
+        * jacobian_dot_qd[state_base_row + 2, 0]
+        + angular[2],
+        mass_diagonals[quadrature_item, 3]
+        * jacobian_dot_qd[state_base_row + 3, 0]
+        + linear[0],
+        mass_diagonals[quadrature_item, 4]
+        * jacobian_dot_qd[state_base_row + 4, 0]
+        + linear[1],
+        mass_diagonals[quadrature_item, 5]
+        * jacobian_dot_qd[state_base_row + 5, 0]
+        + linear[2],
+    )
+
+
+@wp.kernel(enable_backward=False)
+def scalable_force_assembly_kernel(
+    jacobians: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd: wp.array2d(dtype=wp.float64),
+    velocity: wp.array2d(dtype=wp.float64),
+    gravity: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    mass_diagonals: wp.array2d(dtype=wp.float64),
+    num_quadrature_array: wp.array(dtype=wp.int32),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    """Assign one unique thread to each batched generalized-force entry."""
+
+    linear_index = wp.tid()
+    num_dofs = coriolis_qd.shape[1]
+    environment = linear_index // num_dofs
+    output_column = linear_index - environment * num_dofs
+    num_quadrature = num_quadrature_array[0]
+    num_segments = weights.shape[0] // num_quadrature
+
+    coriolis_value = wp.float64(0.0)
+    gravity_value = wp.float64(0.0)
+    segment = int(0)
+    while segment < num_segments:
+        quadrature = int(0)
+        while quadrature < num_quadrature:
+            quadrature_item = segment * num_quadrature + quadrature
+            state_base_row = _state_row(
+                environment,
+                segment,
+                quadrature,
+                0,
+                num_segments,
+                num_quadrature,
+            )
+            wrench = _coadjoint_wrench(
+                velocity,
+                jacobian_dot_qd,
+                mass_diagonals,
+                state_base_row,
+                quadrature_item,
+            )
+            weight = weights[quadrature_item]
+            row = int(0)
+            while row < SPATIAL_DIM:
+                jacobian_value = jacobians[state_base_row + row, output_column]
+                coriolis_value += weight * jacobian_value * wrench[row]
+                gravity_value -= (
+                    weight
+                    * jacobian_value
+                    * mass_diagonals[quadrature_item, row]
+                    * gravity[state_base_row + row, 0]
+                )
+                row += 1
+            quadrature += 1
+        segment += 1
+
+    coriolis_qd[environment, output_column] = coriolis_value
+    gravity_force[environment, output_column] = gravity_value
+
+
+def _scalable_assemble_dynamics(
+    jacobians: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd: wp.array2d(dtype=wp.float64),
+    velocity: wp.array2d(dtype=wp.float64),
+    gravity: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    mass_diagonals: wp.array2d(dtype=wp.float64),
+    num_quadrature: wp.array(dtype=wp.int32),
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    batch_size = coriolis_qd.shape[0]
+    num_dofs = coriolis_qd.shape[1]
+    wp.launch(
+        scalable_inertia_assembly_kernel,
+        dim=batch_size * num_dofs * num_dofs,
+        inputs=[jacobians, weights, mass_diagonals, num_quadrature],
+        outputs=[inertia],
+        block_dim=128,
+    )
+    wp.launch(
+        scalable_force_assembly_kernel,
+        dim=batch_size * num_dofs,
+        inputs=[
+            jacobians,
+            jacobian_dot_qd,
+            velocity,
+            gravity,
+            weights,
+            mass_diagonals,
+            num_quadrature,
+        ],
+        outputs=[coriolis_qd, gravity_force],
+        block_dim=128,
+    )
+
+
+scalable_assemble_dynamics = wp.jax_callable(
+    _scalable_assemble_dynamics, num_outputs=3
+)

--- a/tools/benchmarks/gvs_warp_joint_kernels.py
+++ b/tools/benchmarks/gvs_warp_joint_kernels.py
@@ -1,0 +1,227 @@
+# ruff: noqa: I001, UP018
+"""Shape-generic forward-only GVS joint kernels.
+
+The GVS joint basis already encodes the concrete joint type.  This module
+therefore evaluates every supported joint through the same runtime-sized
+SE(3) path instead of generating a kernel for each joint type or model shape.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+from tools.benchmarks.gvs_warp_lie_kernels import (
+    Vec6d,
+    _ad_action,
+    _adjoint_inverse_action,
+    _adjoint_inverse_entry,
+    _forward_coefficients,
+    _left_action,
+    _left_coefficient_x_derivatives,
+    _left_coefficients,
+    _left_total_derivative_action,
+    _translation,
+)
+
+
+SPATIAL_DIM = 6
+
+
+@wp.func
+def _joint_strain(
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    coordinates: wp.array2d(dtype=wp.float64),
+    local_to_global: wp.array2d(dtype=wp.int32),
+    environment: int,
+    segment: int,
+) -> Vec6d:
+    value = Vec6d(
+        reference[segment, 0],
+        reference[segment, 1],
+        reference[segment, 2],
+        reference[segment, 3],
+        reference[segment, 4],
+        reference[segment, 5],
+    )
+    base_row = segment * SPATIAL_DIM
+    local_column = int(0)
+    while local_column < local_to_global.shape[1]:
+        global_column = local_to_global[segment, local_column]
+        if global_column >= 0:
+            coordinate = coordinates[environment, global_column]
+            row = int(0)
+            while row < SPATIAL_DIM:
+                value[row] += basis[base_row + row, local_column] * coordinate
+                row += 1
+        local_column += 1
+    return value
+
+
+@wp.func
+def _joint_strain_rate(
+    basis: wp.array2d(dtype=wp.float64),
+    velocities: wp.array2d(dtype=wp.float64),
+    local_to_global: wp.array2d(dtype=wp.int32),
+    environment: int,
+    segment: int,
+) -> Vec6d:
+    value = Vec6d()
+    base_row = segment * SPATIAL_DIM
+    local_column = int(0)
+    while local_column < local_to_global.shape[1]:
+        global_column = local_to_global[segment, local_column]
+        if global_column >= 0:
+            velocity = velocities[environment, global_column]
+            row = int(0)
+            while row < SPATIAL_DIM:
+                value[row] += basis[base_row + row, local_column] * velocity
+                row += 1
+        local_column += 1
+    return value
+
+
+@wp.func
+def _joint_basis_column(
+    basis: wp.array2d(dtype=wp.float64), segment: int, column: int
+) -> Vec6d:
+    base_row = segment * SPATIAL_DIM
+    return Vec6d(
+        basis[base_row + 0, column],
+        basis[base_row + 1, column],
+        basis[base_row + 2, column],
+        basis[base_row + 3, column],
+        basis[base_row + 4, column],
+        basis[base_row + 5, column],
+    )
+
+
+@wp.kernel(enable_backward=False)
+def scalable_joint_terms_kernel(
+    q: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    local_to_global: wp.array2d(dtype=wp.int32),
+    adjoint: wp.array2d(dtype=wp.float64),
+    adjoint_dot: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+):
+    """Evaluate one joint per ``(environment, segment)`` work item."""
+
+    work_item = wp.tid()
+    num_segments = reference.shape[0]
+    environment = work_item // num_segments
+    segment = work_item - environment * num_segments
+    output_base_row = work_item * SPATIAL_DIM
+
+    xi = _joint_strain(
+        basis, reference, q, local_to_global, environment, segment
+    )
+    xid = _joint_strain_rate(
+        basis, qd, local_to_global, environment, segment
+    )
+    angle_sq = xi[0] * xi[0] + xi[1] * xi[1] + xi[2] * xi[2]
+    coefficients = _left_coefficients(angle_sq)
+    coefficient_derivatives = _left_coefficient_x_derivatives(angle_sq)
+    angle_sq_dot = wp.float64(2.0) * (
+        xi[0] * xid[0] + xi[1] * xid[1] + xi[2] * xid[2]
+    )
+    omega = wp.vec3d(xi[0], xi[1], xi[2])
+    linear = wp.vec3d(xi[3], xi[4], xi[5])
+    forward = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, forward)
+
+    velocity = _left_action(xi, xid, coefficients)
+    eta = _adjoint_inverse_action(
+        omega, translation, angle_sq, forward, velocity
+    )
+    derivative_velocity = _left_total_derivative_action(
+        xi,
+        xid,
+        xid,
+        Vec6d(),
+        coefficients,
+        coefficient_derivatives * angle_sq_dot,
+    )
+
+    row = int(0)
+    while row < SPATIAL_DIM:
+        tangent_dot_qd[output_base_row + row, 0] = derivative_velocity[row]
+        joint_velocity[output_base_row + row, 0] = velocity[row]
+        column = int(0)
+        while column < SPATIAL_DIM:
+            adjoint_value = _adjoint_inverse_entry(
+                omega,
+                translation,
+                angle_sq,
+                forward,
+                row,
+                column,
+            )
+            adjoint[output_base_row + row, column] = adjoint_value
+            column += 1
+        row += 1
+
+    # Ad_inv_dot = -ad(Ad_inv * joint_velocity) * Ad_inv.  Applying ad to
+    # each already-computed adjoint column avoids materializing a dense ad.
+    column = int(0)
+    while column < SPATIAL_DIM:
+        adjoint_column = Vec6d()
+        row = int(0)
+        while row < SPATIAL_DIM:
+            adjoint_column[row] = adjoint[output_base_row + row, column]
+            row += 1
+        derivative_column = -_ad_action(eta, adjoint_column)
+        row = int(0)
+        while row < SPATIAL_DIM:
+            adjoint_dot[output_base_row + row, column] = derivative_column[row]
+            row += 1
+        column += 1
+
+    local_column = int(0)
+    while local_column < local_to_global.shape[1]:
+        tangent = _left_action(
+            xi,
+            _joint_basis_column(basis, segment, local_column),
+            coefficients,
+        )
+        row = int(0)
+        while row < SPATIAL_DIM:
+            tangent_local[output_base_row + row, local_column] = tangent[row]
+            row += 1
+        local_column += 1
+
+
+def _scalable_joint_terms(
+    q: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    local_to_global: wp.array2d(dtype=wp.int32),
+    adjoint: wp.array2d(dtype=wp.float64),
+    adjoint_dot: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+):
+    wp.launch(
+        scalable_joint_terms_kernel,
+        dim=q.shape[0] * reference.shape[0],
+        inputs=[q, qd, basis, reference, local_to_global],
+        outputs=[
+            adjoint,
+            adjoint_dot,
+            tangent_local,
+            tangent_dot_qd,
+            joint_velocity,
+        ],
+        block_dim=128,
+    )
+
+
+scalable_joint_terms = wp.jax_callable(_scalable_joint_terms, num_outputs=5)

--- a/tools/benchmarks/gvs_warp_kernels.py
+++ b/tools/benchmarks/gvs_warp_kernels.py
@@ -1,0 +1,1891 @@
+# ruff: noqa: I001, UP018
+"""Experimental fixed-shape Warp kernels for the four-segment GVS benchmark.
+
+These kernels intentionally target the benchmark geometry (four constant-strain
+segments, six link cells, and 24 active coordinates).  They are prototypes used
+to measure launch topology before committing to a general public API. Explicit
+``int(0)`` initializers are retained because Warp's DSL uses them to type mutable
+loop variables.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+
+NUM_SEGMENTS = 4
+NUM_CELLS = 6
+NUM_QUADRATURE_CELLS = 5
+NUM_DOFS = 24
+SPATIAL_DIM = 6
+MAX_DOF = 6
+
+
+@wp.func
+def _cross_component(
+    ax: wp.float64,
+    ay: wp.float64,
+    az: wp.float64,
+    bx: wp.float64,
+    by: wp.float64,
+    bz: wp.float64,
+    component: int,
+) -> wp.float64:
+    result = wp.float64(0.0)
+    if component == 0:
+        result = ay * bz - az * by
+    elif component == 1:
+        result = az * bx - ax * bz
+    else:
+        result = ax * by - ay * bx
+    return result
+
+
+@wp.func
+def _source_jacobian_velocity(
+    adjoint: wp.array3d(dtype=wp.float64),
+    jacobian: wp.array3d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    environment: int,
+    row: int,
+) -> wp.float64:
+    value = wp.float64(0.0)
+    for k in range(SPATIAL_DIM):
+        inner = wp.float64(0.0)
+        for column in range(NUM_DOFS):
+            inner += jacobian[environment, k, column] * qd[environment, column]
+        value += adjoint[environment, row, k] * inner
+    return value
+
+
+@wp.kernel(enable_backward=False)
+def fused_cell_advance_kernel(
+    adjoint: wp.array3d(dtype=wp.float64),
+    tangent_active: wp.array3d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_previous: wp.array3d(dtype=wp.float64),
+    jacobian_dot_qd_previous: wp.array2d(dtype=wp.float64),
+    velocity_previous: wp.array2d(dtype=wp.float64),
+    gravity_previous: wp.array2d(dtype=wp.float64),
+    jacobian_next: wp.array3d(dtype=wp.float64),
+    jacobian_dot_qd_next: wp.array2d(dtype=wp.float64),
+    velocity_next: wp.array2d(dtype=wp.float64),
+    gravity_next: wp.array2d(dtype=wp.float64),
+):
+    """Advance one cell with one thread per output Jacobian entry."""
+
+    linear_index = wp.tid()
+    entries_per_environment = SPATIAL_DIM * NUM_DOFS
+    environment = linear_index // entries_per_environment
+    entry = linear_index - environment * entries_per_environment
+    row = entry // NUM_DOFS
+    column = entry - row * NUM_DOFS
+
+    jacobian_value = wp.float64(0.0)
+    for k in range(SPATIAL_DIM):
+        jacobian_value += adjoint[environment, row, k] * (
+            jacobian_previous[environment, k, column]
+            + tangent_active[environment, k, column]
+        )
+    jacobian_next[environment, row, column] = jacobian_value
+
+    if column == 0:
+        velocity_value = wp.float64(0.0)
+        gravity_value = wp.float64(0.0)
+        derivative_value = wp.float64(0.0)
+        for k in range(SPATIAL_DIM):
+            velocity_value += adjoint[environment, row, k] * (
+                velocity_previous[environment, k] + link_velocity[environment, k]
+            )
+            gravity_value += (
+                adjoint[environment, row, k] * gravity_previous[environment, k]
+            )
+            derivative_value += adjoint[environment, row, k] * (
+                jacobian_dot_qd_previous[environment, k]
+                + tangent_velocity_dot[environment, k]
+            )
+
+        eta0 = _source_jacobian_velocity(adjoint, jacobian_previous, qd, environment, 0)
+        eta1 = _source_jacobian_velocity(adjoint, jacobian_previous, qd, environment, 1)
+        eta2 = _source_jacobian_velocity(adjoint, jacobian_previous, qd, environment, 2)
+        eta3 = _source_jacobian_velocity(adjoint, jacobian_previous, qd, environment, 3)
+        eta4 = _source_jacobian_velocity(adjoint, jacobian_previous, qd, environment, 4)
+        eta5 = _source_jacobian_velocity(adjoint, jacobian_previous, qd, environment, 5)
+
+        omega_cross = _cross_component(
+            step_velocity[environment, 0],
+            step_velocity[environment, 1],
+            step_velocity[environment, 2],
+            eta0,
+            eta1,
+            eta2,
+            row % 3,
+        )
+        bracket = omega_cross
+        if row >= 3:
+            bracket = _cross_component(
+                step_velocity[environment, 3],
+                step_velocity[environment, 4],
+                step_velocity[environment, 5],
+                eta0,
+                eta1,
+                eta2,
+                row - 3,
+            )
+            bracket += _cross_component(
+                step_velocity[environment, 0],
+                step_velocity[environment, 1],
+                step_velocity[environment, 2],
+                eta3,
+                eta4,
+                eta5,
+                row - 3,
+            )
+
+        jacobian_dot_qd_next[environment, row] = derivative_value - bracket
+        velocity_next[environment, row] = velocity_value
+        gravity_next[environment, row] = gravity_value
+
+
+def _fused_cell_advance(
+    adjoint: wp.array3d(dtype=wp.float64),
+    tangent_active: wp.array3d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_previous: wp.array3d(dtype=wp.float64),
+    jacobian_dot_qd_previous: wp.array2d(dtype=wp.float64),
+    velocity_previous: wp.array2d(dtype=wp.float64),
+    gravity_previous: wp.array2d(dtype=wp.float64),
+    jacobian_next: wp.array3d(dtype=wp.float64),
+    jacobian_dot_qd_next: wp.array2d(dtype=wp.float64),
+    velocity_next: wp.array2d(dtype=wp.float64),
+    gravity_next: wp.array2d(dtype=wp.float64),
+):
+    wp.launch(
+        fused_cell_advance_kernel,
+        dim=jacobian_previous.size,
+        inputs=[
+            adjoint,
+            tangent_active,
+            link_velocity,
+            step_velocity,
+            tangent_velocity_dot,
+            qd,
+            jacobian_previous,
+            jacobian_dot_qd_previous,
+            velocity_previous,
+            gravity_previous,
+        ],
+        outputs=[
+            jacobian_next,
+            jacobian_dot_qd_next,
+            velocity_next,
+            gravity_next,
+        ],
+        block_dim=128,
+    )
+
+
+fused_cell_advance = wp.jax_callable(_fused_cell_advance, num_outputs=4)
+
+
+@wp.func
+def _segment_source_jacobian(
+    jacobian_initial: wp.array3d(dtype=wp.float64),
+    jacobian_states: wp.array4d(dtype=wp.float64),
+    environment: int,
+    cell: int,
+    row: int,
+    column: int,
+) -> wp.float64:
+    if cell == 0:
+        return jacobian_initial[environment, row, column]
+    return jacobian_states[environment, cell - 1, row, column]
+
+
+@wp.func
+def _segment_source_vector(
+    initial: wp.array2d(dtype=wp.float64),
+    states: wp.array3d(dtype=wp.float64),
+    environment: int,
+    cell: int,
+    row: int,
+) -> wp.float64:
+    if cell == 0:
+        return initial[environment, row]
+    return states[environment, cell - 1, row]
+
+
+@wp.kernel(enable_backward=False)
+def segment_cell_advance_kernel(
+    adjoint: wp.array4d(dtype=wp.float64),
+    tangent_active: wp.array4d(dtype=wp.float64),
+    link_velocity: wp.array3d(dtype=wp.float64),
+    step_velocity: wp.array3d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array3d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_initial: wp.array3d(dtype=wp.float64),
+    jacobian_dot_qd_initial: wp.array2d(dtype=wp.float64),
+    velocity_initial: wp.array2d(dtype=wp.float64),
+    gravity_initial: wp.array2d(dtype=wp.float64),
+    cell: int,
+    jacobian_states: wp.array4d(dtype=wp.float64),
+    jacobian_dot_qd_states: wp.array3d(dtype=wp.float64),
+    velocity_states: wp.array3d(dtype=wp.float64),
+    gravity_states: wp.array3d(dtype=wp.float64),
+):
+    """Advance one segment cell; six launches are captured as one JAX graph."""
+
+    linear_index = wp.tid()
+    entries_per_environment = SPATIAL_DIM * NUM_DOFS
+    environment = linear_index // entries_per_environment
+    entry = linear_index - environment * entries_per_environment
+    row = entry // NUM_DOFS
+    column = entry - row * NUM_DOFS
+
+    jacobian_value = wp.float64(0.0)
+    for k in range(SPATIAL_DIM):
+        jacobian_value += adjoint[environment, cell, row, k] * (
+            _segment_source_jacobian(
+                jacobian_initial,
+                jacobian_states,
+                environment,
+                cell,
+                k,
+                column,
+            )
+            + tangent_active[environment, cell, k, column]
+        )
+    jacobian_states[environment, cell, row, column] = jacobian_value
+
+    if column == 0:
+        eta0 = wp.float64(0.0)
+        eta1 = wp.float64(0.0)
+        eta2 = wp.float64(0.0)
+        eta3 = wp.float64(0.0)
+        eta4 = wp.float64(0.0)
+        eta5 = wp.float64(0.0)
+        for k in range(SPATIAL_DIM):
+            inner = wp.float64(0.0)
+            for source_column in range(NUM_DOFS):
+                inner += (
+                    _segment_source_jacobian(
+                        jacobian_initial,
+                        jacobian_states,
+                        environment,
+                        cell,
+                        k,
+                        source_column,
+                    )
+                    * qd[environment, source_column]
+                )
+            eta0 += adjoint[environment, cell, 0, k] * inner
+            eta1 += adjoint[environment, cell, 1, k] * inner
+            eta2 += adjoint[environment, cell, 2, k] * inner
+            eta3 += adjoint[environment, cell, 3, k] * inner
+            eta4 += adjoint[environment, cell, 4, k] * inner
+            eta5 += adjoint[environment, cell, 5, k] * inner
+
+        velocity_value = wp.float64(0.0)
+        gravity_value = wp.float64(0.0)
+        derivative_value = wp.float64(0.0)
+        for k in range(SPATIAL_DIM):
+            velocity_value += adjoint[environment, cell, row, k] * (
+                _segment_source_vector(
+                    velocity_initial,
+                    velocity_states,
+                    environment,
+                    cell,
+                    k,
+                )
+                + link_velocity[environment, cell, k]
+            )
+            gravity_value += adjoint[environment, cell, row, k] * (
+                _segment_source_vector(
+                    gravity_initial,
+                    gravity_states,
+                    environment,
+                    cell,
+                    k,
+                )
+            )
+            derivative_value += adjoint[environment, cell, row, k] * (
+                _segment_source_vector(
+                    jacobian_dot_qd_initial,
+                    jacobian_dot_qd_states,
+                    environment,
+                    cell,
+                    k,
+                )
+                + tangent_velocity_dot[environment, cell, k]
+            )
+
+        component = row % 3
+        bracket = _cross_component(
+            step_velocity[environment, cell, 0],
+            step_velocity[environment, cell, 1],
+            step_velocity[environment, cell, 2],
+            eta0,
+            eta1,
+            eta2,
+            component,
+        )
+        if row >= 3:
+            bracket = _cross_component(
+                step_velocity[environment, cell, 3],
+                step_velocity[environment, cell, 4],
+                step_velocity[environment, cell, 5],
+                eta0,
+                eta1,
+                eta2,
+                component,
+            )
+            bracket += _cross_component(
+                step_velocity[environment, cell, 0],
+                step_velocity[environment, cell, 1],
+                step_velocity[environment, cell, 2],
+                eta3,
+                eta4,
+                eta5,
+                component,
+            )
+
+        jacobian_dot_qd_states[environment, cell, row] = derivative_value - bracket
+        velocity_states[environment, cell, row] = velocity_value
+        gravity_states[environment, cell, row] = gravity_value
+
+
+def _segment_recurrence(
+    adjoint: wp.array4d(dtype=wp.float64),
+    tangent_active: wp.array4d(dtype=wp.float64),
+    link_velocity: wp.array3d(dtype=wp.float64),
+    step_velocity: wp.array3d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array3d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_initial: wp.array3d(dtype=wp.float64),
+    jacobian_dot_qd_initial: wp.array2d(dtype=wp.float64),
+    velocity_initial: wp.array2d(dtype=wp.float64),
+    gravity_initial: wp.array2d(dtype=wp.float64),
+    jacobian_states: wp.array4d(dtype=wp.float64),
+    jacobian_dot_qd_states: wp.array3d(dtype=wp.float64),
+    velocity_states: wp.array3d(dtype=wp.float64),
+    gravity_states: wp.array3d(dtype=wp.float64),
+):
+    for cell in range(NUM_CELLS):
+        wp.launch(
+            segment_cell_advance_kernel,
+            dim=jacobian_initial.size,
+            inputs=[
+                adjoint,
+                tangent_active,
+                link_velocity,
+                step_velocity,
+                tangent_velocity_dot,
+                qd,
+                jacobian_initial,
+                jacobian_dot_qd_initial,
+                velocity_initial,
+                gravity_initial,
+                cell,
+            ],
+            outputs=[
+                jacobian_states,
+                jacobian_dot_qd_states,
+                velocity_states,
+                gravity_states,
+            ],
+            block_dim=128,
+        )
+
+
+segment_recurrence = wp.jax_callable(_segment_recurrence, num_outputs=4)
+
+
+def _rejected_monolithic_cooperative_segment_dynamics_kernel(
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_initial: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_initial: wp.array2d(dtype=wp.float64),
+    velocity_initial: wp.array2d(dtype=wp.float64),
+    gravity_initial: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    masses: wp.array2d(dtype=wp.float64),
+    jacobian_tip: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_tip: wp.array2d(dtype=wp.float64),
+    velocity_tip: wp.array2d(dtype=wp.float64),
+    gravity_tip: wp.array2d(dtype=wp.float64),
+    inertia: wp.array2d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    """Advance one complete segment cooperatively inside one CUDA block.
+
+    The leading launch dimension identifies an environment; the implicit final
+    tiled-launch dimension assigns a block of threads to that environment.  The
+    six causal cells are advanced in order, while Warp tile operations spread
+    each 6x24 Jacobian update and each quadrature contraction over the block.
+    Only the segment tip and accumulated dynamics terms reach global memory.
+    """
+
+    environment, _lane = wp.tid()
+    jacobian = wp.tile_load(
+        jacobian_initial,
+        shape=(SPATIAL_DIM, NUM_DOFS),
+        offset=(environment * SPATIAL_DIM, 0),
+        storage="shared",
+    )
+    jacobian_dot_qd = wp.tile_load(
+        jacobian_dot_qd_initial,
+        shape=(SPATIAL_DIM, 1),
+        offset=(environment * SPATIAL_DIM, 0),
+        storage="shared",
+    )
+    velocity = wp.tile_load(
+        velocity_initial,
+        shape=(SPATIAL_DIM, 1),
+        offset=(environment * SPATIAL_DIM, 0),
+        storage="shared",
+    )
+    gravity = wp.tile_load(
+        gravity_initial,
+        shape=(SPATIAL_DIM, 1),
+        offset=(environment * SPATIAL_DIM, 0),
+        storage="shared",
+    )
+    generalized_velocity = wp.tile_load(
+        qd,
+        shape=(NUM_DOFS, 1),
+        offset=(environment * NUM_DOFS, 0),
+        storage="shared",
+    )
+    inertia_segment = wp.tile_zeros(
+        shape=(NUM_DOFS, NUM_DOFS), dtype=wp.float64, storage="shared"
+    )
+    coriolis_segment = wp.tile_zeros(
+        shape=(NUM_DOFS, 1), dtype=wp.float64, storage="shared"
+    )
+    gravity_segment = wp.tile_zeros(
+        shape=(NUM_DOFS, 1), dtype=wp.float64, storage="shared"
+    )
+
+    for cell in range(NUM_CELLS):
+        cell_matrix_row = (environment * NUM_CELLS + cell) * SPATIAL_DIM
+        cell_vector_row = cell_matrix_row
+        adjoint_cell = wp.tile_load(
+            adjoint,
+            shape=(SPATIAL_DIM, SPATIAL_DIM),
+            offset=(cell_matrix_row, 0),
+        )
+        tangent_cell = wp.tile_load(
+            tangent_active,
+            shape=(SPATIAL_DIM, NUM_DOFS),
+            offset=(cell_matrix_row, 0),
+        )
+        link_velocity_cell = wp.tile_load(
+            link_velocity,
+            shape=(SPATIAL_DIM, 1),
+            offset=(cell_vector_row, 0),
+        )
+        step_velocity_cell = wp.tile_load(
+            step_velocity,
+            shape=(SPATIAL_DIM, 1),
+            offset=(cell_vector_row, 0),
+        )
+        tangent_velocity_dot_cell = wp.tile_load(
+            tangent_velocity_dot,
+            shape=(SPATIAL_DIM, 1),
+            offset=(cell_vector_row, 0),
+        )
+
+        source_jacobian_velocity = wp.tile_zeros(
+            shape=(SPATIAL_DIM, 1), dtype=wp.float64
+        )
+        wp.tile_matmul(jacobian, generalized_velocity, source_jacobian_velocity)
+        transported_source_velocity = wp.tile_zeros(
+            shape=(SPATIAL_DIM, 1), dtype=wp.float64
+        )
+        wp.tile_matmul(
+            adjoint_cell,
+            source_jacobian_velocity,
+            transported_source_velocity,
+        )
+
+        jacobian_next = wp.tile_zeros(shape=(SPATIAL_DIM, NUM_DOFS), dtype=wp.float64)
+        wp.tile_matmul(adjoint_cell, jacobian + tangent_cell, jacobian_next)
+        velocity_next = wp.tile_zeros(shape=(SPATIAL_DIM, 1), dtype=wp.float64)
+        wp.tile_matmul(adjoint_cell, velocity + link_velocity_cell, velocity_next)
+        gravity_next = wp.tile_zeros(shape=(SPATIAL_DIM, 1), dtype=wp.float64)
+        wp.tile_matmul(adjoint_cell, gravity, gravity_next)
+        jacobian_dot_qd_next = wp.tile_zeros(shape=(SPATIAL_DIM, 1), dtype=wp.float64)
+        wp.tile_matmul(
+            adjoint_cell,
+            jacobian_dot_qd + tangent_velocity_dot_cell,
+            jacobian_dot_qd_next,
+        )
+
+        step0 = wp.tile_extract(step_velocity_cell, 0, 0)
+        step1 = wp.tile_extract(step_velocity_cell, 1, 0)
+        step2 = wp.tile_extract(step_velocity_cell, 2, 0)
+        step3 = wp.tile_extract(step_velocity_cell, 3, 0)
+        step4 = wp.tile_extract(step_velocity_cell, 4, 0)
+        step5 = wp.tile_extract(step_velocity_cell, 5, 0)
+        eta0 = wp.tile_extract(transported_source_velocity, 0, 0)
+        eta1 = wp.tile_extract(transported_source_velocity, 1, 0)
+        eta2 = wp.tile_extract(transported_source_velocity, 2, 0)
+        eta3 = wp.tile_extract(transported_source_velocity, 3, 0)
+        eta4 = wp.tile_extract(transported_source_velocity, 4, 0)
+        eta5 = wp.tile_extract(transported_source_velocity, 5, 0)
+        bracket = wp.tile_zeros(
+            shape=(SPATIAL_DIM, 1), dtype=wp.float64, storage="shared"
+        )
+        bracket0 = step1 * eta2 - step2 * eta1
+        bracket1 = step2 * eta0 - step0 * eta2
+        bracket2 = step0 * eta1 - step1 * eta0
+        bracket3 = step4 * eta2 - step5 * eta1 + step1 * eta5 - step2 * eta4
+        bracket4 = step5 * eta0 - step3 * eta2 + step2 * eta3 - step0 * eta5
+        bracket5 = step3 * eta1 - step4 * eta0 + step0 * eta4 - step1 * eta3
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1), value=bracket0, dtype=wp.float64, storage="register"
+            ),
+            offset=(0, 0),
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1), value=bracket1, dtype=wp.float64, storage="register"
+            ),
+            offset=(1, 0),
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1), value=bracket2, dtype=wp.float64, storage="register"
+            ),
+            offset=(2, 0),
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1), value=bracket3, dtype=wp.float64, storage="register"
+            ),
+            offset=(3, 0),
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1), value=bracket4, dtype=wp.float64, storage="register"
+            ),
+            offset=(4, 0),
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1), value=bracket5, dtype=wp.float64, storage="register"
+            ),
+            offset=(5, 0),
+        )
+        jacobian_dot_qd_next -= bracket
+
+        wp.tile_assign(jacobian, jacobian_next, offset=(0, 0))
+        wp.tile_assign(jacobian_dot_qd, jacobian_dot_qd_next, offset=(0, 0))
+        wp.tile_assign(velocity, velocity_next, offset=(0, 0))
+        wp.tile_assign(gravity, gravity_next, offset=(0, 0))
+
+        if cell < NUM_QUADRATURE_CELLS:
+            mass_row = cell * SPATIAL_DIM
+            mass = wp.tile_load(
+                masses,
+                shape=(SPATIAL_DIM, 1),
+                offset=(mass_row, 0),
+            )
+            weight = weights[cell]
+            momentum = mass * velocity
+
+            omega0 = wp.tile_extract(velocity, 0, 0)
+            omega1 = wp.tile_extract(velocity, 1, 0)
+            omega2 = wp.tile_extract(velocity, 2, 0)
+            linear0 = wp.tile_extract(velocity, 3, 0)
+            linear1 = wp.tile_extract(velocity, 4, 0)
+            linear2 = wp.tile_extract(velocity, 5, 0)
+            moment0 = wp.tile_extract(momentum, 0, 0)
+            moment1 = wp.tile_extract(momentum, 1, 0)
+            moment2 = wp.tile_extract(momentum, 2, 0)
+            force0 = wp.tile_extract(momentum, 3, 0)
+            force1 = wp.tile_extract(momentum, 4, 0)
+            force2 = wp.tile_extract(momentum, 5, 0)
+            coadjoint = wp.tile_zeros(
+                shape=(SPATIAL_DIM, 1), dtype=wp.float64, storage="shared"
+            )
+            coadjoint0 = (
+                omega1 * moment2
+                - omega2 * moment1
+                + linear1 * force2
+                - linear2 * force1
+            )
+            coadjoint1 = (
+                omega2 * moment0
+                - omega0 * moment2
+                + linear2 * force0
+                - linear0 * force2
+            )
+            coadjoint2 = (
+                omega0 * moment1
+                - omega1 * moment0
+                + linear0 * force1
+                - linear1 * force0
+            )
+            coadjoint3 = omega1 * force2 - omega2 * force1
+            coadjoint4 = omega2 * force0 - omega0 * force2
+            coadjoint5 = omega0 * force1 - omega1 * force0
+            wp.tile_assign(
+                coadjoint,
+                wp.tile_full(
+                    shape=(1, 1),
+                    value=coadjoint0,
+                    dtype=wp.float64,
+                    storage="register",
+                ),
+                offset=(0, 0),
+            )
+            wp.tile_assign(
+                coadjoint,
+                wp.tile_full(
+                    shape=(1, 1),
+                    value=coadjoint1,
+                    dtype=wp.float64,
+                    storage="register",
+                ),
+                offset=(1, 0),
+            )
+            wp.tile_assign(
+                coadjoint,
+                wp.tile_full(
+                    shape=(1, 1),
+                    value=coadjoint2,
+                    dtype=wp.float64,
+                    storage="register",
+                ),
+                offset=(2, 0),
+            )
+            wp.tile_assign(
+                coadjoint,
+                wp.tile_full(
+                    shape=(1, 1),
+                    value=coadjoint3,
+                    dtype=wp.float64,
+                    storage="register",
+                ),
+                offset=(3, 0),
+            )
+            wp.tile_assign(
+                coadjoint,
+                wp.tile_full(
+                    shape=(1, 1),
+                    value=coadjoint4,
+                    dtype=wp.float64,
+                    storage="register",
+                ),
+                offset=(4, 0),
+            )
+            wp.tile_assign(
+                coadjoint,
+                wp.tile_full(
+                    shape=(1, 1),
+                    value=coadjoint5,
+                    dtype=wp.float64,
+                    storage="register",
+                ),
+                offset=(5, 0),
+            )
+
+            weighted_mass = mass * weight
+            weighted_jacobian = jacobian * wp.tile_broadcast(
+                weighted_mass, shape=(SPATIAL_DIM, NUM_DOFS)
+            )
+            wp.tile_matmul(
+                wp.tile_transpose(jacobian),
+                weighted_jacobian,
+                inertia_segment,
+            )
+            wrench = mass * jacobian_dot_qd + coadjoint
+            wp.tile_matmul(
+                wp.tile_transpose(jacobian),
+                wrench * weight,
+                coriolis_segment,
+            )
+            wp.tile_matmul(
+                wp.tile_transpose(jacobian),
+                gravity * weighted_mass,
+                gravity_segment,
+                alpha=-1.0,
+            )
+
+    wp.tile_store(jacobian_tip, jacobian, offset=(environment * SPATIAL_DIM, 0))
+    wp.tile_store(
+        jacobian_dot_qd_tip,
+        jacobian_dot_qd,
+        offset=(environment * SPATIAL_DIM, 0),
+    )
+    wp.tile_store(velocity_tip, velocity, offset=(environment * SPATIAL_DIM, 0))
+    wp.tile_store(gravity_tip, gravity, offset=(environment * SPATIAL_DIM, 0))
+    wp.tile_store(inertia, inertia_segment, offset=(environment * NUM_DOFS, 0))
+    wp.tile_store(coriolis_qd, coriolis_segment, offset=(environment * NUM_DOFS, 0))
+    wp.tile_store(gravity_force, gravity_segment, offset=(environment * NUM_DOFS, 0))
+
+
+def _cooperative_segment_dynamics(
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_initial: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_initial: wp.array2d(dtype=wp.float64),
+    velocity_initial: wp.array2d(dtype=wp.float64),
+    gravity_initial: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    masses: wp.array2d(dtype=wp.float64),
+    jacobian_tip: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_tip: wp.array2d(dtype=wp.float64),
+    velocity_tip: wp.array2d(dtype=wp.float64),
+    gravity_tip: wp.array2d(dtype=wp.float64),
+    inertia: wp.array2d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    batch_size = qd.shape[0] // NUM_DOFS
+    wp.launch_tiled(
+        _rejected_monolithic_cooperative_segment_dynamics_kernel,
+        dim=batch_size,
+        inputs=[
+            adjoint,
+            tangent_active,
+            link_velocity,
+            step_velocity,
+            tangent_velocity_dot,
+            qd,
+            jacobian_initial,
+            jacobian_dot_qd_initial,
+            velocity_initial,
+            gravity_initial,
+            weights,
+            masses,
+        ],
+        outputs=[
+            jacobian_tip,
+            jacobian_dot_qd_tip,
+            velocity_tip,
+            gravity_tip,
+            inertia,
+            coriolis_qd,
+            gravity_force,
+        ],
+        block_dim=128,
+    )
+
+
+# This exact monolithic tile experiment is intentionally not registered as a
+# Warp kernel.  It is correct on Warp's CPU lowering but its CUDA compilation
+# did not complete after six minutes.  The split recurrence/assembly variant
+# below preserves the cooperative recurrence and is practical to compile.
+
+
+@wp.kernel(enable_backward=False)
+def cooperative_segment_recurrence_kernel(
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_initial: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_initial: wp.array2d(dtype=wp.float64),
+    velocity_initial: wp.array2d(dtype=wp.float64),
+    gravity_initial: wp.array2d(dtype=wp.float64),
+    jacobian_states: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_states: wp.array2d(dtype=wp.float64),
+    velocity_states: wp.array2d(dtype=wp.float64),
+    gravity_states: wp.array2d(dtype=wp.float64),
+):
+    """Advance all six cells for one environment in one cooperative block."""
+
+    environment, _lane = wp.tid()
+    jacobian = wp.tile_load(
+        jacobian_initial,
+        shape=(SPATIAL_DIM, NUM_DOFS),
+        offset=(environment * SPATIAL_DIM, 0),
+        storage="shared",
+    )
+    jacobian_dot_qd = wp.tile_load(
+        jacobian_dot_qd_initial,
+        shape=(SPATIAL_DIM, 1),
+        offset=(environment * SPATIAL_DIM, 0),
+        storage="shared",
+    )
+    velocity = wp.tile_load(
+        velocity_initial,
+        shape=(SPATIAL_DIM, 1),
+        offset=(environment * SPATIAL_DIM, 0),
+        storage="shared",
+    )
+    gravity = wp.tile_load(
+        gravity_initial,
+        shape=(SPATIAL_DIM, 1),
+        offset=(environment * SPATIAL_DIM, 0),
+        storage="shared",
+    )
+    generalized_velocity = wp.tile_load(
+        qd,
+        shape=(NUM_DOFS, 1),
+        offset=(environment * NUM_DOFS, 0),
+        storage="shared",
+    )
+
+    for cell in range(NUM_CELLS):
+        cell_matrix_row = (environment * NUM_CELLS + cell) * SPATIAL_DIM
+        adjoint_cell = wp.tile_load(
+            adjoint,
+            shape=(SPATIAL_DIM, SPATIAL_DIM),
+            offset=(cell_matrix_row, 0),
+        )
+        tangent_cell = wp.tile_load(
+            tangent_active,
+            shape=(SPATIAL_DIM, NUM_DOFS),
+            offset=(cell_matrix_row, 0),
+        )
+        link_velocity_cell = wp.tile_load(
+            link_velocity,
+            shape=(SPATIAL_DIM, 1),
+            offset=(cell_matrix_row, 0),
+        )
+        step_velocity_cell = wp.tile_load(
+            step_velocity,
+            shape=(SPATIAL_DIM, 1),
+            offset=(cell_matrix_row, 0),
+        )
+        tangent_velocity_dot_cell = wp.tile_load(
+            tangent_velocity_dot,
+            shape=(SPATIAL_DIM, 1),
+            offset=(cell_matrix_row, 0),
+        )
+
+        source_jacobian_velocity = wp.tile_matmul(jacobian, generalized_velocity)
+        transported_source_velocity = wp.tile_matmul(
+            adjoint_cell, source_jacobian_velocity
+        )
+        jacobian_next = wp.tile_matmul(adjoint_cell, jacobian + tangent_cell)
+        velocity_next = wp.tile_matmul(adjoint_cell, velocity + link_velocity_cell)
+        gravity_next = wp.tile_matmul(adjoint_cell, gravity)
+        jacobian_dot_qd_next = wp.tile_matmul(
+            adjoint_cell, jacobian_dot_qd + tangent_velocity_dot_cell
+        )
+
+        step0 = wp.tile_extract(step_velocity_cell, 0, 0)
+        step1 = wp.tile_extract(step_velocity_cell, 1, 0)
+        step2 = wp.tile_extract(step_velocity_cell, 2, 0)
+        step3 = wp.tile_extract(step_velocity_cell, 3, 0)
+        step4 = wp.tile_extract(step_velocity_cell, 4, 0)
+        step5 = wp.tile_extract(step_velocity_cell, 5, 0)
+        eta0 = wp.tile_extract(transported_source_velocity, 0, 0)
+        eta1 = wp.tile_extract(transported_source_velocity, 1, 0)
+        eta2 = wp.tile_extract(transported_source_velocity, 2, 0)
+        eta3 = wp.tile_extract(transported_source_velocity, 3, 0)
+        eta4 = wp.tile_extract(transported_source_velocity, 4, 0)
+        eta5 = wp.tile_extract(transported_source_velocity, 5, 0)
+        bracket = wp.tile_zeros(
+            shape=(SPATIAL_DIM, 1), dtype=wp.float64, storage="shared"
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1),
+                value=step1 * eta2 - step2 * eta1,
+                dtype=wp.float64,
+            ),
+            offset=(0, 0),
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1),
+                value=step2 * eta0 - step0 * eta2,
+                dtype=wp.float64,
+            ),
+            offset=(1, 0),
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1),
+                value=step0 * eta1 - step1 * eta0,
+                dtype=wp.float64,
+            ),
+            offset=(2, 0),
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1),
+                value=(step4 * eta2 - step5 * eta1 + step1 * eta5 - step2 * eta4),
+                dtype=wp.float64,
+            ),
+            offset=(3, 0),
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1),
+                value=(step5 * eta0 - step3 * eta2 + step2 * eta3 - step0 * eta5),
+                dtype=wp.float64,
+            ),
+            offset=(4, 0),
+        )
+        wp.tile_assign(
+            bracket,
+            wp.tile_full(
+                shape=(1, 1),
+                value=(step3 * eta1 - step4 * eta0 + step0 * eta4 - step1 * eta3),
+                dtype=wp.float64,
+            ),
+            offset=(5, 0),
+        )
+        jacobian_dot_qd_next -= bracket
+
+        wp.tile_assign(jacobian, jacobian_next, offset=(0, 0))
+        wp.tile_assign(jacobian_dot_qd, jacobian_dot_qd_next, offset=(0, 0))
+        wp.tile_assign(velocity, velocity_next, offset=(0, 0))
+        wp.tile_assign(gravity, gravity_next, offset=(0, 0))
+
+        state_row = (environment * NUM_CELLS + cell) * SPATIAL_DIM
+        wp.tile_store(jacobian_states, jacobian, offset=(state_row, 0))
+        wp.tile_store(jacobian_dot_qd_states, jacobian_dot_qd, offset=(state_row, 0))
+        wp.tile_store(velocity_states, velocity, offset=(state_row, 0))
+        wp.tile_store(gravity_states, gravity, offset=(state_row, 0))
+
+
+@wp.kernel(enable_backward=False)
+def cooperative_segment_assembly_kernel(
+    jacobian_states: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_states: wp.array2d(dtype=wp.float64),
+    velocity_states: wp.array2d(dtype=wp.float64),
+    gravity_states: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    masses: wp.array2d(dtype=wp.float64),
+    inertia: wp.array2d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    """Assemble one segment with one thread per 24x24 inertia entry."""
+
+    linear_index = wp.tid()
+    entries_per_environment = NUM_DOFS * NUM_DOFS
+    environment = linear_index // entries_per_environment
+    entry = linear_index - environment * entries_per_environment
+    coordinate = entry // NUM_DOFS
+    other_coordinate = entry - coordinate * NUM_DOFS
+
+    inertia_value = wp.float64(0.0)
+    coriolis_value = wp.float64(0.0)
+    gravity_value = wp.float64(0.0)
+    for cell in range(NUM_QUADRATURE_CELLS):
+        weight = weights[cell]
+        state_base = (environment * NUM_CELLS + cell) * SPATIAL_DIM
+        for row in range(SPATIAL_DIM):
+            state_row = state_base + row
+            mass = masses[cell * SPATIAL_DIM + row, 0]
+            jacobian_value = jacobian_states[state_row, coordinate]
+            inertia_value += (
+                jacobian_value
+                * weight
+                * mass
+                * jacobian_states[state_row, other_coordinate]
+            )
+
+            if other_coordinate == 0:
+                omega0 = velocity_states[state_base + 0, 0]
+                omega1 = velocity_states[state_base + 1, 0]
+                omega2 = velocity_states[state_base + 2, 0]
+                linear0 = velocity_states[state_base + 3, 0]
+                linear1 = velocity_states[state_base + 4, 0]
+                linear2 = velocity_states[state_base + 5, 0]
+                moment0 = masses[cell * SPATIAL_DIM + 0, 0] * omega0
+                moment1 = masses[cell * SPATIAL_DIM + 1, 0] * omega1
+                moment2 = masses[cell * SPATIAL_DIM + 2, 0] * omega2
+                force0 = masses[cell * SPATIAL_DIM + 3, 0] * linear0
+                force1 = masses[cell * SPATIAL_DIM + 4, 0] * linear1
+                force2 = masses[cell * SPATIAL_DIM + 5, 0] * linear2
+                coadjoint_value = _cross_component(
+                    omega0,
+                    omega1,
+                    omega2,
+                    moment0,
+                    moment1,
+                    moment2,
+                    row % 3,
+                )
+                if row < 3:
+                    coadjoint_value += _cross_component(
+                        linear0,
+                        linear1,
+                        linear2,
+                        force0,
+                        force1,
+                        force2,
+                        row,
+                    )
+                else:
+                    coadjoint_value = _cross_component(
+                        omega0,
+                        omega1,
+                        omega2,
+                        force0,
+                        force1,
+                        force2,
+                        row - 3,
+                    )
+                wrench = mass * jacobian_dot_qd_states[state_row, 0] + coadjoint_value
+                coriolis_value += jacobian_value * weight * wrench
+                gravity_value -= (
+                    jacobian_value * weight * mass * gravity_states[state_row, 0]
+                )
+
+    inertia[environment * NUM_DOFS + coordinate, other_coordinate] = inertia_value
+    if other_coordinate == 0:
+        coriolis_qd[environment * NUM_DOFS + coordinate, 0] = coriolis_value
+        gravity_force[environment * NUM_DOFS + coordinate, 0] = gravity_value
+
+
+def _cooperative_segment_split(
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_initial: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_initial: wp.array2d(dtype=wp.float64),
+    velocity_initial: wp.array2d(dtype=wp.float64),
+    gravity_initial: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    masses: wp.array2d(dtype=wp.float64),
+    jacobian_states: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_states: wp.array2d(dtype=wp.float64),
+    velocity_states: wp.array2d(dtype=wp.float64),
+    gravity_states: wp.array2d(dtype=wp.float64),
+    inertia: wp.array2d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    batch_size = qd.shape[0] // NUM_DOFS
+    wp.launch_tiled(
+        cooperative_segment_recurrence_kernel,
+        dim=batch_size,
+        inputs=[
+            adjoint,
+            tangent_active,
+            link_velocity,
+            step_velocity,
+            tangent_velocity_dot,
+            qd,
+            jacobian_initial,
+            jacobian_dot_qd_initial,
+            velocity_initial,
+            gravity_initial,
+        ],
+        outputs=[
+            jacobian_states,
+            jacobian_dot_qd_states,
+            velocity_states,
+            gravity_states,
+        ],
+        block_dim=128,
+    )
+    wp.launch(
+        cooperative_segment_assembly_kernel,
+        dim=batch_size * NUM_DOFS * NUM_DOFS,
+        inputs=[
+            jacobian_states,
+            jacobian_dot_qd_states,
+            velocity_states,
+            gravity_states,
+            weights,
+            masses,
+        ],
+        outputs=[inertia, coriolis_qd, gravity_force],
+        block_dim=128,
+    )
+
+
+cooperative_segment_dynamics = wp.jax_callable(
+    _cooperative_segment_split, num_outputs=7
+)
+
+
+@wp.kernel(enable_backward=False)
+def contract_cell_terms_kernel(
+    tangent: wp.array3d(dtype=wp.float64),
+    tangent_dot: wp.array3d(dtype=wp.float64),
+    adjoint: wp.array3d(dtype=wp.float64),
+    magnus_basis: wp.array3d(dtype=wp.float64),
+    magnus_basis_dot: wp.array3d(dtype=wp.float64),
+    qd_link: wp.array3d(dtype=wp.float64),
+    gather_indices: wp.array2d(dtype=wp.int32),
+    gather_mask: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array3d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    """Parallel contraction of local cell terms over environments and cells."""
+
+    linear_index = wp.tid()
+    entries_per_cell = SPATIAL_DIM * NUM_DOFS
+    work_item = linear_index // entries_per_cell
+    entry = linear_index - work_item * entries_per_cell
+    work_items_per_environment = NUM_SEGMENTS * NUM_CELLS
+    environment = work_item // work_items_per_environment
+    environment_remainder = work_item - environment * work_items_per_environment
+    segment = environment_remainder // NUM_CELLS
+    row = entry // NUM_DOFS
+    column = entry - row * NUM_DOFS
+
+    active_value = wp.float64(0.0)
+    for local_column in range(MAX_DOF):
+        if gather_indices[segment, local_column] == column and gather_mask[
+            segment, local_column
+        ] != wp.float64(0.0):
+            local_value = wp.float64(0.0)
+            for k in range(SPATIAL_DIM):
+                local_value += (
+                    tangent[work_item, row, k]
+                    * (magnus_basis[work_item, k, local_column])
+                )
+            active_value += local_value * gather_mask[segment, local_column]
+    tangent_active[work_item, row, column] = active_value
+
+    if column == 0:
+        link_value = wp.float64(0.0)
+        tangent_dot_value = wp.float64(0.0)
+        for local_column in range(MAX_DOF):
+            local_value = wp.float64(0.0)
+            local_dot_value = wp.float64(0.0)
+            for k in range(SPATIAL_DIM):
+                local_value += (
+                    tangent[work_item, row, k]
+                    * (magnus_basis[work_item, k, local_column])
+                )
+                local_dot_value += (
+                    tangent_dot[work_item, row, k]
+                    * magnus_basis[work_item, k, local_column]
+                    + tangent[work_item, row, k]
+                    * magnus_basis_dot[work_item, k, local_column]
+                )
+            link_value += local_value * qd_link[environment, segment, local_column]
+            tangent_dot_value += (
+                local_dot_value * qd_link[environment, segment, local_column]
+            )
+
+        step_value = wp.float64(0.0)
+        for k in range(SPATIAL_DIM):
+            link_k = wp.float64(0.0)
+            for local_column in range(MAX_DOF):
+                local_k = wp.float64(0.0)
+                for inner in range(SPATIAL_DIM):
+                    local_k += (
+                        tangent[work_item, k, inner]
+                        * (magnus_basis[work_item, inner, local_column])
+                    )
+                link_k += local_k * qd_link[environment, segment, local_column]
+            step_value += adjoint[work_item, row, k] * link_k
+
+        link_velocity[work_item, row] = link_value
+        step_velocity[work_item, row] = step_value
+        tangent_velocity_dot[work_item, row] = tangent_dot_value
+
+
+def _contract_cell_terms(
+    tangent: wp.array3d(dtype=wp.float64),
+    tangent_dot: wp.array3d(dtype=wp.float64),
+    adjoint: wp.array3d(dtype=wp.float64),
+    magnus_basis: wp.array3d(dtype=wp.float64),
+    magnus_basis_dot: wp.array3d(dtype=wp.float64),
+    qd_link: wp.array3d(dtype=wp.float64),
+    gather_indices: wp.array2d(dtype=wp.int32),
+    gather_mask: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array3d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    wp.launch(
+        contract_cell_terms_kernel,
+        dim=tangent_active.size,
+        inputs=[
+            tangent,
+            tangent_dot,
+            adjoint,
+            magnus_basis,
+            magnus_basis_dot,
+            qd_link,
+            gather_indices,
+            gather_mask,
+        ],
+        outputs=[
+            tangent_active,
+            link_velocity,
+            step_velocity,
+            tangent_velocity_dot,
+        ],
+        block_dim=128,
+    )
+
+
+contract_cell_terms = wp.jax_callable(_contract_cell_terms, num_outputs=4)
+
+
+@wp.func
+def _raw_local_basis_value(
+    tangent: wp.array3d(dtype=wp.float64),
+    magnus_basis: wp.array3d(dtype=wp.float64),
+    work_item: int,
+    row: int,
+    local_column: int,
+) -> wp.float64:
+    value = wp.float64(0.0)
+    k = int(0)
+    while k < SPATIAL_DIM:
+        value += tangent[work_item, row, k] * magnus_basis[work_item, k, local_column]
+        k += 1
+    return value
+
+
+@wp.func
+def _raw_active_basis_value(
+    tangent: wp.array3d(dtype=wp.float64),
+    magnus_basis: wp.array3d(dtype=wp.float64),
+    gather_indices: wp.array2d(dtype=wp.int32),
+    gather_mask: wp.array2d(dtype=wp.float64),
+    work_item: int,
+    segment: int,
+    row: int,
+    column: int,
+) -> wp.float64:
+    value = wp.float64(0.0)
+    local_column = int(0)
+    while local_column < MAX_DOF:
+        if gather_indices[segment, local_column] == column:
+            value += (
+                _raw_local_basis_value(
+                    tangent, magnus_basis, work_item, row, local_column
+                )
+                * gather_mask[segment, local_column]
+            )
+        local_column += 1
+    return value
+
+
+@wp.func
+def _raw_link_velocity_value(
+    tangent: wp.array3d(dtype=wp.float64),
+    magnus_basis: wp.array3d(dtype=wp.float64),
+    qd_link: wp.array3d(dtype=wp.float64),
+    work_item: int,
+    environment: int,
+    segment: int,
+    row: int,
+) -> wp.float64:
+    value = wp.float64(0.0)
+    local_column = int(0)
+    while local_column < MAX_DOF:
+        value += (
+            _raw_local_basis_value(tangent, magnus_basis, work_item, row, local_column)
+            * qd_link[environment, segment, local_column]
+        )
+        local_column += 1
+    return value
+
+
+@wp.func
+def _raw_tangent_dot_velocity_value(
+    tangent: wp.array3d(dtype=wp.float64),
+    tangent_dot_values: wp.array3d(dtype=wp.float64),
+    magnus_basis: wp.array3d(dtype=wp.float64),
+    magnus_basis_dot: wp.array3d(dtype=wp.float64),
+    qd_link: wp.array3d(dtype=wp.float64),
+    work_item: int,
+    environment: int,
+    segment: int,
+    row: int,
+) -> wp.float64:
+    value = wp.float64(0.0)
+    local_column = int(0)
+    while local_column < MAX_DOF:
+        local_value = wp.float64(0.0)
+        k = int(0)
+        while k < SPATIAL_DIM:
+            local_value += (
+                tangent_dot_values[work_item, row, k]
+                * magnus_basis[work_item, k, local_column]
+                + tangent[work_item, row, k]
+                * magnus_basis_dot[work_item, k, local_column]
+            )
+            k += 1
+        value += local_value * qd_link[environment, segment, local_column]
+        local_column += 1
+    return value
+
+
+@wp.func
+def _raw_step_velocity_value(
+    adjoint: wp.array3d(dtype=wp.float64),
+    tangent: wp.array3d(dtype=wp.float64),
+    magnus_basis: wp.array3d(dtype=wp.float64),
+    qd_link: wp.array3d(dtype=wp.float64),
+    work_item: int,
+    environment: int,
+    segment: int,
+    row: int,
+) -> wp.float64:
+    value = wp.float64(0.0)
+    k = int(0)
+    while k < SPATIAL_DIM:
+        value += adjoint[work_item, row, k] * _raw_link_velocity_value(
+            tangent,
+            magnus_basis,
+            qd_link,
+            work_item,
+            environment,
+            segment,
+            k,
+        )
+        k += 1
+    return value
+
+
+@wp.func
+def _state_jacobian_velocity(
+    adjoint: wp.array3d(dtype=wp.float64),
+    jacobian_states: wp.array4d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    work_item: int,
+    environment: int,
+    state_index: int,
+    row: int,
+) -> wp.float64:
+    value = wp.float64(0.0)
+    k = int(0)
+    while k < SPATIAL_DIM:
+        inner = wp.float64(0.0)
+        column = int(0)
+        while column < NUM_DOFS:
+            inner += (
+                jacobian_states[environment, state_index, k, column]
+                * qd[environment, column]
+            )
+            column += 1
+        value += adjoint[work_item, row, k] * inner
+        k += 1
+    return value
+
+
+@wp.kernel(enable_backward=False)
+def persistent_raw_dynamics_kernel(
+    joint_adjoint: wp.array3d(dtype=wp.float64),
+    joint_adjoint_dot: wp.array3d(dtype=wp.float64),
+    joint_tangent_active: wp.array3d(dtype=wp.float64),
+    joint_tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+    cell_adjoint: wp.array3d(dtype=wp.float64),
+    cell_tangent: wp.array3d(dtype=wp.float64),
+    cell_tangent_dot: wp.array3d(dtype=wp.float64),
+    cell_magnus_basis: wp.array3d(dtype=wp.float64),
+    cell_magnus_basis_dot: wp.array3d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array3d(dtype=wp.float64),
+    gather_indices: wp.array2d(dtype=wp.int32),
+    gather_mask: wp.array2d(dtype=wp.float64),
+    weights: wp.array2d(dtype=wp.float64),
+    masses: wp.array3d(dtype=wp.float64),
+    gravity_base: wp.array(dtype=wp.float64),
+    jacobian_states: wp.array4d(dtype=wp.float64),
+    jacobian_dot_qd_states: wp.array3d(dtype=wp.float64),
+    velocity_states: wp.array3d(dtype=wp.float64),
+    gravity_states: wp.array3d(dtype=wp.float64),
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    """Persistent one-thread-per-environment recurrence and dynamics assembly."""
+
+    environment = wp.tid()
+    row = int(0)
+    while row < NUM_DOFS:
+        coriolis_qd[environment, row] = wp.float64(0.0)
+        gravity_force[environment, row] = wp.float64(0.0)
+        column = int(0)
+        while column < NUM_DOFS:
+            inertia[environment, row, column] = wp.float64(0.0)
+            column += 1
+        row += 1
+
+    segment = int(0)
+    while segment < NUM_SEGMENTS:
+        joint_work_item = environment * NUM_SEGMENTS + segment
+        joint_state = segment * (NUM_CELLS + 1)
+        previous_tip_state = (segment - 1) * (NUM_CELLS + 1) + NUM_CELLS
+
+        spatial_row = int(0)
+        while spatial_row < SPATIAL_DIM:
+            column = int(0)
+            while column < NUM_DOFS:
+                value = wp.float64(0.0)
+                k = int(0)
+                while k < SPATIAL_DIM:
+                    previous_value = wp.float64(0.0)
+                    if segment > 0:
+                        previous_value = jacobian_states[
+                            environment, previous_tip_state, k, column
+                        ]
+                    value += joint_adjoint[joint_work_item, spatial_row, k] * (
+                        previous_value
+                        + joint_tangent_active[joint_work_item, k, column]
+                    )
+                    k += 1
+                jacobian_states[environment, joint_state, spatial_row, column] = value
+                column += 1
+
+            derivative_value = wp.float64(0.0)
+            velocity_value = wp.float64(0.0)
+            gravity_value = wp.float64(0.0)
+            k = int(0)
+            while k < SPATIAL_DIM:
+                previous_derivative = wp.float64(0.0)
+                previous_velocity = wp.float64(0.0)
+                previous_gravity = gravity_base[k]
+                previous_jacobian_qd = wp.float64(0.0)
+                if segment > 0:
+                    previous_derivative = jacobian_dot_qd_states[
+                        environment, previous_tip_state, k
+                    ]
+                    previous_velocity = velocity_states[
+                        environment, previous_tip_state, k
+                    ]
+                    previous_gravity = gravity_states[
+                        environment, previous_tip_state, k
+                    ]
+                    source_column = int(0)
+                    while source_column < NUM_DOFS:
+                        previous_jacobian_qd += (
+                            jacobian_states[
+                                environment, previous_tip_state, k, source_column
+                            ]
+                            * qd[environment, source_column]
+                        )
+                        source_column += 1
+                derivative_value += joint_adjoint[joint_work_item, spatial_row, k] * (
+                    previous_derivative + joint_tangent_dot_qd[joint_work_item, k]
+                )
+                derivative_value += (
+                    joint_adjoint_dot[joint_work_item, spatial_row, k]
+                    * previous_jacobian_qd
+                )
+                velocity_value += joint_adjoint[joint_work_item, spatial_row, k] * (
+                    previous_velocity + joint_velocity[joint_work_item, k]
+                )
+                gravity_value += (
+                    joint_adjoint[joint_work_item, spatial_row, k] * previous_gravity
+                )
+                k += 1
+            jacobian_dot_qd_states[environment, joint_state, spatial_row] = (
+                derivative_value
+            )
+            velocity_states[environment, joint_state, spatial_row] = velocity_value
+            gravity_states[environment, joint_state, spatial_row] = gravity_value
+            spatial_row += 1
+
+        cell = int(0)
+        while cell < NUM_CELLS:
+            cell_work_item = (
+                environment * NUM_SEGMENTS * NUM_CELLS + segment * NUM_CELLS + cell
+            )
+            source_state = joint_state + cell
+            destination_state = source_state + 1
+
+            spatial_row = int(0)
+            while spatial_row < SPATIAL_DIM:
+                column = int(0)
+                while column < NUM_DOFS:
+                    value = wp.float64(0.0)
+                    k = int(0)
+                    while k < SPATIAL_DIM:
+                        value += cell_adjoint[cell_work_item, spatial_row, k] * (
+                            jacobian_states[environment, source_state, k, column]
+                            + _raw_active_basis_value(
+                                cell_tangent,
+                                cell_magnus_basis,
+                                gather_indices,
+                                gather_mask,
+                                cell_work_item,
+                                segment,
+                                k,
+                                column,
+                            )
+                        )
+                        k += 1
+                    jacobian_states[
+                        environment, destination_state, spatial_row, column
+                    ] = value
+                    column += 1
+
+                derivative_value = wp.float64(0.0)
+                velocity_value = wp.float64(0.0)
+                gravity_value = wp.float64(0.0)
+                k = int(0)
+                while k < SPATIAL_DIM:
+                    derivative_value += cell_adjoint[cell_work_item, spatial_row, k] * (
+                        jacobian_dot_qd_states[environment, source_state, k]
+                        + _raw_tangent_dot_velocity_value(
+                            cell_tangent,
+                            cell_tangent_dot,
+                            cell_magnus_basis,
+                            cell_magnus_basis_dot,
+                            qd_link,
+                            cell_work_item,
+                            environment,
+                            segment,
+                            k,
+                        )
+                    )
+                    velocity_value += cell_adjoint[cell_work_item, spatial_row, k] * (
+                        velocity_states[environment, source_state, k]
+                        + _raw_link_velocity_value(
+                            cell_tangent,
+                            cell_magnus_basis,
+                            qd_link,
+                            cell_work_item,
+                            environment,
+                            segment,
+                            k,
+                        )
+                    )
+                    gravity_value += (
+                        cell_adjoint[cell_work_item, spatial_row, k]
+                        * gravity_states[environment, source_state, k]
+                    )
+                    k += 1
+
+                eta0 = _state_jacobian_velocity(
+                    cell_adjoint,
+                    jacobian_states,
+                    qd,
+                    cell_work_item,
+                    environment,
+                    source_state,
+                    0,
+                )
+                eta1 = _state_jacobian_velocity(
+                    cell_adjoint,
+                    jacobian_states,
+                    qd,
+                    cell_work_item,
+                    environment,
+                    source_state,
+                    1,
+                )
+                eta2 = _state_jacobian_velocity(
+                    cell_adjoint,
+                    jacobian_states,
+                    qd,
+                    cell_work_item,
+                    environment,
+                    source_state,
+                    2,
+                )
+                eta3 = _state_jacobian_velocity(
+                    cell_adjoint,
+                    jacobian_states,
+                    qd,
+                    cell_work_item,
+                    environment,
+                    source_state,
+                    3,
+                )
+                eta4 = _state_jacobian_velocity(
+                    cell_adjoint,
+                    jacobian_states,
+                    qd,
+                    cell_work_item,
+                    environment,
+                    source_state,
+                    4,
+                )
+                eta5 = _state_jacobian_velocity(
+                    cell_adjoint,
+                    jacobian_states,
+                    qd,
+                    cell_work_item,
+                    environment,
+                    source_state,
+                    5,
+                )
+                component = spatial_row % 3
+                step0 = _raw_step_velocity_value(
+                    cell_adjoint,
+                    cell_tangent,
+                    cell_magnus_basis,
+                    qd_link,
+                    cell_work_item,
+                    environment,
+                    segment,
+                    0,
+                )
+                step1 = _raw_step_velocity_value(
+                    cell_adjoint,
+                    cell_tangent,
+                    cell_magnus_basis,
+                    qd_link,
+                    cell_work_item,
+                    environment,
+                    segment,
+                    1,
+                )
+                step2 = _raw_step_velocity_value(
+                    cell_adjoint,
+                    cell_tangent,
+                    cell_magnus_basis,
+                    qd_link,
+                    cell_work_item,
+                    environment,
+                    segment,
+                    2,
+                )
+                bracket = _cross_component(
+                    step0, step1, step2, eta0, eta1, eta2, component
+                )
+                if spatial_row >= 3:
+                    step3 = _raw_step_velocity_value(
+                        cell_adjoint,
+                        cell_tangent,
+                        cell_magnus_basis,
+                        qd_link,
+                        cell_work_item,
+                        environment,
+                        segment,
+                        3,
+                    )
+                    step4 = _raw_step_velocity_value(
+                        cell_adjoint,
+                        cell_tangent,
+                        cell_magnus_basis,
+                        qd_link,
+                        cell_work_item,
+                        environment,
+                        segment,
+                        4,
+                    )
+                    step5 = _raw_step_velocity_value(
+                        cell_adjoint,
+                        cell_tangent,
+                        cell_magnus_basis,
+                        qd_link,
+                        cell_work_item,
+                        environment,
+                        segment,
+                        5,
+                    )
+                    bracket = _cross_component(
+                        step3, step4, step5, eta0, eta1, eta2, component
+                    ) + _cross_component(
+                        step0, step1, step2, eta3, eta4, eta5, component
+                    )
+
+                jacobian_dot_qd_states[environment, destination_state, spatial_row] = (
+                    derivative_value - bracket
+                )
+                velocity_states[environment, destination_state, spatial_row] = (
+                    velocity_value
+                )
+                gravity_states[environment, destination_state, spatial_row] = (
+                    gravity_value
+                )
+                spatial_row += 1
+
+            if cell < NUM_QUADRATURE_CELLS:
+                coordinate = int(0)
+                while coordinate < NUM_DOFS:
+                    c_value = wp.float64(0.0)
+                    g_value = wp.float64(0.0)
+                    spatial_row = int(0)
+                    while spatial_row < SPATIAL_DIM:
+                        omega0 = velocity_states[environment, destination_state, 0]
+                        omega1 = velocity_states[environment, destination_state, 1]
+                        omega2 = velocity_states[environment, destination_state, 2]
+                        linear0 = velocity_states[environment, destination_state, 3]
+                        linear1 = velocity_states[environment, destination_state, 4]
+                        linear2 = velocity_states[environment, destination_state, 5]
+                        moment0 = masses[segment, cell, 0] * omega0
+                        moment1 = masses[segment, cell, 1] * omega1
+                        moment2 = masses[segment, cell, 2] * omega2
+                        force0 = masses[segment, cell, 3] * linear0
+                        force1 = masses[segment, cell, 4] * linear1
+                        force2 = masses[segment, cell, 5] * linear2
+                        coadjoint_value = _cross_component(
+                            omega0,
+                            omega1,
+                            omega2,
+                            moment0,
+                            moment1,
+                            moment2,
+                            spatial_row % 3,
+                        )
+                        if spatial_row < 3:
+                            coadjoint_value += _cross_component(
+                                linear0,
+                                linear1,
+                                linear2,
+                                force0,
+                                force1,
+                                force2,
+                                spatial_row,
+                            )
+                        else:
+                            coadjoint_value = _cross_component(
+                                omega0,
+                                omega1,
+                                omega2,
+                                force0,
+                                force1,
+                                force2,
+                                spatial_row - 3,
+                            )
+                        wrench = (
+                            masses[segment, cell, spatial_row]
+                            * jacobian_dot_qd_states[
+                                environment, destination_state, spatial_row
+                            ]
+                            + coadjoint_value
+                        )
+                        jacobian_value = jacobian_states[
+                            environment,
+                            destination_state,
+                            spatial_row,
+                            coordinate,
+                        ]
+                        c_value += jacobian_value * weights[segment, cell] * wrench
+                        g_value -= (
+                            jacobian_value
+                            * weights[segment, cell]
+                            * masses[segment, cell, spatial_row]
+                            * gravity_states[
+                                environment, destination_state, spatial_row
+                            ]
+                        )
+                        spatial_row += 1
+                    coriolis_qd[environment, coordinate] += c_value
+                    gravity_force[environment, coordinate] += g_value
+
+                    other_coordinate = int(0)
+                    while other_coordinate < NUM_DOFS:
+                        b_value = wp.float64(0.0)
+                        spatial_row = int(0)
+                        while spatial_row < SPATIAL_DIM:
+                            b_value += (
+                                jacobian_states[
+                                    environment,
+                                    destination_state,
+                                    spatial_row,
+                                    coordinate,
+                                ]
+                                * weights[segment, cell]
+                                * masses[segment, cell, spatial_row]
+                                * jacobian_states[
+                                    environment,
+                                    destination_state,
+                                    spatial_row,
+                                    other_coordinate,
+                                ]
+                            )
+                            spatial_row += 1
+                        inertia[environment, coordinate, other_coordinate] += b_value
+                        other_coordinate += 1
+                    coordinate += 1
+            cell += 1
+        segment += 1
+
+
+def _persistent_raw_dynamics(
+    joint_adjoint: wp.array3d(dtype=wp.float64),
+    joint_adjoint_dot: wp.array3d(dtype=wp.float64),
+    joint_tangent_active: wp.array3d(dtype=wp.float64),
+    joint_tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+    cell_adjoint: wp.array3d(dtype=wp.float64),
+    cell_tangent: wp.array3d(dtype=wp.float64),
+    cell_tangent_dot: wp.array3d(dtype=wp.float64),
+    cell_magnus_basis: wp.array3d(dtype=wp.float64),
+    cell_magnus_basis_dot: wp.array3d(dtype=wp.float64),
+    qd: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array3d(dtype=wp.float64),
+    gather_indices: wp.array2d(dtype=wp.int32),
+    gather_mask: wp.array2d(dtype=wp.float64),
+    weights: wp.array2d(dtype=wp.float64),
+    masses: wp.array3d(dtype=wp.float64),
+    gravity_base: wp.array(dtype=wp.float64),
+    jacobian_states: wp.array4d(dtype=wp.float64),
+    jacobian_dot_qd_states: wp.array3d(dtype=wp.float64),
+    velocity_states: wp.array3d(dtype=wp.float64),
+    gravity_states: wp.array3d(dtype=wp.float64),
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    wp.launch(
+        persistent_raw_dynamics_kernel,
+        dim=qd.shape[0],
+        inputs=[
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent_active,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            cell_adjoint,
+            cell_tangent,
+            cell_tangent_dot,
+            cell_magnus_basis,
+            cell_magnus_basis_dot,
+            qd,
+            qd_link,
+            gather_indices,
+            gather_mask,
+            weights,
+            masses,
+            gravity_base,
+        ],
+        outputs=[
+            jacobian_states,
+            jacobian_dot_qd_states,
+            velocity_states,
+            gravity_states,
+            inertia,
+            coriolis_qd,
+            gravity_force,
+        ],
+        block_dim=128,
+    )
+
+
+persistent_raw_dynamics = wp.jax_callable(_persistent_raw_dynamics, num_outputs=7)

--- a/tools/benchmarks/gvs_warp_lie_kernels.py
+++ b/tools/benchmarks/gvs_warp_lie_kernels.py
@@ -1,0 +1,782 @@
+# ruff: noqa: I001, UP018
+"""Matrix-free local GVS Lie-algebra preparation kernels.
+
+This fixed-shape prototype computes the cell-local quantities consumed by the
+recurrence directly from link coordinates, velocities, bases, and reference
+strains.  It deliberately applies ``ad`` polynomials to vectors instead of
+materializing dense ``ad``, tangent, or tangent-derivative matrices.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+from tools.benchmarks.gvs_warp_kernels import (
+    MAX_DOF,
+    NUM_CELLS,
+    NUM_DOFS,
+    NUM_SEGMENTS,
+    SPATIAL_DIM,
+)
+
+
+Vec6d = wp.types.vector(length=6, dtype=wp.float64)
+
+
+@wp.func
+def _ad_action(left: Vec6d, right: Vec6d) -> Vec6d:
+    left_omega = wp.vec3d(left[0], left[1], left[2])
+    left_linear = wp.vec3d(left[3], left[4], left[5])
+    right_omega = wp.vec3d(right[0], right[1], right[2])
+    right_linear = wp.vec3d(right[3], right[4], right[5])
+    angular = wp.cross(left_omega, right_omega)
+    linear = wp.cross(left_linear, right_omega) + wp.cross(
+        left_omega, right_linear
+    )
+    return Vec6d(
+        angular[0],
+        angular[1],
+        angular[2],
+        linear[0],
+        linear[1],
+        linear[2],
+    )
+
+
+@wp.func
+def _load_column(
+    matrix: wp.array2d(dtype=wp.float64), base_row: int, column: int
+) -> Vec6d:
+    return Vec6d(
+        matrix[base_row + 0, column],
+        matrix[base_row + 1, column],
+        matrix[base_row + 2, column],
+        matrix[base_row + 3, column],
+        matrix[base_row + 4, column],
+        matrix[base_row + 5, column],
+    )
+
+
+@wp.func
+def _strain(
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    coordinates: wp.array2d(dtype=wp.float64),
+    cell_item: int,
+    coordinate_item: int,
+) -> Vec6d:
+    base_row = cell_item * SPATIAL_DIM
+    value0 = reference[cell_item, 0]
+    value1 = reference[cell_item, 1]
+    value2 = reference[cell_item, 2]
+    value3 = reference[cell_item, 3]
+    value4 = reference[cell_item, 4]
+    value5 = reference[cell_item, 5]
+    for column in range(MAX_DOF):
+        coordinate = coordinates[coordinate_item, column]
+        value0 += basis[base_row + 0, column] * coordinate
+        value1 += basis[base_row + 1, column] * coordinate
+        value2 += basis[base_row + 2, column] * coordinate
+        value3 += basis[base_row + 3, column] * coordinate
+        value4 += basis[base_row + 4, column] * coordinate
+        value5 += basis[base_row + 5, column] * coordinate
+    return Vec6d(value0, value1, value2, value3, value4, value5)
+
+
+@wp.func
+def _strain_rate(
+    basis: wp.array2d(dtype=wp.float64),
+    velocities: wp.array2d(dtype=wp.float64),
+    cell_item: int,
+    coordinate_item: int,
+) -> Vec6d:
+    base_row = cell_item * SPATIAL_DIM
+    value0 = wp.float64(0.0)
+    value1 = wp.float64(0.0)
+    value2 = wp.float64(0.0)
+    value3 = wp.float64(0.0)
+    value4 = wp.float64(0.0)
+    value5 = wp.float64(0.0)
+    for column in range(MAX_DOF):
+        velocity = velocities[coordinate_item, column]
+        value0 += basis[base_row + 0, column] * velocity
+        value1 += basis[base_row + 1, column] * velocity
+        value2 += basis[base_row + 2, column] * velocity
+        value3 += basis[base_row + 3, column] * velocity
+        value4 += basis[base_row + 4, column] * velocity
+        value5 += basis[base_row + 5, column] * velocity
+    return Vec6d(value0, value1, value2, value3, value4, value5)
+
+
+@wp.func
+def _left_coefficients(angle_sq: wp.float64) -> wp.vec4d:
+    c1 = wp.float64(0.0)
+    c2 = wp.float64(0.0)
+    c3 = wp.float64(0.0)
+    c4 = wp.float64(0.0)
+    if angle_sq <= wp.float64(0.00580466633864119):
+        x = angle_sq
+        c1 = wp.float64(0.5) + x * x * (
+            -wp.float64(1.0 / 720.0)
+            + x
+            * (
+                wp.float64(1.0 / 20160.0)
+                - x * wp.float64(1.0 / 1209600.0)
+            )
+        )
+        c2 = wp.float64(1.0 / 6.0) + x * x * (
+            -wp.float64(1.0 / 5040.0)
+            + x
+            * (
+                wp.float64(1.0 / 181440.0)
+                - x * wp.float64(1.0 / 13305600.0)
+            )
+        )
+        c3 = wp.float64(1.0 / 24.0) + x * (
+            -wp.float64(1.0 / 360.0)
+            + x
+            * (
+                wp.float64(1.0 / 13440.0)
+                + x
+                * (
+                    -wp.float64(1.0 / 907200.0)
+                    + x * wp.float64(1.0 / 95800320.0)
+                )
+            )
+        )
+        c4 = wp.float64(1.0 / 120.0) + x * (
+            -wp.float64(1.0 / 2520.0)
+            + x
+            * (
+                wp.float64(1.0 / 120960.0)
+                + x
+                * (
+                    -wp.float64(1.0 / 9979200.0)
+                    + x * wp.float64(1.0 / 1245404160.0)
+                )
+            )
+        )
+    else:
+        theta = wp.sqrt(angle_sq)
+        sine = wp.sin(theta)
+        cosine = wp.cos(theta)
+        theta2 = theta * theta
+        theta3 = theta2 * theta
+        theta4 = theta2 * theta2
+        theta5 = theta4 * theta
+        c1 = (wp.float64(4.0) - wp.float64(4.0) * cosine - theta * sine) / (
+            wp.float64(2.0) * theta2
+        )
+        c2 = (
+            wp.float64(4.0) * theta
+            - wp.float64(5.0) * sine
+            + theta * cosine
+        ) / (wp.float64(2.0) * theta3)
+        c3 = (wp.float64(2.0) - wp.float64(2.0) * cosine - theta * sine) / (
+            wp.float64(2.0) * theta4
+        )
+        c4 = (
+            wp.float64(2.0) * theta
+            - wp.float64(3.0) * sine
+            + theta * cosine
+        ) / (wp.float64(2.0) * theta5)
+    return wp.vec4d(c1, c2, c3, c4)
+
+
+@wp.func
+def _left_coefficient_x_derivatives(angle_sq: wp.float64) -> wp.vec4d:
+    d1 = wp.float64(0.0)
+    d2 = wp.float64(0.0)
+    d3 = wp.float64(0.0)
+    d4 = wp.float64(0.0)
+    if angle_sq <= wp.float64(0.00580466633864119):
+        x = angle_sq
+        d1 = x * (
+            -wp.float64(1.0 / 360.0)
+            + x
+            * (
+                wp.float64(1.0 / 6720.0)
+                - x * wp.float64(1.0 / 302400.0)
+            )
+        )
+        d2 = x * (
+            -wp.float64(1.0 / 2520.0)
+            + x
+            * (
+                wp.float64(1.0 / 60480.0)
+                - x * wp.float64(1.0 / 3326400.0)
+            )
+        )
+        d3 = -wp.float64(1.0 / 360.0) + x * (
+            wp.float64(1.0 / 6720.0)
+            + x
+            * (
+                -wp.float64(1.0 / 302400.0)
+                + x * wp.float64(1.0 / 23950080.0)
+            )
+        )
+        d4 = -wp.float64(1.0 / 2520.0) + x * (
+            wp.float64(1.0 / 60480.0)
+            + x
+            * (
+                -wp.float64(1.0 / 3326400.0)
+                + x * wp.float64(1.0 / 311351040.0)
+            )
+        )
+    else:
+        theta = wp.sqrt(angle_sq)
+        sine = wp.sin(theta)
+        cosine = wp.cos(theta)
+        theta2 = theta * theta
+        theta3 = theta2 * theta
+        theta4 = theta2 * theta2
+        theta5 = theta4 * theta
+        theta6 = theta3 * theta3
+        theta7 = theta6 * theta
+        common = (
+            -wp.float64(8.0)
+            + (wp.float64(8.0) - theta2) * cosine
+            + wp.float64(5.0) * theta * sine
+        )
+        alternate = (
+            -wp.float64(8.0) * theta
+            + (wp.float64(15.0) - theta2) * sine
+            - wp.float64(7.0) * theta * cosine
+        )
+        d1 = common / (wp.float64(4.0) * theta4)
+        d2 = alternate / (wp.float64(4.0) * theta5)
+        d3 = common / (wp.float64(4.0) * theta6)
+        d4 = alternate / (wp.float64(4.0) * theta7)
+    return wp.vec4d(d1, d2, d3, d4)
+
+
+@wp.func
+def _left_action(xi: Vec6d, value: Vec6d, coefficients: wp.vec4d) -> Vec6d:
+    result = value
+    power = value
+    for order in range(4):
+        power = _ad_action(xi, power)
+        result += coefficients[order] * power
+    return result
+
+
+@wp.func
+def _left_total_derivative_action(
+    xi: Vec6d,
+    xi_dot: Vec6d,
+    value: Vec6d,
+    value_dot: Vec6d,
+    coefficients: wp.vec4d,
+    coefficient_directions: wp.vec4d,
+) -> Vec6d:
+    result = value_dot
+    power = value
+    power_dot = value_dot
+    for order in range(4):
+        power_previous = power
+        power = _ad_action(xi, power_previous)
+        power_dot = _ad_action(xi_dot, power_previous) + _ad_action(
+            xi, power_dot
+        )
+        result += coefficient_directions[order] * power
+        result += coefficients[order] * power_dot
+    return result
+
+
+@wp.func
+def _forward_coefficients(angle_sq: wp.float64) -> wp.vec3d:
+    sinc = wp.float64(0.0)
+    cosc = wp.float64(0.0)
+    tanc = wp.float64(0.0)
+    if angle_sq <= wp.float64(0.0024607823917256556):
+        x = angle_sq
+        sinc = wp.float64(1.0) + x * (
+            -wp.float64(1.0 / 6.0)
+            + x
+            * (
+                wp.float64(1.0 / 120.0)
+                + x
+                * (
+                    -wp.float64(1.0 / 5040.0)
+                    + x * wp.float64(1.0 / 362880.0)
+                )
+            )
+        )
+        cosc = wp.float64(0.5) + x * (
+            -wp.float64(1.0 / 24.0)
+            + x
+            * (
+                wp.float64(1.0 / 720.0)
+                + x
+                * (
+                    -wp.float64(1.0 / 40320.0)
+                    + x * wp.float64(1.0 / 3628800.0)
+                )
+            )
+        )
+        tanc = wp.float64(1.0 / 6.0) + x * (
+            -wp.float64(1.0 / 120.0)
+            + x
+            * (
+                wp.float64(1.0 / 5040.0)
+                + x
+                * (
+                    -wp.float64(1.0 / 362880.0)
+                    + x * wp.float64(1.0 / 39916800.0)
+                )
+            )
+        )
+    else:
+        theta = wp.sqrt(angle_sq)
+        sinc = wp.sin(theta) / theta
+        cosc = (wp.float64(1.0) - wp.cos(theta)) / angle_sq
+        tanc = (theta - wp.sin(theta)) / (angle_sq * theta)
+    return wp.vec3d(sinc, cosc, tanc)
+
+
+@wp.func
+def _rotation_entry(
+    omega: wp.vec3d,
+    angle_sq: wp.float64,
+    forward: wp.vec3d,
+    row: int,
+    column: int,
+) -> wp.float64:
+    delta = wp.float64(0.0)
+    if row == column:
+        delta = wp.float64(1.0)
+    skew = wp.float64(0.0)
+    if row == 0 and column == 1:
+        skew = -omega[2]
+    elif row == 0 and column == 2:
+        skew = omega[1]
+    elif row == 1 and column == 0:
+        skew = omega[2]
+    elif row == 1 and column == 2:
+        skew = -omega[0]
+    elif row == 2 and column == 0:
+        skew = -omega[1]
+    elif row == 2 and column == 1:
+        skew = omega[0]
+    square = omega[row] * omega[column] - angle_sq * delta
+    return delta + forward[0] * skew + forward[1] * square
+
+
+@wp.func
+def _translation(
+    omega: wp.vec3d, linear: wp.vec3d, forward: wp.vec3d
+) -> wp.vec3d:
+    first = wp.cross(omega, linear)
+    second = wp.cross(omega, first)
+    return linear + forward[1] * first + forward[2] * second
+
+
+@wp.func
+def _adjoint_inverse_entry(
+    omega: wp.vec3d,
+    translation: wp.vec3d,
+    angle_sq: wp.float64,
+    forward: wp.vec3d,
+    row: int,
+    column: int,
+) -> wp.float64:
+    value = wp.float64(0.0)
+    if row < 3 and column < 3:
+        value = _rotation_entry(omega, angle_sq, forward, column, row)
+    elif row >= 3 and column >= 3:
+        value = _rotation_entry(
+            omega, angle_sq, forward, column - 3, row - 3
+        )
+    elif row >= 3 and column < 3:
+        local_row = row - 3
+        for k in range(3):
+            skew = wp.float64(0.0)
+            if k == 0 and column == 1:
+                skew = -translation[2]
+            elif k == 0 and column == 2:
+                skew = translation[1]
+            elif k == 1 and column == 0:
+                skew = translation[2]
+            elif k == 1 and column == 2:
+                skew = -translation[0]
+            elif k == 2 and column == 0:
+                skew = -translation[1]
+            elif k == 2 and column == 1:
+                skew = translation[0]
+            value -= _rotation_entry(
+                omega, angle_sq, forward, k, local_row
+            ) * skew
+    return value
+
+
+@wp.func
+def _adjoint_inverse_action(
+    omega: wp.vec3d,
+    translation: wp.vec3d,
+    angle_sq: wp.float64,
+    forward: wp.vec3d,
+    value: Vec6d,
+) -> Vec6d:
+    result = Vec6d()
+    for row in range(SPATIAL_DIM):
+        row_value = wp.float64(0.0)
+        for column in range(SPATIAL_DIM):
+            row_value += _adjoint_inverse_entry(
+                omega,
+                translation,
+                angle_sq,
+                forward,
+                row,
+                column,
+            ) * value[column]
+        result[row] = row_value
+    return result
+
+
+@wp.kernel
+def matrix_free_cell_terms_kernel(
+    q_link: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array2d(dtype=wp.float64),
+    basis_z1: wp.array2d(dtype=wp.float64),
+    basis_z2: wp.array2d(dtype=wp.float64),
+    reference_z1: wp.array2d(dtype=wp.float64),
+    reference_z2: wp.array2d(dtype=wp.float64),
+    segment_lengths: wp.array(dtype=wp.float64),
+    cell_widths: wp.array(dtype=wp.float64),
+    gather_indices: wp.array2d(dtype=wp.int32),
+    gather_mask: wp.array2d(dtype=wp.float64),
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    """Compute one active tangent entry per thread and vectors per row leader."""
+
+    linear_index = wp.tid()
+    entries_per_cell = SPATIAL_DIM * NUM_DOFS
+    work_item = linear_index // entries_per_cell
+    entry = linear_index - work_item * entries_per_cell
+    row = entry // NUM_DOFS
+    column = entry - row * NUM_DOFS
+    cells_per_environment = NUM_SEGMENTS * NUM_CELLS
+    environment = work_item // cells_per_environment
+    environment_cell = work_item - environment * cells_per_environment
+    segment = environment_cell // NUM_CELLS
+    cell = environment_cell - segment * NUM_CELLS
+    cell_item = segment * NUM_CELLS + cell
+    coordinate_item = environment * NUM_SEGMENTS + segment
+    base_row = cell_item * SPATIAL_DIM
+
+    xi1 = _strain(
+        basis_z1, reference_z1, q_link, cell_item, coordinate_item
+    )
+    xi2 = _strain(
+        basis_z2, reference_z2, q_link, cell_item, coordinate_item
+    )
+    xid1 = _strain_rate(basis_z1, qd_link, cell_item, coordinate_item)
+    xid2 = _strain_rate(basis_z2, qd_link, cell_item, coordinate_item)
+    length = segment_lengths[segment]
+    width = cell_widths[cell_item]
+    alpha = length * width * wp.float64(0.5)
+    commutator_coefficient = (
+        wp.sqrt(wp.float64(3.0))
+        * length
+        * length
+        * width
+        * width
+        / wp.float64(12.0)
+    )
+    magnus = alpha * (xi1 + xi2) + commutator_coefficient * _ad_action(
+        xi1, xi2
+    )
+    magnus_dot = alpha * (xid1 + xid2) + commutator_coefficient * (
+        _ad_action(xid1, xi2) + _ad_action(xi1, xid2)
+    )
+    angle_sq = (
+        magnus[0] * magnus[0]
+        + magnus[1] * magnus[1]
+        + magnus[2] * magnus[2]
+    )
+    coefficients = _left_coefficients(angle_sq)
+
+    active_value = wp.float64(0.0)
+    for local_column in range(MAX_DOF):
+        if gather_indices[segment, local_column] == column:
+            basis1 = _load_column(basis_z1, base_row, local_column)
+            basis2 = _load_column(basis_z2, base_row, local_column)
+            magnus_basis = alpha * (basis1 + basis2) + commutator_coefficient * (
+                _ad_action(xi1, basis2) - _ad_action(xi2, basis1)
+            )
+            local_tangent = _left_action(magnus, magnus_basis, coefficients)
+            active_value += (
+                local_tangent[row] * gather_mask[segment, local_column]
+            )
+    tangent_active[work_item * SPATIAL_DIM + row, column] = active_value
+
+    omega = wp.vec3d(magnus[0], magnus[1], magnus[2])
+    linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
+    forward = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, forward)
+    if column < SPATIAL_DIM:
+        adjoint[work_item * SPATIAL_DIM + row, column] = (
+            _adjoint_inverse_entry(
+                omega,
+                translation,
+                angle_sq,
+                forward,
+                row,
+                column,
+            )
+        )
+
+    if column == 0:
+        link = _left_action(magnus, magnus_dot, coefficients)
+        step = _adjoint_inverse_action(
+            omega, translation, angle_sq, forward, link
+        )
+        magnus_basis_dot_qd = (
+            wp.float64(2.0)
+            * commutator_coefficient
+            * _ad_action(xid1, xid2)
+        )
+        coefficient_derivatives = _left_coefficient_x_derivatives(angle_sq)
+        angle_sq_dot = wp.float64(2.0) * (
+            magnus[0] * magnus_dot[0]
+            + magnus[1] * magnus_dot[1]
+            + magnus[2] * magnus_dot[2]
+        )
+        coefficient_directions = coefficient_derivatives * angle_sq_dot
+        tangent_dot_velocity = _left_total_derivative_action(
+            magnus,
+            magnus_dot,
+            magnus_dot,
+            magnus_basis_dot_qd,
+            coefficients,
+            coefficient_directions,
+        )
+        vector_row = work_item * SPATIAL_DIM + row
+        link_velocity[vector_row, 0] = link[row]
+        step_velocity[vector_row, 0] = step[row]
+        tangent_velocity_dot[vector_row, 0] = tangent_dot_velocity[row]
+
+
+def _matrix_free_cell_terms(
+    q_link: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array2d(dtype=wp.float64),
+    basis_z1: wp.array2d(dtype=wp.float64),
+    basis_z2: wp.array2d(dtype=wp.float64),
+    reference_z1: wp.array2d(dtype=wp.float64),
+    reference_z2: wp.array2d(dtype=wp.float64),
+    segment_lengths: wp.array(dtype=wp.float64),
+    cell_widths: wp.array(dtype=wp.float64),
+    gather_indices: wp.array2d(dtype=wp.int32),
+    gather_mask: wp.array2d(dtype=wp.float64),
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    work_items = q_link.shape[0] * NUM_CELLS
+    wp.launch(
+        matrix_free_cell_terms_kernel,
+        dim=work_items * SPATIAL_DIM * NUM_DOFS,
+        inputs=[
+            q_link,
+            qd_link,
+            basis_z1,
+            basis_z2,
+            reference_z1,
+            reference_z2,
+            segment_lengths,
+            cell_widths,
+            gather_indices,
+            gather_mask,
+        ],
+        outputs=[
+            adjoint,
+            tangent_active,
+            link_velocity,
+            step_velocity,
+            tangent_velocity_dot,
+        ],
+        block_dim=128,
+    )
+
+
+matrix_free_cell_terms = wp.jax_callable(_matrix_free_cell_terms, num_outputs=5)
+
+
+@wp.kernel
+def matrix_free_cell_terms_serial_kernel(
+    q_link: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array2d(dtype=wp.float64),
+    basis_z1: wp.array2d(dtype=wp.float64),
+    basis_z2: wp.array2d(dtype=wp.float64),
+    reference_z1: wp.array2d(dtype=wp.float64),
+    reference_z2: wp.array2d(dtype=wp.float64),
+    segment_lengths: wp.array(dtype=wp.float64),
+    cell_widths: wp.array(dtype=wp.float64),
+    gather_indices: wp.array2d(dtype=wp.int32),
+    gather_mask: wp.array2d(dtype=wp.float64),
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    """Compute each cell's shared Lie data once in one owning thread."""
+
+    work_item = wp.tid()
+    cells_per_environment = NUM_SEGMENTS * NUM_CELLS
+    environment = work_item // cells_per_environment
+    environment_cell = work_item - environment * cells_per_environment
+    segment = environment_cell // NUM_CELLS
+    cell = environment_cell - segment * NUM_CELLS
+    cell_item = segment * NUM_CELLS + cell
+    coordinate_item = environment * NUM_SEGMENTS + segment
+    base_row = cell_item * SPATIAL_DIM
+    output_base_row = work_item * SPATIAL_DIM
+
+    xi1 = _strain(
+        basis_z1, reference_z1, q_link, cell_item, coordinate_item
+    )
+    xi2 = _strain(
+        basis_z2, reference_z2, q_link, cell_item, coordinate_item
+    )
+    xid1 = _strain_rate(basis_z1, qd_link, cell_item, coordinate_item)
+    xid2 = _strain_rate(basis_z2, qd_link, cell_item, coordinate_item)
+    length = segment_lengths[segment]
+    width = cell_widths[cell_item]
+    alpha = length * width * wp.float64(0.5)
+    commutator_coefficient = (
+        wp.sqrt(wp.float64(3.0))
+        * length
+        * length
+        * width
+        * width
+        / wp.float64(12.0)
+    )
+    magnus = alpha * (xi1 + xi2) + commutator_coefficient * _ad_action(
+        xi1, xi2
+    )
+    magnus_dot = alpha * (xid1 + xid2) + commutator_coefficient * (
+        _ad_action(xid1, xi2) + _ad_action(xi1, xid2)
+    )
+    angle_sq = (
+        magnus[0] * magnus[0]
+        + magnus[1] * magnus[1]
+        + magnus[2] * magnus[2]
+    )
+    coefficients = _left_coefficients(angle_sq)
+    omega = wp.vec3d(magnus[0], magnus[1], magnus[2])
+    linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
+    forward = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, forward)
+
+    for row in range(SPATIAL_DIM):
+        for column in range(NUM_DOFS):
+            tangent_active[output_base_row + row, column] = wp.float64(0.0)
+        for column in range(SPATIAL_DIM):
+            adjoint[output_base_row + row, column] = _adjoint_inverse_entry(
+                omega,
+                translation,
+                angle_sq,
+                forward,
+                row,
+                column,
+            )
+
+    for local_column in range(MAX_DOF):
+        basis1 = _load_column(basis_z1, base_row, local_column)
+        basis2 = _load_column(basis_z2, base_row, local_column)
+        magnus_basis = alpha * (basis1 + basis2) + commutator_coefficient * (
+            _ad_action(xi1, basis2) - _ad_action(xi2, basis1)
+        )
+        local_tangent = _left_action(magnus, magnus_basis, coefficients)
+        active_column = gather_indices[segment, local_column]
+        mask = gather_mask[segment, local_column]
+        for row in range(SPATIAL_DIM):
+            tangent_active[output_base_row + row, active_column] += (
+                local_tangent[row] * mask
+            )
+
+    link = _left_action(magnus, magnus_dot, coefficients)
+    step = _adjoint_inverse_action(
+        omega, translation, angle_sq, forward, link
+    )
+    magnus_basis_dot_qd = (
+        wp.float64(2.0)
+        * commutator_coefficient
+        * _ad_action(xid1, xid2)
+    )
+    coefficient_derivatives = _left_coefficient_x_derivatives(angle_sq)
+    angle_sq_dot = wp.float64(2.0) * (
+        magnus[0] * magnus_dot[0]
+        + magnus[1] * magnus_dot[1]
+        + magnus[2] * magnus_dot[2]
+    )
+    tangent_dot_velocity = _left_total_derivative_action(
+        magnus,
+        magnus_dot,
+        magnus_dot,
+        magnus_basis_dot_qd,
+        coefficients,
+        coefficient_derivatives * angle_sq_dot,
+    )
+    for row in range(SPATIAL_DIM):
+        link_velocity[output_base_row + row, 0] = link[row]
+        step_velocity[output_base_row + row, 0] = step[row]
+        tangent_velocity_dot[output_base_row + row, 0] = (
+            tangent_dot_velocity[row]
+        )
+
+
+def _matrix_free_cell_terms_serial(
+    q_link: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array2d(dtype=wp.float64),
+    basis_z1: wp.array2d(dtype=wp.float64),
+    basis_z2: wp.array2d(dtype=wp.float64),
+    reference_z1: wp.array2d(dtype=wp.float64),
+    reference_z2: wp.array2d(dtype=wp.float64),
+    segment_lengths: wp.array(dtype=wp.float64),
+    cell_widths: wp.array(dtype=wp.float64),
+    gather_indices: wp.array2d(dtype=wp.int32),
+    gather_mask: wp.array2d(dtype=wp.float64),
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    work_items = q_link.shape[0] * NUM_CELLS
+    wp.launch(
+        matrix_free_cell_terms_serial_kernel,
+        dim=work_items,
+        inputs=[
+            q_link,
+            qd_link,
+            basis_z1,
+            basis_z2,
+            reference_z1,
+            reference_z2,
+            segment_lengths,
+            cell_widths,
+            gather_indices,
+            gather_mask,
+        ],
+        outputs=[
+            adjoint,
+            tangent_active,
+            link_velocity,
+            step_velocity,
+            tangent_velocity_dot,
+        ],
+        block_dim=128,
+    )
+
+
+matrix_free_cell_terms_serial = wp.jax_callable(
+    _matrix_free_cell_terms_serial, num_outputs=5
+)

--- a/tools/benchmarks/gvs_warp_persistent_kernels.py
+++ b/tools/benchmarks/gvs_warp_persistent_kernels.py
@@ -1,0 +1,525 @@
+# ruff: noqa: I001, UP018
+"""Runtime-sized persistent whole-chain GVS dynamics kernel."""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+from tools.benchmarks.gvs_warp_lie_kernels import Vec6d, _ad_action
+from tools.benchmarks.gvs_warp_segment_kernels import (
+    _coadjoint_wrench,
+    _matrix_value,
+    _vector_value,
+    _write_matrix_value,
+    _write_vector_value,
+)
+
+
+SPATIAL_DIM = 6
+BLOCK_DIM = 128
+
+
+@wp.kernel(enable_backward=False)
+def scalable_persistent_chain_kernel(
+    joint_adjoint: wp.array2d(dtype=wp.float64),
+    joint_adjoint_dot: wp.array2d(dtype=wp.float64),
+    joint_tangent: wp.array2d(dtype=wp.float64),
+    joint_tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+    cell_adjoint: wp.array2d(dtype=wp.float64),
+    cell_tangent_local: wp.array2d(dtype=wp.float64),
+    cell_link_velocity: wp.array2d(dtype=wp.float64),
+    cell_step_velocity: wp.array2d(dtype=wp.float64),
+    cell_tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    global_to_local: wp.array2d(dtype=wp.int32),
+    active_dofs: wp.array(dtype=wp.int32),
+    qd: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    masses: wp.array2d(dtype=wp.float64),
+    gravity_base: wp.array(dtype=wp.float64),
+    num_cells_array: wp.array(dtype=wp.int32),
+    num_quadrature_array: wp.array(dtype=wp.int32),
+    lanes_per_block: wp.array(dtype=wp.int32),
+    jacobian_first: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_first: wp.array2d(dtype=wp.float64),
+    velocity_first: wp.array2d(dtype=wp.float64),
+    gravity_first: wp.array2d(dtype=wp.float64),
+    jacobian_second: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_second: wp.array2d(dtype=wp.float64),
+    velocity_second: wp.array2d(dtype=wp.float64),
+    gravity_second: wp.array2d(dtype=wp.float64),
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    """Traverse one full serial GVS chain per cooperative block."""
+
+    environment, lane = wp.tid()
+    num_dofs = qd.shape[1]
+    num_cells = num_cells_array[0]
+    num_quadrature = num_quadrature_array[0]
+    num_segments = joint_adjoint.shape[0] // (qd.shape[0] * SPATIAL_DIM)
+    lane_stride = lanes_per_block[0]
+    state_base_row = environment * SPATIAL_DIM
+    barrier = wp.tile_zeros(shape=(1,), dtype=wp.int32, storage="shared")
+
+    entry = lane
+    while entry < SPATIAL_DIM * num_dofs:
+        row = entry // num_dofs
+        column = entry - row * num_dofs
+        jacobian_first[state_base_row + row, column] = wp.float64(0.0)
+        jacobian_second[state_base_row + row, column] = wp.float64(0.0)
+        entry += lane_stride
+    row = lane
+    while row < SPATIAL_DIM:
+        jacobian_dot_qd_first[state_base_row + row, 0] = wp.float64(0.0)
+        velocity_first[state_base_row + row, 0] = wp.float64(0.0)
+        gravity_first[state_base_row + row, 0] = gravity_base[row]
+        row += lane_stride
+    entry = lane
+    while entry < num_dofs * num_dofs:
+        output_row = entry // num_dofs
+        output_column = entry - output_row * num_dofs
+        inertia[environment, output_row, output_column] = wp.float64(0.0)
+        entry += lane_stride
+    column = lane
+    while column < num_dofs:
+        coriolis_qd[environment, column] = wp.float64(0.0)
+        gravity_force[environment, column] = wp.float64(0.0)
+        column += lane_stride
+    wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+
+    current_is_first = bool(True)
+    segment = int(0)
+    while segment < num_segments:
+        segment_dofs = active_dofs[segment]
+        joint_base_row = (
+            (environment * num_segments + segment) * SPATIAL_DIM
+        )
+        destination_is_first = not current_is_first
+
+        entry = lane
+        while entry < SPATIAL_DIM * segment_dofs:
+            row = entry // segment_dofs
+            column = entry - row * segment_dofs
+            value = wp.float64(0.0)
+            k = int(0)
+            while k < SPATIAL_DIM:
+                value += joint_adjoint[joint_base_row + row, k] * (
+                    _matrix_value(
+                        jacobian_first,
+                        jacobian_second,
+                        current_is_first,
+                        state_base_row,
+                        k,
+                        column,
+                    )
+                    + joint_tangent[joint_base_row + k, column]
+                )
+                k += 1
+            _write_matrix_value(
+                jacobian_first,
+                jacobian_second,
+                destination_is_first,
+                state_base_row,
+                row,
+                column,
+                value,
+            )
+            entry += lane_stride
+
+        state_row = lane
+        while state_row < SPATIAL_DIM:
+            source_jacobian_velocity = Vec6d()
+            k = int(0)
+            while k < SPATIAL_DIM:
+                source_column = int(0)
+                while source_column < segment_dofs:
+                    source_jacobian_velocity[k] += _matrix_value(
+                        jacobian_first,
+                        jacobian_second,
+                        current_is_first,
+                        state_base_row,
+                        k,
+                        source_column,
+                    ) * qd[environment, source_column]
+                    source_column += 1
+                k += 1
+            derivative_value = wp.float64(0.0)
+            velocity_value = wp.float64(0.0)
+            gravity_value = wp.float64(0.0)
+            k = int(0)
+            while k < SPATIAL_DIM:
+                derivative_value += (
+                    joint_adjoint[joint_base_row + state_row, k]
+                    * (
+                        _vector_value(
+                            jacobian_dot_qd_first,
+                            jacobian_dot_qd_second,
+                            current_is_first,
+                            state_base_row,
+                            k,
+                        )
+                        + joint_tangent_dot_qd[joint_base_row + k, 0]
+                    )
+                    + joint_adjoint_dot[joint_base_row + state_row, k]
+                    * source_jacobian_velocity[k]
+                )
+                velocity_value += joint_adjoint[
+                    joint_base_row + state_row, k
+                ] * (
+                    _vector_value(
+                        velocity_first,
+                        velocity_second,
+                        current_is_first,
+                        state_base_row,
+                        k,
+                    )
+                    + joint_velocity[joint_base_row + k, 0]
+                )
+                gravity_value += joint_adjoint[
+                    joint_base_row + state_row, k
+                ] * _vector_value(
+                    gravity_first,
+                    gravity_second,
+                    current_is_first,
+                    state_base_row,
+                    k,
+                )
+                k += 1
+            _write_vector_value(
+                jacobian_dot_qd_first,
+                jacobian_dot_qd_second,
+                destination_is_first,
+                state_base_row,
+                state_row,
+                derivative_value,
+            )
+            _write_vector_value(
+                velocity_first,
+                velocity_second,
+                destination_is_first,
+                state_base_row,
+                state_row,
+                velocity_value,
+            )
+            _write_vector_value(
+                gravity_first,
+                gravity_second,
+                destination_is_first,
+                state_base_row,
+                state_row,
+                gravity_value,
+            )
+            state_row += lane_stride
+        wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+        current_is_first = destination_is_first
+
+        cell = int(0)
+        while cell < num_cells:
+            destination_is_first = not current_is_first
+            cell_base_row = (
+                (
+                    (environment * num_segments + segment) * num_cells
+                    + cell
+                )
+                * SPATIAL_DIM
+            )
+
+            entry = lane
+            while entry < SPATIAL_DIM * segment_dofs:
+                row = entry // segment_dofs
+                column = entry - row * segment_dofs
+                local_column = global_to_local[segment, column]
+                value = wp.float64(0.0)
+                k = int(0)
+                while k < SPATIAL_DIM:
+                    tangent_value = wp.float64(0.0)
+                    if local_column >= 0:
+                        tangent_value = cell_tangent_local[
+                            cell_base_row + k, local_column
+                        ]
+                    value += cell_adjoint[cell_base_row + row, k] * (
+                        _matrix_value(
+                            jacobian_first,
+                            jacobian_second,
+                            current_is_first,
+                            state_base_row,
+                            k,
+                            column,
+                        )
+                        + tangent_value
+                    )
+                    k += 1
+                _write_matrix_value(
+                    jacobian_first,
+                    jacobian_second,
+                    destination_is_first,
+                    state_base_row,
+                    row,
+                    column,
+                    value,
+                )
+                entry += lane_stride
+
+            state_row = lane
+            while state_row < SPATIAL_DIM:
+                source_jacobian_velocity = Vec6d()
+                k = int(0)
+                while k < SPATIAL_DIM:
+                    source_column = int(0)
+                    while source_column < segment_dofs:
+                        source_jacobian_velocity[k] += _matrix_value(
+                            jacobian_first,
+                            jacobian_second,
+                            current_is_first,
+                            state_base_row,
+                            k,
+                            source_column,
+                        ) * qd[environment, source_column]
+                        source_column += 1
+                    k += 1
+                transported_source_velocity = Vec6d()
+                target = int(0)
+                while target < SPATIAL_DIM:
+                    k = int(0)
+                    while k < SPATIAL_DIM:
+                        transported_source_velocity[target] += (
+                            cell_adjoint[cell_base_row + target, k]
+                            * source_jacobian_velocity[k]
+                        )
+                        k += 1
+                    target += 1
+                derivative_value = wp.float64(0.0)
+                velocity_value = wp.float64(0.0)
+                gravity_value = wp.float64(0.0)
+                k = int(0)
+                while k < SPATIAL_DIM:
+                    adjoint_value = cell_adjoint[
+                        cell_base_row + state_row, k
+                    ]
+                    derivative_value += adjoint_value * (
+                        _vector_value(
+                            jacobian_dot_qd_first,
+                            jacobian_dot_qd_second,
+                            current_is_first,
+                            state_base_row,
+                            k,
+                        )
+                        + cell_tangent_velocity_dot[cell_base_row + k, 0]
+                    )
+                    velocity_value += adjoint_value * (
+                        _vector_value(
+                            velocity_first,
+                            velocity_second,
+                            current_is_first,
+                            state_base_row,
+                            k,
+                        )
+                        + cell_link_velocity[cell_base_row + k, 0]
+                    )
+                    gravity_value += adjoint_value * _vector_value(
+                        gravity_first,
+                        gravity_second,
+                        current_is_first,
+                        state_base_row,
+                        k,
+                    )
+                    k += 1
+                step = Vec6d(
+                    cell_step_velocity[cell_base_row + 0, 0],
+                    cell_step_velocity[cell_base_row + 1, 0],
+                    cell_step_velocity[cell_base_row + 2, 0],
+                    cell_step_velocity[cell_base_row + 3, 0],
+                    cell_step_velocity[cell_base_row + 4, 0],
+                    cell_step_velocity[cell_base_row + 5, 0],
+                )
+                bracket = _ad_action(step, transported_source_velocity)
+                _write_vector_value(
+                    jacobian_dot_qd_first,
+                    jacobian_dot_qd_second,
+                    destination_is_first,
+                    state_base_row,
+                    state_row,
+                    derivative_value - bracket[state_row],
+                )
+                _write_vector_value(
+                    velocity_first,
+                    velocity_second,
+                    destination_is_first,
+                    state_base_row,
+                    state_row,
+                    velocity_value,
+                )
+                _write_vector_value(
+                    gravity_first,
+                    gravity_second,
+                    destination_is_first,
+                    state_base_row,
+                    state_row,
+                    gravity_value,
+                )
+                state_row += lane_stride
+            wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+            current_is_first = destination_is_first
+
+            if cell < num_quadrature:
+                quadrature_item = segment * num_quadrature + cell
+                weight = weights[quadrature_item]
+                entry = lane
+                while entry < segment_dofs * segment_dofs:
+                    output_row = entry // segment_dofs
+                    output_column = entry - output_row * segment_dofs
+                    value = wp.float64(0.0)
+                    row = int(0)
+                    while row < SPATIAL_DIM:
+                        value += (
+                            _matrix_value(
+                                jacobian_first,
+                                jacobian_second,
+                                current_is_first,
+                                state_base_row,
+                                row,
+                                output_row,
+                            )
+                            * weight
+                            * masses[quadrature_item, row]
+                            * _matrix_value(
+                                jacobian_first,
+                                jacobian_second,
+                                current_is_first,
+                                state_base_row,
+                                row,
+                                output_column,
+                            )
+                        )
+                        row += 1
+                    inertia[environment, output_row, output_column] += value
+                    entry += lane_stride
+
+                column = lane
+                while column < segment_dofs:
+                    wrench = _coadjoint_wrench(
+                        velocity_first,
+                        velocity_second,
+                        jacobian_dot_qd_first,
+                        jacobian_dot_qd_second,
+                        current_is_first,
+                        state_base_row,
+                        masses,
+                        quadrature_item,
+                    )
+                    coriolis_value = wp.float64(0.0)
+                    gravity_value = wp.float64(0.0)
+                    row = int(0)
+                    while row < SPATIAL_DIM:
+                        jacobian_value = _matrix_value(
+                            jacobian_first,
+                            jacobian_second,
+                            current_is_first,
+                            state_base_row,
+                            row,
+                            column,
+                        )
+                        coriolis_value += (
+                            weight * jacobian_value * wrench[row]
+                        )
+                        gravity_value -= (
+                            weight
+                            * jacobian_value
+                            * masses[quadrature_item, row]
+                            * _vector_value(
+                                gravity_first,
+                                gravity_second,
+                                current_is_first,
+                                state_base_row,
+                                row,
+                            )
+                        )
+                        row += 1
+                    coriolis_qd[environment, column] += coriolis_value
+                    gravity_force[environment, column] += gravity_value
+                    column += lane_stride
+            wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+            cell += 1
+        segment += 1
+
+
+def _scalable_persistent_chain(
+    joint_adjoint: wp.array2d(dtype=wp.float64),
+    joint_adjoint_dot: wp.array2d(dtype=wp.float64),
+    joint_tangent: wp.array2d(dtype=wp.float64),
+    joint_tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+    cell_adjoint: wp.array2d(dtype=wp.float64),
+    cell_tangent_local: wp.array2d(dtype=wp.float64),
+    cell_link_velocity: wp.array2d(dtype=wp.float64),
+    cell_step_velocity: wp.array2d(dtype=wp.float64),
+    cell_tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    global_to_local: wp.array2d(dtype=wp.int32),
+    active_dofs: wp.array(dtype=wp.int32),
+    qd: wp.array2d(dtype=wp.float64),
+    weights: wp.array(dtype=wp.float64),
+    masses: wp.array2d(dtype=wp.float64),
+    gravity_base: wp.array(dtype=wp.float64),
+    num_cells: wp.array(dtype=wp.int32),
+    num_quadrature: wp.array(dtype=wp.int32),
+    lanes_per_block: wp.array(dtype=wp.int32),
+    jacobian_first: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_first: wp.array2d(dtype=wp.float64),
+    velocity_first: wp.array2d(dtype=wp.float64),
+    gravity_first: wp.array2d(dtype=wp.float64),
+    jacobian_second: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_second: wp.array2d(dtype=wp.float64),
+    velocity_second: wp.array2d(dtype=wp.float64),
+    gravity_second: wp.array2d(dtype=wp.float64),
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+):
+    wp.launch_tiled(
+        scalable_persistent_chain_kernel,
+        dim=qd.shape[0],
+        inputs=[
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            cell_adjoint,
+            cell_tangent_local,
+            cell_link_velocity,
+            cell_step_velocity,
+            cell_tangent_velocity_dot,
+            global_to_local,
+            active_dofs,
+            qd,
+            weights,
+            masses,
+            gravity_base,
+            num_cells,
+            num_quadrature,
+            lanes_per_block,
+        ],
+        outputs=[
+            jacobian_first,
+            jacobian_dot_qd_first,
+            velocity_first,
+            gravity_first,
+            jacobian_second,
+            jacobian_dot_qd_second,
+            velocity_second,
+            gravity_second,
+            inertia,
+            coriolis_qd,
+            gravity_force,
+        ],
+        block_dim=BLOCK_DIM,
+    )
+
+
+scalable_persistent_chain = wp.jax_callable(
+    _scalable_persistent_chain, num_outputs=11
+)

--- a/tools/benchmarks/gvs_warp_scalable_kernels.py
+++ b/tools/benchmarks/gvs_warp_scalable_kernels.py
@@ -1,0 +1,509 @@
+# ruff: noqa: I001, UP018
+"""Shape-generic Warp kernels for scalable GVS compilation experiments.
+
+The kernels keep spatial dimension six, but obtain the number of generalized
+coordinates and local strain coordinates from array shapes. Runtime ``while``
+loops prevent Warp from expanding work proportional to the number of segments
+into the generated CUDA source.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+from tools.benchmarks.gvs_warp_lie_kernels import (
+    Vec6d,
+    _ad_action,
+    _adjoint_inverse_action,
+    _adjoint_inverse_entry,
+    _forward_coefficients,
+    _left_action,
+    _left_coefficient_x_derivatives,
+    _left_coefficients,
+    _left_total_derivative_action,
+    _translation,
+)
+
+
+SPATIAL_DIM = 6
+
+
+@wp.func
+def _load_dynamic_column(
+    matrix: wp.array2d(dtype=wp.float64), base_row: int, column: int
+) -> Vec6d:
+    return Vec6d(
+        matrix[base_row + 0, column],
+        matrix[base_row + 1, column],
+        matrix[base_row + 2, column],
+        matrix[base_row + 3, column],
+        matrix[base_row + 4, column],
+        matrix[base_row + 5, column],
+    )
+
+
+@wp.func
+def _dynamic_strain(
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    coordinates: wp.array2d(dtype=wp.float64),
+    cell_item: int,
+    coordinate_item: int,
+) -> Vec6d:
+    base_row = cell_item * SPATIAL_DIM
+    value = Vec6d(
+        reference[cell_item, 0],
+        reference[cell_item, 1],
+        reference[cell_item, 2],
+        reference[cell_item, 3],
+        reference[cell_item, 4],
+        reference[cell_item, 5],
+    )
+    column = int(0)
+    while column < coordinates.shape[1]:
+        coordinate = coordinates[coordinate_item, column]
+        row = int(0)
+        while row < SPATIAL_DIM:
+            value[row] += basis[base_row + row, column] * coordinate
+            row += 1
+        column += 1
+    return value
+
+
+@wp.func
+def _dynamic_strain_rate(
+    basis: wp.array2d(dtype=wp.float64),
+    velocities: wp.array2d(dtype=wp.float64),
+    cell_item: int,
+    coordinate_item: int,
+) -> Vec6d:
+    base_row = cell_item * SPATIAL_DIM
+    value = Vec6d()
+    column = int(0)
+    while column < velocities.shape[1]:
+        velocity = velocities[coordinate_item, column]
+        row = int(0)
+        while row < SPATIAL_DIM:
+            value[row] += basis[base_row + row, column] * velocity
+            row += 1
+        column += 1
+    return value
+
+
+@wp.kernel(enable_backward=False)
+def scalable_cell_terms_kernel(
+    q_link: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array2d(dtype=wp.float64),
+    basis_z1: wp.array2d(dtype=wp.float64),
+    basis_z2: wp.array2d(dtype=wp.float64),
+    reference_z1: wp.array2d(dtype=wp.float64),
+    reference_z2: wp.array2d(dtype=wp.float64),
+    segment_lengths: wp.array(dtype=wp.float64),
+    cell_widths: wp.array(dtype=wp.float64),
+    num_cells: wp.array(dtype=wp.int32),
+    order_zero: wp.array(dtype=wp.int32),
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    """Compute general cell-local Lie data with an optional order-zero branch."""
+
+    work_item = wp.tid()
+    cells_per_segment = num_cells[0]
+    cells_per_environment = segment_lengths.shape[0] * cells_per_segment
+    environment = work_item // cells_per_environment
+    environment_cell = work_item - environment * cells_per_environment
+    segment = environment_cell // cells_per_segment
+    cell = environment_cell - segment * cells_per_segment
+    cell_item = segment * cells_per_segment + cell
+    coordinate_item = environment * segment_lengths.shape[0] + segment
+    base_row = cell_item * SPATIAL_DIM
+    output_base_row = work_item * SPATIAL_DIM
+
+    xi1 = _dynamic_strain(
+        basis_z1, reference_z1, q_link, cell_item, coordinate_item
+    )
+    xid1 = _dynamic_strain_rate(
+        basis_z1, qd_link, cell_item, coordinate_item
+    )
+    length = segment_lengths[segment]
+    width = cell_widths[cell_item]
+    alpha = length * width * wp.float64(0.5)
+    commutator_coefficient = (
+        wp.sqrt(wp.float64(3.0))
+        * length
+        * length
+        * width
+        * width
+        / wp.float64(12.0)
+    )
+
+    xi2 = xi1
+    xid2 = xid1
+    magnus = length * width * xi1
+    magnus_dot = length * width * xid1
+    if order_zero[0] == 0:
+        xi2 = _dynamic_strain(
+            basis_z2, reference_z2, q_link, cell_item, coordinate_item
+        )
+        xid2 = _dynamic_strain_rate(
+            basis_z2, qd_link, cell_item, coordinate_item
+        )
+        magnus = alpha * (xi1 + xi2) + commutator_coefficient * _ad_action(
+            xi1, xi2
+        )
+        magnus_dot = alpha * (xid1 + xid2) + commutator_coefficient * (
+            _ad_action(xid1, xi2) + _ad_action(xi1, xid2)
+        )
+
+    angle_sq = (
+        magnus[0] * magnus[0]
+        + magnus[1] * magnus[1]
+        + magnus[2] * magnus[2]
+    )
+    coefficients = _left_coefficients(angle_sq)
+    omega = wp.vec3d(magnus[0], magnus[1], magnus[2])
+    linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
+    forward = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, forward)
+
+    row = int(0)
+    while row < SPATIAL_DIM:
+        column = int(0)
+        while column < SPATIAL_DIM:
+            adjoint[output_base_row + row, column] = _adjoint_inverse_entry(
+                omega,
+                translation,
+                angle_sq,
+                forward,
+                row,
+                column,
+            )
+            column += 1
+        row += 1
+
+    local_column = int(0)
+    while local_column < q_link.shape[1]:
+        basis1 = _load_dynamic_column(basis_z1, base_row, local_column)
+        magnus_basis = length * width * basis1
+        if order_zero[0] == 0:
+            basis2 = _load_dynamic_column(basis_z2, base_row, local_column)
+            magnus_basis = alpha * (
+                basis1 + basis2
+            ) + commutator_coefficient * (
+                _ad_action(xi1, basis2) - _ad_action(xi2, basis1)
+            )
+        local_tangent = _left_action(magnus, magnus_basis, coefficients)
+        row = int(0)
+        while row < SPATIAL_DIM:
+            tangent_local[output_base_row + row, local_column] = local_tangent[row]
+            row += 1
+        local_column += 1
+
+    link = _left_action(magnus, magnus_dot, coefficients)
+    step = _adjoint_inverse_action(
+        omega, translation, angle_sq, forward, link
+    )
+    magnus_basis_dot_qd = Vec6d()
+    if order_zero[0] == 0:
+        magnus_basis_dot_qd = (
+            wp.float64(2.0)
+            * commutator_coefficient
+            * _ad_action(xid1, xid2)
+        )
+    coefficient_derivatives = _left_coefficient_x_derivatives(angle_sq)
+    angle_sq_dot = wp.float64(2.0) * (
+        magnus[0] * magnus_dot[0]
+        + magnus[1] * magnus_dot[1]
+        + magnus[2] * magnus_dot[2]
+    )
+    tangent_dot_velocity_value = _left_total_derivative_action(
+        magnus,
+        magnus_dot,
+        magnus_dot,
+        magnus_basis_dot_qd,
+        coefficients,
+        coefficient_derivatives * angle_sq_dot,
+    )
+    row = int(0)
+    while row < SPATIAL_DIM:
+        link_velocity[output_base_row + row, 0] = link[row]
+        step_velocity[output_base_row + row, 0] = step[row]
+        tangent_velocity_dot[output_base_row + row, 0] = (
+            tangent_dot_velocity_value[row]
+        )
+        row += 1
+
+
+def _scalable_cell_terms(
+    q_link: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array2d(dtype=wp.float64),
+    basis_z1: wp.array2d(dtype=wp.float64),
+    basis_z2: wp.array2d(dtype=wp.float64),
+    reference_z1: wp.array2d(dtype=wp.float64),
+    reference_z2: wp.array2d(dtype=wp.float64),
+    segment_lengths: wp.array(dtype=wp.float64),
+    cell_widths: wp.array(dtype=wp.float64),
+    num_cells: wp.array(dtype=wp.int32),
+    order_zero: wp.array(dtype=wp.int32),
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    # ``num_cells`` has one entry whose value is not available to Python here.
+    # Derive the work count from the reference-strain rows instead.
+    work_items = (q_link.shape[0] * reference_z1.shape[0]) // segment_lengths.shape[0]
+    wp.launch(
+        scalable_cell_terms_kernel,
+        dim=work_items,
+        inputs=[
+            q_link,
+            qd_link,
+            basis_z1,
+            basis_z2,
+            reference_z1,
+            reference_z2,
+            segment_lengths,
+            cell_widths,
+            num_cells,
+            order_zero,
+        ],
+        outputs=[
+            adjoint,
+            tangent_local,
+            link_velocity,
+            step_velocity,
+            tangent_velocity_dot,
+        ],
+        block_dim=128,
+    )
+
+
+scalable_cell_terms = wp.jax_callable(_scalable_cell_terms, num_outputs=5)
+
+
+@wp.func
+def _source_matrix_value(
+    initial: wp.array2d(dtype=wp.float64),
+    states: wp.array2d(dtype=wp.float64),
+    environment: int,
+    cell: int,
+    num_cells: int,
+    row: int,
+    column: int,
+) -> wp.float64:
+    if cell == 0:
+        return initial[environment * SPATIAL_DIM + row, column]
+    state_row = (
+        (environment * num_cells + cell - 1) * SPATIAL_DIM + row
+    )
+    return states[state_row, column]
+
+
+@wp.func
+def _source_vector_value(
+    initial: wp.array2d(dtype=wp.float64),
+    states: wp.array2d(dtype=wp.float64),
+    environment: int,
+    cell: int,
+    num_cells: int,
+    row: int,
+) -> wp.float64:
+    if cell == 0:
+        return initial[environment * SPATIAL_DIM + row, 0]
+    state_row = (
+        (environment * num_cells + cell - 1) * SPATIAL_DIM + row
+    )
+    return states[state_row, 0]
+
+
+@wp.kernel(enable_backward=False)
+def scalable_segment_cell_kernel(
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    global_to_local: wp.array(dtype=wp.int32),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_initial: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_initial: wp.array2d(dtype=wp.float64),
+    velocity_initial: wp.array2d(dtype=wp.float64),
+    gravity_initial: wp.array2d(dtype=wp.float64),
+    cell: int,
+    jacobian_states: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_states: wp.array2d(dtype=wp.float64),
+    velocity_states: wp.array2d(dtype=wp.float64),
+    gravity_states: wp.array2d(dtype=wp.float64),
+):
+    """Advance one cell with runtime global and local coordinate counts."""
+
+    linear_index = wp.tid()
+    num_dofs = qd.shape[1]
+    num_cells = adjoint.shape[0] // (qd.shape[0] * SPATIAL_DIM)
+    entries_per_environment = SPATIAL_DIM * num_dofs
+    environment = linear_index // entries_per_environment
+    entry = linear_index - environment * entries_per_environment
+    row = entry // num_dofs
+    column = entry - row * num_dofs
+    work_item = environment * num_cells + cell
+    cell_base_row = work_item * SPATIAL_DIM
+
+    jacobian_value = wp.float64(0.0)
+    k = int(0)
+    while k < SPATIAL_DIM:
+        tangent_value = wp.float64(0.0)
+        local_column = global_to_local[column]
+        if local_column >= 0:
+            tangent_value = tangent_local[cell_base_row + k, local_column]
+        jacobian_value += adjoint[cell_base_row + row, k] * (
+            _source_matrix_value(
+                jacobian_initial,
+                jacobian_states,
+                environment,
+                cell,
+                num_cells,
+                k,
+                column,
+            )
+            + tangent_value
+        )
+        k += 1
+    state_row = cell_base_row + row
+    jacobian_states[state_row, column] = jacobian_value
+
+    if column == 0:
+        source_velocity = Vec6d()
+        k = int(0)
+        while k < SPATIAL_DIM:
+            source_column = int(0)
+            while source_column < num_dofs:
+                source_velocity[k] += _source_matrix_value(
+                    jacobian_initial,
+                    jacobian_states,
+                    environment,
+                    cell,
+                    num_cells,
+                    k,
+                    source_column,
+                ) * qd[environment, source_column]
+                source_column += 1
+            k += 1
+
+        transported_velocity = Vec6d()
+        derivative_value = wp.float64(0.0)
+        velocity_value = wp.float64(0.0)
+        gravity_value = wp.float64(0.0)
+        k = int(0)
+        while k < SPATIAL_DIM:
+            adjoint_value = adjoint[cell_base_row + row, k]
+            derivative_value += adjoint_value * (
+                _source_vector_value(
+                    jacobian_dot_qd_initial,
+                    jacobian_dot_qd_states,
+                    environment,
+                    cell,
+                    num_cells,
+                    k,
+                )
+                + tangent_velocity_dot[cell_base_row + k, 0]
+            )
+            velocity_value += adjoint_value * (
+                _source_vector_value(
+                    velocity_initial,
+                    velocity_states,
+                    environment,
+                    cell,
+                    num_cells,
+                    k,
+                )
+                + link_velocity[cell_base_row + k, 0]
+            )
+            gravity_value += adjoint_value * _source_vector_value(
+                gravity_initial,
+                gravity_states,
+                environment,
+                cell,
+                num_cells,
+                k,
+            )
+
+            target = int(0)
+            while target < SPATIAL_DIM:
+                transported_velocity[target] += (
+                    adjoint[cell_base_row + target, k] * source_velocity[k]
+                )
+                target += 1
+            k += 1
+
+        step = Vec6d(
+            step_velocity[cell_base_row + 0, 0],
+            step_velocity[cell_base_row + 1, 0],
+            step_velocity[cell_base_row + 2, 0],
+            step_velocity[cell_base_row + 3, 0],
+            step_velocity[cell_base_row + 4, 0],
+            step_velocity[cell_base_row + 5, 0],
+        )
+        bracket = _ad_action(step, transported_velocity)
+        jacobian_dot_qd_states[state_row, 0] = derivative_value - bracket[row]
+        velocity_states[state_row, 0] = velocity_value
+        gravity_states[state_row, 0] = gravity_value
+
+
+def _scalable_segment_recurrence(
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    global_to_local: wp.array(dtype=wp.int32),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_initial: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_initial: wp.array2d(dtype=wp.float64),
+    velocity_initial: wp.array2d(dtype=wp.float64),
+    gravity_initial: wp.array2d(dtype=wp.float64),
+    jacobian_states: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_states: wp.array2d(dtype=wp.float64),
+    velocity_states: wp.array2d(dtype=wp.float64),
+    gravity_states: wp.array2d(dtype=wp.float64),
+):
+    batch_size = qd.shape[0]
+    num_dofs = qd.shape[1]
+    num_cells = adjoint.shape[0] // (batch_size * SPATIAL_DIM)
+    for cell in range(num_cells):
+        wp.launch(
+            scalable_segment_cell_kernel,
+            dim=batch_size * SPATIAL_DIM * num_dofs,
+            inputs=[
+                adjoint,
+                tangent_local,
+                link_velocity,
+                step_velocity,
+                tangent_velocity_dot,
+                global_to_local,
+                qd,
+                jacobian_initial,
+                jacobian_dot_qd_initial,
+                velocity_initial,
+                gravity_initial,
+                cell,
+            ],
+            outputs=[
+                jacobian_states,
+                jacobian_dot_qd_states,
+                velocity_states,
+                gravity_states,
+            ],
+            block_dim=128,
+        )
+
+
+scalable_segment_recurrence = wp.jax_callable(
+    _scalable_segment_recurrence, num_outputs=4
+)

--- a/tools/benchmarks/gvs_warp_segment_kernels.py
+++ b/tools/benchmarks/gvs_warp_segment_kernels.py
@@ -1,0 +1,590 @@
+# ruff: noqa: I001, UP018
+"""Runtime-sized cooperative GVS segment recurrence and assembly."""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+from tools.benchmarks.gvs_warp_lie_kernels import Vec6d, _ad_action
+
+
+SPATIAL_DIM = 6
+BLOCK_DIM = 128
+
+
+@wp.func
+def _matrix_value(
+    first: wp.array2d(dtype=wp.float64),
+    second: wp.array2d(dtype=wp.float64),
+    use_first: bool,
+    base_row: int,
+    row: int,
+    column: int,
+) -> wp.float64:
+    if use_first:
+        return first[base_row + row, column]
+    return second[base_row + row, column]
+
+
+@wp.func
+def _vector_value(
+    first: wp.array2d(dtype=wp.float64),
+    second: wp.array2d(dtype=wp.float64),
+    use_first: bool,
+    base_row: int,
+    row: int,
+) -> wp.float64:
+    if use_first:
+        return first[base_row + row, 0]
+    return second[base_row + row, 0]
+
+
+@wp.func
+def _write_matrix_value(
+    first: wp.array2d(dtype=wp.float64),
+    second: wp.array2d(dtype=wp.float64),
+    use_first: bool,
+    base_row: int,
+    row: int,
+    column: int,
+    value: wp.float64,
+):
+    if use_first:
+        first[base_row + row, column] = value
+    else:
+        second[base_row + row, column] = value
+
+
+@wp.func
+def _write_vector_value(
+    first: wp.array2d(dtype=wp.float64),
+    second: wp.array2d(dtype=wp.float64),
+    use_first: bool,
+    base_row: int,
+    row: int,
+    value: wp.float64,
+):
+    if use_first:
+        first[base_row + row, 0] = value
+    else:
+        second[base_row + row, 0] = value
+
+
+@wp.func
+def _coadjoint_wrench(
+    velocity_first: wp.array2d(dtype=wp.float64),
+    velocity_second: wp.array2d(dtype=wp.float64),
+    derivative_first: wp.array2d(dtype=wp.float64),
+    derivative_second: wp.array2d(dtype=wp.float64),
+    use_first: bool,
+    base_row: int,
+    masses: wp.array2d(dtype=wp.float64),
+    quadrature: int,
+) -> Vec6d:
+    omega = wp.vec3d(
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 0
+        ),
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 1
+        ),
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 2
+        ),
+    )
+    linear_velocity = wp.vec3d(
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 3
+        ),
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 4
+        ),
+        _vector_value(
+            velocity_first, velocity_second, use_first, base_row, 5
+        ),
+    )
+    moment = wp.vec3d(
+        masses[quadrature, 0] * omega[0],
+        masses[quadrature, 1] * omega[1],
+        masses[quadrature, 2] * omega[2],
+    )
+    force = wp.vec3d(
+        masses[quadrature, 3] * linear_velocity[0],
+        masses[quadrature, 4] * linear_velocity[1],
+        masses[quadrature, 5] * linear_velocity[2],
+    )
+    angular = wp.cross(omega, moment) + wp.cross(linear_velocity, force)
+    linear = wp.cross(omega, force)
+    return Vec6d(
+        masses[quadrature, 0]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 0
+        )
+        + angular[0],
+        masses[quadrature, 1]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 1
+        )
+        + angular[1],
+        masses[quadrature, 2]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 2
+        )
+        + angular[2],
+        masses[quadrature, 3]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 3
+        )
+        + linear[0],
+        masses[quadrature, 4]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 4
+        )
+        + linear[1],
+        masses[quadrature, 5]
+        * _vector_value(
+            derivative_first, derivative_second, use_first, base_row, 5
+        )
+        + linear[2],
+    )
+
+
+@wp.kernel(enable_backward=False)
+def scalable_cooperative_segment_kernel(
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    global_to_local: wp.array(dtype=wp.int32),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_initial: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_initial: wp.array2d(dtype=wp.float64),
+    velocity_initial: wp.array2d(dtype=wp.float64),
+    gravity_initial: wp.array2d(dtype=wp.float64),
+    joint_adjoint: wp.array2d(dtype=wp.float64),
+    joint_adjoint_dot: wp.array2d(dtype=wp.float64),
+    joint_tangent: wp.array2d(dtype=wp.float64),
+    joint_tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+    apply_joint: wp.array(dtype=wp.int32),
+    weights: wp.array(dtype=wp.float64),
+    masses: wp.array2d(dtype=wp.float64),
+    lanes_per_block: wp.array(dtype=wp.int32),
+    jacobian_tip: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_tip: wp.array2d(dtype=wp.float64),
+    velocity_tip: wp.array2d(dtype=wp.float64),
+    gravity_tip: wp.array2d(dtype=wp.float64),
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+    jacobian_scratch: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_scratch: wp.array2d(dtype=wp.float64),
+    velocity_scratch: wp.array2d(dtype=wp.float64),
+    gravity_scratch: wp.array2d(dtype=wp.float64),
+):
+    """Advance one environment/segment per block and assemble online."""
+
+    environment, lane = wp.tid()
+    num_dofs = qd.shape[1]
+    num_cells = adjoint.shape[0] // (qd.shape[0] * SPATIAL_DIM)
+    lane_stride = lanes_per_block[0]
+    state_base_row = environment * SPATIAL_DIM
+    barrier = wp.tile_zeros(shape=(1,), dtype=wp.int32, storage="shared")
+
+    entry = lane
+    while entry < SPATIAL_DIM * num_dofs:
+        row = entry // num_dofs
+        column = entry - row * num_dofs
+        value = jacobian_initial[state_base_row + row, column]
+        if apply_joint[0] != 0:
+            value = wp.float64(0.0)
+            k = int(0)
+            while k < SPATIAL_DIM:
+                value += joint_adjoint[state_base_row + row, k] * (
+                    jacobian_initial[state_base_row + k, column]
+                    + joint_tangent[state_base_row + k, column]
+                )
+                k += 1
+        jacobian_tip[state_base_row + row, column] = value
+        entry += lane_stride
+    row = lane
+    while row < SPATIAL_DIM:
+        derivative_value = jacobian_dot_qd_initial[
+            state_base_row + row, 0
+        ]
+        velocity_value = velocity_initial[state_base_row + row, 0]
+        gravity_value = gravity_initial[state_base_row + row, 0]
+        if apply_joint[0] != 0:
+            source_jacobian_velocity = Vec6d()
+            k = int(0)
+            while k < SPATIAL_DIM:
+                column = int(0)
+                while column < num_dofs:
+                    source_jacobian_velocity[k] += jacobian_initial[
+                        state_base_row + k, column
+                    ] * qd[environment, column]
+                    column += 1
+                k += 1
+            derivative_value = wp.float64(0.0)
+            velocity_value = wp.float64(0.0)
+            gravity_value = wp.float64(0.0)
+            k = int(0)
+            while k < SPATIAL_DIM:
+                derivative_value += (
+                    joint_adjoint[state_base_row + row, k]
+                    * (
+                        jacobian_dot_qd_initial[state_base_row + k, 0]
+                        + joint_tangent_dot_qd[state_base_row + k, 0]
+                    )
+                    + joint_adjoint_dot[state_base_row + row, k]
+                    * source_jacobian_velocity[k]
+                )
+                velocity_value += joint_adjoint[
+                    state_base_row + row, k
+                ] * (
+                    velocity_initial[state_base_row + k, 0]
+                    + joint_velocity[state_base_row + k, 0]
+                )
+                gravity_value += joint_adjoint[
+                    state_base_row + row, k
+                ] * gravity_initial[state_base_row + k, 0]
+                k += 1
+        jacobian_dot_qd_tip[state_base_row + row, 0] = derivative_value
+        velocity_tip[state_base_row + row, 0] = velocity_value
+        gravity_tip[state_base_row + row, 0] = gravity_value
+        row += lane_stride
+    entry = lane
+    while entry < num_dofs * num_dofs:
+        output_row = entry // num_dofs
+        output_column = entry - output_row * num_dofs
+        inertia[environment, output_row, output_column] = wp.float64(0.0)
+        entry += lane_stride
+    column = lane
+    while column < num_dofs:
+        coriolis_qd[environment, column] = wp.float64(0.0)
+        gravity_force[environment, column] = wp.float64(0.0)
+        column += lane_stride
+    wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+
+    cell = int(0)
+    while cell < num_cells:
+        source_is_tip = cell % 2 == 0
+        destination_is_tip = not source_is_tip
+        cell_base_row = (environment * num_cells + cell) * SPATIAL_DIM
+
+        entry = lane
+        while entry < SPATIAL_DIM * num_dofs:
+            row = entry // num_dofs
+            column = entry - row * num_dofs
+            local_column = global_to_local[column]
+            value = wp.float64(0.0)
+            k = int(0)
+            while k < SPATIAL_DIM:
+                tangent_value = wp.float64(0.0)
+                if local_column >= 0:
+                    tangent_value = tangent_local[
+                        cell_base_row + k, local_column
+                    ]
+                value += adjoint[cell_base_row + row, k] * (
+                    _matrix_value(
+                        jacobian_tip,
+                        jacobian_scratch,
+                        source_is_tip,
+                        state_base_row,
+                        k,
+                        column,
+                    )
+                    + tangent_value
+                )
+                k += 1
+            _write_matrix_value(
+                jacobian_tip,
+                jacobian_scratch,
+                destination_is_tip,
+                state_base_row,
+                row,
+                column,
+                value,
+            )
+            entry += lane_stride
+
+        state_row = lane
+        while state_row < SPATIAL_DIM:
+            source_jacobian_velocity = Vec6d()
+            k = int(0)
+            while k < SPATIAL_DIM:
+                source_column = int(0)
+                while source_column < num_dofs:
+                    source_jacobian_velocity[k] += _matrix_value(
+                        jacobian_tip,
+                        jacobian_scratch,
+                        source_is_tip,
+                        state_base_row,
+                        k,
+                        source_column,
+                    ) * qd[environment, source_column]
+                    source_column += 1
+                k += 1
+
+            transported_source_velocity = Vec6d()
+            derivative_value = wp.float64(0.0)
+            velocity_value = wp.float64(0.0)
+            gravity_value = wp.float64(0.0)
+            k = int(0)
+            while k < SPATIAL_DIM:
+                adjoint_value = adjoint[cell_base_row + state_row, k]
+                derivative_value += adjoint_value * (
+                    _vector_value(
+                        jacobian_dot_qd_tip,
+                        jacobian_dot_qd_scratch,
+                        source_is_tip,
+                        state_base_row,
+                        k,
+                    )
+                    + tangent_velocity_dot[cell_base_row + k, 0]
+                )
+                velocity_value += adjoint_value * (
+                    _vector_value(
+                        velocity_tip,
+                        velocity_scratch,
+                        source_is_tip,
+                        state_base_row,
+                        k,
+                    )
+                    + link_velocity[cell_base_row + k, 0]
+                )
+                gravity_value += adjoint_value * _vector_value(
+                    gravity_tip,
+                    gravity_scratch,
+                    source_is_tip,
+                    state_base_row,
+                    k,
+                )
+                k += 1
+            target = int(0)
+            while target < SPATIAL_DIM:
+                k = int(0)
+                while k < SPATIAL_DIM:
+                    transported_source_velocity[target] += (
+                        adjoint[cell_base_row + target, k]
+                        * source_jacobian_velocity[k]
+                    )
+                    k += 1
+                target += 1
+            step = Vec6d(
+                step_velocity[cell_base_row + 0, 0],
+                step_velocity[cell_base_row + 1, 0],
+                step_velocity[cell_base_row + 2, 0],
+                step_velocity[cell_base_row + 3, 0],
+                step_velocity[cell_base_row + 4, 0],
+                step_velocity[cell_base_row + 5, 0],
+            )
+            bracket = _ad_action(step, transported_source_velocity)
+            _write_vector_value(
+                jacobian_dot_qd_tip,
+                jacobian_dot_qd_scratch,
+                destination_is_tip,
+                state_base_row,
+                state_row,
+                derivative_value - bracket[state_row],
+            )
+            _write_vector_value(
+                velocity_tip,
+                velocity_scratch,
+                destination_is_tip,
+                state_base_row,
+                state_row,
+                velocity_value,
+            )
+            _write_vector_value(
+                gravity_tip,
+                gravity_scratch,
+                destination_is_tip,
+                state_base_row,
+                state_row,
+                gravity_value,
+            )
+            state_row += lane_stride
+        wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+
+        if cell < weights.shape[0]:
+            weight = weights[cell]
+            entry = lane
+            while entry < num_dofs * num_dofs:
+                output_row = entry // num_dofs
+                output_column = entry - output_row * num_dofs
+                value = wp.float64(0.0)
+                row = int(0)
+                while row < SPATIAL_DIM:
+                    value += (
+                        _matrix_value(
+                            jacobian_tip,
+                            jacobian_scratch,
+                            destination_is_tip,
+                            state_base_row,
+                            row,
+                            output_row,
+                        )
+                        * weight
+                        * masses[cell, row]
+                        * _matrix_value(
+                            jacobian_tip,
+                            jacobian_scratch,
+                            destination_is_tip,
+                            state_base_row,
+                            row,
+                            output_column,
+                        )
+                    )
+                    row += 1
+                inertia[environment, output_row, output_column] += value
+                entry += lane_stride
+
+            column = lane
+            while column < num_dofs:
+                wrench = _coadjoint_wrench(
+                    velocity_tip,
+                    velocity_scratch,
+                    jacobian_dot_qd_tip,
+                    jacobian_dot_qd_scratch,
+                    destination_is_tip,
+                    state_base_row,
+                    masses,
+                    cell,
+                )
+                coriolis_value = wp.float64(0.0)
+                gravity_value = wp.float64(0.0)
+                row = int(0)
+                while row < SPATIAL_DIM:
+                    jacobian_value = _matrix_value(
+                        jacobian_tip,
+                        jacobian_scratch,
+                        destination_is_tip,
+                        state_base_row,
+                        row,
+                        column,
+                    )
+                    coriolis_value += weight * jacobian_value * wrench[row]
+                    gravity_value -= (
+                        weight
+                        * jacobian_value
+                        * masses[cell, row]
+                        * _vector_value(
+                            gravity_tip,
+                            gravity_scratch,
+                            destination_is_tip,
+                            state_base_row,
+                            row,
+                        )
+                    )
+                    row += 1
+                coriolis_qd[environment, column] += coriolis_value
+                gravity_force[environment, column] += gravity_value
+                column += lane_stride
+        wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+        cell += 1
+
+    if num_cells % 2 == 1:
+        entry = lane
+        while entry < SPATIAL_DIM * num_dofs:
+            row = entry // num_dofs
+            column = entry - row * num_dofs
+            jacobian_tip[state_base_row + row, column] = jacobian_scratch[
+                state_base_row + row, column
+            ]
+            entry += lane_stride
+        row = lane
+        while row < SPATIAL_DIM:
+            jacobian_dot_qd_tip[state_base_row + row, 0] = (
+                jacobian_dot_qd_scratch[state_base_row + row, 0]
+            )
+            velocity_tip[state_base_row + row, 0] = velocity_scratch[
+                state_base_row + row, 0
+            ]
+            gravity_tip[state_base_row + row, 0] = gravity_scratch[
+                state_base_row + row, 0
+            ]
+            row += lane_stride
+
+
+def _scalable_cooperative_segment(
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_local: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+    global_to_local: wp.array(dtype=wp.int32),
+    qd: wp.array2d(dtype=wp.float64),
+    jacobian_initial: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_initial: wp.array2d(dtype=wp.float64),
+    velocity_initial: wp.array2d(dtype=wp.float64),
+    gravity_initial: wp.array2d(dtype=wp.float64),
+    joint_adjoint: wp.array2d(dtype=wp.float64),
+    joint_adjoint_dot: wp.array2d(dtype=wp.float64),
+    joint_tangent: wp.array2d(dtype=wp.float64),
+    joint_tangent_dot_qd: wp.array2d(dtype=wp.float64),
+    joint_velocity: wp.array2d(dtype=wp.float64),
+    apply_joint: wp.array(dtype=wp.int32),
+    weights: wp.array(dtype=wp.float64),
+    masses: wp.array2d(dtype=wp.float64),
+    lanes_per_block: wp.array(dtype=wp.int32),
+    jacobian_tip: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_tip: wp.array2d(dtype=wp.float64),
+    velocity_tip: wp.array2d(dtype=wp.float64),
+    gravity_tip: wp.array2d(dtype=wp.float64),
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+    jacobian_scratch: wp.array2d(dtype=wp.float64),
+    jacobian_dot_qd_scratch: wp.array2d(dtype=wp.float64),
+    velocity_scratch: wp.array2d(dtype=wp.float64),
+    gravity_scratch: wp.array2d(dtype=wp.float64),
+):
+    wp.launch_tiled(
+        scalable_cooperative_segment_kernel,
+        dim=qd.shape[0],
+        inputs=[
+            adjoint,
+            tangent_local,
+            link_velocity,
+            step_velocity,
+            tangent_velocity_dot,
+            global_to_local,
+            qd,
+            jacobian_initial,
+            jacobian_dot_qd_initial,
+            velocity_initial,
+            gravity_initial,
+            joint_adjoint,
+            joint_adjoint_dot,
+            joint_tangent,
+            joint_tangent_dot_qd,
+            joint_velocity,
+            apply_joint,
+            weights,
+            masses,
+            lanes_per_block,
+        ],
+        outputs=[
+            jacobian_tip,
+            jacobian_dot_qd_tip,
+            velocity_tip,
+            gravity_tip,
+            inertia,
+            coriolis_qd,
+            gravity_force,
+            jacobian_scratch,
+            jacobian_dot_qd_scratch,
+            velocity_scratch,
+            gravity_scratch,
+        ],
+        block_dim=BLOCK_DIM,
+    )
+
+
+scalable_cooperative_segment = wp.jax_callable(
+    _scalable_cooperative_segment, num_outputs=11
+)

--- a/tools/benchmarks/gvs_warp_solve_kernels.py
+++ b/tools/benchmarks/gvs_warp_solve_kernels.py
@@ -1,0 +1,134 @@
+# ruff: noqa: I001, UP018
+"""Forward-only runtime-sized batched dense Cholesky solve for GVS."""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+
+BLOCK_DIM = 128
+
+
+@wp.kernel(enable_backward=False)
+def scalable_cholesky_solve_kernel(
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+    lanes_per_block: wp.array(dtype=wp.int32),
+    factor: wp.array3d(dtype=wp.float64),
+    intermediate: wp.array2d(dtype=wp.float64),
+    acceleration: wp.array2d(dtype=wp.float64),
+):
+    """Factor and solve one SPD system per cooperative block."""
+
+    environment, lane = wp.tid()
+    num_dofs = inertia.shape[1]
+    lane_stride = lanes_per_block[0]
+    barrier = wp.tile_zeros(shape=(1,), dtype=wp.int32, storage="shared")
+
+    entry = lane
+    while entry < num_dofs * num_dofs:
+        row = entry // num_dofs
+        column = entry - row * num_dofs
+        if row >= column:
+            factor[environment, row, column] = inertia[
+                environment, row, column
+            ]
+        entry += lane_stride
+    column = lane
+    while column < num_dofs:
+        intermediate[environment, column] = -(
+            coriolis_qd[environment, column]
+            + gravity_force[environment, column]
+        )
+        acceleration[environment, column] = wp.float64(0.0)
+        column += lane_stride
+    wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+
+    pivot = int(0)
+    while pivot < num_dofs:
+        if lane == 0:
+            diagonal = factor[environment, pivot, pivot]
+            k = int(0)
+            while k < pivot:
+                value = factor[environment, pivot, k]
+                diagonal -= value * value
+                k += 1
+            factor[environment, pivot, pivot] = wp.sqrt(diagonal)
+        wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+
+        row = pivot + 1 + lane
+        while row < num_dofs:
+            value = factor[environment, row, pivot]
+            k = int(0)
+            while k < pivot:
+                value -= (
+                    factor[environment, row, k]
+                    * factor[environment, pivot, k]
+                )
+                k += 1
+            factor[environment, row, pivot] = (
+                value / factor[environment, pivot, pivot]
+            )
+            row += lane_stride
+        wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+        pivot += 1
+
+    row = int(0)
+    while row < num_dofs:
+        if lane == 0:
+            value = intermediate[environment, row]
+            k = int(0)
+            while k < row:
+                value -= (
+                    factor[environment, row, k]
+                    * intermediate[environment, k]
+                )
+                k += 1
+            intermediate[environment, row] = (
+                value / factor[environment, row, row]
+            )
+        wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+        row += 1
+
+    row = num_dofs - 1
+    while row >= 0:
+        if lane == 0:
+            value = intermediate[environment, row]
+            k = row + 1
+            while k < num_dofs:
+                value -= (
+                    factor[environment, k, row]
+                    * acceleration[environment, k]
+                )
+                k += 1
+            acceleration[environment, row] = (
+                value / factor[environment, row, row]
+            )
+        wp.tile_scatter_masked(barrier, 0, int(0), lane == 0)
+        row -= 1
+
+
+def _scalable_cholesky_solve(
+    inertia: wp.array3d(dtype=wp.float64),
+    coriolis_qd: wp.array2d(dtype=wp.float64),
+    gravity_force: wp.array2d(dtype=wp.float64),
+    lanes_per_block: wp.array(dtype=wp.int32),
+    factor: wp.array3d(dtype=wp.float64),
+    intermediate: wp.array2d(dtype=wp.float64),
+    acceleration: wp.array2d(dtype=wp.float64),
+):
+    wp.launch_tiled(
+        scalable_cholesky_solve_kernel,
+        dim=inertia.shape[0],
+        inputs=[inertia, coriolis_qd, gravity_force, lanes_per_block],
+        outputs=[factor, intermediate, acceleration],
+        block_dim=BLOCK_DIM,
+    )
+
+
+scalable_cholesky_solve = wp.jax_callable(
+    _scalable_cholesky_solve, num_outputs=3
+)

--- a/tools/benchmarks/gvs_warp_specialized_kernels.py
+++ b/tools/benchmarks/gvs_warp_specialized_kernels.py
@@ -1,0 +1,160 @@
+# ruff: noqa: I001, UP018
+"""Exact specializations for the fixed order-zero GVS benchmark."""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+from tools.benchmarks.gvs_warp_kernels import (
+    MAX_DOF,
+    NUM_CELLS,
+    NUM_DOFS,
+    NUM_SEGMENTS,
+    SPATIAL_DIM,
+)
+from tools.benchmarks.gvs_warp_lie_kernels import (
+    Vec6d,
+    _adjoint_inverse_action,
+    _adjoint_inverse_entry,
+    _forward_coefficients,
+    _left_action,
+    _left_coefficient_x_derivatives,
+    _left_coefficients,
+    _left_total_derivative_action,
+    _load_column,
+    _strain,
+    _strain_rate,
+    _translation,
+)
+
+
+@wp.kernel(enable_backward=False)
+def constant_strain_cell_terms_kernel(
+    q_link: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array2d(dtype=wp.float64),
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    segment_lengths: wp.array(dtype=wp.float64),
+    cell_widths: wp.array(dtype=wp.float64),
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    """Exploit B_Z1 == B_Z2 exactly, with one owning thread per cell."""
+
+    work_item = wp.tid()
+    cells_per_environment = NUM_SEGMENTS * NUM_CELLS
+    environment = work_item // cells_per_environment
+    environment_cell = work_item - environment * cells_per_environment
+    segment = environment_cell // NUM_CELLS
+    cell = environment_cell - segment * NUM_CELLS
+    cell_item = segment * NUM_CELLS + cell
+    coordinate_item = environment * NUM_SEGMENTS + segment
+    base_row = cell_item * SPATIAL_DIM
+    output_base_row = work_item * SPATIAL_DIM
+
+    xi = _strain(basis, reference, q_link, cell_item, coordinate_item)
+    xi_dot = _strain_rate(basis, qd_link, cell_item, coordinate_item)
+    scale = segment_lengths[segment] * cell_widths[cell_item]
+    magnus = scale * xi
+    magnus_dot = scale * xi_dot
+    angle_sq = (
+        magnus[0] * magnus[0]
+        + magnus[1] * magnus[1]
+        + magnus[2] * magnus[2]
+    )
+    coefficients = _left_coefficients(angle_sq)
+    omega = wp.vec3d(magnus[0], magnus[1], magnus[2])
+    linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
+    forward = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, forward)
+
+    for row in range(SPATIAL_DIM):
+        for column in range(NUM_DOFS):
+            tangent_active[output_base_row + row, column] = wp.float64(0.0)
+        for column in range(SPATIAL_DIM):
+            adjoint[output_base_row + row, column] = _adjoint_inverse_entry(
+                omega,
+                translation,
+                angle_sq,
+                forward,
+                row,
+                column,
+            )
+
+    for local_column in range(MAX_DOF):
+        magnus_basis = scale * _load_column(basis, base_row, local_column)
+        local_tangent = _left_action(magnus, magnus_basis, coefficients)
+        active_column = segment * MAX_DOF + local_column
+        for row in range(SPATIAL_DIM):
+            tangent_active[output_base_row + row, active_column] = local_tangent[row]
+
+    link = _left_action(magnus, magnus_dot, coefficients)
+    step = _adjoint_inverse_action(
+        omega, translation, angle_sq, forward, link
+    )
+    coefficient_derivatives = _left_coefficient_x_derivatives(angle_sq)
+    angle_sq_dot = wp.float64(2.0) * (
+        magnus[0] * magnus_dot[0]
+        + magnus[1] * magnus_dot[1]
+        + magnus[2] * magnus_dot[2]
+    )
+    tangent_dot_velocity = _left_total_derivative_action(
+        magnus,
+        magnus_dot,
+        magnus_dot,
+        Vec6d(),
+        coefficients,
+        coefficient_derivatives * angle_sq_dot,
+    )
+    for row in range(SPATIAL_DIM):
+        link_velocity[output_base_row + row, 0] = link[row]
+        step_velocity[output_base_row + row, 0] = step[row]
+        tangent_velocity_dot[output_base_row + row, 0] = (
+            tangent_dot_velocity[row]
+        )
+
+
+def _constant_strain_cell_terms(
+    q_link: wp.array2d(dtype=wp.float64),
+    qd_link: wp.array2d(dtype=wp.float64),
+    basis: wp.array2d(dtype=wp.float64),
+    reference: wp.array2d(dtype=wp.float64),
+    segment_lengths: wp.array(dtype=wp.float64),
+    cell_widths: wp.array(dtype=wp.float64),
+    adjoint: wp.array2d(dtype=wp.float64),
+    tangent_active: wp.array2d(dtype=wp.float64),
+    link_velocity: wp.array2d(dtype=wp.float64),
+    step_velocity: wp.array2d(dtype=wp.float64),
+    tangent_velocity_dot: wp.array2d(dtype=wp.float64),
+):
+    work_items = q_link.shape[0] * NUM_CELLS
+    wp.launch(
+        constant_strain_cell_terms_kernel,
+        dim=work_items,
+        inputs=[
+            q_link,
+            qd_link,
+            basis,
+            reference,
+            segment_lengths,
+            cell_widths,
+        ],
+        outputs=[
+            adjoint,
+            tangent_active,
+            link_velocity,
+            step_velocity,
+            tangent_velocity_dot,
+        ],
+        block_dim=128,
+    )
+
+
+constant_strain_cell_terms = wp.jax_callable(
+    _constant_strain_cell_terms, num_outputs=5
+)

--- a/uv.lock
+++ b/uv.lock
@@ -1264,16 +1264,16 @@ version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -1449,16 +1449,16 @@ version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -4046,12 +4046,14 @@ all = [
     { name = "tox" },
     { name = "trimesh" },
     { name = "viser" },
+    { name = "warp-lang" },
     { name = "zensical" },
 ]
 cuda13 = [
     { name = "jax", version = "0.10.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda13"], marker = "python_full_version < '3.12' and sys_platform == 'linux'" },
     { name = "jax", version = "0.11.0", source = { registry = "https://pypi.org/simple" }, extra = ["cuda13"], marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
     { name = "torch", marker = "sys_platform == 'linux'" },
+    { name = "warp-lang", marker = "sys_platform == 'linux'" },
 ]
 dev = [
     { name = "bump2version" },
@@ -4134,6 +4136,9 @@ test = [
     { name = "tox" },
     { name = "trimesh" },
     { name = "viser" },
+]
+warp = [
+    { name = "warp-lang" },
 ]
 
 [package.metadata]
@@ -4242,10 +4247,13 @@ requires-dist = [
     { name = "viser", marker = "extra == 'paper-results'" },
     { name = "viser", marker = "extra == 'rendering'" },
     { name = "viser", marker = "extra == 'test'" },
+    { name = "warp-lang", marker = "sys_platform == 'linux' and extra == 'cuda13'", specifier = ">=1.16.0" },
+    { name = "warp-lang", marker = "extra == 'all'", specifier = ">=1.16.0" },
+    { name = "warp-lang", marker = "extra == 'warp'", specifier = ">=1.16.0" },
     { name = "zensical", marker = "extra == 'all'" },
     { name = "zensical", marker = "extra == 'docs'" },
 ]
-provides-extras = ["cuda13", "dev", "docs", "examples", "paper-results", "rendering", "rl", "test", "all"]
+provides-extras = ["cuda13", "warp", "dev", "docs", "examples", "paper-results", "rendering", "rl", "test", "all"]
 
 [[package]]
 name = "stable-baselines3"
@@ -4641,6 +4649,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1e/67/cbae4bf7683a64755c2c1778c418fea96d00e34395bb91743f08bd951571/wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55", size = 15842, upload-time = "2025-06-18T07:00:42.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953", size = 20516, upload-time = "2025-06-18T07:00:41.684Z" },
+]
+
+[[package]]
+name = "warp-lang"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/8a/8be711f3b5431a6e0bdb97117d681b03cf2bb95d6fcf8869861900898d88/warp_lang-1.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:19a7590c4484e8250ab19165311d2a1774138663b361c41e8be2865c7515c4ae", size = 25221601, upload-time = "2026-08-03T02:26:38.389Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3d/47feef2eee4739437e19d6949ea231ca4181c9eacbaa39144761e6130d94/warp_lang-1.16.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:96449fc1e3b354185e2f09434fb794b5953ab2e8673b104d7e7f48d5d418bb35", size = 163074225, upload-time = "2026-08-03T02:27:03.632Z" },
+    { url = "https://files.pythonhosted.org/packages/db/96/0c2b070b3101c669955cafd36262548b2e8b00dfdeda3aeb7afbc0f9d65c/warp_lang-1.16.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d4715171bd6821436b82293d774c9a082ace08215c189572b4348d1e48fb8ee8", size = 167563789, upload-time = "2026-08-03T02:27:37.512Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/17/c98fab81156f0d25f17200f52f69210b94a9abba101066736df8cc493522/warp_lang-1.16.0-py3-none-win_amd64.whl", hash = "sha256:8690c9096e0a271985339d4aa4b37675e7d62852620ca861ac032dc85b124542", size = 146387135, upload-time = "2026-08-03T02:28:17.956Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds an optional, shape-generic Warp execution backend for GVS dynamics while preserving the true GVS equations and the existing differentiable JAX implementation.

The production interface is now the existing `GVS.dynamics_terms(q, qd, backend=...)` method rather than a separate batched API. It accepts either one state `(num_dofs,)` or a batch `(batch_size, num_dofs)`. The model-level `backend` setting is deliberately general enough to govern additional accelerated GVS operations in the future:

- `backend="auto"` (default): use Warp for GPU primal execution and JAX on CPU;
- `backend="warp"`: explicitly request the Warp primal path;
- `backend="jax"`: explicitly request the reference JAX path;
- any forward- or reverse-mode differentiation: use JAX, even when the primal policy selects Warp.

There is intentionally no batch-size, basis-order, or model-size crossover in the GPU policy. Such thresholds are hardware-dependent. GPU execution consistently selects Warp; CPU auto-dispatch consistently selects JAX.

The Warp implementation supports:

- spatially varying strain bases, including basis order greater than zero;
- two-point Magnus integration along every link cell;
- fixed, revolute, prismatic, helical, cylindrical, planar, spherical, free, and mixed joint chains;
- runtime-varying segment count, local/global DoF counts, quadrature count, basis order, and batch size;
- FP64 assembly of the inertia matrix `B`, contracted Coriolis term `C @ qd`, and gravity force `G`;
- scalar calls, explicit batched calls, and `jax.vmap` without degenerating into one batch-one Warp launch pipeline per environment;
- normal use from `GVS.forward_dynamics` and therefore from the existing rollout APIs.

Warp remains optional through `soromox[warp]`; importing Soromox does not eagerly require it.

## Motivation and constraints

GVS dynamics is not a conventional rigid-body tree algorithm or a nodal cable/rod solver. Each segment propagates pose-dependent Lie quantities, Jacobians, Jacobian-rate contractions, velocity, and gravity through a serial chain while distributed inertia and force contributions are integrated at quadrature points. Higher-order strain bases vary spatially, and general joints add SE(3) propagation between links.

This creates two practical GPU problems in the existing batched JAX implementation:

1. the generated XLA graph grows with model structure and contains many small Lie-algebra, recurrence, and assembly operations;
2. the ordered recurrence inside one environment offers less coarse parallelism than a rigid-body/contact workload, especially at small batches.

The implementation therefore keeps the GVS algorithm intact and reorganizes its execution around the parallelism that actually exists:

- environments provide the outer grid;
- rows, columns, active DoF pairs, joints, and cells provide cooperative work within an environment;
- segment/cell dependencies remain physically ordered;
- invariant topology and numerical operands are flattened and cached once;
- generated Warp source is independent of the concrete robot shape.

The data organization takes inspiration from MuJoCo Warp and Newton: flat persistent model arrays, precomputed topology maps, predictable output ownership, bounded runtime-shaped kernels, and cooperative reuse. It does **not** copy their rigid-body, constraint, or flexible-cable dynamics algorithms. The two-point Magnus link integration, general-joint Lie propagation, distributed quadrature, and GVS equations remain the source of truth.

## Branch contents relative to `main`

After rebasing, the Warp-specific commits in this PR are:

1. `4440dd7` — adds the shape-generic benchmark harness, investigated kernel families, and phase-by-phase report.
2. `b4a7b0b` — records the measured CPU regressions and CPU dispatch decision.
3. `7286fa3` — integrates the first persistent, shape-generic Warp backend into `GVS`.
4. `1140105` — compacts invariant basis data, moves repeated quantities out of runtime kernels, hardens general-joint/model-map handling, and makes GPU auto-dispatch consistently choose Warp.
5. `4809c38` — adds cooperative joint preparation, recurrence-value reuse, weighted-mass caching, upper-triangular inertia assembly, and the selected high-DoF launch configuration.
6. `ea439fa` — unifies scalar and batched execution under `GVS.dynamics_terms`, adds model-level backend configuration, custom batching, transform-aware JAX differentiation, and automatic forward-dynamics integration.

## Production implementation

### Unified API and backend policy

`GVS` has a static `backend: ExecutionBackend` field. `ExecutionBackend` is exported from both `soromox.systems.gvs` and `soromox.systems`. The name describes an execution policy rather than a GVS-specific algorithm and leaves room for the same setting to control future accelerated operations.

`GVS.dynamics_terms()` validates scalar or batched states and resolves an optional per-call override against the model setting. JAX and Warp keep separate compiled implementation boundaries behind this small dispatcher. The dispatcher itself is intentionally not wrapped in `eqx.filter_jit`: differentiation and batching rules must select their implementation before a forward-only Warp primal is staged. The selected JAX assembly and Warp batch pipeline remain JIT compiled.

The former `dynamics_terms_batched()` compatibility wrapper was removed because there were no production callers and the unified method is clearer. Existing code can write either:

```python
B, Cqd, G = model.dynamics_terms(q, qd)
B_batch, Cqd_batch, G_batch = model.dynamics_terms(q_batch, qd_batch)
```

### Transform-aware batching

The Warp primitive has scalar-call semantics at the public boundary, with a `jax.custom_batching.custom_vmap` rule underneath. When `jax.vmap` maps independent `q` and `qd` states, the rule gathers the mapped axis and invokes **one true batched Warp pipeline**. It does not emit `batch_size` independent batch-one pipelines.

This is important for the existing simulation stack: callers can continue to use normal JAX transformations and the GVS implementation still exposes all environments together to the GPU. Explicit two-dimensional calls use the same batching rule and kernel path.

Batching model parameters themselves is rejected because the persistent model arrays describe one robot topology; batching environment states for that model is fully supported.

### Transform-aware differentiation

Warp is used only for primal forward execution. `evaluate_terms` is an Equinox custom-JVP function whose derivative rule evaluates the existing JAX `_assemble_dynamics_terms` implementation. Reverse mode is obtained by JAX transposing that JVP, so both forward- and reverse-mode transformations use the differentiable JAX equations rather than attempting to differentiate the forward-only Warp FFI.

`GVS.forward_dynamics` has the same policy at the complete equation level. A small static custom-JVP bridge surrounds the compiled forward-dynamics implementation; its derivative rule explicitly selects `backend="jax"` for term assembly, forces, and the inertia solve. The bridge is static because `eqx.filter_custom_jvp` is a callable transform rather than a Python method descriptor.

Consequences:

- ordinary GPU simulation uses Warp automatically;
- `jax.jvp`, `jax.linearize`, `jax.grad`, `jax.jacrev`, and reverse-mode transformations use JAX automatically;
- callers do not need to remember to mutate the model backend before differentiating;
- primal outputs retain the Warp numerical path outside transformations.

### Forward dynamics and rollouts

`GVS.forward_dynamics` now resolves the configured backend internally. Therefore existing Diffrax-based `rollout_to`/closed-loop rollout calls reach the selected dynamics backend without a parallel Warp-specific rollout API.

No manual `wp.capture_*` call is embedded in `GVS`. JAX/XLA owns command-buffer/CUDA-graph capture and replay of the compiled computation. The custom batching rule is what makes this useful: each vector-field evaluation presents one batch-shaped Warp primitive instead of a mapped collection of batch-one FFI calls.

Nsight Systems traces of the production methods establish the capture granularity. Ten warm `GVS.forward_dynamics` queries used one graph executable and exactly ten `cuGraphLaunch` calls; each Warp preprocessing/chain kernel and each dense-solve kernel executed ten times. `GVS.rollout_to` also replays captured graphs, but Diffrax/Tsit5 is not captured as one monolithic graph: two 100-step rollouts produced 2,834 graph launches and 1,214 forward-dynamics evaluations. The graphs therefore cover command-buffer fragments inside the solver stages rather than an entire rollout call.

### Persistent model representation

`GVS.precompute()` builds runtime arrays used by the shape-generic kernels:

- padded joint/link local-to-global and global-to-local coordinate maps;
- the active serial coordinate prefix after every segment;
- compact link-basis row selectors and values at both Magnus evaluation points;
- cell widths and length-scaled basis values;
- inner quadrature mass diagonals and preweighted mass diagonals;
- base-frame gravity;
- row/column maps for the upper triangle of the global inertia matrix.

The GVS basis has at most one active spatial row per local basis column. Packing the row and its scalar values avoids repeatedly loading dense `6 x max_dof` basis matrices without assuming constant strain. `update_params()` recomputes all dependent cached operands when model parameters change.

### General-joint and cell preprocessing

One warp-sized block owns each `(environment, segment)` joint. Six lanes form joint strain and strain rate from the padded basis; the block computes shared SE(3) exponential/left-Jacobian coefficients and cooperatively emits inverse adjoint terms, local tangent terms, tangent-rate contraction, and joint velocity.

Joint behavior is encoded by the existing padded basis, so generated source does not specialize on a Python joint class. The same kernel supports all current joint families and mixed chains.

Each link cell evaluates the true two-point Magnus expression and its directional derivative, then emits compact local tangents and Lie quantities consumed by the recurrence. Runtime loop bounds preserve higher-order spatial variation. The production path never assumes `B_Z1 == B_Z2`, a vanishing Magnus commutator, or fixed joints.

### Persistent active-prefix chain

One cooperative block owns one environment and advances segments/cells in physical order while parallelizing matrix/vector work within each step. Two scratch states alternate as recurrence buffers, avoiding a separate JAX operation or launch at every segment boundary.

For a serial GVS chain, segment `s` can only depend on coordinates introduced at or before it. The implementation derives that prefix from the actual joint/link coordinate maps and reduces dominant assembly work from `S * N^2` toward `sum_s N_s^2`. The guard falls back to the full DoF count if a model map is not a contiguous active prefix; it does not assume fixed joints or a particular strain order.

The retained kernel also:

- computes `J @ qd` once per recurrence state and shares it;
- uses preweighted mass diagonals;
- assembles only the upper triangle of symmetric inertia and mirrors it;
- writes final `B`, `C @ qd`, and `G` plus bounded double-buffer scratch;
- uses 128 lanes for models up to 64 DoFs and 192 lanes above 64 DoFs, based on measured occupancy/throughput sweeps.

### Compilation behavior

Segment count, basis order, quadrature count, joint family, global/local DoFs, and batch size are runtime dimensions. Warp compiles a small fixed set of modules rather than regenerating unrolled CUDA source for every robot.

True empty-cache measurements reached the first completed Warp result in 0.901 s for a four-segment order-1 revolute model and 0.942 s for a 16-segment mixed-joint model; both shapes produced identical Warp module hashes. With Warp modules cached, lower plus XLA compilation was 55 ms and 63 ms respectively, compared with about 1.02 s and 1.08 s for JAX. The new dispatch/custom-transform layer does not introduce shape-specialized Warp generation.

## Why this implementation is faster

The speedup is cumulative:

1. matrix-free Lie actions avoid temporary `6 x 6` matrices when only contractions are needed;
2. sparse topology, basis structure, gravity, quadrature weights, and mass terms are packed once;
3. each joint/cell Lie quantity is computed by one natural owner and reused;
4. the persistent chain removes per-segment JAX/FFI recurrence boundaries;
5. active-prefix processing removes structurally zero global-DoF work early in the chain;
6. recurrence velocities are shared rather than recomputed;
7. weighted masses reduce inner-loop arithmetic and loads;
8. upper-triangle assembly nearly halves inertia output-pair work;
9. the 128/192-lane selection exposes useful pair parallelism without the resource loss measured at 256 lanes;
10. custom batching preserves the large batch presented by callers and rollouts.

Relative to the production backend before the final cooperative/cache/triangular changes (`1140105`), the retained kernel changes reduced runtime by approximately 20–30% for order 1 at the priority batches and about 47.5% for order 5 with nine Gauss points.

## Important alternatives evaluated

The benchmark report contains 23 principal implementation families plus focused follow-ups. The main negative results are retained because they explain the final boundaries.

- **Per-cell launches and per-segment CUDA graphs:** reduced launch overhead and beat JAX at moderate batches, but materialized recurrence states globally and approached parity at batch 1024.
- **One serial thread per environment:** removed launches but discarded row/column parallelism and created register/local-memory pressure; it was an order of magnitude slower than cooperative mappings.
- **One block per environment/segment:** useful at small/medium batches, but synchronization and segment-tip handoff lost throughput after saturation.
- **One owner per `6 x N` Lie output:** recomputed the same strain, Magnus coefficients, and SE(3) exponential up to 144 times per cell in the original shape.
- **Fully monolithic Lie + recurrence + quadrature:** failed the compile-feasibility gate; even a smaller recurrence/quadrature form did not finish Warp compilation within six minutes.
- **Constant-strain/fixed-joint specialization:** fast for exact PCS-like order-zero/fixed-joint models, but invalid for general GVS and still took about 31.6 s through the first shape-specialized result.
- **Joint propagation left in JAX:** worked, but preserved a size-dependent JAX graph and prevented the final persistent chain. Moving it to Warp enabled general mixed-joint fusion.
- **One global owner per final output:** deterministic and atomic-free, but reread the entire chain for each output entry and was slower at every batch.
- **Fusing joint propagation separately into every segment block:** duplicated block-local joint work and did not repay the added scheduling/synchronization.
- **Unguarded whole-chain persistence:** initially underoccupied the RTX 5090 at batch 64. It became successful only after active-prefix sparsity, shared recurrence values, weighted masses, and triangular inertia reduced work per block.
- **Cooperative cell layouts:** some helped batch 64 but regressed batch 256 because small cells did not amortize block scheduling, shared memory, and synchronization. Cooperative joint preprocessing was retained because joints contain enough shared SE(3) work.
- **Warp dense solve variants:** helped only at the non-priority large-batch end or only below 64 DoFs. The production backend therefore accelerates term assembly and retains the mature JAX dense solve.
- **Column-owned inertia and 256-lane blocks:** increased repeated quadrature reads or reduced occupancy. Upper-triangle pair ownership with 128/192 lanes was consistently better.

The major remaining bottleneck is the serial per-environment chain plus dense `N x N` inertia assembly. At small batches there are fewer environment blocks than SMs; at high order the active pair count and quadrature work dominate. Further gains should preserve runtime-sized modules and target local joint-tangent storage, cell/recurrence data movement, and multi-block high-order assembly rather than returning to shape-unrolled monolithic kernels.

## Updated benchmarks

Environment: RTX 5090, CUDA 13 driver, Warp 1.16.0, JAX 0.11.0, FP64. Results are synchronized interleaved medians. The current production API was used for both paths (`backend="jax"` versus `backend="warp"`), and every Warp result was compared with JAX before timing.

### GPU dynamics terms: 4 segments, basis order 1, revolute joints (52 DoFs)

| Environments | JAX | Warp | Speedup |
|---:|---:|---:|---:|
| 1 | 1.108 ms | 0.502 ms | 2.21x |
| 64 | 1.711 ms | 0.582 ms | 2.94x |
| 256 | 2.311 ms | 0.630 ms | 3.67x |
| 1024 | 6.007 ms | 1.497 ms | 4.01x |

Maximum absolute term error: `3.44e-12`.

### GPU dynamics terms: 4 segments, basis order 5, 9 Gauss points, revolute joints (148 DoFs)

This is the important coupled high-order case: increasing strain order also increases quadrature resolution.

| Environments | JAX | Warp | Speedup |
|---:|---:|---:|---:|
| 1 | 1.623 ms | 1.467 ms | 1.11x |
| 64 | 3.051 ms | 1.610 ms | 1.89x |
| 256 | 5.913 ms | 2.067 ms | 2.86x |
| 1024 | 21.886 ms | 7.265 ms | 3.01x |

Maximum absolute term error: `1.02e-12`.

### CPU dynamics terms: one environment

| Model | JAX | Warp | Warp regression |
|---|---:|---:|---:|
| order 1, 52 DoFs | 0.270 ms | 0.438 ms | 1.62x slower |
| order 5 / 9 points, 148 DoFs | 0.864 ms | 1.563 ms | 1.81x slower |

This is why `auto` selects JAX on CPU. The regression is documented rather than hidden behind a GPU crossover policy.

### GPU production `GVS.forward_dynamics`

These calls use the complete public method: Warp/JAX dynamics terms, elastic and damping forces, external/actuation handling, and the existing JAX dense inertia solve.

| Basis / quadrature | Environments | JAX | Warp | Speedup |
|---|---:|---:|---:|---:|
| order 1 | 1 | 1.325 ms | 0.685 ms | 1.93x |
| order 1 | 64 | 1.769 ms | 0.708 ms | 2.50x |
| order 1 | 256 | 2.442 ms | 0.909 ms | 2.69x |
| order 1 | 1024 | 6.456 ms | 1.917 ms | 3.37x |
| order 5 / 9 points | 1 | 2.156 ms | 2.015 ms | 1.07x |
| order 5 / 9 points | 64 | 4.139 ms | 2.776 ms | 1.49x |
| order 5 / 9 points | 256 | 7.560 ms | 3.679 ms | 2.05x |
| order 5 / 9 points | 1024 | 27.109 ms | 12.615 ms | 2.15x |

The inertia solve amplifies small term-ordering differences in absolute units because these test states produce large accelerations. Maximum scale-normalized errors remained below `1.7e-10` for order 1 and `1.3e-9` for order 5.

### GPU production `GVS.rollout_to`

These measurements call the standard Diffrax-based `GVS.rollout_to`, vectorized over environments exactly as other system-method benchmarks are. They use the default Tsit5 solver, constant `1e-5 s` solver steps, 100 requested steps (`1e-3 s` duration), and only initial/final state saves. A `1e-4 s` step was rejected because this stiff test model produced non-finite trajectories in both implementations.

| Basis / quadrature | Environments | JAX | Warp | Speedup |
|---|---:|---:|---:|---:|
| order 1 | 1 | 652.843 ms | 285.776 ms | 2.28x |
| order 1 | 64 | 979.368 ms | 363.113 ms | 2.70x |
| order 1 | 256 | 1,350.015 ms | 406.848 ms | 3.32x |
| order 5 / 9 points | 1 | 1,022.919 ms | 955.234 ms | 1.07x |
| order 5 / 9 points | 64 | 2,359.880 ms | 1,496.849 ms | 1.58x |
| order 5 / 9 points | 256 | 4,345.825 ms | 2,034.396 ms | 2.14x |

Maximum scale-normalized trajectory errors remained below `4.7e-10` for order 1 and `2.2e-10` for order 5.

### CPU production methods: one environment

| Method | Model | JAX | Warp | Warp regression |
|---|---|---:|---:|---:|
| `forward_dynamics` | order 1 | 0.342 ms | 0.462 ms | 1.35x slower |
| `forward_dynamics` | order 5 / 9 points | 0.891 ms | 1.589 ms | 1.78x slower |
| `rollout_to` | order 1 | 86.219 ms | 177.472 ms | 2.06x slower |
| `rollout_to` | order 5 / 9 points | 454.034 ms | 719.335 ms | 1.58x slower |

These complete-method results reinforce the JAX-on-CPU auto-dispatch decision.

### CUDA graph evidence

Nsight Systems 2025.5.2 traces used CUDA graph node tracing around warmed production calls at order 1, batch 64.

| Production call | Profiled calls | `cuGraphLaunch` | Forward-kernel instances | Interpretation |
|---|---:|---:|---:|---|
| `GVS.forward_dynamics` | 10 | 10 | 10 | one replayed graph per query |
| `GVS.rollout_to` (100 steps, Tsit5) | 2 | 2,834 | 1,214 | captured stage fragments, not one graph per rollout |

Thus graph capture works as intended for standalone forward queries. It is active and beneficial inside `rollout_to`, but full-rollout capture remains a separate optimization opportunity.

### Compilation scaling

| Segments | Cached Warp lower + XLA compile | JAX lower + XLA compile | Empty-cache Warp through first result |
|---:|---:|---:|---:|
| 4 | 55 ms | 1.02 s | 0.901 s |
| 16 | 63 ms | 1.08 s | 0.942 s |

The same Warp module hashes are used at both shapes, so CUDA generation does not grow with the number of links.

## Correctness and validation

- Every low-level benchmark checks `B`, `C @ qd`, and `G` against JAX before timing; production-method benchmarks compare complete outputs or trajectories.
- Current GPU term errors are approximately `1e-12` to `4e-12`.
- Mixed-joint validation covering every supported joint family stayed below `9.17e-12`.
- Tests verify scalar and explicit-batch calls, real Warp execution, and heterogeneous/length-scaled models.
- A custom-vmap test verifies that mapped scalar calls produce one batch-shaped Warp invocation.
- JVP, linearization, and reverse-mode tests verify that derivative transforms use JAX and do not stage Warp.
- Complete `forward_dynamics` JVP/gradient tests verify the same policy through forces and the inertia solve.
- Production `forward_dynamics` and `rollout_to` benchmarks reject non-finite outputs and report both absolute and scale-normalized differences.
- Parameter-update tests verify that compact bases, weighted masses, and gravity caches track model changes.
- The complete GVS CPU test module passed (`95 passed`); focused post-dispatch CPU and GPU Warp/transform tests also passed.
- `ruff check` and `git diff --check` pass for all committed production and test files.

## Known limitations

- Warp currently requires FP64 `q` and `qd`.
- Warp accelerates primal term assembly; derivative transformations intentionally execute the JAX implementation.
- The persistent kernel targets the current serial-chain GVS topology and does not introduce a rigid-body tree.
- The production forward-dynamics path retains the JAX dense inertia solve.
- CPU auto-dispatch intentionally remains on JAX.

## Recommendation

Use the unified API with the default `backend="auto"`: JAX on CPU, Warp on GPU, and JAX whenever derivatives are requested. This gives one hardware policy at the model boundary, preserves standard `jax.vmap` and rollout usage, and avoids exposing benchmark-era kernel option names in production code.

The resulting implementation supports spatially varying GVS strain and all current joint families, is 1.89–3.67x faster than JAX at the priority GPU batches for the measured order-1 and coupled order-5 models, and retains a sub-second, nearly flat first-result compilation law across four and 16 segments.
