### PR TITLE
Fix rotational basis scaling in batched GVS kinematics

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -49,6 +49,10 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Fixed
 
+- Fixed GVS abscissa-batched partial-cell poses and inertial Jacobians so
+  rotational strain-basis values consistently honor
+  `scale_rotational_basis_by_length` for every supported basis family.
+
 ### Documentation
 
 ### Contributors

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -2689,8 +2689,9 @@ class GVS(SoftRobot):
                     [x_base + self.Z1 * Hp_signed, x_base + self.Z2 * Hp_signed]
                 )
                 Bp = self._eval_B_segment(i, Xp)
-                xi_Z1 = Bp[0] @ q_link + xi_ref_Z1_i[cell_idx]
-                xi_Z2 = Bp[1] @ q_link + xi_ref_Z2_i[cell_idx]
+                Bp_Z1, Bp_Z2 = self._scaled_link_basis_pair(length_i, Bp[0], Bp[1])
+                xi_Z1 = Bp_Z1 @ q_link + xi_ref_Z1_i[cell_idx]
+                xi_Z2 = Bp_Z2 @ q_link + xi_ref_Z2_i[cell_idx]
                 ad_xi_Z1 = se3.small_adjoint(xi_Z1)
                 Magnus = (ds / 2.0) * (xi_Z1 + xi_Z2) + (
                     jnp.sqrt(3.0) * ds * ds / 12.0

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1975,6 +1975,65 @@ def test_rotational_strain_basis_length_scaling_matches_unscaled_coordinates() -
     )
 
 
+@pytest.mark.parametrize(
+    "basis_type",
+    ("monomial", "legendre", "chebyshev", "fourier", "gaussian", "imq"),
+)
+def test_scaled_rotational_basis_batched_partial_cells_match_scalar_paths(
+    basis_type: str,
+) -> None:
+    """Guard batched partial cells for every rotational strain-basis family."""
+
+    length = 0.37
+    segment = GVSSegment(
+        link=LinkSpec.circular(
+            young_modulus=1e6,
+            shear_modulus=1e6 / 3.0,
+            density=1000.0,
+            material_damping_coefficient=0.0,
+            length=length,
+            radius=0.02,
+            reference_strain=[0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        ),
+        joint=JointSpec(type="fixed"),
+        basis=StrainBasisSpec(
+            type=basis_type,
+            strain_selector=[1, 0, 0, 0, 0, 0],
+            basis_order=[1, 0, 0, 0, 0, 0],
+        ),
+        num_gauss_points=5,
+    )
+    robot = GVS.from_segments(
+        [segment],
+        max_dof=8,
+        scale_rotational_basis_by_length=True,
+    )
+    q = jnp.linspace(-0.07, 0.08, robot.num_dofs, dtype=jnp.float64)
+    samples = jnp.array(
+        [0.031, length, 0.0, 0.211, 0.031, length - 1e-7],
+        dtype=jnp.float64,
+    )
+
+    expected_poses = jnp.stack([robot.forward_kinematics(q, s) for s in samples])
+    expected_jacobians = jnp.stack(
+        [robot.jacobian_inertialframe(q, s) for s in samples]
+    )
+
+    assert robot.max_dof > robot.num_dofs
+    assert_allclose(
+        robot.forward_kinematics_batched(q, samples),
+        expected_poses,
+        rtol=RTOL,
+        atol=ATOL,
+    )
+    assert_allclose(
+        robot.jacobian_inertialframe_batched(q, samples),
+        expected_jacobians,
+        rtol=RTOL,
+        atol=ATOL,
+    )
+
+
 def test_scaled_compact_basis_tracks_dynamic_segment_length_updates() -> None:
     robot = build_constant_strain_gvs(
         num_segments=2,

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1952,6 +1952,10 @@ def test_rotational_strain_basis_length_scaling_matches_unscaled_coordinates() -
         J_unscaled = unscaled.jacobian_bodyframe(q_unscaled, float(s))
         assert_allclose(J_scaled, J_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
 
+        Ji_scaled = scaled.jacobian_inertialframe(q_scaled, float(s))
+        Ji_unscaled = unscaled.jacobian_inertialframe(q_unscaled, float(s))
+        assert_allclose(Ji_scaled, Ji_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
+
         J_scaled, Jd_scaled = scaled.jacobian_and_time_derivative_bodyframe(
             q_scaled, qd_scaled, float(s)
         )
@@ -1960,6 +1964,83 @@ def test_rotational_strain_basis_length_scaling_matches_unscaled_coordinates() -
         )
         assert_allclose(J_scaled, J_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
         assert_allclose(Jd_scaled, Jd_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
+
+        Ji_scaled, Jid_scaled = scaled.jacobian_and_time_derivative_inertialframe(
+            q_scaled, qd_scaled, float(s)
+        )
+        Ji_unscaled, Jid_unscaled = unscaled.jacobian_and_time_derivative_inertialframe(
+            q_unscaled, qd_unscaled, float(s)
+        )
+        assert_allclose(Ji_scaled, Ji_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
+        assert_allclose(Jid_scaled, Jid_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
+
+        gs_scaled = scaled.forward_kinematics_arc_length_derivative(q_scaled, float(s))
+        gs_unscaled = unscaled.forward_kinematics_arc_length_derivative(
+            q_unscaled, float(s)
+        )
+        assert_allclose(gs_scaled, gs_unscaled, rtol=RTOL, atol=ATOL)
+
+        J_scaled, Js_scaled = scaled.jacobian_and_arc_length_derivative_bodyframe(
+            q_scaled, float(s)
+        )
+        J_unscaled, Js_unscaled = unscaled.jacobian_and_arc_length_derivative_bodyframe(
+            q_unscaled, float(s)
+        )
+        assert_allclose(J_scaled, J_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
+        assert_allclose(Js_scaled, Js_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
+
+        Ji_scaled, Jis_scaled = scaled.jacobian_and_arc_length_derivative_inertialframe(
+            q_scaled, float(s)
+        )
+        Ji_unscaled, Jis_unscaled = (
+            unscaled.jacobian_and_arc_length_derivative_inertialframe(
+                q_unscaled, float(s)
+            )
+        )
+        assert_allclose(Ji_scaled, Ji_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
+        assert_allclose(Jis_scaled, Jis_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
+
+    assert_allclose(
+        scaled.forward_kinematics_tips(q_scaled),
+        unscaled.forward_kinematics_tips(q_unscaled),
+        rtol=RTOL,
+        atol=ATOL,
+    )
+    assert_allclose(
+        scaled.jacobian_tips(q_scaled),
+        unscaled.jacobian_tips(q_unscaled) @ coordinate_map,
+        rtol=RTOL,
+        atol=ATOL,
+    )
+
+    g_scaled, J_scaled, Jd_scaled = scaled.integration_kinematics(q_scaled, qd_scaled)
+    g_unscaled, J_unscaled, Jd_unscaled = unscaled.integration_kinematics(
+        q_unscaled, qd_unscaled
+    )
+    assert_allclose(g_scaled, g_unscaled, rtol=RTOL, atol=ATOL)
+    assert_allclose(J_scaled, J_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
+    assert_allclose(Jd_scaled, Jd_unscaled @ coordinate_map, rtol=RTOL, atol=ATOL)
+
+    dynamics_scaled = scaled.dynamics_terms(q_scaled, qd_scaled)
+    dynamics_unscaled = unscaled.dynamics_terms(q_unscaled, qd_unscaled)
+    assert_allclose(
+        dynamics_scaled[0],
+        coordinate_map.T @ dynamics_unscaled[0] @ coordinate_map,
+        rtol=RTOL,
+        atol=ATOL,
+    )
+    assert_allclose(
+        dynamics_scaled[1],
+        coordinate_map.T @ dynamics_unscaled[1],
+        rtol=RTOL,
+        atol=ATOL,
+    )
+    assert_allclose(
+        dynamics_scaled[2],
+        coordinate_map.T @ dynamics_unscaled[2],
+        rtol=RTOL,
+        atol=ATOL,
+    )
 
     assert_allclose(
         scaled.stiffness_matrix(),
@@ -2009,14 +2090,35 @@ def test_scaled_rotational_basis_batched_partial_cells_match_scalar_paths(
         scale_rotational_basis_by_length=True,
     )
     q = jnp.linspace(-0.07, 0.08, robot.num_dofs, dtype=jnp.float64)
+    qd = jnp.linspace(0.05, -0.04, robot.num_dofs, dtype=jnp.float64)
     samples = jnp.array(
         [0.031, length, 0.0, 0.211, 0.031, length - 1e-7],
         dtype=jnp.float64,
     )
 
     expected_poses = jnp.stack([robot.forward_kinematics(q, s) for s in samples])
-    expected_jacobians = jnp.stack(
+    expected_body_jacobians = jnp.stack(
+        [robot.jacobian_bodyframe(q, s) for s in samples]
+    )
+    expected_inertial_jacobians = jnp.stack(
         [robot.jacobian_inertialframe(q, s) for s in samples]
+    )
+    expected_body_terms = tuple(
+        jnp.stack(values)
+        for values in zip(
+            *[robot.jacobian_and_time_derivative_bodyframe(q, qd, s) for s in samples],
+            strict=True,
+        )
+    )
+    expected_inertial_terms = tuple(
+        jnp.stack(values)
+        for values in zip(
+            *[
+                robot.jacobian_and_time_derivative_inertialframe(q, qd, s)
+                for s in samples
+            ],
+            strict=True,
+        )
     )
 
     assert robot.max_dof > robot.num_dofs
@@ -2027,11 +2129,29 @@ def test_scaled_rotational_basis_batched_partial_cells_match_scalar_paths(
         atol=ATOL,
     )
     assert_allclose(
-        robot.jacobian_inertialframe_batched(q, samples),
-        expected_jacobians,
+        robot.jacobian_bodyframe_batched(q, samples),
+        expected_body_jacobians,
         rtol=RTOL,
         atol=ATOL,
     )
+    assert_allclose(
+        robot.jacobian_inertialframe_batched(q, samples),
+        expected_inertial_jacobians,
+        rtol=RTOL,
+        atol=ATOL,
+    )
+    actual_body_terms = robot.jacobian_and_time_derivative_bodyframe_batched(
+        q, qd, samples
+    )
+    actual_inertial_terms = robot.jacobian_and_time_derivative_inertialframe_batched(
+        q, qd, samples
+    )
+    for actual, expected in zip(actual_body_terms, expected_body_terms, strict=True):
+        assert_allclose(actual, expected, rtol=RTOL, atol=ATOL)
+    for actual, expected in zip(
+        actual_inertial_terms, expected_inertial_terms, strict=True
+    ):
+        assert_allclose(actual, expected, rtol=RTOL, atol=ATOL)
 
 
 def test_scaled_compact_basis_tracks_dynamic_segment_length_updates() -> None:


### PR DESCRIPTION
## Summary

This PR fixes inconsistent rotational strain-basis normalization in the
specialized GVS abscissa-batched forward-kinematics traversal. When
`scale_rotational_basis_by_length=True`, a partial integration cell evaluated
by `forward_kinematics_batched` used the raw angular basis rows instead of
dividing them by the physical link length.

The incorrect pose also propagated into `jacobian_inertialframe_batched`: its
body-frame Jacobian was assembled with the correctly normalized Magnus helper,
but it was rotated into the inertial frame using the incorrectly integrated
batched pose.

The fix is intentionally small and is accompanied by a broader audit and
regression matrix covering every supported GVS strain-basis family and every
other GVS path that consumes link strain bases.

## Root cause

Most GVS kinematics and dynamics paths pass link bases through
`_scaled_link_basis_pair`, or consume compact basis operands that were already
normalized during `precompute()`. The optimized abscissa-batched pose method is
different: it evaluates a basis directly at the two Magnus points of the
requested partial cell and then assembles the strains inline.

That direct path omitted the normalization step:

1. classify each requested abscissa and select its segment/cell;
2. reuse the stored transform at the closest completed integration node;
3. evaluate the basis at the two points inside the remaining partial cell;
4. assemble and exponentiate the partial Magnus increment.

Step 3 returned the native, unscaled basis. Full cells and scalar partial cells
already applied the rotational length normalization, so the disagreement was
limited to non-boundary samples handled by the specialized batch traversal.

## Implementation

The partial-cell path now sends the two evaluated basis matrices through the
existing `_scaled_link_basis_pair` helper before assembling strain. Reusing the
shared helper keeps the convention identical to the Jacobian, Jacobian-time-
derivative, arc-length-derivative, and integration-kinematics recurrences.

Two alternatives were considered and rejected:

- applying another inline `basis.at[:3].divide(length)` would fix this call but
  duplicate the convention that the shared helper already owns;
- implementing `_eval_B_segment` as an implicitly scaled evaluator would make
  its contract less clear and would double-scale the many callers that already
  pass its output through a normalized Magnus helper.

The selected change therefore repairs the omission without changing the raw
basis evaluator or any generalized-coordinate convention.

## GVS normalization audit

Every consumer of `B_Xs`, `B_Z1`, `B_Z2`, `_eval_B_segment`, and
`_eval_dB_segment` was inspected.

- Scalar and Gauss-node forward kinematics explicitly normalize angular rows.
- Body Jacobians, inertial Jacobians, Jacobian time derivatives, and
  arc-length derivatives use the shared dense Magnus helpers, which normalize
  both basis values and basis derivatives.
- Integration kinematics and the legacy matrix paths use the same helpers.
- Fused dynamics uses compact `scaled_B_Z1_values` and `scaled_B_Z2_values`;
  these are normalized in `precompute()` and refreshed after dynamic link-
  length updates.
- Threadlike routing explicitly normalizes `B_Xs` before computing strain,
  path length, and moment matrices.
- Stiffness and damping already follow the scaled generalized-coordinate
  projection and are covered by coordinate-equivalence tests.

No additional missing normalization was found. The abscissa-batched pose
partial cell was the only direct consumer that used a raw rotational basis
without subsequently normalizing it.

## Regression coverage

The new partial-cell regression is parameterized over all supported GVS basis
families:

- monomial;
- Legendre;
- Chebyshev;
- Fourier;
- Gaussian; and
- inverse multiquadric.

It uses rotational basis order greater than zero, padded local DOFs, interior
partial cells, base/tip and integration boundaries, unsorted samples, and a
duplicate sample. For every family it compares the specialized batched methods
with pointwise scalar evaluation for:

- forward kinematics;
- body-frame and inertial-frame Jacobians; and
- body-frame and inertial-frame Jacobians with time derivatives.

The existing scaled-versus-unscaled coordinate-equivalence test now also
covers:

- scalar poses and body/inertial Jacobians;
- body/inertial Jacobian time derivatives;
- pose and Jacobian arc-length derivatives;
- tip poses and Jacobians;
- integration-point poses, Jacobians, and Jacobian time derivatives;
- fused inertia, Coriolis-force, and gravity assembly; and
- stiffness and damping matrices.

## Scope and merge order

This branch was created directly from `origin/main` and contains no Warp
backend code or API renaming. It is intended to merge before the separate
abscissa-batch naming PR (#180), after which the corrected method keeps the new
name without changing its numerical implementation.

## Validation

- Seven focused normalization tests passed, including all six basis families.
- Ruff lint and formatting checks passed for the changed files.
- `git diff --check` passed.

