### PR TITLE
Rename abscissa-batched system methods

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -41,6 +41,12 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Breaking changes
 
+- Renamed abscissa-only batch APIs to identify their mapped argument:
+  `forward_kinematics_batched(...)` is now
+  `forward_kinematics_abscissa_batched(...)`, `jacobian_batched(...)` is now
+  `jacobian_abscissa_batched(...)`, and the body-frame, inertial-frame, and
+  Jacobian-time-derivative variants follow the same `*_abscissa_batched`
+  convention. The old names have been removed.
 - Moved generic actuator-visualization adaptation out of
   `SoftRobot.actuator_visual_layers(...)` and into
   `soromox.rendering.actuator_visual_layers(...)`. Renderers continue to adapt

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -284,7 +284,7 @@ Ready for something more advanced? Let's simulate a soft continuum robot:
 
     # Compute forward kinematics along the robot
     s_values = jnp.linspace(0, robot.L.sum(), 100)
-    backbone_shape = robot.forward_kinematics_batched(q, s_values)
+    backbone_shape = robot.forward_kinematics_abscissa_batched(q, s_values)
 
     # Extract positions for plotting
     # forward_kinematics returns [theta, px, py] for planar systems

--- a/paper_results/secVe_safety_constrained_control/code/pcs_cf_cbf_clf_common.py
+++ b/paper_results/secVe_safety_constrained_control/code/pcs_cf_cbf_clf_common.py
@@ -239,7 +239,7 @@ class TendonSoroConfig(CLFCBFConfig):
             return jnp.array([0.0])
 
         q, _ = self.setup.dyn.split(y)
-        g_ps = self.setup.robot.forward_kinematics_batched(q, self.s_ps)
+        g_ps = self.setup.robot.forward_kinematics_abscissa_batched(q, self.s_ps)
         p = g_ps[:, :3, 3]
 
         H = pairwise_h(
@@ -420,7 +420,7 @@ def run_case(setup: SimulationSetup, controller_key: str) -> dict[str, Any]:
 
     q_ts, qd_ts = jnp.split(trajectory.y, 2, axis=1)
     g_body_ts = jax.vmap(
-        lambda q: setup.robot.forward_kinematics_batched(q, config.s_ps)
+        lambda q: setup.robot.forward_kinematics_abscissa_batched(q, config.s_ps)
     )(q_ts)
     p_body_ts = g_body_ts[:, :, :3, 3]
     clearances = jnp.linalg.norm(

--- a/src/soromox/coordinate_transformations/operational_space_dynamics.py
+++ b/src/soromox/coordinate_transformations/operational_space_dynamics.py
@@ -452,7 +452,7 @@ class OperationalSpaceDynamics(eqx.Module):
         """
         Compute the full stacked Jacobian for all points (before task selection).
 
-        Uses the robot's jacobian_batched method if available for efficiency.
+        Uses the robot's jacobian_abscissa_batched method if available for efficiency.
 
         The Jacobian relates configuration velocities to operational space velocities.
         It has n_velocity_dim rows per point (6 for 3D, 3 for planar), which is
@@ -465,7 +465,7 @@ class OperationalSpaceDynamics(eqx.Module):
             J_full: Stacked Jacobian of shape (n_points * n_velocity_dim, num_dofs).
         """
         # Use batched method from the robot
-        J_ps = self.robot.jacobian_batched(q, self.s_ps)
+        J_ps = self.robot.jacobian_abscissa_batched(q, self.s_ps)
         # J_ps has shape (n_points, n_velocity_dim, num_dofs)
 
         # Stack to get (n_points * n_velocity_dim, num_dofs)
@@ -480,7 +480,7 @@ class OperationalSpaceDynamics(eqx.Module):
         """
         Compute the full stacked Jacobian and its time derivative for all points.
 
-        Uses the robot's jacobian_and_time_derivative_batched method if available.
+        Uses the robot's jacobian_and_time_derivative_abscissa_batched method if available.
 
         Args:
             q: Generalized coordinates of shape (num_dofs,).
@@ -491,7 +491,7 @@ class OperationalSpaceDynamics(eqx.Module):
             Jd_full: Stacked Jacobian time derivative of shape (n_points * n_velocity_dim, num_dofs).
         """
         # Use batched method from the robot
-        J_ps, Jd_ps = self.robot.jacobian_and_time_derivative_batched(q, qd, self.s_ps)
+        J_ps, Jd_ps = self.robot.jacobian_and_time_derivative_abscissa_batched(q, qd, self.s_ps)
         # J_ps, Jd_ps have shape (n_points, n_pose_dim, num_dofs)
 
         # Stack to get (n_points * n_pose_dim, num_dofs)
@@ -828,7 +828,7 @@ class OperationalSpaceDynamics(eqx.Module):
             compute_task_pose_error: Returns task-selected pose error.
         """
         # Compute forward kinematics at all points
-        fk_results = self.robot.forward_kinematics_batched(q, self.s_ps)
+        fk_results = self.robot.forward_kinematics_abscissa_batched(q, self.s_ps)
 
         # Extract pose vectors from forward kinematics results
         poses = vmap(self._extract_pose_from_fk)(fk_results)

--- a/src/soromox/rendering/base.py
+++ b/src/soromox/rendering/base.py
@@ -313,8 +313,8 @@ class BaseSoftRobotRenderer(ABC):
     def compute_backbone_poses(self, q: Array) -> Array:
         """Compute full FK poses at the configured backbone sample points."""
         s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
-        if hasattr(self.robot, "forward_kinematics_batched"):
-            return self.robot.forward_kinematics_batched(q, s_ps)
+        if hasattr(self.robot, "forward_kinematics_abscissa_batched"):
+            return self.robot.forward_kinematics_abscissa_batched(q, s_ps)
         return jax.vmap(lambda s: self.robot.forward_kinematics(q, s))(s_ps)
 
     def compute_actuator_visual_layers(
@@ -1095,7 +1095,7 @@ class BaseSoftRobotRenderer(ABC):
     ) -> Array:
         """Compute backbone curves for multiple robots with base offsets.
 
-        Uses forward_kinematics_batched if available (optimized), otherwise
+        Uses forward_kinematics_abscissa_batched if available (optimized), otherwise
         falls back to jax.vmap over compute_backbone_curve.
 
         Args:

--- a/src/soromox/rendering/isupport/viser_renderer.py
+++ b/src/soromox/rendering/isupport/viser_renderer.py
@@ -351,7 +351,7 @@ class ISupportViserRenderer(ViserRenderer):
     def _sample_world_poses(self, q: Array, curves: np.ndarray) -> np.ndarray:
         s_points = jnp.asarray(self._sample_s)
         poses = np.array(
-            jax.vmap(lambda q_i: self.robot.forward_kinematics_batched(q_i, s_points))(
+            jax.vmap(lambda q_i: self.robot.forward_kinematics_abscissa_batched(q_i, s_points))(
                 q
             ),
             copy=True,

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -2636,7 +2636,7 @@ class GVS(SoftRobot):
         return self._forward_kinematics_gauss(q_gathered)[:, -1]
 
     @eqx.filter_jit
-    def forward_kinematics_batched(self, q: Array, s_ps: Array) -> Array:
+    def forward_kinematics_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the forward kinematics of the robot at a batch of points along the backbone.
 
@@ -3336,7 +3336,7 @@ class GVS(SoftRobot):
         return Js
 
     @eqx.filter_jit
-    def jacobian_bodyframe_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_bodyframe_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the body-frame Jacobian at multiple arclength locations.
 
@@ -3424,7 +3424,7 @@ class GVS(SoftRobot):
         return vmap(body_single)(s_flat)
 
     @eqx.filter_jit
-    def jacobian_and_time_derivative_bodyframe_batched(
+    def jacobian_and_time_derivative_bodyframe_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -3639,7 +3639,7 @@ class GVS(SoftRobot):
         return vmap(self._body_jacobian_to_inertial)(g_tips, J_local_tips)
 
     @eqx.filter_jit
-    def jacobian_inertialframe_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_inertialframe_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the inertial-frame Jacobian at multiple arclength locations.
 
@@ -3650,13 +3650,13 @@ class GVS(SoftRobot):
         Returns:
             Array: Jacobians with shape (N, 6, num_active_strains).
         """
-        J_body = self.jacobian_bodyframe_batched(q, s_ps)  # (N, 6, num_active_strains)
-        g_ps = self.forward_kinematics_batched(q, s_ps)  # (N, 4, 4)
+        J_body = self.jacobian_bodyframe_abscissa_batched(q, s_ps)  # (N, 6, num_active_strains)
+        g_ps = self.forward_kinematics_abscissa_batched(q, s_ps)  # (N, 4, 4)
 
         return vmap(self._body_jacobian_to_inertial)(g_ps, J_body)
 
     @eqx.filter_jit
-    def jacobian_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute inertial-frame Jacobians at multiple arclength locations.
 
@@ -3673,7 +3673,7 @@ class GVS(SoftRobot):
             J_global (Array): inertial-frame Jacobians with shape
                 ``(N, 6, num_active_strains)``.
         """
-        return self.jacobian_inertialframe_batched(q, s_ps)
+        return self.jacobian_inertialframe_abscissa_batched(q, s_ps)
 
     @eqx.filter_jit
     def _jacobian_time_derivative_gauss(
@@ -4174,7 +4174,7 @@ class GVS(SoftRobot):
         )
 
     @eqx.filter_jit
-    def jacobian_and_time_derivative_inertialframe_batched(
+    def jacobian_and_time_derivative_inertialframe_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -4189,10 +4189,10 @@ class GVS(SoftRobot):
             Tuple[Array, Array]: Jacobians and derivatives with shape
             (N, 6, num_active_strains).
         """
-        J_body, Jd_body = self.jacobian_and_time_derivative_bodyframe_batched(
+        J_body, Jd_body = self.jacobian_and_time_derivative_bodyframe_abscissa_batched(
             q, qd, s_ps
         )
-        g_ps = self.forward_kinematics_batched(q, s_ps)
+        g_ps = self.forward_kinematics_abscissa_batched(q, s_ps)
 
         return vmap(
             self._body_jacobian_time_derivative_to_inertial, in_axes=(0, 0, 0, None)
@@ -4217,7 +4217,7 @@ class GVS(SoftRobot):
         return self.jacobian_and_time_derivative_inertialframe(q, qd, s)
 
     @eqx.filter_jit
-    def jacobian_and_time_derivative_batched(
+    def jacobian_and_time_derivative_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -4238,7 +4238,7 @@ class GVS(SoftRobot):
             Tuple[Array, Array]: inertial-frame Jacobians and time derivatives.
             Each array has shape ``(N, 6, num_active_strains)``.
         """
-        return self.jacobian_and_time_derivative_inertialframe_batched(q, qd, s_ps)
+        return self.jacobian_and_time_derivative_inertialframe_abscissa_batched(q, qd, s_ps)
 
     def _active_selector_blocks(self) -> Array:
         """

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -925,7 +925,7 @@ class PCS(SoftRobot):
         return g_tips
 
     @eqx.filter_jit
-    def forward_kinematics_batched(self, q: Array, s_ps: Array) -> Array:
+    def forward_kinematics_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the forward kinematics of the robot at a batch of points s_ps along the robot.
 
@@ -1100,7 +1100,7 @@ class PCS(SoftRobot):
         return J_local_tips
 
     @eqx.filter_jit
-    def _J_local_batched(self, q: Array, s_ps: Array) -> Array:
+    def _J_local_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the Jacobian for the forward kinematics at a batch of points s_ps along the robot.
 
@@ -1657,7 +1657,7 @@ class PCS(SoftRobot):
         return Js
 
     @eqx.filter_jit
-    def jacobian_bodyframe_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_bodyframe_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the Jacobian of the forward kinematics at a batch of points s_ps along the robot in the body frame.
 
@@ -1668,7 +1668,7 @@ class PCS(SoftRobot):
         Returns:
             J_local_ps (Array): Jacobians evaluated at all points, shape (N, 6, num_active_strains)
         """
-        J_local_ps_ = self._J_local_batched(q, s_ps)  # shape (N, 6, num_strains)
+        J_local_ps_ = self._J_local_abscissa_batched(q, s_ps)  # shape (N, 6, num_strains)
 
         J_local_ps = jnp.einsum(
             "ijk, kl->ijl", J_local_ps_, self.B_xi
@@ -1758,7 +1758,7 @@ class PCS(SoftRobot):
         return Js
 
     @eqx.filter_jit
-    def jacobian_inertialframe_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_inertialframe_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the Jacobian of the forward kinematics at a batch of points s_ps along the robot in the inertial frame.
         Args:
@@ -1769,11 +1769,11 @@ class PCS(SoftRobot):
             J_global_ps (Array): Jacobians evaluated at all points, shape (N, 6, num_active_strains)
         """
         # compute the Jacobian in the body frame
-        J_local_ps = self.jacobian_bodyframe_batched(
+        J_local_ps = self.jacobian_bodyframe_abscissa_batched(
             q, s_ps
         )  # shape (N, 6, num_active_strains)
 
-        g_ps = self.forward_kinematics_batched(q, s_ps)  # shape (N, 4, 4)
+        g_ps = self.forward_kinematics_abscissa_batched(q, s_ps)  # shape (N, 4, 4)
         # construct g with zero translation for the Adjoint transformation
         g_rot_ps = jnp.block(
             [
@@ -1876,7 +1876,7 @@ class PCS(SoftRobot):
         return J_local_tips, Jd_local_tips
 
     @eqx.filter_jit
-    def _J_Jd_local_batched(
+    def _J_Jd_local_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -2061,7 +2061,7 @@ class PCS(SoftRobot):
         return J_local, Jd_local
 
     @eqx.filter_jit
-    def jacobian_and_time_derivative_bodyframe_batched(
+    def jacobian_and_time_derivative_bodyframe_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -2076,7 +2076,7 @@ class PCS(SoftRobot):
             J_local_ps (Array): Jacobians evaluated at all points, shape (N, 6, num_active_strains)
             Jd_local_ps (Array): Time-derivative of the Jacobians, shape (N, 6, num_active_strains)
         """
-        J_local_ps_, Jd_local_ps_ = self._J_Jd_local_batched(
+        J_local_ps_, Jd_local_ps_ = self._J_Jd_local_abscissa_batched(
             q, qd, s_ps
         )  # shape (N, 6, num_strains)
 
@@ -2125,7 +2125,7 @@ class PCS(SoftRobot):
 
         return J_global, Jd_global
 
-    def jacobian_and_time_derivative_inertialframe_batched(
+    def jacobian_and_time_derivative_inertialframe_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -2140,11 +2140,11 @@ class PCS(SoftRobot):
             J_global_ps (Array): Jacobians evaluated at all points, shape (N, 6, num_active_strains)
             Jd_global_ps (Array): Time-derivative of the Jacobians, shape (N, 6, num_active_strains)
         """
-        J_local_ps, Jd_local_ps = self.jacobian_and_time_derivative_bodyframe_batched(
+        J_local_ps, Jd_local_ps = self.jacobian_and_time_derivative_bodyframe_abscissa_batched(
             q, qd, s_ps
         )  # shape (N, 6, num_active_strains)
 
-        g_ps = self.forward_kinematics_batched(q, s_ps)  # shape (N, 4, 4)
+        g_ps = self.forward_kinematics_abscissa_batched(q, s_ps)  # shape (N, 4, 4)
         # construct g with zero translation for the Adjoint transformation
         g_rot_ps = jnp.block(
             [
@@ -2194,7 +2194,7 @@ class PCS(SoftRobot):
         return self.jacobian_and_arc_length_derivative_inertialframe(q, s)
 
     @eqx.filter_jit
-    def jacobian_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """Compute inertial-frame Jacobians at multiple arc-length positions.
 
         Args:
@@ -2206,7 +2206,7 @@ class PCS(SoftRobot):
             Inertial-frame Jacobians with shape
             ``(num_points, 6, num_active_strains)``.
         """
-        return self.jacobian_inertialframe_batched(q, s_ps)
+        return self.jacobian_inertialframe_abscissa_batched(q, s_ps)
 
     @eqx.filter_jit
     def _jacobian_and_time_derivative(
@@ -2216,7 +2216,7 @@ class PCS(SoftRobot):
         return self.jacobian_and_time_derivative_inertialframe(q, qd, s)
 
     @eqx.filter_jit
-    def jacobian_and_time_derivative_batched(
+    def jacobian_and_time_derivative_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """Compute batched inertial Jacobians and their time derivatives.
@@ -2232,7 +2232,7 @@ class PCS(SoftRobot):
             A tuple ``(J, J_dot)`` whose arrays both have shape
             ``(num_points, 6, num_active_strains)``.
         """
-        return self.jacobian_and_time_derivative_inertialframe_batched(q, qd, s_ps)
+        return self.jacobian_and_time_derivative_inertialframe_abscissa_batched(q, qd, s_ps)
 
     # ==========================================
     # Useful functions for the system
@@ -2336,7 +2336,7 @@ class PCS(SoftRobot):
         )  # shape (num_segments, num_gauss_points) for both Xs_scaled and Ws_scaled
 
         # compute the jacobian for each quadrature point
-        J_ps = self._J_local_batched(
+        J_ps = self._J_local_abscissa_batched(
             q, Xs_scaled.flatten()
         )  # shape (num_segments * num_gauss_points, 6, num_active_strains)
         J_ps = J_ps.reshape(
@@ -2416,7 +2416,7 @@ class PCS(SoftRobot):
         )  # shape (num_segments, num_gauss_points) for both Xs_scaled and Ws_scaled
 
         # compute the jacobian and its time-derivative for each quadrature point
-        J_ps, Jd_ps = self._J_Jd_local_batched(
+        J_ps, Jd_ps = self._J_Jd_local_abscissa_batched(
             q, qd, Xs_scaled.flatten()
         )  # shape (num_segments * num_gauss_points, 6, num_active_strains)
         J_ps = J_ps.reshape(
@@ -2494,7 +2494,7 @@ class PCS(SoftRobot):
         )  # shape (num_segments, num_gauss_points) for both Xs_scaled and Ws_scaled
 
         # compute the forward kinematics for each quadrature point
-        g_ps = self.forward_kinematics_batched(
+        g_ps = self.forward_kinematics_abscissa_batched(
             q, Xs_scaled.flatten()
         )  # shape (num_segments * num_gauss_points, 4, 4)
         g_ps = g_ps.reshape(
@@ -2502,7 +2502,7 @@ class PCS(SoftRobot):
         )  # shape (num_segments, num_gauss_points, 4, 4)
 
         # compute the jacobian for each quadrature point
-        J_ps = self._J_local_batched(
+        J_ps = self._J_local_abscissa_batched(
             q, Xs_scaled.flatten()
         )  # shape (num_segments * num_gauss_points, 6, num_active_strains)
         J_ps = J_ps.reshape(
@@ -2818,7 +2818,7 @@ class PCS(SoftRobot):
         )  # shape (num_segments, num_gauss_points) for both Xs_scaled and Ws_scaled
 
         # compute the forward kinematics for each quadrature point
-        g_ps = self.forward_kinematics_batched(
+        g_ps = self.forward_kinematics_abscissa_batched(
             q, Xs_scaled.flatten()
         )  # shape (num_segments * num_gauss_points, 4, 4)
         g_ps = g_ps.reshape(

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -860,7 +860,7 @@ class PlanarPCS(SoftRobot):
         return chi_tips
 
     @eqx.filter_jit
-    def forward_kinematics_batched(self, q: Array, s_ps: Array) -> Array:
+    def forward_kinematics_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the forward kinematics of the robot at a batch of arc-length positions.
 
@@ -1039,7 +1039,7 @@ class PlanarPCS(SoftRobot):
         return J_local_tips
 
     @eqx.filter_jit
-    def _J_local_batched(self, q: Array, s_ps: Array) -> Array:
+    def _J_local_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the body-frame Jacobian at a batch of arc-length positions.
 
@@ -1620,7 +1620,7 @@ class PlanarPCS(SoftRobot):
         return Js
 
     @eqx.filter_jit
-    def jacobian_bodyframe_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_bodyframe_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the Jacobian of the forward kinematics at a batch of points s_ps along the robot in the body frame.
 
@@ -1631,7 +1631,7 @@ class PlanarPCS(SoftRobot):
         Returns:
             J_local_ps (Array): Jacobians evaluated at all points, shape (N, 3, num_active_strains)
         """
-        J_local_ps_full = self._J_local_batched(q, s_ps)  # shape (N, 3, num_strains)
+        J_local_ps_full = self._J_local_abscissa_batched(q, s_ps)  # shape (N, 3, num_strains)
         J_local_ps = jnp.einsum("ijk, kl->ijl", J_local_ps_full, self.B_xi)
 
         return J_local_ps
@@ -1720,7 +1720,7 @@ class PlanarPCS(SoftRobot):
         return Js
 
     @eqx.filter_jit
-    def jacobian_inertialframe_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_inertialframe_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the Jacobian of the forward kinematics at a batch of points s_ps along the robot in the inertial frame.
 
@@ -1731,9 +1731,9 @@ class PlanarPCS(SoftRobot):
         Returns:
             J_global_ps (Array): Jacobians evaluated at all points, shape (N, 3, num_active_strains)
         """
-        J_local_ps = self.jacobian_bodyframe_batched(q, s_ps)
+        J_local_ps = self.jacobian_bodyframe_abscissa_batched(q, s_ps)
 
-        chi_ps = self.forward_kinematics_batched(q, s_ps)  # shape (N, 3)
+        chi_ps = self.forward_kinematics_abscissa_batched(q, s_ps)  # shape (N, 3)
         thetas = chi_ps[:, 0]
 
         def lift_theta(th: Array) -> Array:
@@ -1822,7 +1822,7 @@ class PlanarPCS(SoftRobot):
         return J_local_tips, Jd_local_tips
 
     @eqx.filter_jit
-    def _J_Jd_local_batched(
+    def _J_Jd_local_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -1998,7 +1998,7 @@ class PlanarPCS(SoftRobot):
         return J_local, Jd_local
 
     @eqx.filter_jit
-    def jacobian_and_time_derivative_bodyframe_batched(
+    def jacobian_and_time_derivative_bodyframe_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -2013,7 +2013,7 @@ class PlanarPCS(SoftRobot):
             J_local_ps (Array): Jacobians evaluated at all points, shape (N, 3, num_active_strains)
             Jd_local_ps (Array): Time-derivative of the Jacobians, shape (N, 3, num_active_strains)
         """
-        J_local_ps_full, Jd_local_ps_full = self._J_Jd_local_batched(q, qd, s_ps)
+        J_local_ps_full, Jd_local_ps_full = self._J_Jd_local_abscissa_batched(q, qd, s_ps)
 
         J_local_ps = jnp.einsum("ijk, kl->ijl", J_local_ps_full, self.B_xi)
         Jd_local_ps = jnp.einsum("ijk, kl->ijl", Jd_local_ps_full, self.B_xi)
@@ -2052,7 +2052,7 @@ class PlanarPCS(SoftRobot):
 
         return J_global, Jd_global
 
-    def jacobian_and_time_derivative_inertialframe_batched(
+    def jacobian_and_time_derivative_inertialframe_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -2067,11 +2067,11 @@ class PlanarPCS(SoftRobot):
             J_global_ps (Array): Jacobians evaluated at all points, shape (N, 3, num_active_strains)
             Jd_global_ps (Array): Time-derivative of the Jacobians, shape (N, 3, num_active_strains)
         """
-        J_local_ps, Jd_local_ps = self.jacobian_and_time_derivative_bodyframe_batched(
+        J_local_ps, Jd_local_ps = self.jacobian_and_time_derivative_bodyframe_abscissa_batched(
             q, qd, s_ps
         )
 
-        chi_ps = self.forward_kinematics_batched(q, s_ps)
+        chi_ps = self.forward_kinematics_abscissa_batched(q, s_ps)
         thetas = chi_ps[:, 0]
 
         def lift_theta(th: Array) -> Array:
@@ -2113,7 +2113,7 @@ class PlanarPCS(SoftRobot):
         return self.jacobian_and_arc_length_derivative_inertialframe(q, s)
 
     @eqx.filter_jit
-    def jacobian_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """Compute inertial-frame Jacobians at multiple arc-length positions.
 
         Args:
@@ -2125,7 +2125,7 @@ class PlanarPCS(SoftRobot):
             Inertial-frame Jacobians with shape
             ``(num_points, 3, num_active_strains)``.
         """
-        return self.jacobian_inertialframe_batched(q, s_ps)
+        return self.jacobian_inertialframe_abscissa_batched(q, s_ps)
 
     @eqx.filter_jit
     def _jacobian_and_time_derivative(
@@ -2135,7 +2135,7 @@ class PlanarPCS(SoftRobot):
         return self.jacobian_and_time_derivative_inertialframe(q, qd, s)
 
     @eqx.filter_jit
-    def jacobian_and_time_derivative_batched(
+    def jacobian_and_time_derivative_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """Compute batched inertial Jacobians and their time derivatives.
@@ -2151,7 +2151,7 @@ class PlanarPCS(SoftRobot):
             A tuple ``(J, J_dot)`` whose arrays both have shape
             ``(num_points, 3, num_active_strains)``.
         """
-        return self.jacobian_and_time_derivative_inertialframe_batched(q, qd, s_ps)
+        return self.jacobian_and_time_derivative_inertialframe_abscissa_batched(q, qd, s_ps)
 
     # ==========================================
     # Useful functions for the system
@@ -2244,7 +2244,7 @@ class PlanarPCS(SoftRobot):
             self.L_cum[1:],
         )
 
-        J_ps = self._J_local_batched(q, Xs_scaled.flatten())
+        J_ps = self._J_local_abscissa_batched(q, Xs_scaled.flatten())
         J_ps = J_ps.reshape(
             self.num_segments, self.num_integration_points, *J_ps.shape[1:]
         )
@@ -2308,7 +2308,7 @@ class PlanarPCS(SoftRobot):
             self.L_cum[1:],
         )
 
-        J_ps, Jd_ps = self._J_Jd_local_batched(q, qd, Xs_scaled.flatten())
+        J_ps, Jd_ps = self._J_Jd_local_abscissa_batched(q, qd, Xs_scaled.flatten())
         J_ps = J_ps.reshape(
             self.num_segments, self.num_integration_points, *J_ps.shape[1:]
         )
@@ -2377,11 +2377,11 @@ class PlanarPCS(SoftRobot):
             self.L_cum[1:],
         )
 
-        chi_ps = self.forward_kinematics_batched(q, Xs_scaled.flatten())
+        chi_ps = self.forward_kinematics_abscissa_batched(q, Xs_scaled.flatten())
         g_ps = vmap(poses.planar_pose_to_transform)(chi_ps.reshape(-1, 3))
         g_ps = g_ps.reshape(self.num_segments, self.num_integration_points, 3, 3)
 
-        J_ps = self._J_local_batched(q, Xs_scaled.flatten())
+        J_ps = self._J_local_abscissa_batched(q, Xs_scaled.flatten())
         J_ps = J_ps.reshape(
             self.num_segments, self.num_integration_points, *J_ps.shape[1:]
         )
@@ -2676,7 +2676,7 @@ class PlanarPCS(SoftRobot):
             self.L_cum[1:],
         )
 
-        chi_ps = self.forward_kinematics_batched(q, Xs_scaled.flatten())
+        chi_ps = self.forward_kinematics_abscissa_batched(q, Xs_scaled.flatten())
         chi_ps = chi_ps.reshape(self.num_segments, self.num_integration_points, 3)
 
         def U_G_i(i: Array) -> Array:

--- a/src/soromox/systems/pendulum/pendulum.py
+++ b/src/soromox/systems/pendulum/pendulum.py
@@ -629,7 +629,7 @@ class Pendulum(SoftRobot):
         return chi
 
     @eqx.filter_jit
-    def forward_kinematics_batched(self, q: Array, s_ps: Array) -> Array:
+    def forward_kinematics_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute forward kinematics at multiple arc-length positions.
 
@@ -685,7 +685,7 @@ class Pendulum(SoftRobot):
         return J
 
     @eqx.filter_jit
-    def jacobian_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute Jacobians at multiple arc-length positions.
 
@@ -747,7 +747,7 @@ class Pendulum(SoftRobot):
         return J, Jd
 
     @eqx.filter_jit
-    def jacobian_and_time_derivative_batched(
+    def jacobian_and_time_derivative_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -377,7 +377,7 @@ class SoftRobot(DynamicalSystem):
         s_tips = jnp.cumsum(jnp.atleast_1d(jnp.asarray(self.segment_length)))
         return vmap(lambda s: self.forward_kinematics(q, s))(s_tips)
 
-    def forward_kinematics_batched(self, q: Array, s_ps: Array) -> Array:
+    def forward_kinematics_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the forward kinematics at multiple points along the robot.
 
@@ -530,7 +530,7 @@ class SoftRobot(DynamicalSystem):
         s_tips = jnp.cumsum(jnp.atleast_1d(jnp.asarray(self.segment_length)))
         return vmap(lambda s: self.jacobian(q, s))(s_tips)
 
-    def jacobian_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute the Jacobian at multiple points along the robot.
 
@@ -619,7 +619,7 @@ class SoftRobot(DynamicalSystem):
         J, Jd = jvp(lambda q_: self._jacobian(q_, s), (q,), (qd,))
         return J, Jd
 
-    def jacobian_and_time_derivative_batched(
+    def jacobian_and_time_derivative_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -651,7 +651,7 @@ class SoftRobot(DynamicalSystem):
         J = self.jacobian(q, s)
         return self._inertial_jacobian_to_bodyframe(pose, J)
 
-    def jacobian_bodyframe_batched(self, q: Array, s_ps: Array) -> Array:
+    def jacobian_bodyframe_abscissa_batched(self, q: Array, s_ps: Array) -> Array:
         """
         Compute body-frame Jacobians at multiple points along the robot.
         """
@@ -669,7 +669,7 @@ class SoftRobot(DynamicalSystem):
         J, Jd = jvp(lambda q_: self.jacobian_bodyframe(q_, s), (q,), (qd,))
         return J, Jd
 
-    def jacobian_and_time_derivative_bodyframe_batched(
+    def jacobian_and_time_derivative_bodyframe_abscissa_batched(
         self, q: Array, qd: Array, s_ps: Array
     ) -> tuple[Array, Array]:
         """
@@ -725,7 +725,7 @@ class SoftRobot(DynamicalSystem):
 
         s_flat = s_ps.reshape(-1)
         g_flat = vmap(lambda s: self._homogeneous_forward_kinematics(q, s))(s_flat)
-        J_flat, Jd_flat = self.jacobian_and_time_derivative_bodyframe_batched(
+        J_flat, Jd_flat = self.jacobian_and_time_derivative_bodyframe_abscissa_batched(
             q, qd, s_flat
         )
 

--- a/tests/rendering/test_base_renderer.py
+++ b/tests/rendering/test_base_renderer.py
@@ -41,7 +41,7 @@ class DummyPlanarRobot:
         self.base_pose = jnp.asarray(base_pose)
         self.base_transform = poses.planar_pose_to_transform(self.base_pose)
 
-    def forward_kinematics_batched(self, q, s_ps):
+    def forward_kinematics_abscissa_batched(self, q, s_ps):
         theta = self.base_pose[0]
         direction = jnp.array([jnp.cos(theta), jnp.sin(theta)])
         xy = self.base_pose[1:3] + s_ps[:, None] * direction
@@ -49,7 +49,7 @@ class DummyPlanarRobot:
         return jnp.concatenate([theta_ps, xy], axis=1)
 
     def forward_kinematics(self, q, s):
-        return self.forward_kinematics_batched(q, jnp.asarray([s]))[0]
+        return self.forward_kinematics_abscissa_batched(q, jnp.asarray([s]))[0]
 
     def cross_section_geometry(self, q, s):
         return CrossSectionGeometry.CIRCULAR, jnp.array([0.02])
@@ -64,13 +64,13 @@ class DummySpatialRobot:
         self.base_pose = jnp.asarray(base_pose)
         self.base_transform = poses.quaternion_pose_to_transform(self.base_pose)
 
-    def forward_kinematics_batched(self, q, s_ps):
+    def forward_kinematics_abscissa_batched(self, q, s_ps):
         transforms = jnp.repeat(self.base_transform[None, :, :], s_ps.shape[0], axis=0)
         offsets = s_ps[:, None] * self.base_transform[:3, 0]
         return transforms.at[:, :3, 3].add(offsets)
 
     def forward_kinematics(self, q, s):
-        return self.forward_kinematics_batched(q, jnp.asarray([s]))[0]
+        return self.forward_kinematics_abscissa_batched(q, jnp.asarray([s]))[0]
 
     def cross_section_geometry(self, q, s):
         return CrossSectionGeometry.CIRCULAR, jnp.array([0.02])

--- a/tests/rendering/test_matplotlib_renderer.py
+++ b/tests/rendering/test_matplotlib_renderer.py
@@ -21,7 +21,7 @@ class DummySpatialRobot:
         self.base_pose = jnp.asarray(base_pose)
         self.base_transform = poses.quaternion_pose_to_transform(self.base_pose)
 
-    def forward_kinematics_batched(self, q, s_points):
+    def forward_kinematics_abscissa_batched(self, q, s_points):
         del q
         transforms = jnp.repeat(
             self.base_transform[None, :, :], s_points.shape[0], axis=0

--- a/tests/rendering/test_open3d_renderer.py
+++ b/tests/rendering/test_open3d_renderer.py
@@ -32,7 +32,7 @@ class _AnimatingSpatialRobot:
     base_pose = jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     base_transform = jnp.eye(4)
 
-    def forward_kinematics_batched(self, q, s_points):
+    def forward_kinematics_abscissa_batched(self, q, s_points):
         angles = q[0] * s_points
         cosines = jnp.cos(angles)
         sines = jnp.sin(angles)

--- a/tests/rendering/test_viser_renderer.py
+++ b/tests/rendering/test_viser_renderer.py
@@ -23,13 +23,13 @@ class DummySpatialRobot:
         self.base_pose = jnp.asarray(base_pose)
         self.base_transform = poses.quaternion_pose_to_transform(self.base_pose)
 
-    def forward_kinematics_batched(self, q, s_ps):
+    def forward_kinematics_abscissa_batched(self, q, s_ps):
         transforms = jnp.repeat(self.base_transform[None, :, :], s_ps.shape[0], axis=0)
         offsets = s_ps[:, None] * self.base_transform[:3, 0]
         return transforms.at[:, :3, 3].add(offsets)
 
     def forward_kinematics(self, q, s):
-        return self.forward_kinematics_batched(q, jnp.asarray([s]))[0]
+        return self.forward_kinematics_abscissa_batched(q, jnp.asarray([s]))[0]
 
     def cross_section_geometry(self, q, s):
         return CrossSectionGeometry.CIRCULAR, jnp.array([0.02])
@@ -445,7 +445,7 @@ def test_viser_recording_captures_synchronized_batched_geometry_for_every_frame(
     import soromox.rendering.viser_renderer as viser_module
 
     class AnimatingActuatedRobot(DummySpatialRobot):
-        def forward_kinematics_batched(self, q, s_points):
+        def forward_kinematics_abscissa_batched(self, q, s_points):
             transforms = jnp.broadcast_to(jnp.eye(4), (s_points.size, 4, 4))
             positions = jnp.stack((s_points, q[0] * s_points, q[1] * s_points), axis=-1)
             return transforms.at[:, :3, 3].set(positions)

--- a/tests/systems/test_articulated_soft_robot.py
+++ b/tests/systems/test_articulated_soft_robot.py
@@ -372,15 +372,15 @@ def test_batched_kinematics_and_jacobian_match_pointwise_evaluation(num_links):
     qd = jnp.linspace(0.6, -0.5, num_links)
     s_ps = robot.L_cum[1:]
 
-    g_batched = robot.forward_kinematics_batched(q, s_ps)
+    g_batched = robot.forward_kinematics_abscissa_batched(q, s_ps)
     g_expected = jax.vmap(lambda s: robot.forward_kinematics(q, s))(s_ps)
     assert_allclose(g_batched, g_expected, rtol=Tolerance.rtol(), atol=Tolerance.atol())
 
-    J_batched = robot.jacobian_batched(q, s_ps)
+    J_batched = robot.jacobian_abscissa_batched(q, s_ps)
     J_expected = robot.jacobian_tips(q)
     assert_allclose(J_batched, J_expected, rtol=Tolerance.rtol(), atol=Tolerance.atol())
 
-    J_batched, Jd_batched = robot.jacobian_and_time_derivative_batched(q, qd, s_ps)
+    J_batched, Jd_batched = robot.jacobian_and_time_derivative_abscissa_batched(q, qd, s_ps)
     J_expected, Jd_expected = robot.jacobian_and_time_derivatives_tips(q, qd)
     assert_allclose(J_batched, J_expected, rtol=Tolerance.rtol(), atol=Tolerance.atol())
     assert_allclose(

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1068,7 +1068,7 @@ def test_public_gvs_accessors_geometry_and_actuation_matrix() -> None:
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-def test_forward_kinematics_batched_matches_pointwise_evaluation(
+def test_forward_kinematics_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     robot = build_varied_basis_gvs(num_segments=num_segments)
@@ -1097,7 +1097,7 @@ def test_forward_kinematics_batched_matches_pointwise_evaluation(
             )
         )
 
-        g_batched = robot.forward_kinematics_batched(q, s_points)
+        g_batched = robot.forward_kinematics_abscissa_batched(q, s_points)
         g_expected = stack_forward_kinematics(robot, q, s_points)
 
         assert_allclose(g_batched, g_expected, rtol=RTOL, atol=ATOL)
@@ -1165,7 +1165,7 @@ def test_jacobian_bodyframe_matches_autodiff(num_segments: int) -> None:
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-def test_jacobian_bodyframe_batched_matches_pointwise_evaluation(
+def test_jacobian_bodyframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     robot = build_varied_basis_gvs(num_segments=num_segments)
@@ -1194,7 +1194,7 @@ def test_jacobian_bodyframe_batched_matches_pointwise_evaluation(
             )
         )
 
-        J_batch = robot.jacobian_bodyframe_batched(q, s_points)
+        J_batch = robot.jacobian_bodyframe_abscissa_batched(q, s_points)
         J_expected = stack_jacobians(robot, q, s_points)
 
         assert_allclose(J_batch, J_expected, rtol=RTOL, atol=ATOL)
@@ -1315,7 +1315,7 @@ def test_jacobian_inertialframe_matches_central_differences(num_segments: int) -
 
 
 @pytest.mark.parametrize("num_segments", [1, 2])
-def test_jacobian_inertialframe_batched_matches_pointwise_evaluation(
+def test_jacobian_inertialframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     robot = build_varied_basis_gvs(num_segments=num_segments)
@@ -1344,7 +1344,7 @@ def test_jacobian_inertialframe_batched_matches_pointwise_evaluation(
             )
         )
 
-        J_batch = robot.jacobian_inertialframe_batched(q, s_points)
+        J_batch = robot.jacobian_inertialframe_abscissa_batched(q, s_points)
         J_expected = jnp.stack(
             [robot.jacobian_inertialframe(q, float(s)) for s in s_points],
             axis=0,
@@ -1487,7 +1487,7 @@ def test_jacobian_time_derivative_inertialframe_matches_autograd_jvp(
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-def test_jacobian_and_time_derivative_bodyframe_batched_matches_pointwise_evaluation(
+def test_jacobian_and_time_derivative_bodyframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     robot = build_varied_basis_gvs(num_segments=num_segments)
@@ -1502,7 +1502,7 @@ def test_jacobian_and_time_derivative_bodyframe_batched_matches_pointwise_evalua
     s_points = sample_arc_lengths(robot)
 
     for q, qd in ((zero_cfg, zero_vel), (q_random, qd_random)):
-        J_batch, Jd_batch = robot.jacobian_and_time_derivative_bodyframe_batched(
+        J_batch, Jd_batch = robot.jacobian_and_time_derivative_bodyframe_abscissa_batched(
             q, qd, s_points
         )
 
@@ -1515,7 +1515,7 @@ def test_jacobian_and_time_derivative_bodyframe_batched_matches_pointwise_evalua
 
 
 @pytest.mark.parametrize("num_segments", [1, 2])
-def test_jacobian_and_time_derivative_inertialframe_batched_matches_pointwise_evaluation(
+def test_jacobian_and_time_derivative_inertialframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     robot = build_varied_basis_gvs(num_segments=num_segments)
@@ -1530,7 +1530,7 @@ def test_jacobian_and_time_derivative_inertialframe_batched_matches_pointwise_ev
     s_points = sample_arc_lengths(robot)
 
     for q, qd in ((zero_cfg, zero_vel), (q_random, qd_random)):
-        J_batch, Jd_batch = robot.jacobian_and_time_derivative_inertialframe_batched(
+        J_batch, Jd_batch = robot.jacobian_and_time_derivative_inertialframe_abscissa_batched(
             q, qd, s_points
         )
 
@@ -1557,8 +1557,8 @@ def test_public_gvs_jacobian_adapters_match_inertialframe_methods() -> None:
         atol=ATOL,
     )
     assert_allclose(
-        robot.jacobian_batched(q, s_ps),
-        robot.jacobian_inertialframe_batched(q, s_ps),
+        robot.jacobian_abscissa_batched(q, s_ps),
+        robot.jacobian_inertialframe_abscissa_batched(q, s_ps),
         rtol=RTOL,
         atol=ATOL,
     )
@@ -1568,9 +1568,9 @@ def test_public_gvs_jacobian_adapters_match_inertialframe_methods() -> None:
     assert_allclose(J, J_expected, rtol=RTOL, atol=ATOL)
     assert_allclose(Jd, Jd_expected, rtol=RTOL, atol=ATOL)
 
-    J_batch, Jd_batch = robot.jacobian_and_time_derivative_batched(q, qd, s_ps)
+    J_batch, Jd_batch = robot.jacobian_and_time_derivative_abscissa_batched(q, qd, s_ps)
     J_batch_expected, Jd_batch_expected = (
-        robot.jacobian_and_time_derivative_inertialframe_batched(q, qd, s_ps)
+        robot.jacobian_and_time_derivative_inertialframe_abscissa_batched(q, qd, s_ps)
     )
     assert_allclose(J_batch, J_batch_expected, rtol=RTOL, atol=ATOL)
     assert_allclose(Jd_batch, Jd_batch_expected, rtol=RTOL, atol=ATOL)

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -409,7 +409,7 @@ def test_forward_kinematics_tips_matches_pointwise_evaluation(
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-def test_forward_kinematics_batched_matches_pointwise_evaluation(
+def test_forward_kinematics_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     model, _ = make_pcs(num_segments=num_segments)
@@ -421,7 +421,7 @@ def test_forward_kinematics_batched_matches_pointwise_evaluation(
     s_ps = jnp.asarray(s_values, dtype=jnp.float64)
 
     for q in (zero_cfg, random_cfg):
-        g_batched = model.forward_kinematics_batched(q, s_ps)
+        g_batched = model.forward_kinematics_abscissa_batched(q, s_ps)
         g_expected = jax.vmap(lambda s, q=q: model.forward_kinematics(q, s))(s_ps)
 
         assert_allclose(g_batched, g_expected, rtol=RTOL, atol=ATOL)
@@ -546,7 +546,7 @@ def test_J_local_tips_matches_pointwise_evaluation(num_segments: int):
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-def test_jacobian_bodyframe_batched_matches_pointwise_evaluation(
+def test_jacobian_bodyframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     model, _ = make_pcs(num_segments=num_segments)
@@ -560,7 +560,7 @@ def test_jacobian_bodyframe_batched_matches_pointwise_evaluation(
     s_points = jnp.asarray(sample_arc_lengths(model), dtype=jnp.float64)
 
     for q in (zero_cfg, q_random):
-        J_batch = model.jacobian_bodyframe_batched(q, s_points)
+        J_batch = model.jacobian_bodyframe_abscissa_batched(q, s_points)
 
         for idx, s_val in enumerate(s_points):
             J_single = model.jacobian_bodyframe(q, s_val)
@@ -753,7 +753,7 @@ def test_jacobian_inertialframe_matches_central_differences(num_segments: int):
 
 
 @pytest.mark.parametrize("num_segments", [1, 2])
-def test_jacobian_inertialframe_batched_matches_pointwise_evaluation(
+def test_jacobian_inertialframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     model, _ = make_pcs(num_segments=num_segments)
@@ -767,7 +767,7 @@ def test_jacobian_inertialframe_batched_matches_pointwise_evaluation(
     s_points = jnp.asarray(sample_arc_lengths(model), dtype=jnp.float64)
 
     for q in (zero_cfg, random_cfg):
-        J_batch = model.jacobian_inertialframe_batched(q, s_points)
+        J_batch = model.jacobian_inertialframe_abscissa_batched(q, s_points)
 
         for idx, s_val in enumerate(s_points):
             J_single = model.jacobian_inertialframe(q, s_val)
@@ -879,7 +879,7 @@ def test_J_Jd_local_tips_matches_pointwise_evaluation(num_segments: int) -> None
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-def test_jacobian_and_time_derivative_bodyframe_batched_matches_pointwise_evaluation(
+def test_jacobian_and_time_derivative_bodyframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     model, _ = make_pcs(num_segments=num_segments)
@@ -895,7 +895,7 @@ def test_jacobian_and_time_derivative_bodyframe_batched_matches_pointwise_evalua
     s_points = jnp.asarray(sample_arc_lengths(model), dtype=jnp.float64)
 
     for q, qd in ((zero_cfg, zero_vel), (q_random, qd_random)):
-        J_batch, Jd_batch = model.jacobian_and_time_derivative_bodyframe_batched(
+        J_batch, Jd_batch = model.jacobian_and_time_derivative_bodyframe_abscissa_batched(
             q, qd, s_points
         )
 
@@ -933,7 +933,7 @@ def test_jacobian_time_derivative_inertialframe_matches_autograd_jvp(num_segment
 
 
 @pytest.mark.parametrize("num_segments", [1, 2])
-def test_jacobian_and_time_derivative_inertialframe_batched_matches_pointwise_evaluation(
+def test_jacobian_and_time_derivative_inertialframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     model, _ = make_pcs(num_segments=num_segments)
@@ -949,7 +949,7 @@ def test_jacobian_and_time_derivative_inertialframe_batched_matches_pointwise_ev
     s_points = jnp.asarray(sample_arc_lengths(model), dtype=jnp.float64)
 
     for q, qd in ((zero_cfg, zero_vel), (q_random, qd_random)):
-        J_batch, Jd_batch = model.jacobian_and_time_derivative_inertialframe_batched(
+        J_batch, Jd_batch = model.jacobian_and_time_derivative_inertialframe_abscissa_batched(
             q, qd, s_points
         )
 
@@ -976,8 +976,8 @@ def test_public_pcs_jacobian_wrappers_match_inertialframe_methods() -> None:
         atol=ATOL,
     )
     assert_allclose(
-        model.jacobian_batched(q, s_ps),
-        model.jacobian_inertialframe_batched(q, s_ps),
+        model.jacobian_abscissa_batched(q, s_ps),
+        model.jacobian_inertialframe_abscissa_batched(q, s_ps),
         rtol=RTOL,
         atol=ATOL,
     )
@@ -987,9 +987,9 @@ def test_public_pcs_jacobian_wrappers_match_inertialframe_methods() -> None:
     assert_allclose(J, J_expected, rtol=RTOL, atol=ATOL)
     assert_allclose(Jd, Jd_expected, rtol=RTOL, atol=ATOL)
 
-    J_batch, Jd_batch = model.jacobian_and_time_derivative_batched(q, qd, s_ps)
+    J_batch, Jd_batch = model.jacobian_and_time_derivative_abscissa_batched(q, qd, s_ps)
     J_batch_expected, Jd_batch_expected = (
-        model.jacobian_and_time_derivative_inertialframe_batched(q, qd, s_ps)
+        model.jacobian_and_time_derivative_inertialframe_abscissa_batched(q, qd, s_ps)
     )
     assert_allclose(J_batch, J_batch_expected, rtol=RTOL, atol=ATOL)
     assert_allclose(Jd_batch, Jd_batch_expected, rtol=RTOL, atol=ATOL)
@@ -1384,10 +1384,10 @@ def test_integration_kinematics_matches_existing_batched_path(
     s_points = Xs_scaled.reshape(-1)
     num_inner = model.num_gauss_points
 
-    g_expected = model.forward_kinematics_batched(q, s_points).reshape(
+    g_expected = model.forward_kinematics_abscissa_batched(q, s_points).reshape(
         num_segments, num_inner, 4, 4
     )
-    J_full, Jd_full = model._J_Jd_local_batched(q, qd, s_points)
+    J_full, Jd_full = model._J_Jd_local_abscissa_batched(q, qd, s_points)
     J_expected = (J_full @ model.B_xi).reshape(num_segments, num_inner, 6, dof)
     Jd_expected = (Jd_full @ model.B_xi).reshape(num_segments, num_inner, 6, dof)
 
@@ -1763,8 +1763,8 @@ def test_strain_basis_consistency_strain_and_kinematics(num_segments: int):
     assert g_tips_full.shape == (num_segments, 4, 4)
     assert_allclose(g_tips_full, g_tips_small, rtol=RTOL, atol=ATOL)
 
-    g_batched_small = reduced.forward_kinematics_batched(q_small, s_values)
-    g_batched_full = full.forward_kinematics_batched(q_full, s_values)
+    g_batched_small = reduced.forward_kinematics_abscissa_batched(q_small, s_values)
+    g_batched_full = full.forward_kinematics_abscissa_batched(q_full, s_values)
     N = s_values.shape[0]
     assert g_batched_small.shape == (N, 4, 4)
     assert g_batched_full.shape == (N, 4, 4)
@@ -1854,8 +1854,8 @@ def test_strain_basis_consistency_jacobians_and_time_derivatives(num_segments: i
     )
 
     # Batched body-frame Jacobian (internal helper, returns full-strain size)
-    Jb_batch_small = reduced._J_local_batched(q_small, s_points)
-    Jb_batch_full = full._J_local_batched(q_full, s_points)
+    Jb_batch_small = reduced._J_local_abscissa_batched(q_small, s_points)
+    Jb_batch_full = full._J_local_abscissa_batched(q_full, s_points)
     assert Jb_batch_small.shape == (s_points.shape[0], 6, n_full_strains)
     assert Jb_batch_full.shape == (s_points.shape[0], 6, n_full_strains)
     assert_allclose(Jb_batch_full, Jb_batch_small, rtol=RTOL, atol=ATOL)
@@ -1868,10 +1868,10 @@ def test_strain_basis_consistency_jacobians_and_time_derivatives(num_segments: i
     assert_allclose(Jb_tips_full, Jb_tips_small, rtol=RTOL, atol=ATOL)
 
     # Batched body-frame (J, Jd) internal helper (full-strain size)
-    Jb_batch_small, Jbd_batch_small = reduced._J_Jd_local_batched(
+    Jb_batch_small, Jbd_batch_small = reduced._J_Jd_local_abscissa_batched(
         q_small, qd_small, s_points
     )
-    Jb_batch_full, Jbd_batch_full = full._J_Jd_local_batched(q_full, qd_full, s_points)
+    Jb_batch_full, Jbd_batch_full = full._J_Jd_local_abscissa_batched(q_full, qd_full, s_points)
     assert Jb_batch_small.shape == (s_points.shape[0], 6, n_full_strains)
     assert Jbd_batch_small.shape == (s_points.shape[0], 6, n_full_strains)
     assert Jb_batch_full.shape == (s_points.shape[0], 6, n_full_strains)
@@ -2161,8 +2161,8 @@ def test_reverse_mode_of_vmap_at_zero_configuration() -> None:
 
     for name, fn in (
         (
-            "forward_kinematics_batched",
-            lambda q: jnp.sum(model.forward_kinematics_batched(q, s_ps)),
+            "forward_kinematics_abscissa_batched",
+            lambda q: jnp.sum(model.forward_kinematics_abscissa_batched(q, s_ps)),
         ),
         ("inertia_matrix", lambda q: jnp.sum(model.inertia_matrix(q))),
         ("gravitational_force", lambda q: jnp.sum(model.gravitational_force(q))),

--- a/tests/systems/test_pendulum.py
+++ b/tests/systems/test_pendulum.py
@@ -570,17 +570,17 @@ def test_batched_methods(N):
     s_ps = jnp.array(L_cum[1:])  # all tip positions
 
     # Forward kinematics batched
-    chi_batched = robot.forward_kinematics_batched(q, s_ps)
+    chi_batched = robot.forward_kinematics_abscissa_batched(q, s_ps)
     chi_tips = robot.forward_kinematics_tips(q)
     assert_allclose(chi_batched, chi_tips, rtol=Tolerance.rtol(), atol=Tolerance.atol())
 
     # Jacobian batched
-    J_batched = robot.jacobian_batched(q, s_ps)
+    J_batched = robot.jacobian_abscissa_batched(q, s_ps)
     J_tips = robot.jacobian_tips(q)
     assert_allclose(J_batched, J_tips, rtol=Tolerance.rtol(), atol=Tolerance.atol())
 
     # Jacobian and derivative batched
-    J_batched, Jd_batched = robot.jacobian_and_time_derivative_batched(q, qd, s_ps)
+    J_batched, Jd_batched = robot.jacobian_and_time_derivative_abscissa_batched(q, qd, s_ps)
     J_tips, Jd_tips = robot.jacobian_and_time_derivatives_tips(q, qd)
     assert_allclose(J_batched, J_tips, rtol=Tolerance.rtol(), atol=Tolerance.atol())
     assert_allclose(Jd_batched, Jd_tips, rtol=Tolerance.rtol(), atol=Tolerance.atol())

--- a/tests/systems/test_planar_hsa.py
+++ b/tests/systems/test_planar_hsa.py
@@ -287,10 +287,10 @@ def test_jacobian_tips(seed: int = 0):
 
     s_tips = robot.L_cum[1:]
     J_tips = robot.jacobian_tips(q)
-    J_expected = robot.jacobian_batched(q, s_tips)
+    J_expected = robot.jacobian_abscissa_batched(q, s_tips)
 
     assert jnp.allclose(J_tips, J_expected, atol=1e-12), (
-        "jacobian_tips should match jacobian_batched at segment tips"
+        "jacobian_tips should match jacobian_abscissa_batched at segment tips"
     )
 
 

--- a/tests/systems/test_planar_pcs.py
+++ b/tests/systems/test_planar_pcs.py
@@ -431,7 +431,7 @@ def test_forward_kinematics_tips_matches_pointwise_evaluation(num_segments):
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-def test_forward_kinematics_batched_matches_pointwise_evaluation(num_segments):
+def test_forward_kinematics_abscissa_batched_matches_pointwise_evaluation(num_segments):
     model, _ = make_planar_pcs(num_segments=num_segments)
     dof = int(model.num_active_strains.item())
 
@@ -443,7 +443,7 @@ def test_forward_kinematics_batched_matches_pointwise_evaluation(num_segments):
     s_ps = jnp.asarray(s_values, dtype=jnp.float64)
 
     for q in (zero_cfg, random_cfg):
-        chi_batched = model.forward_kinematics_batched(q, s_ps)
+        chi_batched = model.forward_kinematics_abscissa_batched(q, s_ps)
         chi_expected = jax.vmap(lambda s, q=q: model.forward_kinematics(q, s))(s_ps)
 
         assert_allclose(chi_batched, chi_expected, rtol=RTOL, atol=ATOL)
@@ -494,13 +494,13 @@ def test_planar_tiny_curvature_point_tip_and_batched_paths_agree():
 
     pointwise = model.forward_kinematics(q, tip_s)
     tips = model.forward_kinematics_tips(q)[0]
-    batched = model.forward_kinematics_batched(q, tip_s[None])[0]
+    batched = model.forward_kinematics_abscissa_batched(q, tip_s[None])[0]
 
     assert_allclose(tips, pointwise, rtol=RTOL, atol=ATOL)
     assert_allclose(batched, pointwise, rtol=RTOL, atol=ATOL)
     assert_allclose(
         jacrev(lambda value: model.forward_kinematics_tips(value)[0])(q),
-        jacrev(lambda value: model.forward_kinematics_batched(value, tip_s[None])[0])(
+        jacrev(lambda value: model.forward_kinematics_abscissa_batched(value, tip_s[None])[0])(
             q
         ),
         rtol=1e-9,
@@ -910,7 +910,7 @@ def test_J_local_tips_matches_pointwise_evaluation(num_segments):
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-def test_jacobian_bodyframe_batched_matches_pointwise_evaluation(
+def test_jacobian_bodyframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments,
 ) -> None:
     model, _ = make_planar_pcs(num_segments=num_segments)
@@ -923,7 +923,7 @@ def test_jacobian_bodyframe_batched_matches_pointwise_evaluation(
     s_points = jnp.asarray(sample_arc_lengths(model), dtype=jnp.float64)
 
     for q in (zero_cfg, random_cfg):
-        J_batch = model.jacobian_bodyframe_batched(q, s_points)
+        J_batch = model.jacobian_bodyframe_abscissa_batched(q, s_points)
 
         for idx, s_val in enumerate(s_points):
             J_single = model.jacobian_bodyframe(q, s_val)
@@ -1055,7 +1055,7 @@ def test_jacobian_inertialframe_matches_central_differences(num_segments):
 
 
 @pytest.mark.parametrize("num_segments", [1, 2])
-def test_jacobian_inertialframe_batched_matches_pointwise_evaluation(
+def test_jacobian_inertialframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     model, _ = make_planar_pcs(num_segments=num_segments)
@@ -1068,7 +1068,7 @@ def test_jacobian_inertialframe_batched_matches_pointwise_evaluation(
     s_points = jnp.asarray(sample_arc_lengths(model), dtype=jnp.float64)
 
     for q in (zero_cfg, random_cfg):
-        J_batch = model.jacobian_inertialframe_batched(q, s_points)
+        J_batch = model.jacobian_inertialframe_abscissa_batched(q, s_points)
 
         for idx, s_val in enumerate(s_points):
             J_single = model.jacobian_inertialframe(q, s_val)
@@ -1180,7 +1180,7 @@ def test_jacobian_time_derivative_inertialframe_matches_autograd_jvp(num_segment
 
 
 @pytest.mark.parametrize("num_segments", [1, 2])
-def test_jacobian_and_time_derivative_inertialframe_batched_matches_pointwise_evaluation(
+def test_jacobian_and_time_derivative_inertialframe_abscissa_batched_matches_pointwise_evaluation(
     num_segments: int,
 ) -> None:
     model, _ = make_planar_pcs(num_segments=num_segments)
@@ -1196,7 +1196,7 @@ def test_jacobian_and_time_derivative_inertialframe_batched_matches_pointwise_ev
     s_points = jnp.asarray(sample_arc_lengths(model), dtype=jnp.float64)
 
     for q, qd in ((zero_cfg, zero_vel), (q_random, qd_random)):
-        J_batch, Jd_batch = model.jacobian_and_time_derivative_inertialframe_batched(
+        J_batch, Jd_batch = model.jacobian_and_time_derivative_inertialframe_abscissa_batched(
             q, qd, s_points
         )
 
@@ -1245,7 +1245,7 @@ def test_J_Jd_local_tips_matches_pointwise_evaluation(num_segments: int):
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-def test_J_Jd_local_batched_matches_pointwise_evaluation(num_segments: int):
+def test_J_Jd_local_abscissa_batched_matches_pointwise_evaluation(num_segments: int):
     model, _ = make_planar_pcs(num_segments=num_segments)
     dof = int(model.num_active_strains.item())
 
@@ -1259,7 +1259,7 @@ def test_J_Jd_local_batched_matches_pointwise_evaluation(num_segments: int):
     s_points = jnp.asarray(sample_arc_lengths(model), dtype=jnp.float64)
 
     for q, qd in ((zero_cfg, zero_vel), (q_random, qd_random)):
-        J_batch, Jd_batch = model.jacobian_and_time_derivative_bodyframe_batched(
+        J_batch, Jd_batch = model.jacobian_and_time_derivative_bodyframe_abscissa_batched(
             q, qd, s_points
         )
 
@@ -1286,8 +1286,8 @@ def test_public_planar_pcs_jacobian_wrappers_match_inertialframe_methods() -> No
         atol=ATOL,
     )
     assert_allclose(
-        model.jacobian_batched(q, s_ps),
-        model.jacobian_inertialframe_batched(q, s_ps),
+        model.jacobian_abscissa_batched(q, s_ps),
+        model.jacobian_inertialframe_abscissa_batched(q, s_ps),
         rtol=RTOL,
         atol=ATOL,
     )
@@ -1297,9 +1297,9 @@ def test_public_planar_pcs_jacobian_wrappers_match_inertialframe_methods() -> No
     assert_allclose(J, J_expected, rtol=RTOL, atol=ATOL)
     assert_allclose(Jd, Jd_expected, rtol=RTOL, atol=ATOL)
 
-    J_batch, Jd_batch = model.jacobian_and_time_derivative_batched(q, qd, s_ps)
+    J_batch, Jd_batch = model.jacobian_and_time_derivative_abscissa_batched(q, qd, s_ps)
     J_batch_expected, Jd_batch_expected = (
-        model.jacobian_and_time_derivative_inertialframe_batched(q, qd, s_ps)
+        model.jacobian_and_time_derivative_inertialframe_abscissa_batched(q, qd, s_ps)
     )
     assert_allclose(J_batch, J_batch_expected, rtol=RTOL, atol=ATOL)
     assert_allclose(Jd_batch, Jd_batch_expected, rtol=RTOL, atol=ATOL)
@@ -1565,11 +1565,11 @@ def test_integration_kinematics_matches_existing_batched_path_planar(
     s_points = Xs_scaled.reshape(-1)
     num_inner = model.num_gauss_points
 
-    chi_expected = model.forward_kinematics_batched(q, s_points)
+    chi_expected = model.forward_kinematics_abscissa_batched(q, s_points)
     g_expected = jax.vmap(poses.planar_pose_to_transform)(chi_expected).reshape(
         num_segments, num_inner, 3, 3
     )
-    J_full, Jd_full = model._J_Jd_local_batched(q, qd, s_points)
+    J_full, Jd_full = model._J_Jd_local_abscissa_batched(q, qd, s_points)
     J_expected = (J_full @ model.B_xi).reshape(num_segments, num_inner, 3, dof)
     Jd_expected = (Jd_full @ model.B_xi).reshape(num_segments, num_inner, 3, dof)
 
@@ -2008,8 +2008,8 @@ def test_strain_basis_consistency_strain_and_kinematics_planar(num_segments: int
     assert chi_tips_full.shape == (num_segments, 3)
     assert_allclose(chi_tips_full, chi_tips_small, rtol=RTOL, atol=ATOL)
 
-    chi_batched_small = reduced.forward_kinematics_batched(q_small, s_values)
-    chi_batched_full = full.forward_kinematics_batched(q_full, s_values)
+    chi_batched_small = reduced.forward_kinematics_abscissa_batched(q_small, s_values)
+    chi_batched_full = full.forward_kinematics_abscissa_batched(q_full, s_values)
     N = s_values.shape[0]
     assert chi_batched_small.shape == (N, 3)
     assert chi_batched_full.shape == (N, 3)
@@ -2098,8 +2098,8 @@ def test_strain_basis_consistency_jacobians_and_time_derivatives_planar(
     )
 
     # Batched body-frame Jacobian (internal helper, returns full-strain size)
-    Jb_batch_small = reduced._J_local_batched(q_small, s_points)
-    Jb_batch_full = full._J_local_batched(q_full, s_points)
+    Jb_batch_small = reduced._J_local_abscissa_batched(q_small, s_points)
+    Jb_batch_full = full._J_local_abscissa_batched(q_full, s_points)
     assert Jb_batch_small.shape == (s_points.shape[0], 3, n_full_strains)
     assert Jb_batch_full.shape == (s_points.shape[0], 3, n_full_strains)
     assert_allclose(Jb_batch_full, Jb_batch_small, rtol=RTOL, atol=ATOL)
@@ -2112,10 +2112,10 @@ def test_strain_basis_consistency_jacobians_and_time_derivatives_planar(
     assert_allclose(Jb_tips_full, Jb_tips_small, rtol=RTOL, atol=ATOL)
 
     # Batched body-frame (J, Jd) internal helper (full-strain size)
-    Jb_batch_small, Jbd_batch_small = reduced._J_Jd_local_batched(
+    Jb_batch_small, Jbd_batch_small = reduced._J_Jd_local_abscissa_batched(
         q_small, qd_small, s_points
     )
-    Jb_batch_full, Jbd_batch_full = full._J_Jd_local_batched(q_full, qd_full, s_points)
+    Jb_batch_full, Jbd_batch_full = full._J_Jd_local_abscissa_batched(q_full, qd_full, s_points)
     assert Jb_batch_small.shape == (s_points.shape[0], 3, n_full_strains)
     assert Jbd_batch_small.shape == (s_points.shape[0], 3, n_full_strains)
     assert Jb_batch_full.shape == (s_points.shape[0], 3, n_full_strains)
@@ -2289,8 +2289,8 @@ def test_reverse_mode_of_vmap_at_zero_configuration() -> None:
 
     for name, fn in (
         (
-            "forward_kinematics_batched",
-            lambda q: jnp.sum(model.forward_kinematics_batched(q, s_ps)),
+            "forward_kinematics_abscissa_batched",
+            lambda q: jnp.sum(model.forward_kinematics_abscissa_batched(q, s_ps)),
         ),
         ("inertia_matrix", lambda q: jnp.sum(model.inertia_matrix(q))),
         ("gravitational_force", lambda q: jnp.sum(model.gravitational_force(q))),

--- a/tests/systems/test_soft_robot_defaults.py
+++ b/tests/systems/test_soft_robot_defaults.py
@@ -363,7 +363,7 @@ def test_default_integration_kinematics_uses_bodyframe_samples() -> None:
     g_expected = jax.vmap(
         lambda s: poses.planar_pose_to_transform(robot.forward_kinematics(q, s))
     )(s_flat).reshape(2, 1, 3, 3)
-    J_expected, Jd_expected = robot.jacobian_and_time_derivative_bodyframe_batched(
+    J_expected, Jd_expected = robot.jacobian_and_time_derivative_bodyframe_abscissa_batched(
         q, qd, s_flat
     )
 

--- a/tools/benchmarks/benchmark_system_methods.py
+++ b/tools/benchmarks/benchmark_system_methods.py
@@ -416,9 +416,9 @@ def _build_system_registry() -> Mapping[str, SystemBenchmark]:
             ),
         ),
         BenchmarkCase(
-            name="forward_kinematics_batched",
+            name="forward_kinematics_abscissa_batched",
             builder=lambda sys, ctx, _: (
-                sys.forward_kinematics_batched,
+                sys.forward_kinematics_abscissa_batched,
                 (ctx["q"], ctx["s_points"]),
             ),
         ),
@@ -901,7 +901,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
                     per_point_note = ""
                     if (
-                        case.name == "forward_kinematics_batched"
+                        case.name == "forward_kinematics_abscissa_batched"
                         and len(call_args) >= 2
                     ):
                         s_arg = call_args[1]


### PR DESCRIPTION
## Summary

This PR renames system methods whose batching axis is specifically the
curvilinear backbone coordinate. The previous generic `*_batched` suffix did
not say which argument was mapped and became actively misleading once
kinematics also needed to support batches of configurations and combined
configuration-by-coordinate batches.

The new suffix is `*_abscissa_batched`. In continuum-robotics terminology, the
abscissa is the scalar coordinate along the robot backbone, so the name states
the mapped parameter without conflating it with environment/configuration
batching or with three-dimensional spatial algebra.

This is an intentional breaking change. The old names are removed rather than
retained as compatibility aliases, and the change is recorded under
"Breaking changes" in the changelog.

## Motivation

For a method such as:

```python
forward_kinematics_batched(q, s_ps)
```

the suffix could plausibly mean any of the following:

- `q` contains several configurations;
- `s_ps` contains several backbone locations;
- both inputs form a pairwise batch; or
- both inputs define a Cartesian environment-by-backbone batch.

The existing methods implement only the second interpretation: one
configuration is evaluated at multiple backbone coordinates. That distinction
matters for API documentation, custom `vmap` dispatch, shape reasoning, and
future fused execution backends. Encoding the mapped argument in the method
name makes the optimized abscissa traversal explicit while leaving ordinary
configuration batching to JAX transforms or backend dispatch.

## Selected naming

The chosen form is:

```python
forward_kinematics_abscissa_batched(q, s_ps)
```

`abscissa` is the established field term for the curvilinear backbone
coordinate. Placing it before `batched` reads as "the abscissa is batched" and
preserves `batched` as the final operation modifier across the API.

The following alternatives were considered:

- `*_backbone_coordinates_batched` is clear but unnecessarily long for a
  frequently used numerical API;
- `*_backbone_batch` is shorter but does not identify whether the coordinates,
  configurations, or complete backbone states are batched;
- `*_spatial_batched` conflicts with the established use of "spatial" for
  SE(3)/six-dimensional spatial-vector quantities;
- `*_s_batched` mirrors the parameter name but is too terse for a public API;
- `*_batched_abscissa` and `*_abscissa_batch` are less consistent with the
  existing adjective-style method suffixes; and
- keeping `*_batched` with a documentation clarification leaves the ambiguity
  in every call site and does not scale to environment-plus-abscissa batching.

Compatibility aliases were also rejected. They would preserve two names for
the same optimized traversal, prolong the ambiguity, and complicate dispatch
and documentation. The project is taking the breaking change explicitly and
updates all in-repository consumers in the same PR.

## Renamed APIs

The following public method families now use the `*_abscissa_batched` suffix:

- `forward_kinematics`;
- generic, body-frame, and inertial-frame `jacobian`;
- generic, body-frame, and inertial-frame
  `jacobian_and_time_derivative`.

The protected PCS traversal helpers are renamed consistently:

- `_J_local_batched` becomes `_J_local_abscissa_batched`;
- `_J_Jd_local_batched` becomes `_J_Jd_local_abscissa_batched`.

The interface and implementations are updated across:

- `SoftRobot`;
- `Pendulum`;
- `PlanarPCS` and inherited `PlanarHSA` behavior;
- `PCS`;
- `GVS`; and
- inherited articulated-soft-robot defaults.

## Updated consumers

Every in-repository usage was migrated, including:

- renderer feature detection and kinematics adapters;
- operational-space dynamics;
- safety-constrained-control paper code;
- the Quick Start;
- system-method benchmarks; and
- rendering, system, and benchmark tests.

APIs that genuinely batch configurations or other values retain their current
names. In particular, renderer methods such as
`compute_backbone_curves_batched` and actuator-visualization batching are not
abscissa-only methods and are intentionally unchanged.

## Behavioral scope

This PR changes names only. Numerical algorithms, accepted shapes, return
shapes, JIT behavior, and the specialized abscissa traversals are unchanged.
It does not add environment batching or fused Warp kinematics; it makes the
existing batching contract unambiguous so those capabilities can compose with
it cleanly in subsequent work.

## Scope and merge order

This branch was created directly from `origin/main` and is independent of the
Warp backend PR. The recommended order is:

1. merge the rotational-basis correctness fix (#179);
2. merge this naming change; and
3. rebase the fused Warp kinematics work onto both prerequisites.

This order keeps numerical correction, API migration, and backend acceleration
as separately reviewable changes.

## Validation

- 761 affected-area CPU tests passed across systems, coordinate
  transformations, rendering adapters, and benchmark tooling.
- Repository search found no remaining old identifiers outside the changelog
  migration note.
- Ruff lint passed for every changed Python file.
- `git diff --check` passed.

