### PR TITLE
Adopt scalar-last quaternion convention

### DIFF
--- a/docs/api/utilities/parameters.md
+++ b/docs/api/utilities/parameters.md
@@ -115,10 +115,10 @@ base mounting does not rotate the gravity vector.
 The exact default values are:
 
 - Planar upright pose: `[pi / 2, 0, 0]`; gravity: `[0, -9.81]` m/s².
-- Spatial upright pose: `[sqrt(0.5), 0, -sqrt(0.5), 0, 0, 0, 0]`;
+- Spatial upright pose: `[0, -sqrt(0.5), 0, sqrt(0.5), 0, 0, 0]`;
   gravity: `[0, 0, -9.81]` m/s².
-- Planar poses use `[theta, x, y]`. Spatial poses use scalar-first Hamilton
-  quaternions in `[qw, qx, qy, qz, x, y, z]` order.
+- Planar poses use `[theta, x, y]`. Spatial poses use scalar-last Hamilton
+  quaternions in `[qx, qy, qz, qw, x, y, z]` order.
 
 Omitting both the robot constructor's `base_pose` and the parameter tree's
 `gravity` selects the defaults. For example, the factory below constructs an

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -37,10 +37,6 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Changed
 
-- Changed all SoRoMoX quaternion coordinates to the scalar-last Hamilton
-  convention `[qx, qy, qz, qw]`, including spatial base poses, operational-space
-  poses, floating-base state, and JAX and Warp execution. This is a breaking
-  change for code that constructs or indexes quaternions directly.
 - Made effort laws declare their transmission-state dependencies so
   `DirectEffort` skips unused actuator-coordinate and velocity evaluation, and
   generalized-force assembly evaluates each actuator moment matrix only once.
@@ -88,6 +84,10 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Breaking changes
 
+- Changed all SoRoMoX quaternion coordinates to the scalar-last Hamilton
+  convention `[qx, qy, qz, qw]`, including spatial base poses, operational-space
+  poses, floating-base state, and JAX and Warp execution. Code that constructs
+  or indexes quaternions directly must use the new coordinate order.
 - Replaced the ambiguous `SoftRobot.num_dofs` attribute with explicit
   `num_internal_dofs`, `num_coordinates`, and `num_velocities` dimensions.
   Code that allocates configurations, velocities, or internal controller state

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -37,6 +37,10 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Changed
 
+- Changed all SoRoMoX quaternion coordinates to the scalar-last Hamilton
+  convention `[qx, qy, qz, qw]`, including spatial base poses, operational-space
+  poses, floating-base state, and JAX and Warp execution. This is a breaking
+  change for code that constructs or indexes quaternions directly.
 - Made effort laws declare their transmission-state dependencies so
   `DirectEffort` skips unused actuator-coordinate and velocity evaluation, and
   generalized-force assembly evaluates each actuator moment matrix only once.

--- a/docs/user-guide/floating-base-systems.md
+++ b/docs/user-guide/floating-base-systems.md
@@ -30,11 +30,11 @@ adds seven stored base coordinates but only six base velocity coordinates.
 Spatial floating systems use
 
 ```text
-q = [qw, qx, qy, qz, px, py, pz, q_internal...]
+q = [qx, qy, qz, qw, px, py, pz, q_internal...]
 v = [wx, wy, wz, vx, vy, vz, qd_internal...]
 ```
 
-The quaternion is SoRoMoX's scalar-first Hamilton quaternion. Both angular and
+The quaternion is SoRoMoX's scalar-last Hamilton quaternion. Both angular and
 linear base velocity are expressed in the world frame; linear velocity is at
 the base-frame origin. Planar systems use
 
@@ -51,7 +51,7 @@ helpers preserve arbitrary broadcast-compatible leading batch axes.
 For spatial systems,
 
 ```text
-qdot_quaternion = 0.5 [0, omega_world] * q_quaternion
+qdot_quaternion = 0.5 [omega_world, 0] * q_quaternion
 pdot = v_origin_world
 ```
 

--- a/examples/control/actuation_space/setpoint_regulation_comparison.py
+++ b/examples/control/actuation_space/setpoint_regulation_comparison.py
@@ -82,7 +82,7 @@ def create_robot() -> tuple[PCS, int]:
             )
             for index in range(num_segments)
         ],
-        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
+        base_pose=jnp.array([0.5, -0.5, 0.5, 0.5, 0.0, 0.0, 0.0]),
         gravity=jnp.array([0.0, 0.0, 9.81]),
     )
 

--- a/examples/control/operational_space/control_tendon_actuated_pcs_with_synergistic.py
+++ b/examples/control/operational_space/control_tendon_actuated_pcs_with_synergistic.py
@@ -51,8 +51,8 @@ def main(
     num_segments = 2
     rho = 1070 * jnp.ones((num_segments,))  # Volumetric density [kg/m^3]
 
-    # Define the initial scalar-first quaternion base pose.
-    p0 = jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0])
+    # Define the initial scalar-last quaternion base pose.
+    p0 = jnp.array([0.5, -0.5, 0.5, 0.5, 0.0, 0.0, 0.0])
 
     segment_lengths = 1e-1 * jnp.ones((num_segments,))
     material_damping_coefficient = 362.0

--- a/examples/simulation/articulated/simulate_mckibben_umarm.py
+++ b/examples/simulation/articulated/simulate_mckibben_umarm.py
@@ -23,7 +23,7 @@ DEFAULT_VIDEO_PATH = (
     Path(__file__).resolve().parent / "videos" / "simulate_mckibben_umarm.mp4"
 )
 UMARM_Z_DOWN_BASE_POSE = jnp.array(
-    [2**-0.5, 0.0, 2**-0.5, 0.0, 0.0, 0.0, 1.2],
+    [0.0, 2**-0.5, 0.0, 2**-0.5, 0.0, 0.0, 1.2],
     dtype=jnp.float64,
 )
 

--- a/examples/simulation/gvs/simulate_tendon_actuated_gvs.py
+++ b/examples/simulation/gvs/simulate_tendon_actuated_gvs.py
@@ -103,7 +103,7 @@ active_tendon_routing = ThreadlikeRouting.linear(
 )
 # attention: 0DEG -> Y+, 180DEG -> Y-, 90DEG -> Z+, 270DEG -> Z-
 
-p0 = jnp.array([jnp.sqrt(0.5), 0.0, jnp.sqrt(0.5), 0.0, 0.0, 0.0, 0.0])
+p0 = jnp.array([0.0, jnp.sqrt(0.5), 0.0, jnp.sqrt(0.5), 0.0, 0.0, 0.0])
 
 # 2 link version
 segments = [

--- a/examples/simulation/pcs/simulate_batched_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_batched_tendon_actuated_pcs.py
@@ -60,7 +60,7 @@ def build_robot() -> PCS:
             )
             for index in range(num_segments)
         ],
-        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
+        base_pose=jnp.array([0.5, -0.5, 0.5, 0.5, 0.0, 0.0, 0.0]),
         gravity=jnp.array([0.0, 0.0, 9.81]),
     )
     active_tendon_routing = ThreadlikeRouting.linear(

--- a/examples/simulation/pcs/simulate_isupport.py
+++ b/examples/simulation/pcs/simulate_isupport.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
         for index in range(len(rigid_segment_selector))
     ]
     params = ISupportParams(
-        base_pose=jnp.array([0.5, 0.5, 0.5, -0.5, 0.0, 0.0, 0.0]),
+        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
         gravity=jnp.array([0.0, 0.0, -9.81]),
         link=PCS.params_from_links(links).link,
         chamber_inner_radius=6.39 * 1e-3 * jnp.ones((num_pneumatic_segments,)),

--- a/examples/simulation/pcs/simulate_pcs.py
+++ b/examples/simulation/pcs/simulate_pcs.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
             for index in range(num_segments)
         ],
         base_pose=jnp.array(
-            [0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]
+            [0.5, -0.5, 0.5, 0.5, 0.0, 0.0, 0.0]
         ),  # Initial position and orientation
         gravity=jnp.array([0.0, 0.0, 9.81]),  # Gravity vector [m/s^2]
     )

--- a/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
+++ b/examples/simulation/pcs/simulate_tendon_actuated_pcs.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
             )
             for index in range(num_segments)
         ],
-        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
+        base_pose=jnp.array([0.5, -0.5, 0.5, 0.5, 0.0, 0.0, 0.0]),
         gravity=jnp.array([0.0, 0.0, 9.81]),
     )
     active_tendon_routing = ThreadlikeRouting.linear(

--- a/src/soromox/coordinate_transformations/operational_space_dynamics.py
+++ b/src/soromox/coordinate_transformations/operational_space_dynamics.py
@@ -518,7 +518,7 @@ class OperationalSpaceDynamics(eqx.Module):
         For 3D robots (PCS), forward_kinematics returns a 4x4 SE(3) matrix.
         We extract the pose using the configured rotation representation:
         - ROTATION_VECTOR: [omega_x, omega_y, omega_z, p_x, p_y, p_z] (6D)
-        - QUATERNION: [q_w, q_x, q_y, q_z, p_x, p_y, p_z] (7D)
+        - QUATERNION: [q_x, q_y, q_z, q_w, p_x, p_y, p_z] (7D)
         - ROTATION_MATRIX_6D: [r6d_0, ..., r6d_5, p_x, p_y, p_z] (9D)
 
         For planar robots (PlanarPCS, Pendulum), forward_kinematics returns
@@ -787,7 +787,7 @@ class OperationalSpaceDynamics(eqx.Module):
 
         For 3D robots, the FULL pose at each point depends on rotation_representation:
         - ROTATION_VECTOR: [rx, ry, rz, p_x, p_y, p_z] (6D per point)
-        - QUATERNION: [q_w, q_x, q_y, q_z, p_x, p_y, p_z] (7D per point)
+        - QUATERNION: [q_x, q_y, q_z, q_w, p_x, p_y, p_z] (7D per point)
         - ROTATION_MATRIX_6D: [r6d_0, ..., r6d_5, p_x, p_y, p_z] (9D per point)
 
         For planar robots, the pose at each point is [theta, x, y] (3D per point).
@@ -822,7 +822,7 @@ class OperationalSpaceDynamics(eqx.Module):
 
         For 3D robots, the pose at each point depends on rotation_representation:
         - ROTATION_VECTOR: [rx, ry, rz, p_x, p_y, p_z] (6D per point)
-        - QUATERNION: [q_w, q_x, q_y, q_z, p_x, p_y, p_z] (7D per point)
+        - QUATERNION: [q_x, q_y, q_z, q_w, p_x, p_y, p_z] (7D per point)
         - ROTATION_MATRIX_6D: [r6d_0, ..., r6d_5, p_x, p_y, p_z] (9D per point)
 
         For planar robots, the pose at each point is [theta, x, y] (3D per point).

--- a/src/soromox/execution/warp/common/floating_base.py
+++ b/src/soromox/execution/warp/common/floating_base.py
@@ -41,7 +41,7 @@ def _quaternion_rotation_transpose_entry(
     """Return one normalized quaternion rotation-transpose entry.
 
     Args:
-        base_pose: Batched scalar-first quaternion poses with shape ``(E, 7)``.
+        base_pose: Batched scalar-last quaternion poses with shape ``(E, 7)``.
         environment: Environment row in ``base_pose``.
         row: Requested matrix row.
         column: Requested matrix column.
@@ -51,10 +51,10 @@ def _quaternion_rotation_transpose_entry(
         transpose. A zero runtime quaternion follows the trace-safe JAX path
         and maps to identity.
     """
-    w = base_pose[environment, 0]
-    x = base_pose[environment, 1]
-    y = base_pose[environment, 2]
-    z = base_pose[environment, 3]
+    x = base_pose[environment, 0]
+    y = base_pose[environment, 1]
+    z = base_pose[environment, 2]
+    w = base_pose[environment, 3]
     norm_sq = w * w + x * x + y * y + z * z
     if norm_sq <= wp.float64(0.0):
         value = wp.float64(0.0)
@@ -96,7 +96,7 @@ def _spatial_root_jacobian_entry(
     """Return one root body-Jacobian entry for world-frame base velocity.
 
     Args:
-        base_pose: Batched scalar-first quaternion poses with shape ``(E, 7)``.
+        base_pose: Batched scalar-last quaternion poses with shape ``(E, 7)``.
         environment: Environment row in ``base_pose``.
         row: Requested spatial row.
         column: Requested base-velocity column.

--- a/src/soromox/execution/warp/gvs/floating_chain.py
+++ b/src/soromox/execution/warp/gvs/floating_chain.py
@@ -83,7 +83,7 @@ def floating_persistent_chain_kernel(
         cell_tangent_velocity_dot: Cell tangent-derivative actions.
         global_to_local: Internal active-to-local link-coordinate map.
         active_dofs: Cumulative internal coordinate count by segment.
-        base_pose: Runtime scalar-first quaternion poses with shape ``(E, 7)``.
+        base_pose: Runtime scalar-last quaternion poses with shape ``(E, 7)``.
         velocity: Total angular-first generalized velocities.
         inertia_upper_rows: Packed augmented upper-inertia row indices.
         inertia_upper_columns: Packed augmented upper-inertia column indices.
@@ -682,7 +682,7 @@ def launch_floating_persistent_chain(
         cell_tangent_velocity_dot: Cell tangent-derivative actions.
         global_to_local: Internal active-to-local link-coordinate map.
         active_dofs: Cumulative internal coordinate count by segment.
-        base_pose: Batched runtime scalar-first quaternion poses.
+        base_pose: Batched runtime scalar-last quaternion poses.
         velocity: Batched total generalized velocities.
         inertia_upper_rows: Packed augmented upper-inertia row indices.
         inertia_upper_columns: Matching upper-inertia column indices.

--- a/src/soromox/execution/warp/pcs/spatial_floating_kernels.py
+++ b/src/soromox/execution/warp/pcs/spatial_floating_kernels.py
@@ -64,7 +64,7 @@ def spatial_floating_persistent_chain_kernel(
         active_indices: Internal-coordinate index of each strain component.
         active_scales: Scale applied to each active strain component.
         active_dof_ends: Cumulative internal coordinate count by segment.
-        base_pose: Runtime scalar-first quaternion poses with shape ``(E, 7)``.
+        base_pose: Runtime scalar-last quaternion poses with shape ``(E, 7)``.
         velocity: Total angular-first generalized velocities.
         inertia_upper_rows: Packed augmented upper-inertia row indices.
         inertia_upper_columns: Packed augmented upper-inertia column indices.
@@ -428,7 +428,7 @@ def launch_spatial_floating_persistent_chain(
         active_indices: Internal-coordinate index of each strain row.
         active_scales: Scale applied to each active strain row.
         active_dof_ends: Cumulative internal coordinate count by segment.
-        base_pose: Batched runtime scalar-first quaternion poses.
+        base_pose: Batched runtime scalar-last quaternion poses.
         velocity: Batched total generalized velocities.
         inertia_upper_rows: Packed augmented upper-inertia row indices.
         inertia_upper_columns: Matching upper-inertia column indices.

--- a/src/soromox/rendering/base.py
+++ b/src/soromox/rendering/base.py
@@ -58,8 +58,8 @@ class BaseSoftRobotRenderer(ABC):
         color_config: Shared color configuration for renderers
         L_max: Total length of the robot backbone
         base_pose: Robot base pose coordinates. Planar robots use
-            ``[theta, x, y]``; spatial robots use scalar-first quaternion pose
-            ``[qw, qx, qy, qz, x, y, z]``.
+            ``[theta, x, y]``; spatial robots use scalar-last quaternion pose
+            ``[qx, qy, qz, qw, x, y, z]``.
         base_transform: Homogeneous base transform. Shape ``(3, 3)`` for
             planar robots and ``(4, 4)`` for spatial robots.
         show_ground_plane: Whether supported backends render a ground reference

--- a/src/soromox/systems/gvs/_assembly.py
+++ b/src/soromox/systems/gvs/_assembly.py
@@ -274,7 +274,7 @@ def assign_gvs_runtime_arrays(
     )
 
     if p0 is None:
-        p0_arr = jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=jnp.float64)
+        p0_arr = jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0], dtype=jnp.float64)
     else:
         p0_arr = jnp.asarray(p0, dtype=jnp.float64)
     validate_quaternion_base_pose("p0", p0_arr, (7,))

--- a/src/soromox/systems/params.py
+++ b/src/soromox/systems/params.py
@@ -61,13 +61,13 @@ def validate_quaternion_base_pose(
     *,
     min_norm: float = 1e-12,
 ) -> None:
-    """Validate a scalar-first quaternion base pose.
+    """Validate a scalar-last quaternion base pose.
 
     Args:
         name: Parameter name used in error messages.
-        value: Base pose array whose first four entries are a scalar-first
-            Hamilton quaternion in ``[qw, qx, qy, qz]`` order. Spatial systems
-            use shape ``(7,)`` with ``[qw, qx, qy, qz, x, y, z]``.
+        value: Base pose array whose first four entries are a scalar-last
+            Hamilton quaternion in ``[qx, qy, qz, qw]`` order. Spatial systems
+            use shape ``(7,)`` with ``[qx, qy, qz, qw, x, y, z]``.
         expected_shape: Required full pose shape, typically ``(7,)``.
         min_norm: Minimum allowed Euclidean norm for the quaternion component.
 

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -108,8 +108,8 @@ class SoftRobot(DynamicalSystem):
                 If not provided, defaults to 10x machine epsilon for float64.
             base_pose: Optional base frame pose coordinates. Planar robots
                 expect shape ``(3,)`` with ``[theta, x, y]``. Spatial robots
-                expect shape ``(7,)`` with ``[qw, qx, qy, qz, x, y, z]``.
-                Spatial quaternions are scalar-first Hamilton quaternions,
+                expect shape ``(7,)`` with ``[qx, qy, qz, qw, x, y, z]``.
+                Spatial quaternions are scalar-last Hamilton quaternions,
                 normalized before use, and must have nonzero finite norm. If
                 omitted, the upright pose is used: the backbone points along
                 world +y for planar robots and world +z for spatial robots.
@@ -221,12 +221,12 @@ class SoftRobot(DynamicalSystem):
         """Return the identity pose for mounting-independent recurrences.
 
         Returns:
-            Planar ``[theta, x, y]`` or spatial scalar-first quaternion and
+            Planar ``[theta, x, y]`` or spatial scalar-last quaternion and
             position coordinates.
         """
         if self.is_planar:
             return jnp.zeros((3,), dtype=jnp.float64)
-        return jnp.asarray([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        return jnp.asarray([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
 
     @property
     def _kinematic_base_pose(self) -> Array:
@@ -413,7 +413,7 @@ class SoftRobot(DynamicalSystem):
 
         Returns:
             The unchanged input for fixed or planar robots, or a configuration
-            whose leading scalar-first quaternion has unit norm.
+            whose leading scalar-last quaternion has unit norm.
 
         Raises:
             ValueError: If a concrete spatial quaternion is zero or non-finite.
@@ -432,7 +432,7 @@ class SoftRobot(DynamicalSystem):
         regular = jnp.isfinite(norm_sq) & (norm_sq > 0.0)
         safe_norm_sq = jnp.where(regular, norm_sq, jnp.ones_like(norm_sq))
         normalized = quaternion / jnp.sqrt(safe_norm_sq)
-        identity = jnp.zeros_like(quaternion).at[..., 0].set(1.0)
+        identity = jnp.zeros_like(quaternion).at[..., 3].set(1.0)
         normalized = jnp.where(regular, normalized, identity)
         return jnp.concatenate([normalized, q[..., 4:]], axis=-1)
 
@@ -441,7 +441,7 @@ class SoftRobot(DynamicalSystem):
 
         Fixed and planar systems return the original state without additional
         array operations. Spatial floating systems normalize the leading
-        scalar-first quaternion while preserving velocity and auxiliary state.
+        scalar-last quaternion while preserving velocity and auxiliary state.
 
         Args:
             y: State with trailing dimension ``state_size``.
@@ -475,7 +475,7 @@ class SoftRobot(DynamicalSystem):
         if self.is_planar:
             return jnp.concatenate([v_base, qd_internal], axis=-1)
         omega_quaternion = jnp.concatenate(
-            [jnp.zeros_like(v_base[..., :1]), v_base[..., :3]], axis=-1
+            [v_base[..., :3], jnp.zeros_like(v_base[..., :1])], axis=-1
         )
         quaternion_dot = 0.5 * quaternion_multiply(omega_quaternion, q[..., :4])
         return jnp.concatenate([quaternion_dot, v_base[..., 3:6], qd_internal], axis=-1)
@@ -490,7 +490,7 @@ class SoftRobot(DynamicalSystem):
 
         Returns:
             Updated configuration. Spatial rotation increments left-multiply
-            the scalar-first quaternion and the result is normalized.
+            the scalar-last quaternion and the result is normalized.
         """
         q = self._check_trailing_dimension("q", q, self.num_coordinates)
         delta_v = self._check_trailing_dimension(
@@ -512,7 +512,7 @@ class SoftRobot(DynamicalSystem):
             jnp.sin(half) / safe_angle,
             0.5 - angle * angle / 48.0,
         )
-        increment = jnp.concatenate([jnp.cos(half), scale * rotation], axis=-1)
+        increment = jnp.concatenate([scale * rotation, jnp.cos(half)], axis=-1)
         quaternion = quaternion_multiply(increment, q[..., :4])
         result = jnp.concatenate(
             [
@@ -556,7 +556,7 @@ class SoftRobot(DynamicalSystem):
         """Return a fixed robot with a different mounting pose.
 
         Args:
-            pose: Planar pose with shape ``(3,)`` or spatial scalar-first
+            pose: Planar pose with shape ``(3,)`` or spatial scalar-last
                 quaternion pose with shape ``(7,)``.
 
         Returns:
@@ -760,8 +760,8 @@ class SoftRobot(DynamicalSystem):
 
         Planar robots consume ``[theta, x, y]`` and return an SE(2) matrix with
         shape ``(3, 3)``. Spatial robots consume
-        ``[qw, qx, qy, qz, x, y, z]`` and return an SE(3) matrix with shape
-        ``(4, 4)``. Spatial quaternions are scalar-first Hamilton quaternions.
+        ``[qx, qy, qz, qw, x, y, z]`` and return an SE(3) matrix with shape
+        ``(4, 4)``. Spatial quaternions are scalar-last Hamilton quaternions.
         """
         pose = self._kinematic_base_pose
         if self.is_planar:

--- a/src/soromox/utils/geometry/errors.py
+++ b/src/soromox/utils/geometry/errors.py
@@ -99,16 +99,16 @@ def quaternion_geodesic_error(
 ) -> Array:
     """Compute the geodesic orientation error between two quaternions.
 
-    Quaternions use the scalar-first Hamilton convention
-    ``[qw, qx, qy, qz]``. The relative quaternion is
+    Quaternions use the scalar-last Hamilton convention
+    ``[qx, qy, qz, qw]``. The relative quaternion is
     ``q_desired * conjugate(q_current)`` and is flipped when needed so the
     scalar component is nonnegative. That resolves the antipodal ambiguity and
     returns the shortest-path rotation vector.
 
     Args:
-        q_current: Current quaternion with shape ``(4,)`` in scalar-first
+        q_current: Current quaternion with shape ``(4,)`` in scalar-last
             Hamilton order.
-        q_desired: Desired quaternion with shape ``(4,)`` in scalar-first
+        q_desired: Desired quaternion with shape ``(4,)`` in scalar-last
             Hamilton order.
         eps: Small nonnegative scalar threshold passed to quaternion-to-vector
             conversion.
@@ -119,5 +119,5 @@ def quaternion_geodesic_error(
     """
     q_current_inv = quaternion_conjugate(q_current)
     q_error = quaternion_multiply(q_desired, q_current_inv)
-    q_error = jnp.where(q_error[0] < 0.0, -q_error, q_error)
+    q_error = jnp.where(q_error[3] < 0.0, -q_error, q_error)
     return quaternion_to_rotation_vector(q_error, eps=eps)

--- a/src/soromox/utils/geometry/poses.py
+++ b/src/soromox/utils/geometry/poses.py
@@ -42,23 +42,23 @@ def planar_mounting_pose(
 def spatial_mounting_pose(
     mounting: str = "upright", position: Array | None = None
 ) -> Array:
-    """Return a named scalar-first quaternion and position mounting pose.
+    """Return a named scalar-last quaternion and position mounting pose.
 
     Args:
         mounting: ``"horizontal"``, ``"upright"``, or ``"hanging"``.
         position: Optional finite translation with shape ``(3,)``.
 
     Returns:
-        Spatial pose ``[qw, qx, qy, qz, x, y, z]`` with shape ``(7,)``.
+        Spatial pose ``[qx, qy, qz, qw, x, y, z]`` with shape ``(7,)``.
 
     Raises:
         ValueError: If the mounting name or position is invalid.
     """
     sqrt_half = jnp.sqrt(jnp.asarray(0.5))
     quaternions = {
-        "horizontal": jnp.asarray([1.0, 0.0, 0.0, 0.0]),
-        "upright": jnp.asarray([sqrt_half, 0.0, -sqrt_half, 0.0]),
-        "hanging": jnp.asarray([sqrt_half, 0.0, sqrt_half, 0.0]),
+        "horizontal": jnp.asarray([0.0, 0.0, 0.0, 1.0]),
+        "upright": jnp.asarray([0.0, -sqrt_half, 0.0, sqrt_half]),
+        "hanging": jnp.asarray([0.0, sqrt_half, 0.0, sqrt_half]),
     }
     if mounting not in quaternions:
         raise ValueError("mounting must be 'horizontal', 'upright', or 'hanging'.")
@@ -156,14 +156,14 @@ def quaternion_pose_to_transform(pose: Array) -> Array:
 
     This helper treats the final three entries as direct translation
     coordinates, not as Lie-algebra twist coordinates. The quaternion is
-    scalar-first and is normalized by ``quaternion_to_rotation_matrix`` before
+    scalar-last and is normalized by ``quaternion_to_rotation_matrix`` before
     constructing the rotation block. Use ``se3.exp`` when the input is an
     ``se(3)`` twist whose translational part must be integrated through the
     ``SE(3)`` left Jacobian.
 
     Args:
         pose: Spatial pose with shape ``(7,)`` or ``(7, 1)`` in
-            ``[qw, qx, qy, qz, x, y, z]`` order. The quaternion is scalar-first
+            ``[qx, qy, qz, qw, x, y, z]`` order. The quaternion is scalar-last
             and the translation ``[x, y, z]`` is inserted directly into the
             homogeneous transform.
 

--- a/src/soromox/utils/geometry/rotations.py
+++ b/src/soromox/utils/geometry/rotations.py
@@ -8,10 +8,10 @@ rotations (θ ≈ π) correctly.
 All functions are JAX-compatible and can be used with jit, vmap, and grad.
 
 Quaternion Convention:
-    This module uses scalar-first Hamilton quaternions in ``[qw, qx, qy, qz]``
+    This module uses scalar-last Hamilton quaternions in ``[qx, qy, qz, qw]``
     order, where ``qw`` is the scalar part and ``[qx, qy, qz]`` is the vector
     part. A rotation by angle θ around unit axis n is represented as:
-        q = [cos(θ/2), sin(θ/2) * n_x, sin(θ/2) * n_y, sin(θ/2) * n_z]
+        q = [sin(θ/2) * n_x, sin(θ/2) * n_y, sin(θ/2) * n_z, cos(θ/2)]
 
 Rotation Representations:
     This module supports multiple rotation representations via the RotationRepresentation
@@ -137,10 +137,10 @@ def normalize_quaternion(
     quaternion: Array,
     eps: float | Array | None = None,
 ) -> Array:
-    """Normalize a scalar-first Hamilton quaternion.
+    """Normalize a scalar-last Hamilton quaternion.
 
     Args:
-        quaternion: Quaternion with shape ``(4,)`` in ``[qw, qx, qy, qz]``
+        quaternion: Quaternion with shape ``(4,)`` in ``[qx, qy, qz, qw]``
             order. ``qw`` is the scalar component and ``[qx, qy, qz]`` is the
             vector component.
         eps: Optional nonnegative norm threshold. If the quaternion norm is
@@ -148,16 +148,16 @@ def normalize_quaternion(
             Defaults to machine epsilon for the quaternion dtype.
 
     Returns:
-        Array: Unit quaternion with shape ``(4,)`` in ``[qw, qx, qy, qz]``
+        Array: Unit quaternion with shape ``(4,)`` in ``[qx, qy, qz, qw]``
         order. If the input norm is numerically smaller than ``eps``, the
-        identity quaternion ``[1, 0, 0, 0]`` is returned to avoid
+        identity quaternion ``[0, 0, 0, 1]`` is returned to avoid
         division-by-zero NaNs in traced computations. Parameter validators
         reject zero-norm configured poses.
     """
     dtype = jnp.result_type(quaternion, 1.0)
     q = jnp.asarray(quaternion, dtype=dtype).reshape(-1)
     eps_arr = eps_for_dtype(eps, q.dtype)
-    identity = jnp.array([1.0, 0.0, 0.0, 0.0], dtype=q.dtype)
+    identity = jnp.array([0.0, 0.0, 0.0, 1.0], dtype=q.dtype)
     norm_sq = jnp.dot(q, q)
     regular = norm_sq > eps_arr**2
     norm_sq_safe = jnp.where(regular, norm_sq, jnp.ones_like(norm_sq))
@@ -180,8 +180,8 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
         eps: Small value to avoid division by zero. Default is 1e-10.
 
     Returns:
-        q: Unit quaternion with shape ``(4,)`` in scalar-first
-            ``[qw, qx, qy, qz]`` order.
+        q: Unit quaternion with shape ``(4,)`` in scalar-last
+            ``[qx, qy, qz, qw]`` order.
 
     Example:
         ```python
@@ -189,7 +189,7 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
         from soromox.utils.geometry.rotations import rotation_matrix_to_quaternion
 
         R = jnp.eye(3)
-        q = rotation_matrix_to_quaternion(R)  # approximately [1, 0, 0, 0]
+        q = rotation_matrix_to_quaternion(R)  # approximately [0, 0, 0, 1]
         ```
 
     References:
@@ -205,10 +205,10 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
         denom = jnp.maximum(s, eps_arr)
         return jnp.array(
             [
-                0.25 * s,
                 (R[2, 1] - R[1, 2]) / denom,
                 (R[0, 2] - R[2, 0]) / denom,
                 (R[1, 0] - R[0, 1]) / denom,
+                0.25 * s,
             ],
             dtype=R.dtype,
         )
@@ -218,10 +218,10 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
         denom = jnp.maximum(s, eps_arr)
         return jnp.array(
             [
-                (R[2, 1] - R[1, 2]) / denom,
                 0.25 * s,
                 (R[0, 1] + R[1, 0]) / denom,
                 (R[0, 2] + R[2, 0]) / denom,
+                (R[2, 1] - R[1, 2]) / denom,
             ],
             dtype=R.dtype,
         )
@@ -231,10 +231,10 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
         denom = jnp.maximum(s, eps_arr)
         return jnp.array(
             [
-                (R[0, 2] - R[2, 0]) / denom,
                 (R[0, 1] + R[1, 0]) / denom,
                 0.25 * s,
                 (R[1, 2] + R[2, 1]) / denom,
+                (R[0, 2] - R[2, 0]) / denom,
             ],
             dtype=R.dtype,
         )
@@ -244,10 +244,10 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
         denom = jnp.maximum(s, eps_arr)
         return jnp.array(
             [
-                (R[1, 0] - R[0, 1]) / denom,
                 (R[0, 2] + R[2, 0]) / denom,
                 (R[1, 2] + R[2, 1]) / denom,
                 0.25 * s,
+                (R[1, 0] - R[0, 1]) / denom,
             ],
             dtype=R.dtype,
         )
@@ -263,7 +263,7 @@ def rotation_matrix_to_quaternion(R: Array, eps: float = DEFAULT_ROTATION_EPS) -
     quat = lax.cond(trace > 0.0, _trace_branch, _diagonal_branch, operand=None)
 
     # Ensure canonical form with positive scalar part (qw >= 0)
-    quat = jnp.where(quat[0] < 0, -quat, quat)
+    quat = jnp.where(quat[3] < 0, -quat, quat)
 
     quat = normalize_quaternion(quat, eps=eps)
 
@@ -275,8 +275,8 @@ def quaternion_to_rotation_matrix(quat: Array) -> Array:
     Convert a unit quaternion to a rotation matrix.
 
     Args:
-        quat: Quaternion with shape ``(4,)`` in scalar-first Hamilton
-            ``[qw, qx, qy, qz]`` order. The quaternion is normalized before
+        quat: Quaternion with shape ``(4,)`` in scalar-last Hamilton
+            ``[qx, qy, qz, qw]`` order. The quaternion is normalized before
             constructing the matrix.
 
     Returns:
@@ -287,7 +287,7 @@ def quaternion_to_rotation_matrix(quat: Array) -> Array:
         import jax.numpy as jnp
         from soromox.utils.geometry.rotations import quaternion_to_rotation_matrix
 
-        q = jnp.array([1.0, 0.0, 0.0, 0.0])
+        q = jnp.array([0.0, 0.0, 0.0, 1.0])
         R = quaternion_to_rotation_matrix(q)  # approximately eye(3)
         ```
 
@@ -297,7 +297,7 @@ def quaternion_to_rotation_matrix(quat: Array) -> Array:
         validated separately and reject zero-norm quaternions.
     """
     quat = normalize_quaternion(quat)
-    w, x, y, z = quat[0], quat[1], quat[2], quat[3]
+    x, y, z, w = quat[0], quat[1], quat[2], quat[3]
 
     # Pre-compute squared terms
     x2, y2, z2, w2 = x * x, y * y, z * z, w * w
@@ -334,8 +334,8 @@ def quaternion_to_rotation_vector(
     unit axis n, the rotation vector is ω = θ * n.
 
     Args:
-        quat: Unit quaternion with shape ``(4,)`` in scalar-first Hamilton
-            ``[qw, qx, qy, qz]`` order.
+        quat: Unit quaternion with shape ``(4,)`` in scalar-last Hamilton
+            ``[qx, qy, qz, qw]`` order.
         eps: Small value to avoid division by zero. Default is 1e-10.
 
     Returns:
@@ -347,13 +347,13 @@ def quaternion_to_rotation_vector(
         from soromox.utils.geometry.rotations import quaternion_to_rotation_vector
 
         # 90-degree rotation around the z-axis
-        q = jnp.array([jnp.cos(jnp.pi / 4), 0, 0, jnp.sin(jnp.pi / 4)])
+        q = jnp.array([0, 0, jnp.sin(jnp.pi / 4), jnp.cos(jnp.pi / 4)])
         omega = quaternion_to_rotation_vector(q)  # approximately [0, 0, pi/2]
         ```
     """
     quat = normalize_quaternion(quat, eps=eps)
-    q_w = quat[0]
-    q_vec = quat[1:4]
+    q_w = quat[3]
+    q_vec = quat[:3]
     eps_arr = eps_for_dtype(eps, quat.dtype)
     q_vec_norm_sq = jnp.dot(q_vec, q_vec)
     regular = q_vec_norm_sq > eps_arr**2
@@ -387,8 +387,8 @@ def rotation_vector_to_quaternion(
         eps: Small value for numerical stability at small angles. Default is 1e-10.
 
     Returns:
-        q: Unit quaternion with shape ``(4,)`` in scalar-first Hamilton
-            ``[qw, qx, qy, qz]`` order.
+        q: Unit quaternion with shape ``(4,)`` in scalar-last Hamilton
+            ``[qx, qy, qz, qw]`` order.
 
     Example:
         ```python
@@ -398,7 +398,7 @@ def rotation_vector_to_quaternion(
         # 90-degree rotation around the z-axis
         omega = jnp.array([0.0, 0.0, jnp.pi / 2])
         q = rotation_vector_to_quaternion(omega)
-        # q is approximately [cos(pi/4), 0, 0, sin(pi/4)]
+        # q is approximately [0, 0, sin(pi/4), cos(pi/4)]
         ```
     """
     omega = jnp.asarray(omega).reshape(-1)
@@ -409,7 +409,7 @@ def rotation_vector_to_quaternion(
 
     def _small(_: None) -> Array:
         return jnp.array(
-            [1.0, 0.5 * omega[0], 0.5 * omega[1], 0.5 * omega[2]],
+            [0.5 * omega[0], 0.5 * omega[1], 0.5 * omega[2], 1.0],
             dtype=omega.dtype,
         )
 
@@ -417,7 +417,7 @@ def rotation_vector_to_quaternion(
         angle = jnp.sqrt(angle_sq_safe)
         half_angle = angle / 2.0
         q_vec = omega * (jnp.sin(half_angle) / angle)
-        return jnp.array([jnp.cos(half_angle), q_vec[0], q_vec[1], q_vec[2]])
+        return jnp.array([q_vec[0], q_vec[1], q_vec[2], jnp.cos(half_angle)])
 
     quat = lax.cond(regular, _general, _small, operand=None)
 
@@ -595,36 +595,36 @@ def quaternion_multiply(q1: Array, q2: Array) -> Array:
     That is, q1 * q2 represents rotating by q2 first, then by q1.
 
     Args:
-        q1: First quaternion with trailing shape ``(..., 4)`` in scalar-first Hamilton
-            ``[qw, qx, qy, qz]`` order.
-        q2: Second quaternion with trailing shape ``(..., 4)`` in scalar-first Hamilton
-            ``[qw, qx, qy, qz]`` order.
+        q1: First quaternion with trailing shape ``(..., 4)`` in scalar-last Hamilton
+            ``[qx, qy, qz, qw]`` order.
+        q2: Second quaternion with trailing shape ``(..., 4)`` in scalar-last Hamilton
+            ``[qx, qy, qz, qw]`` order.
 
     Returns:
         q: Product quaternion with broadcast leading dimensions and trailing
-            shape ``(4,)`` in ``[qw, qx, qy, qz]`` order.
+            shape ``(4,)`` in ``[qx, qy, qz, qw]`` order.
 
     Example:
         ```python
         import jax.numpy as jnp
         from soromox.utils.geometry.rotations import quaternion_multiply
 
-        q1 = jnp.array([1, 0, 0, 0])
-        q2 = jnp.array([jnp.cos(jnp.pi / 4), 0, 0, jnp.sin(jnp.pi / 4)])
+        q1 = jnp.array([0, 0, 0, 1])
+        q2 = jnp.array([0, 0, jnp.sin(jnp.pi / 4), jnp.cos(jnp.pi / 4)])
         q = quaternion_multiply(q1, q2)  # approximately q2
         ```
     """
     left = jnp.asarray(q1)
     right = jnp.asarray(q2)
-    scalar_left, vector_left = left[..., :1], left[..., 1:]
-    scalar_right, vector_right = right[..., :1], right[..., 1:]
+    vector_left, scalar_left = left[..., :3], left[..., 3:]
+    vector_right, scalar_right = right[..., :3], right[..., 3:]
     return jnp.concatenate(
         [
-            scalar_left * scalar_right
-            - jnp.sum(vector_left * vector_right, axis=-1, keepdims=True),
             scalar_left * vector_right
             + scalar_right * vector_left
             + jnp.cross(vector_left, vector_right),
+            scalar_left * scalar_right
+            - jnp.sum(vector_left * vector_right, axis=-1, keepdims=True),
         ],
         axis=-1,
     )
@@ -638,20 +638,21 @@ def quaternion_conjugate(q: Array) -> Array:
     the opposite rotation.
 
     Args:
-        q: Quaternion with shape ``(4,)`` in scalar-first Hamilton
-            ``[qw, qx, qy, qz]`` order.
+        q: Quaternion with shape ``(4,)`` in scalar-last Hamilton
+            ``[qx, qy, qz, qw]`` order.
 
     Returns:
         q_conj: Conjugate quaternion with shape ``(4,)`` and coordinates
-            ``[qw, -qx, -qy, -qz]``.
+            ``[-qx, -qy, -qz, qw]``.
 
     Example:
         ```python
         import jax.numpy as jnp
         from soromox.utils.geometry.rotations import quaternion_conjugate
 
-        q = jnp.array([jnp.cos(jnp.pi / 4), 0, 0, jnp.sin(jnp.pi / 4)])
+        q = jnp.array([0, 0, jnp.sin(jnp.pi / 4), jnp.cos(jnp.pi / 4)])
         q_conj = quaternion_conjugate(q)  # represents -90 degrees around z
         ```
     """
-    return jnp.array([q[0], -q[1], -q[2], -q[3]])
+    q = jnp.asarray(q)
+    return jnp.concatenate([-q[..., :3], q[..., 3:]], axis=-1)

--- a/tests/execution/warp/actuation/test_threadlike.py
+++ b/tests/execution/warp/actuation/test_threadlike.py
@@ -143,7 +143,7 @@ def test_floating_gvs_fused_dynamics_and_threadlike_force_matches_jax(
     )
     q = model.pack_configuration(
         jnp.linspace(-0.02, 0.03, model.num_internal_dofs),
-        base_pose=jnp.array([0.97, 0.1, -0.05, 0.16, 0.2, -0.1, 0.3]),
+        base_pose=jnp.array([0.1, -0.05, 0.16, 0.97, 0.2, -0.1, 0.3]),
     )
     velocity = model.pack_velocity(
         jnp.linspace(0.03, -0.02, model.num_internal_dofs),

--- a/tests/geometry/test_poses.py
+++ b/tests/geometry/test_poses.py
@@ -22,7 +22,7 @@ def _embed_se2_transform(mat3):
 
 def _quaternion_z(theta):
     half = 0.5 * theta
-    return jnp.array([jnp.cos(half), 0.0, 0.0, jnp.sin(half)])
+    return jnp.array([0.0, 0.0, jnp.sin(half), jnp.cos(half)])
 
 
 def _assert_forward_and_reverse_mode_finite(fn, arg):

--- a/tests/geometry/test_rotations.py
+++ b/tests/geometry/test_rotations.py
@@ -19,6 +19,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from scipy.spatial.transform import Rotation
 
 from soromox.utils.geometry.errors import (
     angle_geodesic_error,
@@ -100,16 +101,16 @@ def nested_grad_of_vmap(fn, singular, regular, tangent):
 
 
 def test_normalize_quaternion_uses_configurable_eps():
-    q = jnp.array([1e-8, 1e-8, 0.0, 0.0])
+    q = jnp.array([1e-8, 0.0, 0.0, 1e-8])
 
     assert_allclose(
         normalize_quaternion(q, eps=1e-6),
-        jnp.array([1.0, 0.0, 0.0, 0.0]),
+        jnp.array([0.0, 0.0, 0.0, 1.0]),
         atol=1e-12,
     )
     assert_allclose(
         normalize_quaternion(q, eps=1e-10),
-        jnp.array([jnp.sqrt(0.5), jnp.sqrt(0.5), 0.0, 0.0]),
+        jnp.array([jnp.sqrt(0.5), 0.0, 0.0, jnp.sqrt(0.5)]),
         atol=1e-12,
     )
 
@@ -120,13 +121,13 @@ def test_normalize_quaternion_uses_configurable_eps():
         (
             lambda q: normalize_quaternion(q, eps=1e-10),
             jnp.zeros(4),
-            jnp.array([0.9, 0.1, 0.2, 0.3]),
+            jnp.array([0.1, 0.2, 0.3, 0.9]),
             jnp.ones(4),
         ),
         (
             lambda q: quaternion_to_rotation_vector(q, eps=1e-10),
-            jnp.array([1.0, 0.0, 0.0, 0.0]),
-            jnp.array([jnp.cos(0.1), 0.0, 0.0, jnp.sin(0.1)]),
+            jnp.array([0.0, 0.0, 0.0, 1.0]),
+            jnp.array([0.0, 0.0, jnp.sin(0.1), jnp.cos(0.1)]),
             jnp.ones(4),
         ),
         (
@@ -138,7 +139,7 @@ def test_normalize_quaternion_uses_configurable_eps():
         (
             quaternion_to_rotation_matrix,
             jnp.zeros(4),
-            jnp.array([0.9, 0.1, 0.2, 0.3]),
+            jnp.array([0.1, 0.2, 0.3, 0.9]),
             jnp.ones(4),
         ),
     ],
@@ -165,8 +166,8 @@ class TestRotationMatrixToQuaternion:
         R = jnp.eye(3)
         q = rotation_matrix_to_quaternion(R)
 
-        # Identity quaternion is [1, 0, 0, 0]
-        expected = jnp.array([1.0, 0.0, 0.0, 0.0])
+        # Identity quaternion is [0, 0, 0, 1]
+        expected = jnp.array([0.0, 0.0, 0.0, 1.0])
         assert_allclose(q, expected, atol=1e-10)
 
     @pytest.mark.parametrize(
@@ -187,10 +188,10 @@ class TestRotationMatrixToQuaternion:
         assert_allclose(jnp.linalg.norm(q), 1.0, atol=1e-10)
 
         # scalar component should be cos(45°) = sqrt(2)/2
-        assert_allclose(q[0], np.cos(angle / 2), atol=1e-10)
+        assert_allclose(q[3], np.cos(angle / 2), atol=1e-10)
 
         # Vector part norm should be sin(45°) = sqrt(2)/2
-        assert_allclose(jnp.linalg.norm(q[1:4]), np.sin(angle / 2), atol=1e-10)
+        assert_allclose(jnp.linalg.norm(q[:3]), np.sin(angle / 2), atol=1e-10)
 
     def test_quaternion_is_normalized(self):
         """Test that output quaternion is always normalized."""
@@ -200,13 +201,22 @@ class TestRotationMatrixToQuaternion:
 
         assert_allclose(jnp.linalg.norm(q), 1.0, atol=1e-10)
 
+    def test_matches_scipy_scalar_last_order(self):
+        """Match SciPy's default XYZW representation without reordering."""
+        rotation_vector = np.array([0.3, -0.4, 0.2])
+        scipy_rotation = Rotation.from_rotvec(rotation_vector)
+
+        q = rotation_matrix_to_quaternion(jnp.asarray(scipy_rotation.as_matrix()))
+
+        assert_allclose(q, scipy_rotation.as_quat(), atol=1e-10)
+
     def test_positive_w_convention(self):
         """Test that scalar component is non-negative (canonical form)."""
         for angle in [0.5, 1.5, 2.5, 3.0]:
             for axis in [[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 1]]:
                 R = rotation_matrix_from_axis_angle(axis, angle)
                 q = rotation_matrix_to_quaternion(R)
-                assert q[0] >= 0, f"scalar component should be non-negative, got {q[0]}"
+                assert q[3] >= 0, f"scalar component should be non-negative, got {q[3]}"
 
     def test_custom_eps(self):
         """Test that custom eps parameter works."""
@@ -222,7 +232,7 @@ class TestQuaternionToRotationMatrix:
 
     def test_identity_quaternion(self):
         """Test that identity quaternion gives identity rotation matrix."""
-        q = jnp.array([1.0, 0.0, 0.0, 0.0])
+        q = jnp.array([0.0, 0.0, 0.0, 1.0])
         R = quaternion_to_rotation_matrix(q)
 
         assert_allclose(R, jnp.eye(3), atol=1e-10)
@@ -243,10 +253,10 @@ class TestQuaternionToRotationMatrix:
         # Create quaternion for 90-degree rotation
         q = jnp.array(
             [
-                np.cos(angle / 2),
                 axis_normalized[0] * np.sin(angle / 2),
                 axis_normalized[1] * np.sin(angle / 2),
                 axis_normalized[2] * np.sin(angle / 2),
+                np.cos(angle / 2),
             ]
         )
 
@@ -257,7 +267,7 @@ class TestQuaternionToRotationMatrix:
 
     def test_rotation_matrix_is_orthonormal(self):
         """Test that output rotation matrix is orthonormal."""
-        q = jnp.array([0.9, 0.1, 0.2, 0.3])
+        q = jnp.array([0.1, 0.2, 0.3, 0.9])
         q = q / jnp.linalg.norm(q)  # Normalize
 
         R = quaternion_to_rotation_matrix(q)
@@ -286,7 +296,7 @@ class TestQuaternionToRotationVector:
 
     def test_identity_quaternion(self):
         """Test that identity quaternion gives zero rotation vector."""
-        q = jnp.array([1.0, 0.0, 0.0, 0.0])
+        q = jnp.array([0.0, 0.0, 0.0, 1.0])
         omega = quaternion_to_rotation_vector(q)
 
         assert_allclose(omega, jnp.zeros(3), atol=1e-10)
@@ -305,10 +315,10 @@ class TestQuaternionToRotationVector:
         axis = np.array(axis) / np.linalg.norm(axis)
         q = jnp.array(
             [
-                np.cos(angle / 2),
                 axis[0] * np.sin(angle / 2),
                 axis[1] * np.sin(angle / 2),
                 axis[2] * np.sin(angle / 2),
+                np.cos(angle / 2),
             ]
         )
         omega = quaternion_to_rotation_vector(q)
@@ -317,7 +327,7 @@ class TestQuaternionToRotationVector:
 
     def test_custom_eps(self):
         """Test that custom eps parameter works."""
-        q = jnp.array([0.0, 0.0, 0.1, 0.995])
+        q = jnp.array([0.0, 0.1, 0.995, 0.0])
         q = q / jnp.linalg.norm(q)
         omega1 = quaternion_to_rotation_vector(q, eps=1e-10)
         omega2 = quaternion_to_rotation_vector(q, eps=1e-6)
@@ -332,7 +342,7 @@ class TestRotationVectorToQuaternion:
         omega = jnp.zeros(3)
         q = rotation_vector_to_quaternion(omega)
 
-        expected = jnp.array([1.0, 0.0, 0.0, 0.0])
+        expected = jnp.array([0.0, 0.0, 0.0, 1.0])
         assert_allclose(q, expected, atol=1e-10)
 
     @pytest.mark.parametrize(
@@ -354,16 +364,16 @@ class TestRotationVectorToQuaternion:
         # Expected quaternion
         q_expected = jnp.array(
             [
-                np.cos(angle / 2),
                 axis[0] * np.sin(angle / 2),
                 axis[1] * np.sin(angle / 2),
                 axis[2] * np.sin(angle / 2),
+                np.cos(angle / 2),
             ]
         )
 
         # Quaternions may differ by sign (q and -q represent same rotation)
         # Compare with canonical form (positive scalar component)
-        if q_expected[0] < 0:
+        if q_expected[3] < 0:
             q_expected = -q_expected
 
         assert_allclose(q, q_expected, atol=1e-6)
@@ -395,8 +405,8 @@ class TestRotationVectorToQuaternion:
             q = rotation_vector_to_quaternion(omega)
 
             # Should be close to identity with small z component
-            assert_allclose(q[0], 1.0, atol=1e-4)
-            assert_allclose(jnp.linalg.norm(q[1:4]), angle / 2, atol=angle)
+            assert_allclose(q[3], 1.0, atol=1e-4)
+            assert_allclose(jnp.linalg.norm(q[:3]), angle / 2, atol=angle)
 
     def test_custom_eps(self):
         """Test that custom eps parameter works."""
@@ -635,7 +645,7 @@ class TestJAXCompatibility:
         def loss_fn(q_vec_angle):
             # Create a quaternion from angle (rotation around z-axis)
             half_angle = q_vec_angle / 2
-            quat = jnp.array([jnp.cos(half_angle), 0.0, 0.0, jnp.sin(half_angle)])
+            quat = jnp.array([0.0, 0.0, jnp.sin(half_angle), jnp.cos(half_angle)])
             omega = quaternion_to_rotation_vector(quat)
             return jnp.sum(omega**2)
 
@@ -670,7 +680,7 @@ class TestJAXCompatibility:
             R = quaternion_to_rotation_matrix(q)
             return jnp.sum(R**2)
 
-        q = jnp.array([0.9, 0.1, 0.2, 0.3])
+        q = jnp.array([0.1, 0.2, 0.3, 0.9])
         grad_fn = jax.grad(loss_fn)
 
         grad_q = grad_fn(q)
@@ -727,7 +737,7 @@ class TestJAXCompatibility:
 
     def test_quaternion_identity_log_branch_is_forward_and_reverse_mode_finite(self):
         """Test finite autodiff through the zero-vector branch of quaternion log."""
-        identity_quat = jnp.array([1.0, 0.0, 0.0, 0.0])
+        identity_quat = jnp.array([0.0, 0.0, 0.0, 1.0])
 
         assert_forward_and_reverse_mode_finite(
             lambda q: quaternion_to_rotation_vector(q, eps=1e-10),
@@ -858,8 +868,8 @@ class TestQuaternionOperations:
 
     def test_quaternion_identity_multiply(self):
         """Test that multiplying by identity gives the same quaternion."""
-        q_identity = jnp.array([1.0, 0.0, 0.0, 0.0])
-        q = jnp.array([0.9, 0.1, 0.2, 0.3])
+        q_identity = jnp.array([0.0, 0.0, 0.0, 1.0])
+        q = jnp.array([0.1, 0.2, 0.3, 0.9])
         q = q / jnp.linalg.norm(q)
 
         result = quaternion_multiply(q_identity, q)
@@ -870,35 +880,35 @@ class TestQuaternionOperations:
 
     def test_quaternion_multiply_inverse(self):
         """Test that q * q^{-1} = identity."""
-        q = jnp.array([0.9, 0.1, 0.2, 0.3])
+        q = jnp.array([0.1, 0.2, 0.3, 0.9])
         q = q / jnp.linalg.norm(q)
 
         q_inv = quaternion_conjugate(q)
         result = quaternion_multiply(q, q_inv)
 
         # Should be identity quaternion
-        identity = jnp.array([1.0, 0.0, 0.0, 0.0])
+        identity = jnp.array([0.0, 0.0, 0.0, 1.0])
         assert_allclose(result, identity, atol=1e-10)
 
     def test_quaternion_conjugate(self):
         """Test quaternion conjugate."""
-        q = jnp.array([0.9, 0.1, 0.2, 0.3])
+        q = jnp.array([0.1, 0.2, 0.3, 0.9])
         q_conj = quaternion_conjugate(q)
 
-        expected = jnp.array([0.9, -0.1, -0.2, -0.3])
+        expected = jnp.array([-0.1, -0.2, -0.3, 0.9])
         assert_allclose(q_conj, expected, atol=1e-10)
 
     def test_quaternion_multiply_composition(self):
         """Test that quaternion multiplication correctly composes rotations."""
         # Two 90-degree rotations around z-axis should give 180-degree rotation
         angle = np.pi / 2
-        q_90z = jnp.array([np.cos(angle / 2), 0, 0, np.sin(angle / 2)])
+        q_90z = jnp.array([0, 0, np.sin(angle / 2), np.cos(angle / 2)])
 
         q_180z = quaternion_multiply(q_90z, q_90z)
 
         # Should represent 180-degree rotation around z
-        # q = [cos(90°), 0, 0, sin(90°)] = [0, 0, 0, 1]
-        expected = jnp.array([0.0, 0.0, 0.0, 1.0])
+        # q = [0, 0, sin(90°), cos(90°)] = [0, 0, 1, 0]
+        expected = jnp.array([0.0, 0.0, 1.0, 0.0])
         assert_allclose(jnp.abs(q_180z), jnp.abs(expected), atol=1e-10)
 
 
@@ -1123,7 +1133,7 @@ class TestRotationQuatError:
 
     def test_small_rotation_error(self):
         """Test small rotation error."""
-        q_current = jnp.array([1.0, 0.0, 0.0, 0.0])  # Identity
+        q_current = jnp.array([0.0, 0.0, 0.0, 1.0])  # Identity
         omega_error = jnp.array([0.0, 0.0, 0.1])
         q_desired = rotation_vector_to_quaternion(omega_error)
 
@@ -1155,7 +1165,7 @@ class TestRotationQuatError:
 
     def test_antipodal_handling(self):
         """Test that antipodal quaternions give zero error."""
-        q = jnp.array([0.9, 0.1, 0.2, 0.3])
+        q = jnp.array([0.1, 0.2, 0.3, 0.9])
         q = q / jnp.linalg.norm(q)
 
         # Antipodal quaternion represents the same rotation
@@ -1175,7 +1185,7 @@ class TestRotationQuatError:
     )
     def test_forward_and_reverse_mode_autodiff_is_finite(self, omega_error):
         """Test autodiff through identity, small, regular, and near-pi errors."""
-        q_current = jnp.array([1.0, 0.0, 0.0, 0.0])
+        q_current = jnp.array([0.0, 0.0, 0.0, 1.0])
         q_desired = rotation_vector_to_quaternion(omega_error)
 
         assert_forward_and_reverse_mode_finite(
@@ -1185,7 +1195,7 @@ class TestRotationQuatError:
 
     def test_exact_pi_error_is_finite_value_only(self):
         """Check exact pi, where the axis sign is finite but not unique."""
-        q_current = jnp.array([1.0, 0.0, 0.0, 0.0])
+        q_current = jnp.array([0.0, 0.0, 0.0, 1.0])
         q_desired = rotation_vector_to_quaternion(jnp.array([0.0, jnp.pi, 0.0]))
 
         error = quaternion_geodesic_error(q_current, q_desired)

--- a/tests/rendering/test_base_renderer.py
+++ b/tests/rendering/test_base_renderer.py
@@ -235,7 +235,7 @@ def test_renderer_exposes_base_pose_transform_and_axis():
 
 
 def test_renderer_centralizes_ground_plane_configuration():
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = DummyRenderer(
         robot,
         show_ground_plane=True,
@@ -248,7 +248,7 @@ def test_renderer_centralizes_ground_plane_configuration():
 
 
 def test_renderer_resolves_robot_scaled_ground_plane_size():
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = DummyRenderer(robot)
 
     assert renderer._resolve_ground_plane_size() == pytest.approx(1.35)
@@ -257,7 +257,7 @@ def test_renderer_resolves_robot_scaled_ground_plane_size():
 
 @pytest.mark.parametrize("ground_plane_size", [0.0, -0.1])
 def test_renderer_rejects_nonpositive_ground_plane_size(ground_plane_size):
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
 
     with pytest.raises(ValueError, match="ground_plane_size must be positive"):
         DummyRenderer(robot, ground_plane_size=ground_plane_size)
@@ -277,7 +277,7 @@ def test_open3d_and_viser_ground_plane_arguments_follow_base_plate_arguments():
 
 
 def test_backbone_geometry_sampling_preserves_fk_material_frames():
-    robot = DummySpatialRobot(jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.5, -0.5, 0.5, 0.5, 0.0, 0.0, 0.0]))
     renderer = DummyRenderer(robot)
 
     curves, frames = renderer.compute_backbone_curves_and_frames_batched(
@@ -372,7 +372,7 @@ def test_renderer_rejects_extra_explicit_base_offsets_by_default():
 
 
 def test_renderer_computes_actuator_visual_layers_single_and_batched():
-    robot = DummyActuatedSpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummyActuatedSpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = DummyRenderer(robot, num_points=5)
 
     single = renderer.compute_actuator_visual_layers(jnp.array([]))
@@ -399,7 +399,7 @@ def test_renderer_computes_actuator_visual_layers_single_and_batched():
 
 def test_renderer_uses_batched_actuator_visual_fast_path():
     robot = DummyBatchedActuatedSpatialRobot(
-        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
     )
     renderer = DummyRenderer(robot, num_points=5)
 
@@ -424,7 +424,7 @@ def test_renderer_uses_batched_actuator_visual_fast_path():
 
 
 def test_renderer_computes_trajectory_actuator_visual_layers():
-    robot = DummyActuatedSpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummyActuatedSpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = DummyRenderer(robot, num_points=4)
 
     layers = renderer.compute_actuator_visual_layers_trajectory(
@@ -443,7 +443,7 @@ def test_renderer_computes_trajectory_actuator_visual_layers():
 
 def test_renderer_uses_trajectory_actuator_visual_fast_path():
     robot = DummyTrajectoryActuatedSpatialRobot(
-        jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
     )
     renderer = DummyRenderer(robot, num_points=4)
 

--- a/tests/rendering/test_floating_base_renderer.py
+++ b/tests/rendering/test_floating_base_renderer.py
@@ -78,7 +78,7 @@ def test_renderer_follows_runtime_base_pose(factory) -> None:
     """Follow the runtime base in both spatial and planar geometry paths."""
     robot = factory()
     base_pose = (
-        jnp.array([0.96, 0.1, -0.2, 0.15, 0.3, -0.2, 0.4])
+        jnp.array([0.1, -0.2, 0.15, 0.96, 0.3, -0.2, 0.4])
         if not robot.is_planar
         else jnp.array([0.4, 0.3, -0.2])
     )

--- a/tests/rendering/test_isupport_viser_renderer.py
+++ b/tests/rendering/test_isupport_viser_renderer.py
@@ -135,7 +135,7 @@ def _make_robot(*, connectors: bool = True) -> ISupport:
     )
     return ISupport(
         params=params,
-        base_pose=jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        base_pose=jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
         structure=ISupportStructure(
             num_gauss_points=1,
             pcs_segment_counts=(2, 1),

--- a/tests/rendering/test_matplotlib_renderer.py
+++ b/tests/rendering/test_matplotlib_renderer.py
@@ -108,7 +108,7 @@ def test_ground_plane_arguments_follow_color_configuration():
 
 
 def test_3d_default_camera_uses_base_pose_orientation():
-    robot = DummySpatialRobot(jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.5, -0.5, 0.5, 0.5, 0.0, 0.0, 0.0]))
     renderer = MatplotlibRenderer(robot)
     axis = FakeMatplotlib3DAxis()
 
@@ -137,7 +137,7 @@ def test_3d_default_camera_uses_base_pose_orientation():
 
 
 def test_3d_camera_supports_matplotlib_without_focal_length_or_zoom_keywords():
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = MatplotlibRenderer(robot)
     axis = LegacyFakeMatplotlib3DAxis()
 
@@ -154,7 +154,7 @@ def test_3d_camera_supports_matplotlib_without_focal_length_or_zoom_keywords():
 
 
 def test_3d_camera_uses_shared_field_of_view():
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = MatplotlibRenderer(robot)
     axis = FakeMatplotlib3DAxis()
 
@@ -174,7 +174,7 @@ def test_3d_camera_uses_shared_field_of_view():
 
 
 def test_actuator_overlay_changes_rendered_frame():
-    robot = DummyActuatedSpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummyActuatedSpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = MatplotlibRenderer(robot, width=240, height=180, num_points=8)
 
     without_actuators = renderer.render_frame(jnp.array([]), render_actuators=False)
@@ -185,7 +185,7 @@ def test_actuator_overlay_changes_rendered_frame():
 
 
 def test_ground_plane_changes_spatial_rendered_frame():
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     with_ground = MatplotlibRenderer(
         robot,
         width=240,

--- a/tests/rendering/test_open3d_renderer.py
+++ b/tests/rendering/test_open3d_renderer.py
@@ -29,7 +29,7 @@ class _AnimatingSpatialRobot:
     is_planar = False
     length = jnp.array(1.0)
     segment_length = jnp.array([1.0])
-    base_pose = jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    base_pose = jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
     base_transform = jnp.eye(4)
 
     def forward_kinematics_abscissa_batched(self, q, s_points):

--- a/tests/rendering/test_viser_renderer.py
+++ b/tests/rendering/test_viser_renderer.py
@@ -251,7 +251,7 @@ class FakeViserPlaybackServer:
 def test_viser_camera_uses_shared_up_and_radian_fov():
     from soromox.rendering.viser_renderer import ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
     client = FakeViserClient()
     server = FakeViserServer({"client": client})
@@ -278,7 +278,7 @@ def test_viser_camera_uses_shared_up_and_radian_fov():
 def test_viser_camera_accepts_full_trajectory_curves_for_bounds():
     from soromox.rendering.viser_renderer import ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
     client = FakeViserClient()
     renderer._server = FakeViserServer({"client": client})
@@ -305,7 +305,7 @@ def test_viser_camera_accepts_full_trajectory_curves_for_bounds():
 def test_viser_capture_rejects_missing_frame():
     from soromox.rendering.viser_renderer import ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
     client = FakeViserClient()
     renderer._server = FakeViserServer({"client": client})
@@ -345,7 +345,7 @@ def test_viser_sequence_hooks_and_capture_reuse(monkeypatch, tmp_path):
         def close(self):
             self.closed = True
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = HookedRenderer(
         robot,
         width=4,
@@ -484,7 +484,7 @@ def test_viser_recording_captures_synchronized_batched_geometry_for_every_frame(
         def close(self):
             self.closed = True
 
-    robot = AnimatingActuatedRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = AnimatingActuatedRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = viser_module.ViserRenderer(
         robot,
         width=4,
@@ -615,7 +615,7 @@ def test_viser_snapshot_paths_are_validated_before_rendering(
 ):
     from soromox.rendering.viser_renderer import ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
     renderer._server = FakeViserServer({})
 
@@ -631,7 +631,7 @@ def test_viser_snapshot_paths_are_validated_before_rendering(
 def test_viser_capture_timeout_is_explicit():
     from soromox.rendering.viser_renderer import ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
     client = FakeViserClient()
     renderer._server = FakeViserServer({"client": client})
@@ -651,7 +651,7 @@ def test_viser_capture_timeout_is_explicit():
 def test_viser_discrete_backbone_batches_positions_colors_and_robot_radius():
     from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False, backbone_style="discrete")
     server = FakeViserActuatorServer()
     renderer._server = server
@@ -695,7 +695,7 @@ def test_viser_batched_instance_colors_preserve_regular_handle_srgb_appearance()
 def test_viser_defaults_to_swept_backbone():
     from soromox.rendering.viser_renderer import ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
 
     assert renderer._backbone_style == "swept"
@@ -704,7 +704,7 @@ def test_viser_defaults_to_swept_backbone():
 def test_viser_ground_plane_uses_native_grid():
     from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(
         robot,
         auto_start=False,
@@ -726,7 +726,7 @@ def test_viser_ground_plane_uses_native_grid():
 def test_viser_automatic_ground_plane_covers_batched_base_layout():
     from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
     server = FakeViserActuatorServer()
     renderer._server = server
@@ -743,7 +743,7 @@ def test_viser_automatic_ground_plane_covers_batched_base_layout():
 def test_viser_swept_backbone_uses_material_frame_rings():
     from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(
         robot, auto_start=False, backbone_style="swept", cylinder_sections=8
     )
@@ -768,7 +768,7 @@ def test_viser_swept_backbone_uses_material_frame_rings():
 def test_viser_swept_body_owns_closed_tip_and_updates_atomically():
     from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(
         robot, auto_start=False, backbone_style="swept", cylinder_sections=8
     )
@@ -801,7 +801,7 @@ def test_viser_swept_body_owns_closed_tip_and_updates_atomically():
 def test_viser_frame_update_uses_one_atomic_transaction():
     from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(
         robot,
         auto_start=False,
@@ -844,7 +844,7 @@ def test_viser_swept_batches_match_segment_geometry_across_animation_frames():
         _oriented_tube_segment_mesh,
     )
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(
         robot,
         auto_start=False,
@@ -914,7 +914,7 @@ def test_viser_swept_batches_match_segment_geometry_across_animation_frames():
 def test_viser_default_camera_uses_backend_specific_distance():
     from soromox.rendering.viser_renderer import ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
     client = FakeViserClient()
     renderer._server = FakeViserServer({"client": client})
@@ -933,7 +933,7 @@ def test_viser_default_camera_uses_backend_specific_distance():
 def test_viser_actuator_geometry_updates_existing_line_handles():
     from soromox.rendering.viser_renderer import SceneHandles, ViserRenderer
 
-    robot = DummyActuatedSpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummyActuatedSpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
     renderer._server = FakeViserActuatorServer()
     renderer._scene_handles = SceneHandles()
@@ -964,7 +964,7 @@ def test_viser_actuator_geometry_updates_existing_line_handles():
 def test_viser_paused_frame_slider_seeks_rendered_frame():
     from soromox.rendering.viser_renderer import AnimationState, ViserRenderer
 
-    robot = DummySpatialRobot(jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    robot = DummySpatialRobot(jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
     renderer = ViserRenderer(robot, auto_start=False)
     renderer._server = FakeViserPlaybackServer()
     renderer._animation_state = AnimationState(

--- a/tests/system_param_builders.py
+++ b/tests/system_param_builders.py
@@ -19,7 +19,7 @@ from soromox.systems import (
 def spatial_base_pose(
     x: float | Array = 0.0, y: float | Array = 0.0, z: float | Array = 0.0
 ) -> Array:
-    return jnp.array([1.0, 0.0, 0.0, 0.0, x, y, z])
+    return jnp.array([0.0, 0.0, 0.0, 1.0, x, y, z])
 
 
 def planar_base_pose(

--- a/tests/systems/test_floating_base.py
+++ b/tests/systems/test_floating_base.py
@@ -149,7 +149,7 @@ def test_continuum_floating_state_and_dynamics_contract(factory) -> None:
     robot = factory()
     spatial = not robot.is_planar
     base_pose = (
-        jnp.array([0.98, 0.1, -0.05, 0.12, 0.2, -0.1, 0.3])
+        jnp.array([0.1, -0.05, 0.12, 0.98, 0.2, -0.1, 0.3])
         if spatial
         else jnp.array([0.2, 0.3, -0.1])
     )
@@ -201,7 +201,7 @@ def test_articulated_floating_state_and_dynamics_contract(factory) -> None:
     robot = factory()
     spatial = not robot.is_planar
     base_pose = (
-        jnp.array([0.98, 0.1, -0.05, 0.12, 0.2, -0.1, 0.3])
+        jnp.array([0.1, -0.05, 0.12, 0.98, 0.2, -0.1, 0.3])
         if spatial
         else jnp.array([0.2, 0.3, -0.1])
     )
@@ -235,7 +235,7 @@ def test_spatial_quaternion_derivative_and_retraction_are_consistent() -> None:
     robot = _spatial_pcs()
     q = robot.pack_configuration(
         jnp.zeros(robot.num_internal_dofs),
-        base_pose=jnp.array([0.9, 0.2, -0.1, 0.3, 0.1, -0.2, 0.4]),
+        base_pose=jnp.array([0.2, -0.1, 0.3, 0.9, 0.1, -0.2, 0.4]),
     )
     v = robot.pack_velocity(
         jnp.linspace(-0.02, 0.03, robot.num_internal_dofs),
@@ -261,7 +261,7 @@ def test_floating_gvs_warp_matches_jax_for_batch_and_jvp(
     robot = _gvs()
     q = robot.pack_configuration(
         jnp.zeros(robot.num_internal_dofs),
-        base_pose=jnp.array([0.98, 0.1, -0.05, 0.12, 0.2, -0.1, 0.3]),
+        base_pose=jnp.array([0.1, -0.05, 0.12, 0.98, 0.2, -0.1, 0.3]),
     )
     v = robot.pack_velocity(
         jnp.linspace(-0.03, 0.04, robot.num_internal_dofs),
@@ -394,7 +394,7 @@ def test_spatial_rollout_projection_normalizes_only_base_quaternion() -> None:
         jnp.linspace(0.04, -0.01, robot.num_internal_dofs),
         base_velocity=jnp.linspace(-0.1, 0.2, robot.num_base_velocities),
     )
-    q = jnp.concatenate([jnp.array([1.8, 0.2, -0.1, 0.3, 0.1, -0.2, 0.4]), q_internal])
+    q = jnp.concatenate([jnp.array([0.2, -0.1, 0.3, 1.8, 0.1, -0.2, 0.4]), q_internal])
     auxiliary = jnp.zeros((robot.num_auxiliary_states,))
     y = robot.pack_state(q, v, auxiliary)
 
@@ -416,7 +416,7 @@ def test_floating_continuum_warp_kinematics_matches_jax(
     pytest.importorskip("warp")
     robot = factory()
     base_pose = (
-        jnp.array([0.96, 0.1, -0.2, 0.15, 0.3, -0.2, 0.4])
+        jnp.array([0.1, -0.2, 0.15, 0.96, 0.3, -0.2, 0.4])
         if not robot.is_planar
         else jnp.array([0.4, 0.3, -0.2])
     )
@@ -469,7 +469,7 @@ def test_floating_pcs_warp_dynamics_matches_jax_on_cuda(
 
     robot = factory()
     base_pose = (
-        jnp.array([0.96, 0.1, -0.2, 0.15, 0.3, -0.2, 0.4])
+        jnp.array([0.1, -0.2, 0.15, 0.96, 0.3, -0.2, 0.4])
         if not robot.is_planar
         else jnp.array([0.4, 0.3, -0.2])
     )

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -190,7 +190,7 @@ def test_gvs_compiled_partial_base_pose_updates_match_eager_forces():
     sqrt_half = jnp.sqrt(jnp.asarray(0.5, dtype=jnp.float64))
     base_poses = (
         robot.fixed_base_pose,
-        jnp.array([sqrt_half, 0.0, sqrt_half, 0.0, 0.01, -0.02, 0.03]),
+        jnp.array([0.0, sqrt_half, 0.0, sqrt_half, 0.01, -0.02, 0.03]),
     )
     trace_count = {"value": 0}
 
@@ -323,7 +323,7 @@ def test_params_from_segments_uses_spatial_environment_defaults():
 
     assert_allclose(
         robot.fixed_base_pose,
-        jnp.array([jnp.sqrt(0.5), 0.0, -jnp.sqrt(0.5), 0.0, 0.0, 0.0, 0.0]),
+        jnp.array([0.0, -jnp.sqrt(0.5), 0.0, jnp.sqrt(0.5), 0.0, 0.0, 0.0]),
     )
     assert_allclose(params.gravity, jnp.array([0.0, 0.0, -9.81]))
 

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -326,7 +326,7 @@ def test_constant_strain_call():
     # test energies
     print("\nTesting energies... ------------------------")
     robot = robot.with_fixed_base_pose(
-        jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
+        jnp.array([0.5, -0.5, 0.5, 0.5, 0.0, 0.0, 0.0]),
     )
     q = jnp.zeros((6,))
     qd = jnp.zeros((6,))

--- a/tests/systems/test_soft_robot.py
+++ b/tests/systems/test_soft_robot.py
@@ -125,7 +125,7 @@ def test_spatial_normalization_validation_and_trace_safe_fallback() -> None:
     q_internal = jnp.zeros((robot.num_internal_dofs,))
     q = robot.pack_configuration(
         q_internal,
-        base_pose=jnp.array([2.0, -0.2, 0.1, 0.3, 0.4, -0.5, 0.6]),
+        base_pose=jnp.array([-0.2, 0.1, 0.3, 2.0, 0.4, -0.5, 0.6]),
     )
 
     assert_allclose(jnp.linalg.norm(q[:4]), 1.0)
@@ -136,14 +136,14 @@ def test_spatial_normalization_validation_and_trace_safe_fallback() -> None:
         robot.normalize_configuration(q.at[0].set(jnp.inf))
 
     traced = eqx.filter_jit(robot.normalize_configuration)(q.at[:4].set(0.0))
-    assert_allclose(traced[:4], jnp.array([1.0, 0.0, 0.0, 0.0]))
+    assert_allclose(traced[:4], jnp.array([0.0, 0.0, 0.0, 1.0]))
 
 
 def test_configuration_derivative_matches_retraction_tangent() -> None:
     robot = _spatial_robot(floating_base=True)
     q = robot.pack_configuration(
         jnp.linspace(-0.02, 0.03, robot.num_internal_dofs),
-        base_pose=jnp.array([0.9, 0.2, -0.1, 0.3, 0.1, -0.2, 0.4]),
+        base_pose=jnp.array([0.2, -0.1, 0.3, 0.9, 0.1, -0.2, 0.4]),
     )
     v = robot.pack_velocity(
         jnp.linspace(0.03, -0.02, robot.num_internal_dofs),
@@ -162,7 +162,7 @@ def test_configuration_derivative_matches_retraction_tangent() -> None:
 def test_fixed_mount_update_and_public_state_projection() -> None:
     floating = _spatial_robot(floating_base=True)
     q_internal = jnp.zeros((floating.num_internal_dofs,))
-    base_pose = jnp.array([1.0, 0.0, 0.0, 0.0, 0.2, -0.1, 0.3])
+    base_pose = jnp.array([0.0, 0.0, 0.0, 1.0, 0.2, -0.1, 0.3])
     q = floating.pack_configuration(q_internal, base_pose=base_pose)
     v = floating.pack_velocity(jnp.zeros((floating.num_internal_dofs,)))
     y = floating.pack_state(q.at[:4].multiply(1.8), v)

--- a/tests/utils/test_twist_from_pose.py
+++ b/tests/utils/test_twist_from_pose.py
@@ -230,9 +230,9 @@ class TestCreateTwistFromPoseFnQuaternion:
     def test_quaternion_constant_pose(self):
         """Constant quaternion pose should give zero angular velocity."""
 
-        # Unit quaternion for identity rotation: [1, 0, 0, 0]
+        # Unit quaternion for identity rotation: [0, 0, 0, 1]
         def pose_fn(t):
-            return jnp.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])  # [quat, pos]
+            return jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])  # [quat, pos]
 
         twist_fn = twist_callable_from_pose_callable_factory(
             pose_fn=pose_fn,
@@ -253,7 +253,7 @@ class TestCreateTwistFromPoseFnQuaternion:
 
         def pose_fn(t):
             # Identity quaternion (constant), position moving
-            return jnp.array([1.0, 0.0, 0.0, 0.0, t * 0.1, 0.0, 0.0])
+            return jnp.array([0.0, 0.0, 0.0, 1.0, t * 0.1, 0.0, 0.0])
 
         twist_fn = twist_callable_from_pose_callable_factory(
             pose_fn=pose_fn,


### PR DESCRIPTION
## Summary

This PR builds on #185 and changes all SoRoMoX quaternion coordinates from the
scalar-first Hamilton convention `[qw, qx, qy, qz]` to the scalar-last
convention `[qx, qy, qz, qw]`.

- Aligns SoRoMoX with the quaternion representation used by Warp, Newton, and
  standard ROS geometry interfaces.
- Updates quaternion utilities, spatial base and operational-space poses,
  floating-base state integration, and both JAX and Warp execution.
- Migrates examples, tests, API documentation, and the floating-base guide
  while preserving the represented physical orientations.
- Records the coordinate-order migration as a breaking change.

The main motivation is interoperability with the robotics and execution
ecosystem around SoRoMoX. Warp quaternions and Newton rigid-body state use
scalar-last coordinates; standard ROS `geometry_msgs/Quaternion` messages and
`tf2::Quaternion` interfaces likewise use the `x, y, z, w` order. Adopting the
same layout avoids repeated component shuffles at these integration boundaries
and reduces the risk of silently interpreting a valid four-element array in
the wrong order. Scalar-last also matches SciPy's default quaternion
representation, making that common conversion path direct.

This stack is the appropriate point for the breaking change: #184 introduces
runtime quaternion floating-base state, and #185 exposes the execution package
at the top level for integrations such as Newton. Changing the convention here
keeps those new public state and execution interfaces aligned from the outset
instead of establishing a scalar-first layout that downstream integrations
would immediately need to adapt.

## Implementation

Quaternion construction, conversion, multiplication, conjugation, error
calculation, normalization, differentiation, and retraction now consistently
use scalar-last coordinates. Spatial poses use
`[qx, qy, qz, qw, x, y, z]`, and the spatial floating-base configuration uses
the same quaternion prefix followed by world position.

The shared geometry implementation and the floating-base JAX path use the new
layout directly. Warp floating-base kernels read the vector components from
indices 0 through 2 and the scalar from index 3. Existing quaternion literals
in system parameters, examples, renderer tests, and dynamics tests are
reordered so they continue to describe the same rotations.

External interfaces retain their documented conventions. In particular,
Viser's `wxyz` properties remain scalar-first at that API boundary. A SciPy
interop regression test verifies that SoRoMoX quaternion output now matches
SciPy's default scalar-last order without reordering.

## Validation

- Core geometry, pose, floating-base, typed-parameter, and soft-robot suite:
  `203 passed, 2 skipped`
- Focused Warp floating-base suite: `4 passed, 2 skipped` (CUDA-only PCS Warp
  dynamics unavailable on the test host)
- Convention-sensitive system and operational-space suite: `26 passed`
- Renderer suite: `92 passed`; the 8 remaining failures reproduce on #185 and
  come from Open3D test doubles that lack the existing `floating_base` field
- Repository-wide convention audit, `git diff --check`, and the Zensical
  documentation build pass

## Stack

This PR targets `codex/promote-execution-package` and should be retargeted to
`main` after #185 merges.
