### PR TITLE
Optimize JAX GVS dynamics with bounded prefix buckets

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -22,6 +22,12 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Performance
 
+- Accelerated JAX GVS dynamics-term assembly with compact strain bases,
+  velocity reuse, and four bounded active-DOF prefix buckets. Against the
+  previous full-width scan for a 16-segment, strain-order-5/9-Gauss-point model,
+  warmed runtime fell 36.4% on single-environment CPU (12.65 to 8.04 ms) and
+  35.7% on 256-environment GPU (146.76 to 94.32 ms); see
+  [PR #174](https://github.com/tud-phi/soromox/pull/174).
 - Refreshed the RTX 5090 parallel-rollout results for 216 matched configurations
   spanning 1–256 environments, with a 1.49× geometric-mean speedup over the
   previous committed measurements, and synchronized the publication figures.

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -102,8 +102,14 @@ class GVS(SoftRobot):
         max_num_integration_points: Maximum number of integration points per link (= max_num_gauss_points + 2).
         num_dofs: Total number of DOFs for the robot (sum of joint + link DOFs).
         num_padded_dofs: Theoretical maximum number of DOFs (num_segments * 2 * max_dof).
-        num_dynamics_prefix_buckets: Maximum number of active-DOF prefix
-            widths used by the dynamics reductions.
+        num_dynamics_prefix_buckets: Upper bound on the number of specialized
+            active-DOF widths compiled for the dynamics reductions. A segment
+            can depend only on its own and preceding segments' DOFs, so ordered
+            segments are grouped into at most this many buckets and each bucket
+            reduces only up to its largest required DOF prefix. Higher values
+            remove more zero-padded arithmetic, but add compiled branches and
+            can increase JAX compilation time. The default is 4; a value of 1
+            uses one full-width reduction branch.
         active_dof_map: Basis matrix mapping active DOFs into the full padded
             joint/link coordinate space.
         scale_rotational_basis_by_length: If True, apply scaling to the angular component of the strain basis matrix for improved numerical stability.
@@ -266,9 +272,14 @@ class GVS(SoftRobot):
                 model.
             passive_elements: Optional passive element or tuple of passive
                 elements. Pass ``None`` or an empty tuple to disable them.
-            num_dynamics_prefix_buckets: Maximum number of active-DOF prefix
-                widths compiled for the dynamics reductions. Larger values can
-                reduce padded arithmetic at the cost of additional compilation.
+            num_dynamics_prefix_buckets: Upper bound on the number of
+                specialized active-DOF widths compiled for dynamics. Ordered
+                segments are grouped into at most this many buckets, and each
+                bucket reduces only up to the largest causal DOF prefix needed
+                by one of its segments. Higher values remove more zero-padded
+                arithmetic, but add compiled branches and can increase JAX
+                compilation time. The default is 4; a value of 1 uses one
+                full-width reduction branch.
             **kwargs: Additional keyword arguments forwarded to
                 :class:`BaseContinuumSoftRobot`.
 
@@ -389,8 +400,12 @@ class GVS(SoftRobot):
             max_num_gauss_points: Optional common quadrature padding size.
             scale_rotational_basis_by_length: Whether to normalize rotational
                 strain-basis rows by link length.
-            num_dynamics_prefix_buckets: Maximum number of active-DOF prefix
-                widths compiled for the dynamics reductions.
+            num_dynamics_prefix_buckets: Upper bound on the number of
+                specialized active-DOF widths compiled for dynamics. Segments
+                are grouped in order, and each bucket reduces only up to its
+                largest required causal DOF prefix. Higher values trade more
+                compiled branches for less zero-padded arithmetic. The default
+                is 4; a value of 1 uses one full-width reduction branch.
             **kwargs: Additional keyword arguments forwarded to the GVS
                 constructor, such as actuators or passive elements.
 
@@ -790,7 +805,30 @@ class GVS(SoftRobot):
     def _compact_link_basis_operands(
         self, segment_lengths: Array
     ) -> tuple[Array, Array, Array]:
-        """Pack the structurally one-row columns of each link strain basis."""
+        """Pack the structurally one-row columns of every link strain basis.
+
+        Every active generalized-coordinate column in a link basis belongs to
+        exactly one of the six strain rows. Storing that row index and its value
+        avoids dense ``(6, self.max_dof)`` matrix products in the dynamics path.
+        Columns used only for padding receive row index ``-1``.
+
+        When rotational basis scaling is enabled, the values for strain rows
+        ``0:3`` are divided by the supplied link lengths. Passing lengths into
+        this helper keeps them dynamic JAX parameters: :meth:`with_params`
+        recomputes these compact values whenever a user updates link lengths.
+
+        Args:
+            segment_lengths: Current physical link lengths, shape
+                ``(self.num_segments,)``.
+
+        Returns:
+            Tuple ``(basis_rows, B_Z1_values, B_Z2_values)``. ``basis_rows`` has
+            shape ``(self.num_segments, self.max_dof)`` and maps active columns
+            to strain rows. Each values array has shape
+            ``(self.num_segments, self.max_num_integration_points - 1,
+            self.max_dof)`` and contains the corresponding scalar basis value
+            at a Magnus quadrature point.
+        """
         active = self.basis_active_params.astype(jnp.int32)
         orders = self.basis_order_params.astype(jnp.int32)
         standard_widths = active * (orders + 1)
@@ -1658,33 +1696,74 @@ class GVS(SoftRobot):
         xi_ref_Z1: Array,
         xi_ref_Z2: Array,
     ) -> tuple[Array, Array, Array, Array, Array, Array]:
-        """Evaluate one cell from compact one-row-per-column basis operands."""
-        valid = basis_rows >= 0
-        safe_rows = jnp.maximum(basis_rows, 0)
-        values_Z1 = jnp.where(valid, B_Z1_values, 0.0)
-        values_Z2 = jnp.where(valid, B_Z2_values, 0.0)
-        row_indicators = (
-            jax.nn.one_hot(safe_rows, 6, dtype=q_i.dtype).T * valid[None, :]
+        """Compute local ``J`` and ``Jdot`` terms from compact link bases.
+
+        This is algebraically equivalent to
+        :meth:`_magnus_jacobian_time_derivative_step_terms`, but exploits the
+        GVS basis structure that every active generalized-coordinate column has
+        a value in exactly one of the six strain rows. ``basis_rows`` and the
+        two value vectors reconstruct only the row selectors needed by the
+        second-order Magnus expansion; no dense link-basis matrices are formed.
+
+        The returned terms support the same local product-rule recurrence for
+        propagating a body Jacobian and its time derivative. Rotational basis
+        values are already length-scaled when that model option is enabled.
+
+        Args:
+            length: Physical length of the current link. Shape ``()``.
+            H: Normalized full or partial cell width. Shape ``()``.
+            q_i: Padded link generalized coordinates, shape
+                ``(self.max_dof,)``.
+            qd_i: Padded link generalized velocities, shape
+                ``(self.max_dof,)``.
+            basis_rows: Strain-row index for each compact basis column, shape
+                ``(self.max_dof,)``. Padding columns are marked with ``-1``.
+            B_Z1_values: Scalar basis value for each column at the first Magnus
+                quadrature point, shape ``(self.max_dof,)``.
+            B_Z2_values: Scalar basis value for each column at the second Magnus
+                quadrature point, shape ``(self.max_dof,)``.
+            xi_ref_Z1: Reference strain at the first quadrature point, shape
+                ``(6,)``.
+            xi_ref_Z2: Reference strain at the second quadrature point, shape
+                ``(6,)``.
+
+        Returns:
+            Tuple ``(g_step, T_step, Td_step, Ad_step_inv, B_Magnus,
+            B_Magnus_dot)``. ``g_step`` has shape ``(4, 4)``; ``T_step``,
+            ``Td_step``, and ``Ad_step_inv`` have shape ``(6, 6)``;
+            ``B_Magnus`` and ``B_Magnus_dot`` have shape
+            ``(6, self.max_dof)``.
+        """
+        # The compact arrays retain ``self.max_dof`` columns for fixed JAX
+        # shapes. A row of -1 marks a padding column with no strain-basis entry.
+        active_basis_columns = basis_rows >= 0
+        safe_basis_rows = jnp.maximum(basis_rows, 0)
+        masked_B_Z1_values = jnp.where(active_basis_columns, B_Z1_values, 0.0)
+        masked_B_Z2_values = jnp.where(active_basis_columns, B_Z2_values, 0.0)
+        basis_row_selectors = (
+            jax.nn.one_hot(safe_basis_rows, 6, dtype=q_i.dtype).T
+            * active_basis_columns[None, :]
         )
 
-        xi_Z1 = row_indicators @ (values_Z1 * q_i) + xi_ref_Z1
-        xi_Z2 = row_indicators @ (values_Z2 * q_i) + xi_ref_Z2
-        xid_Z1 = row_indicators @ (values_Z1 * qd_i)
-        xid_Z2 = row_indicators @ (values_Z2 * qd_i)
+        xi_Z1 = basis_row_selectors @ (masked_B_Z1_values * q_i) + xi_ref_Z1
+        xi_Z2 = basis_row_selectors @ (masked_B_Z2_values * q_i) + xi_ref_Z2
+        xid_Z1 = basis_row_selectors @ (masked_B_Z1_values * qd_i)
+        xid_Z2 = basis_row_selectors @ (masked_B_Z2_values * qd_i)
 
         ad_xi_Z1 = se3.small_adjoint(xi_Z1)
         ad_xi_Z2 = se3.small_adjoint(xi_Z2)
         comm_coeff = jnp.sqrt(3) * (length**2) * H**2 / 12
         Magnus = length * (H / 2) * (xi_Z1 + xi_Z2) + comm_coeff * (ad_xi_Z1 @ xi_Z2)
-        B_Magnus = length * (H / 2) * row_indicators * (values_Z1 + values_Z2)[
-            None, :
-        ] + comm_coeff * (
-            ad_xi_Z1[:, safe_rows] * values_Z2[None, :]
-            - ad_xi_Z2[:, safe_rows] * values_Z1[None, :]
+        B_Magnus = length * (H / 2) * basis_row_selectors * (
+            masked_B_Z1_values + masked_B_Z2_values
+        )[None, :] + comm_coeff * (
+            ad_xi_Z1[:, safe_basis_rows] * masked_B_Z2_values[None, :]
+            - ad_xi_Z2[:, safe_basis_rows] * masked_B_Z1_values[None, :]
         )
         B_Magnus_dot = comm_coeff * (
-            se3.small_adjoint(xid_Z1)[:, safe_rows] * values_Z2[None, :]
-            - se3.small_adjoint(xid_Z2)[:, safe_rows] * values_Z1[None, :]
+            se3.small_adjoint(xid_Z1)[:, safe_basis_rows] * masked_B_Z2_values[None, :]
+            - se3.small_adjoint(xid_Z2)[:, safe_basis_rows]
+            * masked_B_Z1_values[None, :]
         )
         Magnusd = B_Magnus @ qd_i
 

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -65,6 +65,25 @@ from soromox.utils.numerics import safe_divide, safe_norm, safe_normalize
 
 __all__ = ["GVS"]
 
+_DEFAULT_NUM_DYNAMICS_PREFIX_BUCKETS = 4
+
+
+def _equal_count_prefix_buckets(
+    active_prefixes: tuple[int, ...], bucket_count: int
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Partition ordered segments into equally populated prefix buckets."""
+    effective_bucket_count = min(bucket_count, len(active_prefixes))
+    bucket_ends = tuple(
+        math.ceil(len(active_prefixes) * index / effective_bucket_count)
+        for index in range(1, effective_bucket_count + 1)
+    )
+    widths = tuple(active_prefixes[end - 1] for end in bucket_ends)
+    bucket_indices = tuple(
+        next(index for index, end in enumerate(bucket_ends) if segment < end)
+        for segment in range(len(active_prefixes))
+    )
+    return widths, bucket_indices
+
 
 class GVS(SoftRobot):
     """
@@ -83,6 +102,8 @@ class GVS(SoftRobot):
         max_num_integration_points: Maximum number of integration points per link (= max_num_gauss_points + 2).
         num_dofs: Total number of DOFs for the robot (sum of joint + link DOFs).
         num_padded_dofs: Theoretical maximum number of DOFs (num_segments * 2 * max_dof).
+        num_dynamics_prefix_buckets: Maximum number of active-DOF prefix
+            widths used by the dynamics reductions.
         active_dof_map: Basis matrix mapping active DOFs into the full padded
             joint/link coordinate space.
         scale_rotational_basis_by_length: If True, apply scaling to the angular component of the strain basis matrix for improved numerical stability.
@@ -155,6 +176,8 @@ class GVS(SoftRobot):
     num_padded_dofs: int = eqx.field(
         static=True
     )  # Total number of DOFs for the robot, considering the maximum DOFs per link: num_segments * 2 * max_dof
+    num_dynamics_prefix_buckets: int = eqx.field(static=True)
+    active_dof_prefixes: tuple[int, ...] = eqx.field(static=True)
 
     Z1: float = eqx.field(static=True, default=0.5 - math.sqrt(3) / 6)
     Z2: float = eqx.field(static=True, default=0.5 + math.sqrt(3) / 6)
@@ -179,6 +202,9 @@ class GVS(SoftRobot):
     inner_integration_weights: Array
     mass_matrices: Array
     inner_mass_matrices: Array
+    link_basis_rows: Array
+    scaled_B_Z1_values: Array
+    scaled_B_Z2_values: Array
 
     B_joint: Array
     B_Xs: Array
@@ -226,6 +252,7 @@ class GVS(SoftRobot):
         structure: GVSStructure,
         actuators: Actuator | tuple[Actuator, ...] | None = None,
         passive_elements: PassiveElement | tuple[PassiveElement, ...] | None = (),
+        num_dynamics_prefix_buckets: int = _DEFAULT_NUM_DYNAMICS_PREFIX_BUCKETS,
         **kwargs: Any,
     ) -> None:
         """Initialize a GVS robot from typed parameters and static structure.
@@ -239,6 +266,9 @@ class GVS(SoftRobot):
                 model.
             passive_elements: Optional passive element or tuple of passive
                 elements. Pass ``None`` or an empty tuple to disable them.
+            num_dynamics_prefix_buckets: Maximum number of active-DOF prefix
+                widths compiled for the dynamics reductions. Larger values can
+                reduce padded arithmetic at the cost of additional compilation.
             **kwargs: Additional keyword arguments forwarded to
                 :class:`BaseContinuumSoftRobot`.
 
@@ -251,10 +281,17 @@ class GVS(SoftRobot):
             raise TypeError("params must be a GVSParams instance.")
         if not isinstance(structure, GVSStructure):
             raise TypeError("structure must be a GVSStructure instance.")
+        if isinstance(num_dynamics_prefix_buckets, bool) or not isinstance(
+            num_dynamics_prefix_buckets, int
+        ):
+            raise TypeError("num_dynamics_prefix_buckets must be an integer.")
+        if num_dynamics_prefix_buckets < 1:
+            raise ValueError("num_dynamics_prefix_buckets must be positive.")
         structure = _resolve_structure(params, structure)
         super().__init__(base_pose=params.base_pose, **kwargs)
         self.params = params
         self.structure = structure
+        self.num_dynamics_prefix_buckets = num_dynamics_prefix_buckets
         self.scale_rotational_basis_by_length = bool(
             structure.scale_rotational_basis_by_length
         )
@@ -333,6 +370,7 @@ class GVS(SoftRobot):
         max_dof: int | None = None,
         max_num_gauss_points: int | None = None,
         scale_rotational_basis_by_length: bool = False,
+        num_dynamics_prefix_buckets: int = _DEFAULT_NUM_DYNAMICS_PREFIX_BUCKETS,
         **kwargs: Any,
     ) -> "GVS":
         """Construct a GVS model directly from user-facing segment specs.
@@ -351,6 +389,8 @@ class GVS(SoftRobot):
             max_num_gauss_points: Optional common quadrature padding size.
             scale_rotational_basis_by_length: Whether to normalize rotational
                 strain-basis rows by link length.
+            num_dynamics_prefix_buckets: Maximum number of active-DOF prefix
+                widths compiled for the dynamics reductions.
             **kwargs: Additional keyword arguments forwarded to the GVS
                 constructor, such as actuators or passive elements.
 
@@ -371,7 +411,12 @@ class GVS(SoftRobot):
             max_num_gauss_points=max_num_gauss_points,
             scale_rotational_basis_by_length=scale_rotational_basis_by_length,
         )
-        return cls(params=params, structure=structure, **kwargs)
+        return cls(
+            params=params,
+            structure=structure,
+            num_dynamics_prefix_buckets=num_dynamics_prefix_buckets,
+            **kwargs,
+        )
 
     @property
     def is_planar(self) -> bool:
@@ -742,6 +787,44 @@ class GVS(SoftRobot):
             joint_stiffness=K_joint_full,
         )
 
+    def _compact_link_basis_operands(
+        self, segment_lengths: Array
+    ) -> tuple[Array, Array, Array]:
+        """Pack the structurally one-row columns of each link strain basis."""
+        active = self.basis_active_params.astype(jnp.int32)
+        orders = self.basis_order_params.astype(jnp.int32)
+        standard_widths = active * (orders + 1)
+        fourier_widths = active * (2 * orders + 1)
+        widths = jnp.where(
+            (self.basis_type_index == Basis.BASISTYPE_MAP["fourier"])[:, None],
+            fourier_widths,
+            standard_widths,
+        )
+        offsets = jnp.concatenate(
+            [
+                jnp.zeros((self.num_segments, 1), dtype=jnp.int32),
+                jnp.cumsum(widths[:, :-1], axis=1),
+            ],
+            axis=1,
+        )
+        columns = jnp.arange(self.max_dof, dtype=jnp.int32)[None, None, :]
+        row_numbers = jnp.arange(6, dtype=jnp.int32)[None, :, None]
+        active_columns = (columns >= offsets[:, :, None]) & (
+            columns < (offsets + widths)[:, :, None]
+        )
+        rows = jnp.max(jnp.where(active_columns, row_numbers, -1), axis=1)
+
+        B_Z1 = self.B_Z1
+        B_Z2 = self.B_Z2
+        if self.scale_rotational_basis_by_length:
+            scales = segment_lengths[:, None, None, None]
+            B_Z1 = B_Z1.at[:, :, :3].divide(scales)
+            B_Z2 = B_Z2.at[:, :, :3].divide(scales)
+        gather_rows = jnp.maximum(rows, 0)[:, None, None, :]
+        values_Z1 = jnp.take_along_axis(B_Z1, gather_rows, axis=2).squeeze(2)
+        values_Z2 = jnp.take_along_axis(B_Z2, gather_rows, axis=2).squeeze(2)
+        return rows.astype(jnp.int32), values_Z1, values_Z2
+
     def precompute(self) -> None:
         """Precompute padded gathers and canonical system matrices.
 
@@ -754,6 +837,10 @@ class GVS(SoftRobot):
             initial construction.
         """
         dofs_flat = self.dofs_per_segment.reshape(-1)
+        active_dof_prefixes = tuple(
+            int(value) for value in jnp.cumsum(jnp.sum(self.dofs_per_segment, axis=1))
+        )
+        object.__setattr__(self, "active_dof_prefixes", active_dof_prefixes)
         start_indices_flat = jnp.cumsum(jnp.pad(dofs_flat, (1, 0)))[:-1]
         start_indices = start_indices_flat.reshape(self.num_segments, 2)
         gather_indices = start_indices[..., None] + jnp.arange(self.max_dof)
@@ -782,6 +869,12 @@ class GVS(SoftRobot):
             "inner_mass_matrices",
             self.mass_matrices[:, 1 : self.max_num_integration_points - 1],
         )
+        link_basis_rows, scaled_B_Z1_values, scaled_B_Z2_values = (
+            self._compact_link_basis_operands(self.segment_lengths)
+        )
+        object.__setattr__(self, "link_basis_rows", link_basis_rows)
+        object.__setattr__(self, "scaled_B_Z1_values", scaled_B_Z1_values)
+        object.__setattr__(self, "scaled_B_Z2_values", scaled_B_Z2_values)
         object.__setattr__(self, "gather_indices", gather_indices)
         object.__setattr__(self, "gather_mask", gather_mask)
         object.__setattr__(self, "young_stiffness_operator", young_operator)
@@ -1041,10 +1134,16 @@ class GVS(SoftRobot):
         young_operator, shear_operator, damping_operator = (
             material_operators_from_params(params, self.structure)
         )
+        link_basis_rows, scaled_B_Z1_values, scaled_B_Z2_values = (
+            updated_self._compact_link_basis_operands(updated_self.segment_lengths)
+        )
         return eqx.tree_at(
             lambda model: (
                 model.inner_integration_weights,
                 model.inner_mass_matrices,
+                model.link_basis_rows,
+                model.scaled_B_Z1_values,
+                model.scaled_B_Z2_values,
                 model.young_stiffness_operator,
                 model.shear_stiffness_operator,
                 model.material_damping_operator,
@@ -1062,6 +1161,9 @@ class GVS(SoftRobot):
                 updated_self.mass_matrices[
                     :, 1 : updated_self.max_num_integration_points - 1
                 ],
+                link_basis_rows,
+                scaled_B_Z1_values,
+                scaled_B_Z2_values,
                 young_operator,
                 shear_operator,
                 damping_operator,
@@ -1533,6 +1635,56 @@ class GVS(SoftRobot):
         )
         B_Magnus_dot = comm_coeff * (
             se3.small_adjoint(xid_Z1) @ B_Z2 - se3.small_adjoint(xid_Z2) @ B_Z1
+        )
+        Magnusd = B_Magnus @ qd_i
+
+        g_step, T_step, Td_step = (
+            se3._exp_with_left_jacobian_and_directional_derivative(
+                Magnus, Magnusd, self.global_eps, self.tangent_eps
+            )
+        )
+        Ad_step_inv = se3.adjoint_inverse(g_step)
+        return g_step, T_step, Td_step, Ad_step_inv, B_Magnus, B_Magnus_dot
+
+    def _compact_magnus_jacobian_time_derivative_step_terms(
+        self,
+        length: Array,
+        H: Array,
+        q_i: Array,
+        qd_i: Array,
+        basis_rows: Array,
+        B_Z1_values: Array,
+        B_Z2_values: Array,
+        xi_ref_Z1: Array,
+        xi_ref_Z2: Array,
+    ) -> tuple[Array, Array, Array, Array, Array, Array]:
+        """Evaluate one cell from compact one-row-per-column basis operands."""
+        valid = basis_rows >= 0
+        safe_rows = jnp.maximum(basis_rows, 0)
+        values_Z1 = jnp.where(valid, B_Z1_values, 0.0)
+        values_Z2 = jnp.where(valid, B_Z2_values, 0.0)
+        row_indicators = (
+            jax.nn.one_hot(safe_rows, 6, dtype=q_i.dtype).T * valid[None, :]
+        )
+
+        xi_Z1 = row_indicators @ (values_Z1 * q_i) + xi_ref_Z1
+        xi_Z2 = row_indicators @ (values_Z2 * q_i) + xi_ref_Z2
+        xid_Z1 = row_indicators @ (values_Z1 * qd_i)
+        xid_Z2 = row_indicators @ (values_Z2 * qd_i)
+
+        ad_xi_Z1 = se3.small_adjoint(xi_Z1)
+        ad_xi_Z2 = se3.small_adjoint(xi_Z2)
+        comm_coeff = jnp.sqrt(3) * (length**2) * H**2 / 12
+        Magnus = length * (H / 2) * (xi_Z1 + xi_Z2) + comm_coeff * (ad_xi_Z1 @ xi_Z2)
+        B_Magnus = length * (H / 2) * row_indicators * (values_Z1 + values_Z2)[
+            None, :
+        ] + comm_coeff * (
+            ad_xi_Z1[:, safe_rows] * values_Z2[None, :]
+            - ad_xi_Z2[:, safe_rows] * values_Z1[None, :]
+        )
+        B_Magnus_dot = comm_coeff * (
+            se3.small_adjoint(xid_Z1)[:, safe_rows] * values_Z2[None, :]
+            - se3.small_adjoint(xid_Z2)[:, safe_rows] * values_Z1[None, :]
         )
         Magnusd = B_Magnus @ qd_i
 
@@ -4369,11 +4521,14 @@ class GVS(SoftRobot):
         interior quadrature values are reduced with matrix products. The
         Jacobian remains in active coordinates throughout; masked scatters
         insert the current joint or link basis without multiplying by dense
-        selectors. Keeping both scan bodies independent of a segment's concrete
-        DOF and quadrature counts bounds tracing work as the number of segments
-        grows. Gravity is propagated directly between local frames, and
-        ``C(q, qd) @ qd`` is assembled without constructing the complete
-        Coriolis matrix.
+        selectors. The three global reductions dispatch over at most
+        ``num_dynamics_prefix_buckets`` equally populated active-prefix widths.
+        This bounds the compiled branch count independently of the number of
+        segments while avoiding most arithmetic on future-segment DOFs. Keeping
+        both scan bodies independent of a segment's concrete DOF and quadrature
+        counts bounds tracing work as the number of segments grows. Gravity is
+        propagated directly between local frames, and ``C(q, qd) @ qd`` is
+        assembled without constructing the complete Coriolis matrix.
 
         Args:
             q: Active generalized coordinates, shape
@@ -4437,13 +4592,14 @@ class GVS(SoftRobot):
                     adjoint_inverse,
                     magnus_basis,
                     magnus_basis_dot,
-                ) = self._magnus_jacobian_time_derivative_step_terms(
+                ) = self._compact_magnus_jacobian_time_derivative_step_terms(
                     self.segment_lengths[segment_index],
                     cell_width,
                     q_blocks[segment_index, 1],
                     qd_blocks[segment_index, 1],
-                    self.B_Z1[segment_index, cell_index],
-                    self.B_Z2[segment_index, cell_index],
+                    self.link_basis_rows[segment_index],
+                    self.scaled_B_Z1_values[segment_index, cell_index],
+                    self.scaled_B_Z2_values[segment_index, cell_index],
                     self.xi_ref_Z1[segment_index, cell_index],
                     self.xi_ref_Z2[segment_index, cell_index],
                 )
@@ -4467,6 +4623,52 @@ class GVS(SoftRobot):
         gravity_initial = se3.adjoint_inverse(self.g0) @ self.g
         inertia_initial = jnp.zeros((self.num_dofs, self.num_dofs), dtype=dtype)
         generalized_vector_initial = jnp.zeros((self.num_dofs,), dtype=dtype)
+        prefix_bucket_widths, segment_bucket_indices = _equal_count_prefix_buckets(
+            self.active_dof_prefixes, self.num_dynamics_prefix_buckets
+        )
+        segment_bucket_indices_array = jnp.asarray(segment_bucket_indices)
+
+        def make_reduction_branch(bucket_width: int):
+            def reduce_bucket(
+                operands: tuple[Array, Array, Array, Array, Array],
+            ) -> tuple[Array, Array, Array]:
+                (
+                    jacobians,
+                    weights,
+                    mass_diagonals_i,
+                    wrenches,
+                    gravity_wrenches,
+                ) = operands
+                flattened_row_count = (self.max_num_integration_points - 2) * 6
+                jacobians_prefix = jacobians[..., :bucket_width]
+                jacobians_flat = jacobians_prefix.reshape(
+                    flattened_row_count, bucket_width
+                )
+                weighted_jacobians_flat = (
+                    weights[:, None, None]
+                    * mass_diagonals_i[:, :, None]
+                    * jacobians_prefix
+                ).reshape(flattened_row_count, bucket_width)
+                inertia_prefix = jacobians_flat.T @ weighted_jacobians_flat
+                coriolis_prefix = jacobians_flat.T @ (
+                    weights[:, None] * wrenches
+                ).reshape(flattened_row_count)
+                gravity_prefix = -jacobians_flat.T @ (
+                    weights[:, None] * gravity_wrenches
+                ).reshape(flattened_row_count)
+                vector_padding = (0, self.num_dofs - bucket_width)
+                matrix_padding = (vector_padding, vector_padding)
+                return (
+                    jnp.pad(inertia_prefix, matrix_padding),
+                    jnp.pad(coriolis_prefix, vector_padding),
+                    jnp.pad(gravity_prefix, vector_padding),
+                )
+
+            return reduce_bucket
+
+        reduction_branches = tuple(
+            make_reduction_branch(width) for width in prefix_bucket_widths
+        )
 
         def insert_local_basis(
             local_basis: Array, segment_index: Array, block_index: int
@@ -4513,10 +4715,14 @@ class GVS(SoftRobot):
 
             joint_tangent = insert_local_basis(joint_tangent_basis, segment_index, 0)
             jacobian_joint = joint_adjoint_inverse @ (jacobian_tip + joint_tangent)
-            jacobian_dot_qd_joint = joint_adjoint_inverse @ (
-                jacobian_dot_qd_tip
-                + joint_tangent_basis_dot @ qd_blocks[segment_index, 0]
-            ) + joint_adjoint_inverse_dot @ (jacobian_tip @ qd)
+            jacobian_dot_qd_joint = (
+                joint_adjoint_inverse
+                @ (
+                    jacobian_dot_qd_tip
+                    + joint_tangent_basis_dot @ qd_blocks[segment_index, 0]
+                )
+                + joint_adjoint_inverse_dot @ velocity_tip
+            )
             velocity_joint = joint_adjoint_inverse @ (velocity_tip + joint_velocity)
             gravity_joint = joint_adjoint_inverse @ gravity_tip
 
@@ -4552,7 +4758,7 @@ class GVS(SoftRobot):
                 jacobian_dot_qd_next = adjoint_inverse @ (
                     jacobian_dot_qd_previous + tangent_velocity_dot
                 ) - se3.small_adjoint_action(
-                    step_velocity, adjoint_inverse @ (jacobian_previous @ qd)
+                    step_velocity, adjoint_inverse @ velocity_previous
                 )
                 gravity_next = adjoint_inverse @ gravity_previous
                 return (
@@ -4591,21 +4797,21 @@ class GVS(SoftRobot):
 
             weights = self.inner_integration_weights[segment_index]
             mass_diagonals_i = mass_diagonals[segment_index]
-            flattened_row_count = (self.max_num_integration_points - 2) * 6
-            jacobians_flat = jacobians.reshape(flattened_row_count, self.num_dofs)
-            inertia_segment = jacobians_flat.T @ (
-                weights[:, None, None] * mass_diagonals_i[:, :, None] * jacobians
-            ).reshape(flattened_row_count, self.num_dofs)
-
             momenta = mass_diagonals_i * velocities
             coadjoint_momenta = jax.vmap(se3.coadjoint_action)(velocities, momenta)
             wrenches = mass_diagonals_i * jacobians_dot_qd + coadjoint_momenta
-            coriolis_segment = jacobians_flat.T @ (weights[:, None] * wrenches).reshape(
-                flattened_row_count
+            gravity_wrenches = mass_diagonals_i * gravities
+            inertia_segment, coriolis_segment, gravity_segment = lax.switch(
+                segment_bucket_indices_array[segment_index],
+                reduction_branches,
+                (
+                    jacobians,
+                    weights,
+                    mass_diagonals_i,
+                    wrenches,
+                    gravity_wrenches,
+                ),
             )
-            gravity_segment = -jacobians_flat.T @ (
-                weights[:, None] * mass_diagonals_i * gravities
-            ).reshape(flattened_row_count)
 
             kinematics_tip = advance_cell(kinematics_last_quad, tip_cell_terms_i)
             return (

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1975,6 +1975,61 @@ def test_rotational_strain_basis_length_scaling_matches_unscaled_coordinates() -
     )
 
 
+def test_scaled_compact_basis_tracks_dynamic_segment_length_updates() -> None:
+    robot = build_constant_strain_gvs(
+        num_segments=2,
+        max_dof=8,
+        segment_length=0.2,
+        scale_rotational_basis_by_length=True,
+    )
+    updated_lengths = jnp.array([0.15, 0.32], dtype=robot.segment_lengths.dtype)
+    updated_params = robot.params.replace(
+        link=robot.params.link.replace(length=updated_lengths)
+    )
+    updated = robot.with_params(updated_params)
+
+    rotational_columns = (robot.link_basis_rows >= 0) & (robot.link_basis_rows < 3)
+    length_ratio = robot.segment_lengths[:, None, None] / updated_lengths[:, None, None]
+    for original_values, updated_values in (
+        (robot.scaled_B_Z1_values, updated.scaled_B_Z1_values),
+        (robot.scaled_B_Z2_values, updated.scaled_B_Z2_values),
+    ):
+        expected_values = jnp.where(
+            rotational_columns[:, None, :],
+            original_values * length_ratio,
+            original_values,
+        )
+        assert_allclose(updated_values, expected_values, rtol=RTOL, atol=ATOL)
+        assert not jnp.allclose(updated_values, original_values)
+
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_compact_basis(current_params):
+        trace_count["value"] += 1
+        current = robot.with_params(current_params)
+        return (
+            current.segment_lengths,
+            current.scaled_B_Z1_values,
+            current.scaled_B_Z2_values,
+        )
+
+    compiled_compact_basis(robot.params)
+    actual = compiled_compact_basis(updated_params)
+
+    assert trace_count["value"] == 1
+    for actual_array, expected_array in zip(
+        actual,
+        (
+            updated.segment_lengths,
+            updated.scaled_B_Z1_values,
+            updated.scaled_B_Z2_values,
+        ),
+        strict=True,
+    ):
+        assert_allclose(actual_array, expected_array, rtol=RTOL, atol=ATOL)
+
+
 @pytest.mark.parametrize("num_segments", [1, 2])
 def test_strain_basis_consistency_kinematics_jacobians_and_dynamics(
     num_segments: int,

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -534,6 +534,68 @@ def build_constant_strain_gvs(
     return GVS(params=params, structure=structure)
 
 
+def test_gvs_dynamics_prefix_bucket_count_is_configurable() -> None:
+    default = build_constant_strain_gvs(num_segments=3)
+    one_bucket = GVS(
+        params=default.params,
+        structure=default.structure,
+        num_dynamics_prefix_buckets=1,
+    )
+    many_buckets = GVS(
+        params=default.params,
+        structure=default.structure,
+        num_dynamics_prefix_buckets=16,
+    )
+    q = jnp.linspace(-0.02, 0.02, default.num_dofs)
+    qd = jnp.linspace(0.03, -0.03, default.num_dofs)
+
+    assert default.num_dynamics_prefix_buckets == 4
+    assert one_bucket.num_dynamics_prefix_buckets == 1
+    assert many_buckets.num_dynamics_prefix_buckets == 16
+    expected = default.dynamics_terms(q, qd)
+    for actual in (
+        one_bucket.dynamics_terms(q, qd),
+        many_buckets.dynamics_terms(q, qd),
+    ):
+        for actual_term, expected_term in zip(actual, expected, strict=True):
+            assert_allclose(actual_term, expected_term, rtol=RTOL, atol=ATOL)
+
+    tangent = (0.1 * jnp.ones_like(q), -0.2 * jnp.ones_like(qd))
+
+    def dynamics_jvp(robot: GVS):
+        return jvp(
+            lambda state: robot.dynamics_terms(*state),
+            ((q, qd),),
+            (tangent,),
+        )
+
+    expected_primal, expected_tangent = dynamics_jvp(default)
+    for robot in (one_bucket, many_buckets):
+        actual_primal, actual_tangent = dynamics_jvp(robot)
+        for actual_tree, expected_tree in (
+            (actual_primal, expected_primal),
+            (actual_tangent, expected_tangent),
+        ):
+            for actual_term, expected_term in zip(
+                actual_tree, expected_tree, strict=True
+            ):
+                assert_allclose(actual_term, expected_term, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize(
+    ("value", "error"),
+    [(0, ValueError), (-1, ValueError), (True, TypeError), (2.0, TypeError)],
+)
+def test_gvs_dynamics_prefix_bucket_count_validation(value, error) -> None:
+    default = build_constant_strain_gvs()
+    with pytest.raises(error, match="num_dynamics_prefix_buckets"):
+        GVS(
+            params=default.params,
+            structure=default.structure,
+            num_dynamics_prefix_buckets=value,
+        )
+
+
 def test_gvs_segment_factories_match_explicit_constructor() -> None:
     segments = [
         GVSSegment(

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -1677,6 +1677,44 @@ def test_rotational_strain_basis_length_scaling_matches_unscaled_coordinates():
     )
 
 
+def test_scaled_strain_basis_tracks_dynamic_segment_length_updates():
+    model, params = make_pcs(
+        num_segments=2,
+        total_length=0.4,
+        scale_rotational_basis_by_length=True,
+    )
+    updated_lengths = jnp.array([0.15, 0.32], dtype=model.L.dtype)
+    updated_params = params.replace(link=params.link.replace(length=updated_lengths))
+    updated = model.with_params(updated_params)
+
+    rotational_rows = jnp.arange(model.num_strains) % 6 < 3
+    length_ratio_by_row = jnp.repeat(model.L / updated_lengths, 6)
+    expected_basis = jnp.where(
+        rotational_rows[:, None],
+        model.B_xi * length_ratio_by_row[:, None],
+        model.B_xi,
+    )
+    assert_allclose(updated.B_xi, expected_basis, rtol=RTOL, atol=ATOL)
+    assert not jnp.allclose(updated.B_xi, model.B_xi)
+
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_scaled_basis(current_params):
+        trace_count["value"] += 1
+        current = model.with_params(current_params)
+        return current.L, current.B_xi
+
+    compiled_scaled_basis(params)
+    actual = compiled_scaled_basis(updated_params)
+
+    assert trace_count["value"] == 1
+    for actual_array, expected_array in zip(
+        actual, (updated.L, updated.B_xi), strict=True
+    ):
+        assert_allclose(actual_array, expected_array, rtol=RTOL, atol=ATOL)
+
+
 def _make_full_and_reduced_pcs(num_segments: int, selector_per_segment: Array):
     """Utility to build a full-DOF PCS and a reduced-DOF PCS sharing parameters.
 

--- a/tests/systems/test_planar_pcs.py
+++ b/tests/systems/test_planar_pcs.py
@@ -1921,6 +1921,44 @@ def test_rotational_strain_basis_length_scaling_matches_unscaled_coordinates_pla
     )
 
 
+def test_scaled_strain_basis_tracks_dynamic_segment_length_updates_planar():
+    model, params = make_planar_pcs(
+        num_segments=2,
+        total_length=0.4,
+        scale_rotational_basis_by_length=True,
+    )
+    updated_lengths = jnp.array([0.15, 0.32], dtype=model.L.dtype)
+    updated_params = params.replace(link=params.link.replace(length=updated_lengths))
+    updated = model.with_params(updated_params)
+
+    rotational_rows = jnp.arange(model.num_strains) % 3 == 0
+    length_ratio_by_row = jnp.repeat(model.L / updated_lengths, 3)
+    expected_basis = jnp.where(
+        rotational_rows[:, None],
+        model.B_xi * length_ratio_by_row[:, None],
+        model.B_xi,
+    )
+    assert_allclose(updated.B_xi, expected_basis, rtol=RTOL, atol=ATOL)
+    assert not jnp.allclose(updated.B_xi, model.B_xi)
+
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_scaled_basis(current_params):
+        trace_count["value"] += 1
+        current = model.with_params(current_params)
+        return current.L, current.B_xi
+
+    compiled_scaled_basis(params)
+    actual = compiled_scaled_basis(updated_params)
+
+    assert trace_count["value"] == 1
+    for actual_array, expected_array in zip(
+        actual, (updated.L, updated.B_xi), strict=True
+    ):
+        assert_allclose(actual_array, expected_array, rtol=RTOL, atol=ATOL)
+
+
 def _make_full_and_reduced_planar(num_segments: int, selector_per_segment: Array):
     strain_selector = jnp.tile(selector_per_segment, num_segments)
 


### PR DESCRIPTION
## Summary

This PR transfers the useful, differentiable parts of #173 into the existing JAX GVS dynamics path without adding a second backend:

- reuse the body velocity already carried by the segment/cell recurrence instead of recomputing `J @ qd`;
- store each link strain-basis column as its one active spatial row plus two scalar Magnus-point values;
- reduce `B`, `C @ qd`, and `G` only over bounded active-DOF prefixes;
- select among at most K reusable prefix widths inside the existing outer `lax.scan`; and
- make K user-configurable as `num_dynamics_prefix_buckets`, with K=4 as the default.

The production implementation contains one dynamics path only. The previous full-width reduction and the exact/full-prefix segment-unrolled implementation are not retained as alternatives. This preserves the fixed recurrence graph and avoids changing compilation-time scaling from bounded control flow to one separately traced body per segment.

The implementation remains pure JAX, supports forward- and reverse-mode differentiation, and does not change the GVS equations, joint families, strain bases, or quadrature scheme.

## Branch strategy

The phase-by-phase implementation and benchmark history was first preserved and pushed as `codex/pr173-jax-evaluation`. The exact unrolled prefix implementation is additionally preserved on `codex/pr173-jax-active-prefix-snapshot` at `38ad507b90`.

This PR comes from the clean branch `codex/jax-dynamics-prefix-buckets`, created directly from `origin/main` (`683fb66`). It contains a single production commit and only two changed repository files: the GVS implementation and focused GVS tests. Benchmark scripts and reports used during the investigation are deliberately not included.

## Motivation and design constraint

The original fixed-shape JAX implementation already uses one outer segment `lax.scan` and one inner cell `lax.scan`, which gives it a valuable property: the recurrence/control-flow graph does not grow with segment count. Its main runtime inefficiency is different. At segment `s`, the Jacobian can only depend on the active coordinates introduced up to `s`, but the three global quadrature reductions still process all final system DOFs.

The exact active-prefix experiment removed all of that padded work and achieved the best isolated runtime. However, it used a Python loop with one concretely sized body per segment. The generated StableHLO and compiler time consequently grew linearly with segment count. For the high-order CPU case, compiler time increased by about 0.45 seconds per additional segment and reached about 15.3 seconds at 32 segments, versus about 2.3 seconds for the original scan.

The selected design keeps the scan and introduces only a fixed number of reusable reduction shapes. It therefore trades a small amount of remaining padded arithmetic for a bounded graph.

## Public API and parameter name

Both `GVS(...)` and `GVS.from_segments(...)` now accept:

```python
num_dynamics_prefix_buckets: int = 4
```

The value must be a positive non-boolean integer. The effective branch count is capped by the segment count. Because it is an Equinox static field, changing it intentionally produces a separately compiled executable.

`num_dynamics_prefix_buckets` was selected because it identifies:

1. that this is a count (`num_`);
2. that it affects only dynamics compilation/execution; and
3. that each branch represents an active-coordinate prefix bucket.

The alternatives were less precise: `branch_budget` exposed an implementation detail, `num_reduction_buckets` was too broad, and `num_active_dof_buckets` did not identify the dynamics path.

K=1 or K=2 can be appropriate when cold compilation dominates. K=8 can be useful for a long-lived, throughput-dominated executable. K=4 was the best tested general Pareto point and is therefore the default.

## Production implementation

### Compact link-basis operands

Every GVS link basis column has at most one structurally active spatial row. `precompute()` now stores:

- the row index of each padded local basis column;
- the scalar basis value at the first Magnus point; and
- the scalar basis value at the second Magnus point.

The compact cell helper reconstructs strain and strain rate from those row/value operands and computes the same two-point Magnus increment, tangent, tangent directional derivative, `B_Magnus`, and `B_Magnus_dot` as the dense helper. Padded columns are masked. Fourier widths and optional rotational length scaling are handled explicitly.

The cached scalar values are refreshed by `with_params()` when segment lengths or other dynamic parameters change.

### Recurrence-velocity reuse

The segment/cell recurrence already propagates body velocity. The contracted Jacobian-derivative recurrence now consumes that value directly at joints and cells instead of repeatedly forming `J_previous @ qd`. This is algebraically identical because the recurrence maintains `velocity_previous == J_previous @ qd`.

### Equal-count active-prefix buckets

Construction records the cumulative active-coordinate prefix after each segment. The ordered segments are divided into at most K equally populated groups. Each group ends at an actual active prefix, so its reduction branch slices the quadrature Jacobians to that width, performs the three contractions, and pads the result back to the final active-coordinate shape.

Only the global reductions are inside `lax.switch`. Joint evaluation, Magnus cell evaluation, and both causal recurrences remain in their single reusable scan bodies.

This is intentionally different from branching on local segment DOF or `(DOF, Gauss points)`. A segment's global prefix depends on every preceding segment, not only on its own local shape. Grouping equal local shapes in model order can still help bucket placement indirectly, but it does not justify duplicating the cell evaluator.

## Measurement method

- JAX 0.11.0, Python 3.12.13, FP64.
- CPU: Intel Core Ultra 9 285K. Every CPU benchmark was pinned to high-performance logical core 1 with `taskset -c 1` and `OMP_NUM_THREADS=1`; the benchmark aborted unless affinity was exactly `(1,)`.
- GPU: NVIDIA GeForce RTX 5090, 32 GB, driver 595.84.
- GVS segments: 1, 4, 8, 16, and 32.
- Coupled strain-order/Gauss-point pairs: 0/5, 1/5, 3/7, and 5/9.
- CPU: one environment. GPU: batches 1, 64, 256, and 1024; the 32-segment endpoint was measured through batch 256.
- Runtime: synchronized medians after 8--10 warm-up calls, normally over 30 CPU or 15 GPU samples.
- Compilation-scaling cells: fresh Python/JAX processes. Lowering, `lowered.compile()`, first execution, StableHLO text size, operation count, `case` count, and `while` count were recorded separately.
- Candidate values and JVP directional derivatives were compared with the original fixed-width scan before timing.

## Pareto optimization of the branch budget

The representative order-5 / 9-Gauss-point results below are fresh-process compiler seconds / warmed term-assembly milliseconds.

| Device/workload | Full width | K=2 | K=4 | K=8 | Exact prefix |
|---|---:|---:|---:|---:|---:|
| CPU, S=16, B=1 | 1.97 / 13.04 | 2.07 / 9.49 | 2.18 / 8.34 | 2.48 / 8.11 | 7.90 / 5.88 |
| GPU, S=16, B=256 | 3.35 / 146.98 | 3.58 / 112.00 | 4.54 / 96.39 | 7.17 / 89.28 | 14.99 / 57.97 |
| GPU, S=16, B=1024 | 4.39 / 576.79 | 5.21 / 429.40 | 6.64 / 369.35 | 10.77 / 346.14 | 19.83 / 219.88 |
| GPU, S=32, B=256 | 4.40 / 1004.56 | 5.13 / 752.84 | 6.83 / 646.87 | 10.65 / 606.36 | not run |

K=4 captures about 59--68% of the exact-prefix runtime gain in these large cases. K=8 improves runtime only another 4--7% while roughly doubling incremental compile cost. K=16 was only another 2--3% faster than K=8. K=4 is therefore the knee of the measured compile/runtime frontier.

## Compilation scaling

### StableHLO graph law

| Segments | CPU full width | CPU K=4 | CPU exact | GPU B=256 full width | GPU B=256 K=4 | GPU B=256 exact |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 2,933 | 3,147 | 3,260 | 3,121 | 3,347 | 3,480 |
| 8 | 2,933 | 3,147 | 4,048 | 3,121 | 3,347 | 4,364 |
| 16 | 2,933 | 3,147 | 5,624 | 3,121 | 3,347 | 6,132 |
| 32 | 2,933 | 3,147 | 8,776 | 3,121 | 3,347 | not run |

The exact path adds 197 CPU or 221 batched-GPU StableHLO operations per segment. K=4 adds a fixed 214 CPU or 226 batched-GPU operations once all branches exist and then plateaus. Both full-width and K=4 retain two `while` operations; K=4 adds one bounded `case`.

StableHLO text still grows with tensor dimensions and embedded constants. That is shape growth, not recurrence-body duplication: operation count and control-flow topology stay fixed.

### Fresh-process CPU compiler time

Cells are full width / K=4 / exact seconds.

| Segments | order 1 / GQ 5 | order 5 / GQ 9 |
|---:|---:|---:|
| 4 | 1.878 / 2.043 / 2.697 | 1.922 / 2.110 / 2.846 |
| 8 | 1.867 / 2.052 / 4.350 | 1.969 / 2.162 / 4.488 |
| 16 | 1.967 / 2.118 / 7.858 | 1.988 / 2.260 / 7.898 |
| 32 | 1.937 / 2.106 / 15.255 | 2.294 / 2.468 / 15.326 |

Linear compiler slopes over 4--32 segments:

| Path | order 1 | order 5 |
|---|---:|---:|
| Full width | 0.0026 s/segment | 0.0132 s/segment |
| K=4 | 0.0023 s/segment | 0.0128 s/segment |
| Exact prefix | 0.4502 s/segment | 0.4472 s/segment |

K=4 preserves the full-width CPU scaling law. At 32 segments it compiles in 2.11--2.47 seconds, versus 15.26--15.33 seconds for exact prefix.

### Fresh-process GPU compiler time

High-order cells are full width / K=4 / exact seconds.

| Segments | batch 1 | batch 256 | batch 1024 |
|---:|---:|---:|---:|
| 4 | 1.74 / 3.55 / 3.80 | 2.64 / 4.06 / 4.50 | 2.81 / 4.89 / 5.82 |
| 8 | 1.72 / 3.25 / 6.45 | 2.88 / 4.30 / 8.26 | 3.09 / 4.70 / 8.84 |
| 16 | 1.68 / 3.30 / 12.30 | 3.15 / 4.54 / 14.99 | 4.42 / 6.64 / 19.83 |
| 32 | 1.88 / 3.27 / not run | 4.36 / 6.83 / not run | not run |

At batch 1, K=4 is flat from 4--32 segments while exact prefix adds about 0.71 seconds per segment. At 16 segments, K=4 compiles 67--73% faster than exact prefix depending on batch size.

K=4 compiler time still grows at high order and large batch despite a constant 3,347-operation graph. The same shape/layout/GEMM code-generation effect exists in the full-width scan. It is fundamentally different from the exact path's per-segment graph growth.

## Warmed runtime

Representative dynamics-term assembly:

| Workload | Full width | K=4 | Speed-up |
|---|---:|---:|---:|
| CPU, S=16, order 5/GQ 9, B=1 | 12.65 ms | 8.04 ms | 36.4% |
| CPU, S=32, order 5/GQ 9, B=1 | 100.95 ms | 68.04 ms | 32.6% |
| GPU, S=16, order 5/GQ 9, B=256 | 146.76 ms | 94.32 ms | 35.7% |
| GPU, S=16, order 5/GQ 9, B=1024 | 578.00 ms | 367.33 ms | 36.4% |
| GPU, S=32, order 5/GQ 9, B=256 | 1.007 s | 0.664 s | 34.1% |

Across the pinned-CPU order/Gauss sweep, S=16 improved 24.9--36.4% and S=32 improved 28.6--33.2%. GPU batch-1 includes regressions at some small shapes (up to 15.3% for the measured S=4/order-5 case); the target multi-environment workloads improve consistently once branch overhead is amortized.

Complete forward dynamics retains smaller but material gains because the dense solve dilutes term-assembly savings:

| Segments | order / GQ | CPU B=1 | GPU B=64 | GPU B=256 |
|---:|:---|---:|---:|---:|
| 4 | 5 / 9 | 32.2% | 10.4% | 17.2% |
| 8 | 1 / 5 | 16.6% | 2.2% | 10.2% |
| 8 | 5 / 9 | 28.5% | 10.8% | 24.1% |
| 16 | 1 / 5 | 27.3% | 7.3% | 13.6% |
| 16 | 5 / 9 | 31.2% | 20.4% | 26.8% |

At S=16/order-5, complete forward dynamics falls from 14.46 to 9.95 ms on CPU and from 193.17 to 141.38 ms on GPU B=256.

### Heterogeneous segment shapes

Alternating order-3/GQ-7 and order-5/GQ-9 links, and the same shapes grouped contiguously, were both evaluated:

| Layout | CPU B=1 | GPU B=256 |
|---|---:|---:|
| Alternating | 8.79 -> 5.63 ms (35.9%) | 103.59 -> 68.97 ms (33.4%) |
| Equal shapes grouped | 8.85 -> 5.28 ms (40.3%) | 103.54 -> 65.79 ms (36.5%) |

Grouping equal local shapes is modestly useful as a model-ordering property, but a separate compiled evaluator branch per shape is not.

## PlanarPCS and PCS transfer evaluation

Velocity reuse and compact selector bases were implemented experimentally and measured separately for both PCS systems over S=1/4/8/16, GQ=5/9, CPU B=1, and GPU B=1/256/1024. CPU runs used 100 synchronized samples on core 1. GPU runs used 100 samples; critical compact-basis cases were repeated in three independent fresh processes.

Numerical differences were exactly zero for PlanarPCS and at most `5.3e-23` for PCS.

Pinned-CPU medians (baseline / velocity only / compact only):

| System/workload | Runtime | Compiler time |
|---|---:|---:|
| PlanarPCS, S=4, GQ=5 | 0.030 / 0.031 / 0.034 ms | 1.028 / 1.011 / 1.014 s |
| PlanarPCS, S=16, GQ=9 | 0.127 / 0.127 / 0.121 ms | 2.720 / 2.735 / 2.719 s |
| PCS, S=4, GQ=5 | 0.050 / 0.049 / 0.048 ms | 1.514 / 1.471 / 1.460 s |
| PCS, S=16, GQ=9 | 0.389 / 0.390 / 0.388 ms | 3.004 / 3.019 / 2.990 s |

Across the CPU grid, median velocity-reuse speed-up was 0.4% for PlanarPCS and 1.7% for PCS. Compact-basis medians were 4.3% and 0.5%, but the absolute differences were only microseconds and included regressions.

Three-run GPU medians for compact basis at critical large shapes:

| System/workload | Runtime change | Compiler change |
|---|---:|---:|
| PlanarPCS, S=8, GQ=5, B=256 | 0.580 -> 0.617 ms (-6.0%) | 1.349 -> 1.162 s (+16.1%) |
| PlanarPCS, S=16, GQ=5, B=1024 | 3.050 -> 2.895 ms (+5.4%) | 2.565 -> 1.877 s (+36.7%) |
| PlanarPCS, S=16, GQ=9, B=1024 | 4.129 -> 4.080 ms (+1.2%) | 2.706 -> 2.737 s (-1.2%) |
| PCS, S=8, GQ=5, B=256 | 1.125 -> 1.263 ms (-10.9%) | 2.002 -> 1.898 s (+5.5%) |
| PCS, S=16, GQ=5, B=1024 | 9.486 -> 9.255 ms (+2.5%) | 4.146 -> 2.925 s (+41.7%) |
| PCS, S=16, GQ=9, B=1024 | 15.738 -> 15.625 ms (+0.7%) | 7.117 -> 7.290 s (-2.4%) |

Velocity reuse added only 8--11 StableHLO operations and compact basis added 55--67, independent of segment count, so neither worsened the existing PCS graph law. However, velocity reuse was neutral overall on GPU (median -0.2% for PlanarPCS and -0.3% for PCS), and compact basis was inconsistent. Its large compile benefit was mostly confined to 5-Gauss-point, 16-segment GPU cases and disappeared at 9 Gauss points.

Neither PCS experiment is retained. They add representation/update-path complexity without a portable runtime win. The narrow compact-basis compiler result remains useful evidence for possible future work focused specifically on large, low-quadrature PCS models.

## Alternatives evaluated and rejected

The preserved evaluation history contains each phase. The important negative results are:

### Exact per-segment active prefixes

This gives the best small/medium runtime but adds 197--221 StableHLO operations per segment and about 0.45 CPU compiler seconds per segment. It is the fundamental compilation-law regression this PR avoids.

### Bucket placement policies

- Uniform prefix widths are reasonable but less aligned with the serial segment distribution.
- A nominal padding-cost-optimal policy reduced arithmetic on paper but was 1--4% slower on GPU, apparently because its irregular GEMM widths were less efficient.
- Equal segment counts were simple, robust, and selected.

### Grouping by local DOF or `(DOF, Gauss points)`

Separate local evaluator branches grew StableHLO from about 3,151 to 4,726--4,891 operations and were neutral to 5% slower. Equal local DOF does not imply equal global active prefix, so it does not address the dominant reduction padding.

### Bucketing the recurrence transforms

Also specializing the 6-by-N recurrence work added 91--171 StableHLO operations and regressed runtime by about 3--7% on CPU and 1--13% on GPU.

### Dynamic tiled reductions

Fixed tiles of 32/64/128 preserved a bounded graph but created many small GEMMs and regressed CPU/GPU runtime by 19--45%.

### Larger branch budgets

K=8 is on the Pareto table but not the default. K=16 bought only 2--3% over K=8 while doubling branch count.

### Other arithmetic/cache ideas

Preweighted quadrature/cached transforms, matrix-free adjoints, triangular inertia assembly, and fused evaluation were individually neutral or slower in A/B tests and are not retained.

## Correctness and validation

- K=1, default K=4, and K greater than the segment count produce matching `B`, `C @ qd`, and `G`.
- JVP directional derivatives match across those public bucket settings.
- Experimental K=2/4/8 policies and exact prefix were also compared with the original fixed-width values and JVPs before timing.
- Compact operands are refreshed by parameter updates.
- The full existing GVS suite passed: `88 passed`.
- New bucket configuration, value equivalence, JVP equivalence, and validation tests passed: `5 passed`.
- `tests/systems/test_planar_pcs.py`, `tests/systems/test_pcs.py`, and `tests/systems/test_pcs_2d_vs_3d_coherence.py`: `263 passed`.
- `ruff check src/soromox/systems/gvs/core.py tests/systems/test_gvs.py`.
- `git diff --cached --check`.

Per the requested scope, the unrelated repository-wide suite was not rerun.

## Generalization and tuning guidance

The bounded branch count and constant StableHLO operation count after K is saturated are structural properties and should generalize across CPUs and GPUs.

The exact K=4 runtime Pareto point is less portable. CPU vector/cache behavior, GPU `case` dispatch, GEMM shape efficiency, compiler version, batch size, and strain/quadrature order all move the crossover. The default should therefore be understood as the best balanced value on the measured Core Ultra 9 285K / RTX 5090 environment, not as a universal optimum.

The user-configurable static parameter is the portability mechanism:

- prefer K=1/2 when cold compilation and small models dominate;
- keep K=4 for the measured general balance; and
- consider K=8 for long-lived, large-batch/high-order executables after benchmarking the target hardware.

This keeps policy explicit without maintaining multiple dynamics algorithms or reintroducing segment-dependent graph growth.
