### PR TITLE
Move actuator visualization into rendering

### DIFF
--- a/docs/api/rendering/renderers.md
+++ b/docs/api/rendering/renderers.md
@@ -30,16 +30,21 @@ BaseSoftRobotRenderer (abstract base)
 
 ### Actuator and Helper Geometry
 
-If a robot exposes
-`actuator_visual_layers(q, s_points, *, actuator_inputs=None)`, the renderers
-can display its semantic actuator geometry when `render_actuators=True`. The
-hook returns one or more `ActuatorVisualLayer` objects with points shaped
-`(num_actuators_in_layer, num_points, dim)`.
+For `SoftRobot` systems, the rendering layer automatically adapts supported
+installed actuators and passive elements into semantic geometry when
+`render_actuators=True`. The adapter returns one or more `ActuatorVisualLayer`
+objects with points shaped
+`(num_actuators_in_layer, num_points, dim)`. It is also available directly as
+`soromox.rendering.actuator_visual_layers(...)`.
+
+Specialized or third-party robots may override this default by exposing
+`actuator_visual_layers(q, s_points, *, actuator_inputs=None)`.
 
 For batches and trajectories, robots may additionally provide
 `actuator_visual_layers_batched(...)` or
 `actuator_visual_layers_trajectory(...)`. The base renderer uses these hooks
-when available and otherwise falls back to the single-configuration hook.
+when available and otherwise falls back to the generic adapter or the
+single-configuration custom hook.
 
 Open3D and Viser also accept helper spheres through
 `static_spheres_positions`, `static_spheres_radii`, and

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -33,6 +33,12 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Breaking changes
 
+- Moved generic actuator-visualization adaptation out of
+  `SoftRobot.actuator_visual_layers(...)` and into
+  `soromox.rendering.actuator_visual_layers(...)`. Renderers continue to adapt
+  standard `SoftRobot` systems automatically, while robot-defined hooks remain
+  available for specialized visualization behavior.
+
 ### Fixed
 
 ### Documentation

--- a/docs/development/extending.md
+++ b/docs/development/extending.md
@@ -799,14 +799,15 @@ The base class provides useful helpers:
 backbone = self.compute_backbone_curve(q)
 # Returns: (num_points, 2) for 2D or (num_points, 3) for 3D
 
-# Get actuator visual layers (if robot exposes actuator_visual_layers)
+# Get actuator visual layers from the renderer-owned generic adapter or a
+# robot-specific override
 actuator_layers = self.compute_actuator_visual_layers(q)
 # Returns: tuple of ActuatorVisualLayer objects
 
 # Batched and trajectory actuator visual helpers use optional robot fast paths
 # named actuator_visual_layers_batched(...) and
-# actuator_visual_layers_trajectory(...) when available. Otherwise they fall
-# back to repeated calls to the single-configuration actuator_visual_layers(...).
+# actuator_visual_layers_trajectory(...) when available. Otherwise they use the
+# generic SoftRobot adapter or fall back to repeated custom-hook calls.
 
 # Resolve colors with hierarchy
 colors = self.resolve_backbone_colors(num_robots=1, color_config=color_config)

--- a/src/soromox/rendering/__init__.py
+++ b/src/soromox/rendering/__init__.py
@@ -11,6 +11,7 @@ This module provides various backends for visualizing robots:
 - OpenCVPlanarRenderer: Generic renderer for planar robots
 """
 
+from soromox.rendering.actuation import actuator_visual_layers
 from soromox.rendering.actuators import (
     ActuatorVisualLayer,
     BatchedActuatorVisualLayer,
@@ -83,6 +84,7 @@ __all__ = [
     "ActuatorVisualLayer",
     "BatchedActuatorVisualLayer",
     "TrajectoryActuatorVisualLayer",
+    "actuator_visual_layers",
     # Generic renderers
     "MatplotlibRenderer",
     "Open3DRenderer",

--- a/src/soromox/rendering/actuation.py
+++ b/src/soromox/rendering/actuation.py
@@ -8,22 +8,38 @@ from jax import numpy as jnp
 
 from soromox.actuation.mckibben import ArticulatedMcKibbenActuator
 from soromox.actuation.threadlike import ThreadlikeActuator, ThreadlikeImpedance
+from soromox.systems.soft_robot import SoftRobot
 
 from .actuators import ActuatorVisualLayer, TrajectoryActuatorVisualLayer
 
 
 def actuator_visual_layers(
-    robot,
+    robot: SoftRobot,
     q: Array,
     s_points: Array,
     *,
     actuator_inputs: Array | None = None,
 ) -> tuple[ActuatorVisualLayer, ...]:
-    """Adapt installed actuator mechanics to renderer-facing visual layers.
+    """Return renderer-facing geometry for installed actuation components.
 
-    Actuation objects provide path geometry and semantic kinds. Visual styling is
-    deliberately left unset here so renderer configuration owns colors, radii,
-    line widths, and scalar colormaps.
+    The returned layers describe semantic geometry and optional scalar fields
+    for supported active actuators and passive elements. Actuation objects
+    provide path geometry and semantic kinds, while visual styling such as
+    colors, radii, line widths, and scalar colormaps remains the renderer's
+    responsibility. Unsupported components do not produce a layer.
+
+    Args:
+        robot: Soft robot containing the installed actuation components.
+        q: Generalized coordinates of shape ``(robot.num_dofs,)``.
+        s_points: Backbone sample coordinates with shape ``(num_points,)``
+            used for routed continuum geometry.
+        actuator_inputs: Optional actuator inputs of shape
+            ``(robot.num_actuators,)``. When supplied, supported adapters attach
+            input-dependent scalar fields such as pressure or axial force.
+
+    Returns:
+        layers: Tuple of semantic actuator visual layers. The tuple is empty
+            when no installed component has a renderer adapter.
     """
     layers: list[ActuatorVisualLayer] = []
     start = 0
@@ -89,7 +105,7 @@ def actuator_visual_layers(
 
 
 def vectorized_actuator_visual_layers_trajectory(
-    robot,
+    robot: SoftRobot,
     q_ts: Array,
     s_points: Array,
     *,

--- a/src/soromox/rendering/base.py
+++ b/src/soromox/rendering/base.py
@@ -11,6 +11,7 @@ import numpy as np
 from jax import Array
 
 from soromox.rendering.actuation import (
+    actuator_visual_layers,
     vectorized_actuator_visual_layers_trajectory,
 )
 from soromox.rendering.actuators import (
@@ -111,8 +112,8 @@ class BaseSoftRobotRenderer(ABC):
         self.L_max = float(jnp.asarray(robot.length))
 
         # Explicit hooks let specialized and third-party robots override the
-        # native SoftRobot visualization contract.
-        self._has_actuator_visual_layers = callable(
+        # generic renderer-owned SoftRobot adapter.
+        self._has_custom_actuator_visual_layers = callable(
             getattr(robot, "actuator_visual_layers", None)
         )
         self._has_batched_actuator_visual_layers = hasattr(
@@ -121,10 +122,12 @@ class BaseSoftRobotRenderer(ABC):
         self._has_trajectory_actuator_visual_layers = hasattr(
             robot, "actuator_visual_layers_trajectory"
         )
-        self._uses_native_actuator_visual_adapter = (
-            isinstance(robot, SoftRobot)
-            and getattr(type(robot), "actuator_visual_layers", None)
-            is SoftRobot.actuator_visual_layers
+        self._uses_generic_actuator_visual_adapter = (
+            isinstance(robot, SoftRobot) and not self._has_custom_actuator_visual_layers
+        )
+        self._has_actuator_visual_layers = (
+            self._has_custom_actuator_visual_layers
+            or self._uses_generic_actuator_visual_adapter
         )
         self._has_actuator_visuals = (
             self._has_actuator_visual_layers
@@ -324,9 +327,14 @@ class BaseSoftRobotRenderer(ABC):
         if not self._has_actuator_visual_layers:
             return ()
         s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
-        layers = self.robot.actuator_visual_layers(  # type: ignore[attr-defined]
-            q, s_ps, actuator_inputs=actuator_inputs
-        )
+        if self._uses_generic_actuator_visual_adapter:
+            layers = actuator_visual_layers(
+                self.robot, q, s_ps, actuator_inputs=actuator_inputs
+            )
+        else:
+            layers = self.robot.actuator_visual_layers(  # type: ignore[attr-defined]
+                q, s_ps, actuator_inputs=actuator_inputs
+            )
         return normalize_actuator_layers(layers)
 
     def _offset_batched_actuator_layers(
@@ -567,9 +575,9 @@ class BaseSoftRobotRenderer(ABC):
             )
             return self._offset_trajectory_actuator_layers(layers, base_offsets)
 
-        # Native SoftRobot geometry is renderer-owned and JAX-vectorizable.
+        # Generic SoftRobot geometry is renderer-owned and JAX-vectorizable.
         # Specialized robot hooks take precedence in the branch above.
-        if self._uses_native_actuator_visual_adapter:
+        if self._uses_generic_actuator_visual_adapter:
             s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
             raw_layers = vectorized_actuator_visual_layers_trajectory(
                 self.robot,

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -3,7 +3,7 @@ __all__ = [
 ]
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Self
+from typing import Any, Self
 
 import equinox as eqx
 from jax import Array, grad, jacfwd, jvp, lax, vmap
@@ -23,9 +23,6 @@ from soromox.systems.params import (
     validate_quaternion_base_pose,
 )
 from soromox.utils.geometry import poses
-
-if TYPE_CHECKING:
-    from soromox.rendering.actuators import ActuatorVisualLayer
 
 
 class SoftRobot(DynamicalSystem):
@@ -1258,39 +1255,6 @@ class SoftRobot(DynamicalSystem):
         for element in self.passive_elements:
             energy = energy + element.elastic_energy(self, q)
         return energy
-
-    def actuator_visual_layers(
-        self,
-        q: Array,
-        s_points: Array,
-        *,
-        actuator_inputs: Array | None = None,
-    ) -> tuple["ActuatorVisualLayer", ...]:
-        """
-        Return renderer-facing geometry for installed actuation components.
-
-        The returned layers describe semantic geometry and optional scalar
-        fields for supported active actuators and passive elements. Visual
-        styling such as colors, radii, and line widths remains the renderer's
-        responsibility. Unsupported components do not produce a layer.
-
-        Args:
-            q: Generalized coordinates of shape ``(num_dofs,)``.
-            s_points: Backbone sample coordinates with shape
-                ``(num_points,)`` used for routed continuum geometry.
-            actuator_inputs: Optional actuator inputs of shape
-                ``(num_actuators,)``. When supplied, supported adapters attach
-                input-dependent scalar fields such as pressure or axial force.
-
-        Returns:
-            layers: Tuple of semantic actuator visual layers. The tuple is
-                empty when no installed component has a renderer adapter.
-        """
-        from soromox.rendering.actuation import actuator_visual_layers
-
-        return actuator_visual_layers(
-            self, q, s_points, actuator_inputs=actuator_inputs
-        )
 
     # -----------------------------------------
     # Energy methods

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -23,6 +23,7 @@ from soromox.actuation import (
     ThreadlikeImpedance,
     ThreadlikeRouting,
 )
+from soromox.rendering import MatplotlibRenderer, actuator_visual_layers
 from soromox.systems import (
     GVS,
     PCS,
@@ -713,10 +714,22 @@ def test_actuator_nested_update_and_topology_rejection():
 def test_visual_layers_are_semantic_unstyled_and_carry_inputs():
     actuator = ThreadlikeActuator.muscles(_routing(count=2))
     robot = _spatial_pcs(actuators=actuator)
-    layers = robot.actuator_visual_layers(
-        jnp.zeros(robot.num_dofs),
+    q = jnp.zeros(robot.num_dofs)
+    actuator_inputs = jnp.array([2.0, 3.0])
+    layers = actuator_visual_layers(
+        robot,
+        q,
         jnp.linspace(0.0, robot.length, 8),
-        actuator_inputs=jnp.array([2.0, 3.0]),
+        actuator_inputs=actuator_inputs,
+    )
+    renderer_layers = MatplotlibRenderer(
+        robot, num_points=8
+    ).compute_actuator_visual_layers(q, actuator_inputs=actuator_inputs)
+    assert not hasattr(robot, "actuator_visual_layers")
+    assert_allclose(renderer_layers[0].points, layers[0].points)
+    assert_allclose(
+        renderer_layers[0].scalar_fields["input"],
+        layers[0].scalar_fields["input"],
     )
     assert len(layers) == 1
     assert layers[0].kind == "muscle"

--- a/tests/systems/test_mckibben_umarm.py
+++ b/tests/systems/test_mckibben_umarm.py
@@ -19,6 +19,7 @@ from examples.simulation.articulated.simulate_mckibben_umarm import (
     build_robot as build_example_robot,
 )
 from soromox.actuation import ArticulatedMcKibbenActuator
+from soromox.rendering import actuator_visual_layers
 from soromox.rendering.viser_renderer import VISER_AVAILABLE
 from soromox.systems import (
     PCS,
@@ -143,7 +144,7 @@ def test_zero_actuator_umarm_exposes_empty_actuator_interface() -> None:
     assert actuator.axial_forces(q, pressures).shape == (0,)
     assert robot.actuation_matrix(q).shape == (robot.num_dofs, 0)
     assert_allclose(robot.actuation_force(q, pressures), jnp.zeros((robot.num_dofs,)))
-    assert robot.actuator_visual_layers(q, jnp.linspace(0.0, 1.0, 3)) == ()
+    assert actuator_visual_layers(robot, q, jnp.linspace(0.0, 1.0, 3)) == ()
     assert robot.forward_dynamics(jnp.array(0.0), y, (pressures, None)).shape == y.shape
 
 

--- a/tests/systems/test_pressure_actuated_pcs_models.py
+++ b/tests/systems/test_pressure_actuated_pcs_models.py
@@ -9,6 +9,7 @@ import pytest
 from system_param_builders import spatial_base_pose
 
 from soromox.actuation import ThreadlikeActuator
+from soromox.rendering import MatplotlibRenderer
 from soromox.systems import (
     PCS,
     ContinuumLinkParams,
@@ -365,6 +366,12 @@ def test_isupport_uses_threadlike_pressure_chambers_and_resolves_area():
     assert (
         robot.actuator_visual_layers(
             jnp.zeros((robot.num_dofs,)), jnp.linspace(0.0, robot.length, 5)
+        )
+        == ()
+    )
+    assert (
+        MatplotlibRenderer(robot, num_points=5).compute_actuator_visual_layers(
+            jnp.zeros((robot.num_dofs,))
         )
         == ()
     )


### PR DESCRIPTION
## Summary

- Move generic actuator-visualization adaptation from `SoftRobot` into `soromox.rendering`.
- Keep automatic renderer integration for standard `SoftRobot` systems while preserving specialized robot hooks.
- Update renderer API documentation, changelog, and actuator integration coverage.

## Validation

- `uv run --extra rendering --extra test pytest tests/rendering tests/actuation/test_threadlike.py tests/systems/test_mckibben_umarm.py tests/systems/test_pressure_actuated_pcs_models.py` — **179 passed**.
- `.venv/bin/zensical build --clean` — passed.
- Ruff check, changed-file format check, and `git diff --check` — passed.
- Full `uv run --extra test pytest tests` run reached the renderer tests cleanly; 1,135 tests passed before it was stopped after the unrelated pre-existing Section Vd fixture failure (`optimization_results.npz` contains pickled data while the test uses `allow_pickle=False`).