### PR TITLE
Avoid unused actuator transmission-state evaluation

### DIFF
--- a/docs/api/actuation/index.md
+++ b/docs/api/actuation/index.md
@@ -79,10 +79,8 @@ tau = robot.actuation_force(q, u, qd=qd)
 metadata = robot.actuator_input_metadata
 ```
 
-`qd` is optional for effort and force evaluation. Omitting it evaluates the
-effort model at zero actuator velocity. This is exactly equivalent for
-`DirectEffort`; forward dynamics supplies the actual `qd` so future
-velocity-dependent effort laws receive the physical actuator velocity.
+`qd` is optional for effort and force evaluation. For an effort law that
+requires velocity, omitting it evaluates the law at zero actuator velocity.
 
 [Actuation-space controllers](../control/actuation-space.md) consume the same
 `actuator_coordinates(q)` contract. The coordinate transformation requires the

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -15,6 +15,9 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Changed
 
+- Made effort laws declare their transmission-state dependencies so
+  `DirectEffort` skips unused actuator-coordinate and velocity evaluation, and
+  generalized-force assembly evaluates each actuator moment matrix only once.
 - Made the system-method benchmark device-selectable and reproducible on
   heterogeneous CPUs by recording the JAX backend and CPU affinity, adding an
   optional steady-state warmup, and reporting the median of synchronized

--- a/docs/development/extending.md
+++ b/docs/development/extending.md
@@ -1149,6 +1149,9 @@ New actuator modalities should implement the composable `Transmission` and
 `EffortModel` contracts described in the
 [actuation model](../api/actuation/index.md), rather than introducing a new
 continuum host subclass.
+An effort law should set its static `requires_coordinate` and
+`requires_velocity` flags to `False` for transmission state that it does not
+consume. The defaults are both `True`, which is safe for state-dependent laws.
 
 Operate directly in the transmission's work coordinates:
 

--- a/src/soromox/actuation/core.py
+++ b/src/soromox/actuation/core.py
@@ -198,7 +198,20 @@ class Actuator(eqx.Module):
     def velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
         return self.transmission.velocities(robot, q, qd)
 
-    def moment_matrix(self, robot: SoftRobot, q: Array) -> Array:
+    def transmission_matrix(self, robot: SoftRobot, q: Array) -> Array:
+        """Return this actuator's transmission matrix.
+
+        The returned matrix is the moment matrix of the installed transmission,
+        with one column per actuator channel.
+
+        Args:
+            robot: Soft robot on which the actuator is installed.
+            q: Generalized coordinates of shape ``(robot.num_dofs,)``.
+
+        Returns:
+            A: Transmission matrix of shape
+                ``(robot.num_dofs, self.num_channels)``.
+        """
         return self.transmission.moment_matrix(robot, q)
 
     def efforts(
@@ -207,19 +220,43 @@ class Actuator(eqx.Module):
         q: Array,
         control: Array,
         qd: Array | None = None,
-    ) -> Array:
-        return self._efforts(robot, q, control, qd=qd)
-
-    def _efforts(
-        self,
-        robot: SoftRobot,
-        q: Array,
-        control: Array,
-        qd: Array | None = None,
         *,
-        moment_matrix: Array | None = None,
+        transmission_matrix: Array | None = None,
     ) -> Array:
-        """Evaluate effort using only the transmission state required by its law."""
+        """Map controls to work-conjugate efforts for this actuator.
+
+        Only transmission coordinates and velocities required by the installed
+        effort model are evaluated. A precomputed transmission matrix may be
+        supplied to reuse it when evaluating actuator-coordinate velocities.
+
+        Args:
+            robot: Soft robot on which the actuator is installed.
+            q: Generalized coordinates of shape ``(robot.num_dofs,)``.
+            control: Controls for this actuator with shape
+                ``(self.num_channels,)``.
+            qd: Optional generalized velocities of shape
+                ``(robot.num_dofs,)``. If omitted for a velocity-dependent
+                effort model, zero generalized velocity is used.
+            transmission_matrix: Optional precomputed transmission matrix with
+                shape ``(robot.num_dofs, self.num_channels)``.
+
+        Returns:
+            e: Work-conjugate actuator efforts with shape
+                ``(self.num_channels,)``.
+
+        Raises:
+            ValueError: If ``transmission_matrix`` has an incompatible shape.
+        """
+        if transmission_matrix is not None and transmission_matrix.shape != (
+            robot.num_dofs,
+            self.num_channels,
+        ):
+            raise ValueError(
+                "transmission_matrix must have shape "
+                f"({robot.num_dofs}, {self.num_channels}), got "
+                f"{transmission_matrix.shape}."
+            )
+
         coordinate = None
         if self.effort_model.requires_coordinate:
             coordinate = self.coordinates(robot, q)
@@ -228,10 +265,10 @@ class Actuator(eqx.Module):
         if self.effort_model.requires_velocity:
             if qd is None:
                 qd = jnp.zeros_like(q)
-            if moment_matrix is None:
+            if transmission_matrix is None:
                 velocity = self.velocities(robot, q, qd)
             else:
-                velocity = moment_matrix.T @ qd
+                velocity = transmission_matrix.T @ qd
 
         return self.effort_model.effort(control, coordinate, velocity)
 

--- a/src/soromox/actuation/core.py
+++ b/src/soromox/actuation/core.py
@@ -9,7 +9,7 @@ those coordinates, and generalized actuation forces are ``A(q) @ effort``.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Literal, final
+from typing import TYPE_CHECKING, ClassVar, Literal, final
 
 import equinox as eqx
 from jax import Array, ensure_compile_time_eval
@@ -94,8 +94,16 @@ class Transmission(eqx.Module):
 class EffortModel(eqx.Module):
     """Map controls to efforts work-conjugate to transmission coordinates."""
 
+    requires_coordinate: ClassVar[bool] = True
+    requires_velocity: ClassVar[bool] = True
+
     @abstractmethod
-    def effort(self, control: Array, coordinate: Array, velocity: Array) -> Array:
+    def effort(
+        self,
+        control: Array,
+        coordinate: Array | None,
+        velocity: Array | None,
+    ) -> Array:
         """Return actuator effort for the current control and transmission state."""
         ...
 
@@ -103,7 +111,15 @@ class EffortModel(eqx.Module):
 class DirectEffort(EffortModel):
     """Stateless effort model for which effort is exactly the user control."""
 
-    def effort(self, control: Array, coordinate: Array, velocity: Array) -> Array:
+    requires_coordinate: ClassVar[bool] = False
+    requires_velocity: ClassVar[bool] = False
+
+    def effort(
+        self,
+        control: Array,
+        coordinate: Array | None,
+        velocity: Array | None,
+    ) -> Array:
         del coordinate, velocity
         return control
 
@@ -192,10 +208,31 @@ class Actuator(eqx.Module):
         control: Array,
         qd: Array | None = None,
     ) -> Array:
-        if qd is None:
-            qd = jnp.zeros_like(q)
-        coordinate = self.coordinates(robot, q)
-        velocity = self.velocities(robot, q, qd)
+        return self._efforts(robot, q, control, qd=qd)
+
+    def _efforts(
+        self,
+        robot: SoftRobot,
+        q: Array,
+        control: Array,
+        qd: Array | None = None,
+        *,
+        moment_matrix: Array | None = None,
+    ) -> Array:
+        """Evaluate effort using only the transmission state required by its law."""
+        coordinate = None
+        if self.effort_model.requires_coordinate:
+            coordinate = self.coordinates(robot, q)
+
+        velocity = None
+        if self.effort_model.requires_velocity:
+            if qd is None:
+                qd = jnp.zeros_like(q)
+            if moment_matrix is None:
+                velocity = self.velocities(robot, q, qd)
+            else:
+                velocity = moment_matrix.T @ qd
+
         return self.effort_model.effort(control, coordinate, velocity)
 
     def validate_structure_for_robot(self, robot: SoftRobot) -> None:

--- a/src/soromox/actuation/core.py
+++ b/src/soromox/actuation/core.py
@@ -198,22 +198,6 @@ class Actuator(eqx.Module):
     def velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
         return self.transmission.velocities(robot, q, qd)
 
-    def transmission_matrix(self, robot: SoftRobot, q: Array) -> Array:
-        """Return this actuator's transmission matrix.
-
-        The returned matrix is the moment matrix of the installed transmission,
-        with one column per actuator channel.
-
-        Args:
-            robot: Soft robot on which the actuator is installed.
-            q: Generalized coordinates of shape ``(robot.num_dofs,)``.
-
-        Returns:
-            A: Transmission matrix of shape
-                ``(robot.num_dofs, self.num_channels)``.
-        """
-        return self.transmission.moment_matrix(robot, q)
-
     def efforts(
         self,
         robot: SoftRobot,

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -1093,7 +1093,10 @@ class SoftRobot(DynamicalSystem):
         if not self.actuators:
             return jnp.zeros((self.num_dofs, 0), dtype=q.dtype)
         return jnp.concatenate(
-            tuple(actuator.transmission_matrix(self, q) for actuator in self.actuators),
+            tuple(
+                actuator.transmission.moment_matrix(self, q)
+                for actuator in self.actuators
+            ),
             axis=1,
         )
 

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -1029,7 +1029,25 @@ class SoftRobot(DynamicalSystem):
         )
 
     def actuation_matrix(self, q: Array) -> Array:
-        """Return the concatenated transmission moment matrix."""
+        """
+        Return the actuator transmission matrix ``A(q)``.
+
+        ``A(q)`` is the concatenated moment-arm matrix of the installed
+        transmissions. It maps work-conjugate actuator efforts ``u`` to
+        generalized forces,
+
+        ``tau_u = A(q) @ u``.
+
+        Equivalently, ``A(q).T`` is the Jacobian of the actuator coordinates
+        with respect to the generalized coordinates.
+
+        Args:
+            q: Generalized coordinates of shape (num_dofs,).
+
+        Returns:
+            A: Actuator transmission matrix of shape
+                (num_dofs, num_actuators).
+        """
         if not self.actuators:
             return jnp.zeros((self.num_dofs, 0), dtype=q.dtype)
         return jnp.concatenate(
@@ -1038,29 +1056,92 @@ class SoftRobot(DynamicalSystem):
         )
 
     def actuator_efforts(self, q: Array, u: Array, qd: Array | None = None) -> Array:
-        """Map ordered user controls to ordered work-conjugate efforts."""
-        if qd is None:
-            qd = jnp.zeros_like(q)
+        """
+        Map user controls to work-conjugate actuator efforts.
+
+        Controls and returned efforts follow the order of the installed
+        actuators. Effort models evaluate the actuator coordinates or
+        velocities only when those quantities are required. If an effort model
+        requires velocity and ``qd`` is omitted, zero generalized velocity is
+        used.
+
+        Args:
+            q: Generalized coordinates of shape (num_dofs,).
+            u: Actuator controls of shape (num_actuators,).
+            qd: Optional generalized velocities of shape (num_dofs,).
+
+        Returns:
+            e: Work-conjugate actuator efforts of shape (num_actuators,).
+
+        Raises:
+            ValueError: If ``u`` does not have shape (num_actuators,).
+        """
+        return self._actuator_efforts(q, u, qd=qd)
+
+    def _actuator_efforts(
+        self,
+        q: Array,
+        u: Array,
+        qd: Array | None = None,
+        *,
+        moment_matrix: Array | None = None,
+    ) -> Array:
+        """Evaluate efforts, optionally reusing a concatenated moment matrix."""
         u = jnp.asarray(u)
         if u.shape != (self.num_actuators,):
             raise ValueError(
                 f"u must have shape ({self.num_actuators},), got {u.shape}."
             )
         if not self.actuators:
-            # Legacy SoftRobot subclasses may provide their own actuation_matrix
-            # without installing composable actuator objects.
-            return u
+            return jnp.zeros((0,), dtype=u.dtype)
         efforts = []
         start = 0
         for actuator in self.actuators:
             stop = start + actuator.num_channels
-            efforts.append(actuator.efforts(self, q, u[start:stop], qd=qd))
+            actuator_moment_matrix = (
+                None if moment_matrix is None else moment_matrix[:, start:stop]
+            )
+            efforts.append(
+                actuator._efforts(
+                    self,
+                    q,
+                    u[start:stop],
+                    qd=qd,
+                    moment_matrix=actuator_moment_matrix,
+                )
+            )
             start = stop
         return jnp.concatenate(tuple(efforts))
 
     def actuation_force(self, q: Array, u: Array, qd: Array | None = None) -> Array:
-        """Return generalized actuation force ``A(q) @ effort``."""
-        return self.actuation_matrix(q) @ self.actuator_efforts(q, u, qd=qd)
+        """
+        Compute the generalized actuation force.
+
+        The installed effort models first map the ordered controls ``u`` to
+        work-conjugate actuator efforts ``e``. The actuator transmission matrix
+        then maps those efforts to generalized forces as
+
+        ``tau_u = A(q) @ e``.
+
+        Args:
+            q: Generalized coordinates of shape (num_dofs,).
+            u: Actuator controls of shape (num_actuators,).
+            qd: Optional generalized velocities of shape (num_dofs,).
+
+        Returns:
+            tau_u: Generalized actuation force of shape (num_dofs,).
+
+        Raises:
+            ValueError: If ``u`` does not have shape (num_actuators,).
+        """
+        moment_matrix = self.actuation_matrix(q)
+        effort = self._actuator_efforts(
+            q,
+            u,
+            qd=qd,
+            moment_matrix=moment_matrix,
+        )
+        return moment_matrix @ effort
 
     def passive_elastic_force(self, q: Array) -> Array:
         """Return the sum of installed passive conservative forces."""

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -3,7 +3,7 @@ __all__ = [
 ]
 
 from abc import abstractmethod
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 import equinox as eqx
 from jax import Array, grad, jacfwd, jvp, lax, vmap
@@ -23,6 +23,9 @@ from soromox.systems.params import (
     validate_quaternion_base_pose,
 )
 from soromox.utils.geometry import poses
+
+if TYPE_CHECKING:
+    from soromox.rendering.actuators import ActuatorVisualLayer
 
 
 class SoftRobot(DynamicalSystem):
@@ -1007,13 +1010,37 @@ class SoftRobot(DynamicalSystem):
         """
         Protected gravitational-force hook.
 
-        Default implementation differentiates the protected gravitational-energy
-        hook to avoid recursively invoking the public custom-JVP energy wrapper.
+        The default implementation differentiates the protected
+        :meth:`_gravitational_energy` hook. Subclasses may override this method
+        with an analytical or fused implementation. Differentiating the
+        protected energy hook avoids recursively invoking the public
+        custom-JVP energy wrapper.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+
+        Returns:
+            G: Gravitational generalized force of shape ``(num_dofs,)``.
         """
         return grad(lambda q_: self._gravitational_energy(q_))(q)
 
     def actuator_coordinates(self, q: Array) -> Array:
-        """Return all work-conjugate actuator coordinates in control order."""
+        """
+        Return the installed transmissions' work-conjugate coordinates.
+
+        Coordinates are concatenated in actuator and channel order, matching
+        the columns of :meth:`actuation_matrix` and the entries returned by
+        :meth:`actuator_efforts`. Their physical units may differ between
+        actuator families, such as length for tendons or volume for pressure
+        actuation.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+
+        Returns:
+            y_a: Actuator coordinates of shape ``(num_actuators,)``. An
+                unactuated robot returns an empty array.
+        """
         if not self.actuators:
             return jnp.zeros((0,), dtype=q.dtype)
         return jnp.concatenate(
@@ -1021,7 +1048,22 @@ class SoftRobot(DynamicalSystem):
         )
 
     def actuator_velocities(self, q: Array, qd: Array) -> Array:
-        """Return all actuator-coordinate velocities in control order."""
+        """
+        Return the installed transmissions' coordinate velocities.
+
+        Velocities are concatenated in actuator and channel order and satisfy
+        ``yd_a = A(q).T @ qd``, where ``A(q)`` is the concatenated actuator
+        transmission matrix.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+            qd: Generalized velocities of shape ``(num_dofs,)``.
+
+        Returns:
+            yd_a: Actuator-coordinate velocities of shape
+                ``(num_actuators,)``. An unactuated robot returns an empty
+                array.
+        """
         if not self.actuators:
             return jnp.zeros((0,), dtype=q.dtype)
         return jnp.concatenate(
@@ -1033,10 +1075,10 @@ class SoftRobot(DynamicalSystem):
         Return the actuator transmission matrix ``A(q)``.
 
         ``A(q)`` is the concatenated moment-arm matrix of the installed
-        transmissions. It maps work-conjugate actuator efforts ``u`` to
+        transmissions. It maps work-conjugate actuator efforts ``e`` to
         generalized forces,
 
-        ``tau_u = A(q) @ u``.
+        ``tau_u = A(q) @ e``.
 
         Equivalently, ``A(q).T`` is the Jacobian of the actuator coordinates
         with respect to the generalized coordinates.
@@ -1051,11 +1093,18 @@ class SoftRobot(DynamicalSystem):
         if not self.actuators:
             return jnp.zeros((self.num_dofs, 0), dtype=q.dtype)
         return jnp.concatenate(
-            tuple(actuator.moment_matrix(self, q) for actuator in self.actuators),
+            tuple(actuator.transmission_matrix(self, q) for actuator in self.actuators),
             axis=1,
         )
 
-    def actuator_efforts(self, q: Array, u: Array, qd: Array | None = None) -> Array:
+    def actuator_efforts(
+        self,
+        q: Array,
+        u: Array,
+        qd: Array | None = None,
+        *,
+        actuation_matrix: Array | None = None,
+    ) -> Array:
         """
         Map user controls to work-conjugate actuator efforts.
 
@@ -1069,28 +1118,30 @@ class SoftRobot(DynamicalSystem):
             q: Generalized coordinates of shape (num_dofs,).
             u: Actuator controls of shape (num_actuators,).
             qd: Optional generalized velocities of shape (num_dofs,).
+            actuation_matrix: Optional precomputed actuator transmission matrix
+                with shape ``(num_dofs, num_actuators)``. It is reused for
+                velocity-dependent effort laws.
 
         Returns:
             e: Work-conjugate actuator efforts of shape (num_actuators,).
 
         Raises:
-            ValueError: If ``u`` does not have shape (num_actuators,).
+            ValueError: If ``u`` or ``actuation_matrix`` has an incompatible
+                shape.
         """
-        return self._actuator_efforts(q, u, qd=qd)
-
-    def _actuator_efforts(
-        self,
-        q: Array,
-        u: Array,
-        qd: Array | None = None,
-        *,
-        moment_matrix: Array | None = None,
-    ) -> Array:
-        """Evaluate efforts, optionally reusing a concatenated moment matrix."""
         u = jnp.asarray(u)
         if u.shape != (self.num_actuators,):
             raise ValueError(
                 f"u must have shape ({self.num_actuators},), got {u.shape}."
+            )
+        if actuation_matrix is not None and actuation_matrix.shape != (
+            self.num_dofs,
+            self.num_actuators,
+        ):
+            raise ValueError(
+                "actuation_matrix must have shape "
+                f"({self.num_dofs}, {self.num_actuators}), got "
+                f"{actuation_matrix.shape}."
             )
         if not self.actuators:
             return jnp.zeros((0,), dtype=u.dtype)
@@ -1098,16 +1149,16 @@ class SoftRobot(DynamicalSystem):
         start = 0
         for actuator in self.actuators:
             stop = start + actuator.num_channels
-            actuator_moment_matrix = (
-                None if moment_matrix is None else moment_matrix[:, start:stop]
+            actuator_transmission_matrix = (
+                None if actuation_matrix is None else actuation_matrix[:, start:stop]
             )
             efforts.append(
-                actuator._efforts(
+                actuator.efforts(
                     self,
                     q,
                     u[start:stop],
                     qd=qd,
-                    moment_matrix=actuator_moment_matrix,
+                    transmission_matrix=actuator_transmission_matrix,
                 )
             )
             start = stop
@@ -1134,31 +1185,72 @@ class SoftRobot(DynamicalSystem):
         Raises:
             ValueError: If ``u`` does not have shape (num_actuators,).
         """
-        moment_matrix = self.actuation_matrix(q)
-        effort = self._actuator_efforts(
+        actuation_matrix = self.actuation_matrix(q)
+        effort = self.actuator_efforts(
             q,
             u,
             qd=qd,
-            moment_matrix=moment_matrix,
+            actuation_matrix=actuation_matrix,
         )
-        return moment_matrix @ effort
+        return actuation_matrix @ effort
 
     def passive_elastic_force(self, q: Array) -> Array:
-        """Return the sum of installed passive conservative forces."""
+        """
+        Return the installed passive elements' elastic generalized force.
+
+        This method sums only composable passive-element contributions. System
+        implementations add the result to their intrinsic body elasticity when
+        evaluating :meth:`elastic_force`.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+
+        Returns:
+            tau_passive: Passive elastic generalized force of shape
+                ``(num_dofs,)``. A robot without passive elements returns
+                zeros.
+        """
         force = jnp.zeros((self.num_dofs,), dtype=q.dtype)
         for element in self.passive_elements:
             force = force + element.elastic_force(self, q)
         return force
 
     def passive_damping_matrix(self, q: Array) -> Array:
-        """Return the sum of installed passive damping matrices."""
+        """
+        Return the installed passive elements' generalized damping matrix.
+
+        This method sums only composable passive-element contributions. System
+        implementations add the result to their intrinsic body damping when
+        evaluating :meth:`damping_matrix`.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+
+        Returns:
+            D_passive: Passive damping matrix of shape
+                ``(num_dofs, num_dofs)``. A robot without passive elements
+                returns zeros.
+        """
         matrix = jnp.zeros((self.num_dofs, self.num_dofs), dtype=q.dtype)
         for element in self.passive_elements:
             matrix = matrix + element.damping_matrix(self, q)
         return matrix
 
     def passive_elastic_energy(self, q: Array) -> Array:
-        """Return the sum of installed passive elastic energies."""
+        """
+        Return the installed passive elements' stored elastic energy.
+
+        This method sums only composable passive-element contributions. System
+        implementations add the result to their intrinsic body strain energy
+        when evaluating elastic or potential energy.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+
+        Returns:
+            U_passive: Scalar passive elastic energy. A robot without passive
+                elements returns zero.
+        """
         energy = jnp.zeros((), dtype=q.dtype)
         for element in self.passive_elements:
             energy = energy + element.elastic_energy(self, q)
@@ -1170,8 +1262,27 @@ class SoftRobot(DynamicalSystem):
         s_points: Array,
         *,
         actuator_inputs: Array | None = None,
-    ):
-        """Return semantic active and passive actuator geometry for renderers."""
+    ) -> tuple["ActuatorVisualLayer", ...]:
+        """
+        Return renderer-facing geometry for installed actuation components.
+
+        The returned layers describe semantic geometry and optional scalar
+        fields for supported active actuators and passive elements. Visual
+        styling such as colors, radii, and line widths remains the renderer's
+        responsibility. Unsupported components do not produce a layer.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+            s_points: Backbone sample coordinates with shape
+                ``(num_points,)`` used for routed continuum geometry.
+            actuator_inputs: Optional actuator inputs of shape
+                ``(num_actuators,)``. When supplied, supported adapters attach
+                input-dependent scalar fields such as pressure or axial force.
+
+        Returns:
+            layers: Tuple of semantic actuator visual layers. The tuple is
+                empty when no installed component has a renderer adapter.
+        """
         from soromox.rendering.actuation import actuator_visual_layers
 
         return actuator_visual_layers(

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -16,6 +16,7 @@ from system_param_builders import (
 
 from soromox.actuation import (
     BaseThreadlikeRoutingParams,
+    EffortModel,
     IdentityActuator,
     IdentityTransmission,
     ThreadlikeActuator,
@@ -336,6 +337,111 @@ def test_identity_unactuated_and_mixed_construction():
 def test_identity_actuator_rejects_channel_count_mismatch_during_construction():
     with pytest.raises(ValueError, match="one channel per robot degree of freedom"):
         _spatial_pcs(actuators=IdentityActuator(3))
+
+
+@pytest.mark.parametrize("factory", [_spatial_pcs, _planar_pcs, _gvs])
+@pytest.mark.parametrize(
+    "configuration",
+    ["identity", "unactuated", "threadlike", "mixed_threadlike"],
+)
+def test_actuation_force_matches_matrix_times_effort(factory, configuration):
+    if configuration == "identity":
+        robot = factory()
+    elif configuration == "unactuated":
+        robot = factory(actuators=())
+    elif configuration == "threadlike":
+        robot = factory(actuators=ThreadlikeActuator.tendons(_routing()))
+    else:
+        routing = _routing()
+        robot = factory(
+            actuators=(
+                ThreadlikeActuator.tendons(routing),
+                ThreadlikeActuator.push_rods(routing),
+            )
+        )
+
+    q = jnp.linspace(-0.02, 0.03, robot.num_dofs)
+    qd = jnp.linspace(0.04, -0.01, robot.num_dofs)
+    control = jnp.linspace(1.0, 2.0, robot.num_actuators)
+
+    expected = robot.actuation_matrix(q) @ robot.actuator_efforts(q, control, qd=qd)
+    assert_allclose(robot.actuation_force(q, control, qd=qd), expected)
+
+
+def test_direct_effort_skips_unused_threadlike_state(monkeypatch):
+    robot = _spatial_pcs(actuators=ThreadlikeActuator.tendons(_routing()))
+    q = jnp.linspace(-0.02, 0.03, robot.num_dofs)
+    qd = jnp.linspace(0.04, -0.01, robot.num_dofs)
+    control = jnp.array([3.0, 4.0])
+    expected_force = robot.actuation_matrix(q) @ control
+    calls = {"moment_matrix": 0}
+    original_moment_matrix = PCS._threadlike_moment_matrix
+
+    def counted_moment_matrix(self, q, routing):
+        calls["moment_matrix"] += 1
+        return original_moment_matrix(self, q, routing)
+
+    def unexpected_path_lengths(self, q, routing):
+        del self, q, routing
+        raise AssertionError("DirectEffort must not evaluate actuator coordinates.")
+
+    monkeypatch.setattr(PCS, "_threadlike_moment_matrix", counted_moment_matrix)
+    monkeypatch.setattr(PCS, "_threadlike_path_lengths", unexpected_path_lengths)
+
+    assert_allclose(robot.actuator_efforts(q, control, qd=qd), control)
+    assert calls["moment_matrix"] == 0
+
+    assert_allclose(
+        robot.actuation_force(q, control, qd=qd),
+        expected_force,
+    )
+    assert calls["moment_matrix"] == 1
+
+
+class CoordinateVelocityEffort(EffortModel):
+    """Test law exercising both optional transmission-state dependencies."""
+
+    def effort(self, control, coordinate, velocity):
+        assert coordinate is not None
+        assert velocity is not None
+        return control + coordinate + velocity
+
+
+def test_state_dependent_effort_reuses_generalized_force_moment_matrix(monkeypatch):
+    actuator = ThreadlikeActuator.tendons(_routing())
+    actuator = eqx.tree_at(
+        lambda current: current._effort_model,
+        actuator,
+        CoordinateVelocityEffort(),
+    )
+    robot = _spatial_pcs(actuators=actuator)
+    q = jnp.linspace(-0.02, 0.03, robot.num_dofs)
+    qd = jnp.linspace(0.04, -0.01, robot.num_dofs)
+    control = jnp.array([3.0, 4.0])
+
+    matrix = robot.actuation_matrix(q)
+    coordinate = robot.actuator_coordinates(q)
+    expected_effort = robot.actuator_efforts(q, control, qd=qd)
+    assert_allclose(expected_effort, control + coordinate + matrix.T @ qd)
+    expected_force = matrix @ expected_effort
+
+    calls = {"moment_matrix": 0, "path_lengths": 0}
+    original_moment_matrix = PCS._threadlike_moment_matrix
+    original_path_lengths = PCS._threadlike_path_lengths
+
+    def counted_moment_matrix(self, q, routing):
+        calls["moment_matrix"] += 1
+        return original_moment_matrix(self, q, routing)
+
+    def counted_path_lengths(self, q, routing):
+        calls["path_lengths"] += 1
+        return original_path_lengths(self, q, routing)
+
+    monkeypatch.setattr(PCS, "_threadlike_moment_matrix", counted_moment_matrix)
+    monkeypatch.setattr(PCS, "_threadlike_path_lengths", counted_path_lengths)
+
+    assert_allclose(robot.actuation_force(q, control, qd=qd), expected_force)
+    assert calls == {"moment_matrix": 1, "path_lengths": 1}
 
 
 @pytest.mark.parametrize("factory", [_spatial_pcs, _planar_pcs, _gvs])

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -444,17 +444,6 @@ def test_state_dependent_effort_reuses_generalized_force_moment_matrix(monkeypat
     assert calls == {"moment_matrix": 1, "path_lengths": 1}
 
 
-def test_actuator_transmission_matrix_delegates_to_transmission_moment_matrix():
-    actuator = ThreadlikeActuator.tendons(_routing())
-    robot = _spatial_pcs(actuators=actuator)
-    q = jnp.linspace(-0.02, 0.03, robot.num_dofs)
-
-    assert_allclose(
-        actuator.transmission_matrix(robot, q),
-        actuator.transmission.moment_matrix(robot, q),
-    )
-
-
 def test_precomputed_transmission_matrices_require_compatible_shapes():
     actuator = ThreadlikeActuator.tendons(_routing())
     robot = _spatial_pcs(actuators=actuator)

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -444,6 +444,39 @@ def test_state_dependent_effort_reuses_generalized_force_moment_matrix(monkeypat
     assert calls == {"moment_matrix": 1, "path_lengths": 1}
 
 
+def test_actuator_transmission_matrix_delegates_to_transmission_moment_matrix():
+    actuator = ThreadlikeActuator.tendons(_routing())
+    robot = _spatial_pcs(actuators=actuator)
+    q = jnp.linspace(-0.02, 0.03, robot.num_dofs)
+
+    assert_allclose(
+        actuator.transmission_matrix(robot, q),
+        actuator.transmission.moment_matrix(robot, q),
+    )
+
+
+def test_precomputed_transmission_matrices_require_compatible_shapes():
+    actuator = ThreadlikeActuator.tendons(_routing())
+    robot = _spatial_pcs(actuators=actuator)
+    q = jnp.zeros(robot.num_dofs)
+    control = jnp.ones(robot.num_actuators)
+
+    with pytest.raises(ValueError, match="actuation_matrix must have shape"):
+        robot.actuator_efforts(
+            q,
+            control,
+            actuation_matrix=jnp.zeros((robot.num_dofs, robot.num_actuators + 1)),
+        )
+
+    with pytest.raises(ValueError, match="transmission_matrix must have shape"):
+        actuator.efforts(
+            robot,
+            q,
+            control,
+            transmission_matrix=jnp.zeros((robot.num_dofs, actuator.num_channels + 1)),
+        )
+
+
 @pytest.mark.parametrize("factory", [_spatial_pcs, _planar_pcs, _gvs])
 def test_coordinate_jacobian_equals_moment_matrix_transpose(factory):
     actuator = ThreadlikeActuator.tendons(_routing())

--- a/tests/systems/test_soft_robot_defaults.py
+++ b/tests/systems/test_soft_robot_defaults.py
@@ -18,16 +18,17 @@ jax.config.update("jax_enable_x64", True)
 
 class _PlanarDefaultRobot(SoftRobot):
     L: Array
+    _num_fixture_dofs = 2
 
     def __init__(self):
         super().__init__()
-        self.num_dofs = 2
-        self.num_actuators = 2
+        self.num_dofs = self._num_fixture_dofs
         self.L = jnp.array([1.0, 2.0], dtype=jnp.float64)
         self.num_gauss_points = 1
         self.num_integration_points = 3
         self.integration_points = jnp.array([0.0, 0.5, 1.0], dtype=jnp.float64)
         self.integration_weights = jnp.array([0.0, 1.0, 0.0], dtype=jnp.float64)
+        self._configure_actuation(None)
 
     @property
     def segment_length(self) -> Array:
@@ -70,9 +71,6 @@ class _PlanarDefaultRobot(SoftRobot):
     def _gravitational_energy(self, q: Array) -> Array:
         return q[0] ** 2 + 3.0 * q[1]
 
-    def actuation_matrix(self, q: Array) -> Array:
-        return jnp.eye(2, dtype=q.dtype)
-
 
 class _SpatialDefaultRobot(_PlanarDefaultRobot):
     @property
@@ -100,9 +98,7 @@ class _SpatialDefaultRobot(_PlanarDefaultRobot):
 class _SpatialLieExpDefaultRobot(_SpatialDefaultRobot):
     """Spatial default-hook fixture whose protected pose uses the SE(3) branch."""
 
-    def __init__(self):
-        super().__init__()
-        self.num_dofs = 6
+    _num_fixture_dofs = 6
 
     def _forward_kinematics(self, q: Array, s: Array) -> Array:
         return se3.exp(s * q, eps=jnp.asarray(1e-10, dtype=q.dtype))


### PR DESCRIPTION
## Motivation

`Actuator.efforts(...)` previously evaluated actuator coordinates and velocities unconditionally. The only currently installed effort law, `DirectEffort`, discards both quantities. For threadlike actuators this caused unused path-length and moment-matrix work, while `actuation_force(...)` separately evaluated the actuation matrix again.

## Changes

- Declare whether an effort model requires actuator coordinates or velocities.
- Skip unused transmission-state evaluation for `DirectEffort`.
- Evaluate the concatenated actuation matrix once in `actuation_force(...)` and reuse it for velocity-dependent effort laws.
- Collapse the duplicate public/private effort helpers into one public method with an optional precomputed-matrix keyword.
- Keep per-component matrix evaluation on `Transmission.moment_matrix(...)`; `SoftRobot.actuation_matrix(...)` concatenates those matrices directly without a redundant `Actuator`-level façade.
- Keep the generalized-force definition explicit as `tau_u = A(q) @ e`, where `e` is the work-conjugate actuator effort.
- Remove the legacy no-actuator fallback from the composable actuator path.
- Expand regression coverage across identity, unactuated, threadlike, and mixed-threadlike configurations on PCS, PlanarPCS, and GVS.
- Move generic actuator-visualization adaptation from `SoftRobot` into `soromox.rendering`, eliminating the systems-to-rendering dependency while retaining automatic renderer dispatch and specialized robot hooks.
- Expand the actuator, passive-element, gravity-hook, and rendering docstrings; document the optional generalized-velocity behavior; and add Unreleased changelog entries.

The call-count regressions verify that direct threadlike effort evaluation computes neither path lengths nor a moment matrix, and that generalized-force evaluation computes the moment matrix exactly once. A state-dependent test also verifies reuse of that matrix when actuator velocity is required.

## Scope

This PR removes redundant work inside the existing actuation path. It does not yet fuse continuum body-dynamics assembly with transmission evaluation or introduce dynamic actuator states; those are separate architectural and benchmark-gated follow-ups.

## Validation

- `uv run pytest tests/actuation tests/systems/test_soft_robot_defaults.py tests/systems/test_pressure_actuated_pcs_models.py tests/systems/test_mckibben_umarm.py` — 117 passed
- `uv run pytest tests/actuation/test_threadlike.py tests/systems/test_mckibben_umarm.py tests/systems/test_pressure_actuated_pcs_models.py tests/rendering/test_base_renderer.py tests/rendering/test_matplotlib_renderer.py tests/rendering/test_viser_renderer.py` — 135 passed
- `uv run ruff check src/soromox/actuation/core.py src/soromox/systems/soft_robot.py tests/actuation/test_threadlike.py tests/systems/test_soft_robot_defaults.py`
- `uv run ruff format --check src/soromox/actuation/core.py src/soromox/systems/soft_robot.py tests/actuation/test_threadlike.py tests/systems/test_soft_robot_defaults.py`
- `uv run --extra docs zensical build --clean`
- `git diff --check origin/main...HEAD`
