### PR TITLE
Add analytical PCS dynamics Jacobians

### DIFF
--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -4,7 +4,7 @@ __all__ = ["PCS"]
 from typing import Any, Self
 
 import equinox as eqx
-from jax import Array, lax, vmap
+from jax import Array, jvp, lax, vmap
 from jax import numpy as jnp
 
 from soromox.actuation.core import Actuator, PassiveElement
@@ -12,6 +12,7 @@ from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
     ThreadlikeRouting,
 )
+from soromox.autodiff import custom_jvp_enabled
 from soromox.systems.components import (
     ContinuumLinkParams,
     CrossSectionGeometry,
@@ -29,6 +30,10 @@ from soromox.utils.integration import (
     gauss_quadrature,
     scale_gaussian_quadrature,
     scale_interior_gaussian_quadrature,
+)
+from soromox.utils.joint_motion_subspace import (
+    joint_dSdq_qd,
+    joint_motion_subspace_with_derivatives,
 )
 from soromox.utils.lie_algebra import se3, so3
 from soromox.utils.lie_algebra.constant_strain import se3 as constant_strain_se3
@@ -1668,7 +1673,9 @@ class PCS(SoftRobot):
         Returns:
             J_local_ps (Array): Jacobians evaluated at all points, shape (N, 6, num_active_strains)
         """
-        J_local_ps_ = self._J_local_abscissa_batched(q, s_ps)  # shape (N, 6, num_strains)
+        J_local_ps_ = self._J_local_abscissa_batched(
+            q, s_ps
+        )  # shape (N, 6, num_strains)
 
         J_local_ps = jnp.einsum(
             "ijk, kl->ijl", J_local_ps_, self.B_xi
@@ -2140,8 +2147,8 @@ class PCS(SoftRobot):
             J_global_ps (Array): Jacobians evaluated at all points, shape (N, 6, num_active_strains)
             Jd_global_ps (Array): Time-derivative of the Jacobians, shape (N, 6, num_active_strains)
         """
-        J_local_ps, Jd_local_ps = self.jacobian_and_time_derivative_bodyframe_abscissa_batched(
-            q, qd, s_ps
+        J_local_ps, Jd_local_ps = (
+            self.jacobian_and_time_derivative_bodyframe_abscissa_batched(q, qd, s_ps)
         )  # shape (N, 6, num_active_strains)
 
         g_ps = self.forward_kinematics_abscissa_batched(q, s_ps)  # shape (N, 4, 4)
@@ -2232,7 +2239,9 @@ class PCS(SoftRobot):
             A tuple ``(J, J_dot)`` whose arrays both have shape
             ``(num_points, 6, num_active_strains)``.
         """
-        return self.jacobian_and_time_derivative_inertialframe_abscissa_batched(q, qd, s_ps)
+        return self.jacobian_and_time_derivative_inertialframe_abscissa_batched(
+            q, qd, s_ps
+        )
 
     # ==========================================
     # Useful functions for the system
@@ -3310,6 +3319,16 @@ class PCS(SoftRobot):
         Returns:
             yd (Array): Time derivative of the state vector.
         """
+        if custom_jvp_enabled():
+            return PCS._forward_dynamics_custom_jvp(self, t, y, actuation_args)
+        return self._forward_dynamics(t, y, actuation_args)
+
+    def _forward_dynamics(
+        self, t: Array, y: Array, actuation_args: tuple | None = None
+    ) -> Array:
+        """Evaluate the PCS forward-dynamics primal without a custom JVP."""
+        del t
+
         # Split the state vector into configuration and velocity
         q, qd = jnp.split(y, 2)
 
@@ -3339,3 +3358,879 @@ class PCS(SoftRobot):
         yd = jnp.concatenate([qd, qdd])
 
         return yd
+
+    @eqx.filter_custom_jvp
+    @staticmethod
+    def _forward_dynamics_custom_jvp(
+        robot: "PCS",
+        t: Array,
+        y: Array,
+        actuation_args: tuple | None,
+    ) -> Array:
+        """Custom-JVP entry point for PCS forward dynamics."""
+        return robot._forward_dynamics(t, y, actuation_args)
+
+    @_forward_dynamics_custom_jvp.def_jvp
+    def _forward_dynamics_custom_jvp_jvp(
+        primals: tuple["PCS", Array, Array, tuple | None],
+        tangents: tuple[Any, Array | None, Array | None, tuple | None],
+    ) -> tuple[Array, Array]:
+        """
+        Evaluate a hybrid analytical/autodiff forward-dynamics JVP.
+
+        The inertial, Coriolis, and gravity directions use the analytical
+        inverse-dynamics Jacobian passes. Actuator and passive-element force
+        directions remain under JAX autodiff so configuration-dependent
+        components retain their exact derivatives.
+        """
+        robot, t, y, actuation_args = primals
+        _, _, y_tangent, actuation_args_tangent = tangents
+
+        yd = robot._forward_dynamics(t, y, actuation_args)
+        q, qd = jnp.split(y, 2)
+        _, qdd = jnp.split(yd, 2)
+
+        if y_tangent is None:
+            q_tangent = jnp.zeros_like(q)
+            qd_tangent = jnp.zeros_like(qd)
+        else:
+            q_tangent, qd_tangent = jnp.split(y_tangent, 2)
+
+        if actuation_args is None:
+            u = jnp.zeros((robot.num_actuators,), dtype=q.dtype)
+            tau_ext = jnp.zeros_like(q)
+            u_tangent = jnp.zeros_like(u)
+            tau_ext_tangent = jnp.zeros_like(tau_ext)
+        else:
+            u = actuation_args[0]
+            tau_ext = actuation_args[1] if len(actuation_args) == 2 else None
+            if actuation_args_tangent is None:
+                u_tangent = None
+                tau_ext_tangent = None
+            else:
+                u_tangent = actuation_args_tangent[0]
+                tau_ext_tangent = (
+                    actuation_args_tangent[1]
+                    if len(actuation_args_tangent) == 2
+                    else None
+                )
+
+            if u is None:
+                u = jnp.zeros((robot.num_actuators,), dtype=q.dtype)
+            if tau_ext is None:
+                tau_ext = jnp.zeros_like(q)
+            if u_tangent is None:
+                u_tangent = jnp.zeros_like(u)
+            if tau_ext_tangent is None:
+                tau_ext_tangent = jnp.zeros_like(tau_ext)
+
+        def applied_force(
+            q_value: Array,
+            qd_value: Array,
+            u_value: Array,
+            tau_ext_value: Array,
+        ) -> Array:
+            return (
+                robot.actuation_force(q_value, u_value, qd=qd_value)
+                + tau_ext_value
+                - robot.elastic_force(q_value)
+                - robot.damping_matrix(q_value) @ qd_value
+            )
+
+        _, applied_force_tangent = jvp(
+            applied_force,
+            (q, qd, u, tau_ext),
+            (q_tangent, qd_tangent, u_tangent, tau_ext_tangent),
+        )
+
+        if y_tangent is None:
+            mass_matrix = robot.inertia_matrix(q)
+            inverse_dynamics_tangent = jnp.zeros_like(q)
+        else:
+            (
+                dID_dq,
+                dID_dqd,
+                mass_matrix,
+                _,
+                _,
+                _,
+                _,
+            ) = robot.inverse_dynamics_backward_pass(q, qd, qdd)
+            inverse_dynamics_tangent = dID_dq @ q_tangent + dID_dqd @ qd_tangent
+
+        qdd_tangent = robot._solve_inertia(
+            mass_matrix,
+            applied_force_tangent - inverse_dynamics_tangent,
+        )
+        yd_tangent = jnp.concatenate([qd_tangent, qdd_tangent])
+        return yd, yd_tangent
+
+    @eqx.filter_jit
+    def _local_id_jacobian_kinematics(
+        self,
+        segment_idx: Array,
+        H: Array,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[Array, Array, Array, Array, Array]:
+        """
+        Compute the local kinematics used by the inverse-dynamics Jacobian passes.
+
+        Args:
+            segment_idx (Array): Index of the PCS segment containing the
+                interval. Shape is ``()``.
+            H (Array): Length of the local quadrature interval. Shape is
+                ``()``.
+            q (Array): Active generalized coordinates. Shape is
+                ``(self.num_dofs,)``.
+            qd (Array): Active generalized velocities. Shape is
+                ``(self.num_dofs,)``.
+            qdd (Array): Active generalized accelerations. Shape is
+                ``(self.num_dofs,)``.
+
+        Returns:
+            tuple[Array, Array, Array, Array, Array]: Tuple
+            ``(g_local, S, Sd, deta_dq, detad_dq)``, where ``g_local`` is the
+            interval transformation with shape ``(4, 4)``. The remaining
+            arrays have shape ``(6, self.num_dofs)`` and contain the local
+            joint motion subspace, its time derivative, and the configuration
+            derivatives of the local velocity and acceleration twists.
+        """
+        B_xi_segments = self.B_xi.reshape(
+            self.num_segments,
+            6,
+            self.num_dofs,
+        )
+        xi_ref_segments = self.xi_ref.reshape(self.num_segments, 6)
+
+        B_xi_i = B_xi_segments[segment_idx]
+        xi_ref_i = xi_ref_segments[segment_idx]
+
+        (
+            g_local,
+            S,
+            Sd,
+            deta_dq,
+            dS_dq_qdd,
+            dSd_dq_qd,
+        ) = joint_motion_subspace_with_derivatives(
+            H,
+            B_xi_i,
+            xi_ref_i,
+            q,
+            qd,
+            qdd,
+            self.global_eps,
+        )
+        detad_dq = dS_dq_qdd + dSd_dq_qd
+
+        return g_local, S, Sd, deta_dq, detad_dq
+
+    @eqx.filter_jit
+    def _inverse_dynamics_jacobian_forward_pass(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+    ]:
+        """
+        Propagate ID-Jacobian kinematics through all quadrature intervals.
+
+        The propagated derivative quantities are ``J = d(eta) / d(qd)``,
+        ``Jdot = d(J) / dt``, ``R = d(eta) / d(q)``,
+        ``A = d(etad) / d(q)``, and
+        ``Y = d(etad) / d(qd) = Jdot + R``.
+
+        Local interval quantities are evaluated in parallel with vmap. A
+        single parent-to-child scan then propagates the global quantities.
+        All returned arrays use flattened segment-major interval ordering.
+
+        Args:
+            q (Array): Active generalized coordinates. Shape is
+                ``(self.num_dofs,)``.
+            qd (Array): Active generalized velocities. Shape is
+                ``(self.num_dofs,)``.
+            qdd (Array): Active generalized accelerations. Shape is
+                ``(self.num_dofs,)``.
+
+        Returns:
+            tuple[Array, ...]: Tuple ``(segment_indices, H, mass_weights, g,
+            eta, etad, J, Jdot, R, A, Y, Adginv, S)``. Let
+            ``num_intervals = self.num_segments *
+            (self.num_integration_points - 1)``. ``segment_indices``, ``H``,
+            and ``mass_weights`` have shape ``(num_intervals,)``; ``g`` has
+            shape ``(num_intervals, 4, 4)``; ``eta`` and ``etad`` have shape
+            ``(num_intervals, 6)``; ``J``, ``Jdot``, ``R``, ``A``, ``Y``,
+            and ``S`` have shape
+            ``(num_intervals, 6, self.num_dofs)``; and ``Adginv`` has shape
+            ``(num_intervals, 6, 6)``.
+        """
+        Xs_nodes, Ws_nodes = vmap(
+            scale_gaussian_quadrature, in_axes=(None, None, 0, 0)
+        )(
+            self.integration_points,
+            self.integration_weights,
+            self.L_cum[:-1],
+            self.L_cum[1:],
+        )
+        s_local_nodes = Xs_nodes - self.L_cum[:-1, None]
+        H_steps = jnp.diff(s_local_nodes, axis=1)
+
+        n_steps = self.num_integration_points - 1
+        segment_indices = jnp.repeat(
+            jnp.arange(self.num_segments, dtype=jnp.int32),
+            n_steps,
+        )
+        H_flat = H_steps.reshape(-1)
+        mass_weights = Ws_nodes[:, 1:].reshape(-1)
+
+        (
+            g_local,
+            S,
+            Sd,
+            deta_dq,
+            detad_dq,
+        ) = vmap(
+            self._local_id_jacobian_kinematics,
+            in_axes=(0, 0, None, None, None),
+        )(
+            segment_indices,
+            H_flat,
+            q,
+            qd,
+            qdd,
+        )
+        Adginv = vmap(se3.adjoint_inverse)(g_local)
+
+        zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
+        zeros_6 = jnp.zeros((6,), dtype=q.dtype)
+        carry_init = (
+            self.g0,
+            zeros_6,
+            zeros_6,
+            zeros_6n,
+            zeros_6n,
+            zeros_6n,
+            zeros_6n,
+        )
+
+        def propagate_interval(
+            carry: tuple[Array, Array, Array, Array, Array, Array, Array],
+            local: tuple[Array, Array, Array, Array, Array, Array],
+        ) -> tuple[
+            tuple[Array, Array, Array, Array, Array, Array, Array],
+            tuple[Array, Array, Array, Array, Array, Array, Array, Array],
+        ]:
+            (
+                g_base,
+                eta_base,
+                etad_base,
+                J_base,
+                Jdot_base,
+                R_base,
+                A_base,
+            ) = carry
+            g_local_i, Adginv_i, S_i, Sd_i, deta_dq_i, detad_dq_i = local
+
+            eta_local = S_i @ qd
+            etad_local = S_i @ qdd + Sd_i @ qd
+            eta_plus = eta_base + eta_local  # Intermediate velocity twist
+            etad_plus = etad_base + etad_local + se3.small_adjoint(eta_base) @ eta_local
+
+            g_tip = g_base @ g_local_i
+            eta_tip = Adginv_i @ eta_plus
+            etad_tip = Adginv_i @ etad_plus
+
+            J_pre = J_base + S_i
+            Jdot_pre = Jdot_base + Sd_i - se3.small_adjoint(eta_local) @ J_pre
+            J_tip = Adginv_i @ J_pre
+            Jdot_tip = Adginv_i @ Jdot_pre
+
+            R_local = se3.small_adjoint(eta_plus) @ S_i + deta_dq_i
+            R_tip = Adginv_i @ (R_base + R_local)
+
+            A_local = (
+                se3.small_adjoint(etad_plus) @ S_i
+                + se3.small_adjoint(eta_base) @ deta_dq_i
+                + detad_dq_i
+            )
+            A_pre = A_base - se3.small_adjoint(eta_local) @ R_base + A_local
+            A_tip = Adginv_i @ A_pre
+            Y_tip = Jdot_tip + R_tip
+
+            carry_next = (
+                g_tip,
+                eta_tip,
+                etad_tip,
+                J_tip,
+                Jdot_tip,
+                R_tip,
+                A_tip,
+            )
+            output = (
+                g_tip,
+                eta_tip,
+                etad_tip,
+                J_tip,
+                Jdot_tip,
+                R_tip,
+                A_tip,
+                Y_tip,
+            )
+            return carry_next, output
+
+        (
+            _,
+            (
+                g,
+                eta,
+                etad,
+                J,
+                Jdot,
+                R,
+                A,
+                Y,
+            ),
+        ) = lax.scan(
+            propagate_interval,
+            carry_init,
+            (g_local, Adginv, S, Sd, deta_dq, detad_dq),
+        )
+
+        return (
+            segment_indices,
+            H_flat,
+            mass_weights,
+            g,
+            eta,
+            etad,
+            J,
+            Jdot,
+            R,
+            A,
+            Y,
+            Adginv,
+            S,
+        )
+
+    @eqx.filter_jit
+    def inverse_dynamics_backward_pass(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[Array, Array, Array, Array, Array, Array, Array]:
+        """
+        Recurse the composite wrench and its Jacobians from tip to base.
+
+        At an interval, ``F_res`` is the resultant spatial wrench
+        produced by that interval and every interval downstream toward the
+        robot tip, transported into the current interval's base frame. It is
+        ordered as ``[moment, force]`` and is projected into generalized
+        coordinates by ``S.T @ F_res``.
+
+        Args:
+            q (Array): Active generalized coordinates. Shape is
+                ``(self.num_dofs,)``.
+            qd (Array): Active generalized velocities. Shape is
+                ``(self.num_dofs,)``.
+            qdd (Array): Active generalized accelerations. Shape is
+                ``(self.num_dofs,)``.
+
+        Returns:
+            tuple[Array, Array, Array, Array, Array, Array, Array]: Tuple
+            ``(dID_dq, dID_dqd, dID_dqdd, F_res, dF_res_dq,
+            dF_res_dqd, dF_res_dqdd)``. The first three inverse-dynamics
+            derivatives have shape ``(self.num_dofs, self.num_dofs)``;
+            ``dID_dqdd`` is also the generalized inertia matrix. ``F_res``
+            has shape ``(self.num_segments,
+            self.num_integration_points - 1, 6)``. Its three derivatives
+            have shape ``(self.num_segments,
+            self.num_integration_points - 1, 6, self.num_dofs)``.
+        """
+        (
+            segment_indices,
+            H_steps,
+            mass_weights,
+            g,
+            eta,
+            etad,
+            J,
+            _,
+            R,
+            A,
+            Y,
+            Adginv,
+            S,
+        ) = self._inverse_dynamics_jacobian_forward_pass(q, qd, qdd)
+
+        zeros_6 = jnp.zeros((6,), dtype=q.dtype)
+        zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
+        zeros_nn = jnp.zeros((self.num_dofs, self.num_dofs), dtype=q.dtype)
+        q_basis = jnp.eye(self.num_dofs, dtype=q.dtype)
+        B_xi_segments = self.B_xi.reshape(
+            self.num_segments,
+            6,
+            self.num_dofs,
+        )
+        xi_ref_segments = self.xi_ref.reshape(self.num_segments, 6)
+
+        carry_init = (
+            zeros_6,
+            zeros_6n,
+            zeros_6n,
+            zeros_6n,
+            zeros_nn,
+            zeros_nn,
+            zeros_nn,
+        )
+
+        def propagate_interval_backward(
+            carry: tuple[Array, Array, Array, Array, Array, Array, Array],
+            step_idx: Array,
+        ) -> tuple[
+            tuple[Array, Array, Array, Array, Array, Array, Array],
+            tuple[Array, Array, Array, Array],
+        ]:
+            (
+                F_res_child,
+                dF_res_dq_child,
+                dF_res_dqd_child,
+                dF_res_dqdd_child,
+                dID_dq,
+                dID_dqd,
+                dID_dqdd,
+            ) = carry
+
+            segment_idx = segment_indices[step_idx]
+            M = mass_weights[step_idx] * self.M_segments[segment_idx]
+            g_i = g[step_idx]
+            eta_i = eta[step_idx]
+            etad_i = etad[step_idx]
+            J_i = J[step_idx]
+            R_i = R[step_idx]
+            A_i = A[step_idx]
+            Y_i = Y[step_idx]
+            Adginv_i = Adginv[step_idx]
+            S_i = S[step_idx]
+
+            M_eta = M @ eta_i
+            gravity_i = se3.adjoint_inverse(g_i) @ self.g
+            F_i = M @ etad_i + se3.coadjoint(eta_i) @ M_eta - M @ gravity_i
+            N = se3.coadjoint(eta_i) @ M + se3.coadjoint_bar(M_eta)
+
+            F_res_tip = F_res_child + F_i
+            dF_res_dq_tip = (
+                dF_res_dq_child
+                + M @ A_i
+                + N @ R_i
+                - M @ se3.small_adjoint(gravity_i) @ J_i
+            )
+            dF_res_dqd_tip = dF_res_dqd_child + M @ Y_i + N @ J_i
+            dF_res_dqdd_tip = dF_res_dqdd_child + M @ J_i
+
+            coAdg = Adginv_i.T
+            F_res = coAdg @ F_res_tip
+            dF_res_dq = coAdg @ dF_res_dq_tip
+            dF_res_dqd = coAdg @ dF_res_dqd_tip
+            dF_res_dqdd = coAdg @ dF_res_dqdd_tip
+
+            dF_res_dq = dF_res_dq + se3.coadjoint_bar(F_res) @ S_i
+
+            B_xi_i = B_xi_segments[segment_idx]
+            xi_ref_i = xi_ref_segments[segment_idx]
+            H_i = H_steps[step_idx]
+
+            def projected_wrench_row(q_unit: Array) -> Array:
+                dS_dq_direction = joint_dSdq_qd(
+                    H_i,
+                    B_xi_i,
+                    xi_ref_i,
+                    q,
+                    q_unit,
+                    self.global_eps,
+                )
+                return F_res @ dS_dq_direction
+
+            dSTF_res_dq = vmap(projected_wrench_row)(q_basis)
+
+            dID_dq = dID_dq + S_i.T @ dF_res_dq + dSTF_res_dq
+            dID_dqd = dID_dqd + S_i.T @ dF_res_dqd
+            dID_dqdd = dID_dqdd + S_i.T @ dF_res_dqdd
+
+            carry_next = (
+                F_res,
+                dF_res_dq,
+                dF_res_dqd,
+                dF_res_dqdd,
+                dID_dq,
+                dID_dqd,
+                dID_dqdd,
+            )
+            output = (
+                F_res,
+                dF_res_dq,
+                dF_res_dqd,
+                dF_res_dqdd,
+            )
+            return carry_next, output
+
+        num_intervals = segment_indices.shape[0]
+        reverse_indices = jnp.arange(
+            num_intervals - 1,
+            -1,
+            -1,
+            dtype=jnp.int32,
+        )
+        (
+            (
+                _,
+                _,
+                _,
+                _,
+                dID_dq,
+                dID_dqd,
+                dID_dqdd,
+            ),
+            reverse_outputs,
+        ) = lax.scan(
+            propagate_interval_backward,
+            carry_init,
+            reverse_indices,
+        )
+
+        (
+            F_res,
+            dF_res_dq,
+            dF_res_dqd,
+            dF_res_dqdd,
+        ) = (jnp.flip(value, axis=0) for value in reverse_outputs)
+        step_shape = (self.num_segments, self.num_integration_points - 1)
+        F_res = F_res.reshape(*step_shape, 6)
+        dF_res_dq = dF_res_dq.reshape(*step_shape, 6, self.num_dofs)
+        dF_res_dqd = dF_res_dqd.reshape(*step_shape, 6, self.num_dofs)
+        dF_res_dqdd = dF_res_dqdd.reshape(*step_shape, 6, self.num_dofs)
+
+        return (
+            dID_dq,
+            dID_dqd,
+            dID_dqdd,
+            F_res,
+            dF_res_dq,
+            dF_res_dqd,
+            dF_res_dqdd,
+        )
+
+    @eqx.filter_jit
+    def inverse_dynamics_derivatives(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[Array, Array]:
+        """
+        Return inverse-dynamics derivatives from the analytical PCS passes.
+
+        Args:
+            q (Array): Active generalized coordinates. Shape is
+                ``(self.num_dofs,)``.
+            qd (Array): Active generalized velocities. Shape is
+                ``(self.num_dofs,)``.
+            qdd (Array): Active generalized accelerations. Shape is
+                ``(self.num_dofs,)``.
+
+        Returns:
+            tuple[Array, Array]: The derivatives ``(dID_dq, dID_dqd)``. Both
+            arrays have shape ``(self.num_dofs, self.num_dofs)``.
+        """
+        dID_dq, dID_dqd, _, _, _, _, _ = self.inverse_dynamics_backward_pass(
+            q,
+            qd,
+            qdd,
+        )
+        return dID_dq, dID_dqd
+
+    @eqx.filter_jit
+    def elastic_force_derivative_q(self, q: Array) -> Array:
+        """
+        Return the analytical configuration derivative of the elastic force.
+
+        Args:
+            q (Array): Active generalized coordinates. Shape is
+                ``(self.num_dofs,)``.
+
+        Returns:
+            Array: Derivative ``d(tau_el) / d(q)`` with shape
+            ``(self.num_dofs, self.num_dofs)``.
+        """
+        del q
+        return self.stiffness_matrix()
+
+    @eqx.filter_jit
+    def damping_force_derivatives(
+        self,
+        q: Array,
+        qd: Array,
+    ) -> tuple[Array, Array]:
+        """
+        Return analytical derivatives of the generalized damping force.
+
+        Args:
+            q (Array): Active generalized coordinates. Shape is
+                ``(self.num_dofs,)``.
+            qd (Array): Active generalized velocities. Shape is
+                ``(self.num_dofs,)``.
+
+        Returns:
+            tuple[Array, Array]: Derivatives of ``damping_matrix(q) @ qd``
+            with respect to ``q`` and ``qd``, respectively. Both arrays have
+            shape ``(self.num_dofs, self.num_dofs)``.
+        """
+        del qd
+        return (
+            jnp.zeros((q.shape[0], q.shape[0]), dtype=q.dtype),
+            self.damping_matrix(q),
+        )
+
+    @eqx.filter_jit
+    def actuation_force_derivative_q(
+        self,
+        q: Array,
+        u: Array,
+    ) -> Array:
+        """
+        Return the analytical configuration derivative of the actuation force.
+
+        Args:
+            q (Array): Active generalized coordinates. Shape is
+                ``(self.num_dofs,)``.
+            u (Array): Actuation inputs. Shape is ``(self.num_actuators,)``.
+
+        Returns:
+            Array: Derivative ``d(tau_u) / d(q)`` with shape
+            ``(self.num_dofs, self.num_dofs)``.
+        """
+        del u
+        return jnp.zeros((q.shape[0], q.shape[0]), dtype=q.dtype)
+
+    @eqx.filter_jit
+    def actuation_force_derivative_u(
+        self,
+        q: Array,
+    ) -> Array:
+        """
+        Return the analytical input derivative of the actuation force.
+
+        Args:
+            q (Array): Active generalized coordinates. Shape is
+                ``(self.num_dofs,)``.
+
+        Returns:
+            Array: Derivative ``d(tau_u) / d(u)`` with shape
+            ``(self.num_dofs, self.num_actuators)``.
+        """
+        return self.actuation_matrix(q)
+
+    @eqx.filter_jit
+    def forward_dynamics_derivatives(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+        u: Array | None = None,
+    ) -> tuple[Array, Array]:
+        """
+        Return analytical ``dqdd/dq`` and ``dqdd/dqd``.
+
+        The derivatives follow from the unconstrained PCS dynamics solve:
+
+        ``dqdd_dq = M \\ (dtau_dq - dID_dq)``
+        ``dqdd_dqd = M \\ (dtau_dqd - dID_dqd)``
+
+        For base PCS, ``dtau_dq = -K`` and ``dtau_dqd = -D`` because the
+        actuation matrix, stiffness, and damping are configuration independent.
+
+        Args:
+            q (Array): Active generalized coordinates. Shape is
+                ``(self.num_dofs,)``.
+            qd (Array): Active generalized velocities. Shape is
+                ``(self.num_dofs,)``.
+            qdd (Array): Active generalized accelerations. Shape is
+                ``(self.num_dofs,)``.
+            u (Array, optional): Actuation inputs. Shape is
+                ``(self.num_actuators,)``. Defaults to a zero input.
+
+        Returns:
+            tuple[Array, Array]: Derivatives ``(dqdd_dq, dqdd_dqd)``. Both
+            arrays have shape ``(self.num_dofs, self.num_dofs)``.
+        """
+        if u is None:
+            u = jnp.zeros((self.num_actuators,), dtype=q.dtype)
+
+        (
+            dID_dq,
+            dID_dqd,
+            mass_matrix,
+            _,
+            _,
+            _,
+            _,
+        ) = self.inverse_dynamics_backward_pass(q, qd, qdd)
+
+        d_elastic_dq = self.elastic_force_derivative_q(q)
+        d_damping_dq, d_damping_dqd = self.damping_force_derivatives(q, qd)
+        d_actuation_dq = self.actuation_force_derivative_q(q, u)
+
+        dtau_dq = d_actuation_dq - d_elastic_dq - d_damping_dq
+        dtau_dqd = -d_damping_dqd
+
+        dqdd_dq = self._solve_inertia(mass_matrix, dtau_dq - dID_dq)
+        dqdd_dqd = self._solve_inertia(mass_matrix, dtau_dqd - dID_dqd)
+
+        return dqdd_dq, dqdd_dqd
+
+    @eqx.filter_jit
+    def forward_dynamics_input_derivatives(
+        self,
+        q: Array,
+    ) -> tuple[Array, Array]:
+        """
+        Return analytical ``dqdd/du`` and ``dqdd/dtau_ext``.
+
+        ``tau_ext`` is the direct generalized-force input used by
+        ``forward_dynamics``. Its derivative is therefore ``M(q)^{-1}``.
+
+        Args:
+            q (Array): Active generalized coordinates. Shape is
+                ``(self.num_dofs,)``.
+
+        Returns:
+            tuple[Array, Array]: Derivatives ``(dqdd_du, dqdd_dtau_ext)``.
+            Their shapes are ``(self.num_dofs, self.num_actuators)`` and
+            ``(self.num_dofs, self.num_dofs)``, respectively.
+        """
+        mass_matrix = self.inertia_matrix(q)
+        dqdd_du = self._solve_inertia(
+            mass_matrix,
+            self.actuation_force_derivative_u(q),
+        )
+        dqdd_dtau_ext = self._solve_inertia(
+            mass_matrix,
+            jnp.eye(q.shape[0], dtype=q.dtype),
+        )
+
+        return dqdd_du, dqdd_dtau_ext
+
+    @eqx.filter_jit
+    def forward_dynamics_state_jacobian(
+        self,
+        t: Array,
+        y: Array,
+        actuation_args: tuple | None = None,
+    ) -> Array:
+        """
+        Return the analytical state Jacobian ``d([qd, qdd]) / d([q, qd])``.
+
+        The returned blocks follow the unconstrained PCS state ordering.
+
+        Args:
+            t (Array): Current time. Shape is ``()``.
+            y (Array): State ``[q, qd]``. Shape is
+                ``(2 * self.num_dofs,)``.
+            actuation_args (tuple, optional): Tuple containing ``u`` with
+                shape ``(self.num_actuators,)`` and optionally ``tau_ext``
+                with shape ``(self.num_dofs,)``. Defaults to zero inputs.
+
+        Returns:
+            Array: State Jacobian ``d([qd, qdd]) / d([q, qd])`` with shape
+            ``(2 * self.num_dofs, 2 * self.num_dofs)``.
+        """
+        q, qd = jnp.split(y, 2)
+
+        if actuation_args is None:
+            u, tau_ext = None, None
+        elif len(actuation_args) == 1:
+            u = actuation_args[0]
+            tau_ext = None
+        elif len(actuation_args) == 2:
+            u, tau_ext = actuation_args
+        else:
+            raise ValueError("actuation_args must be a tuple of length 1 or 2.")
+
+        if u is None:
+            u = jnp.zeros((self.num_actuators,), dtype=q.dtype)
+        if tau_ext is None:
+            tau_ext = jnp.zeros((q.shape[0],), dtype=q.dtype)
+
+        yd = self.forward_dynamics(t, y, (u, tau_ext))
+        _, qdd = jnp.split(yd, 2)
+        dqdd_dq, dqdd_dqd = self.forward_dynamics_derivatives(q, qd, qdd, u)
+
+        eye = jnp.eye(q.shape[0], dtype=q.dtype)
+        zeros = jnp.zeros_like(eye)
+        return jnp.block([[zeros, eye], [dqdd_dq, dqdd_dqd]])
+
+    @eqx.filter_jit
+    def forward_dynamics_jacobians(
+        self,
+        t: Array,
+        y: Array,
+        actuation_args: tuple | None = None,
+    ) -> tuple[Array, Array, Array]:
+        """
+        Return state, actuation-input, and external-force Jacobians.
+
+        The returned tuple is ``(dyd_dy, dyd_du, dyd_dtau_ext)`` where
+        ``yd = forward_dynamics(t, y, actuation_args)``.
+
+        Args:
+            t (Array): Current time. Shape is ``()``.
+            y (Array): State ``[q, qd]``. Shape is
+                ``(2 * self.num_dofs,)``.
+            actuation_args (tuple, optional): Tuple containing ``u`` with
+                shape ``(self.num_actuators,)`` and optionally ``tau_ext``
+                with shape ``(self.num_dofs,)``. Defaults to zero inputs.
+
+        Returns:
+            tuple[Array, Array, Array]: State, actuation-input, and external
+            generalized-force Jacobians ``(dyd_dy, dyd_du, dyd_dtau_ext)``.
+            Their shapes are ``(2 * self.num_dofs, 2 * self.num_dofs)``,
+            ``(2 * self.num_dofs, self.num_actuators)``, and
+            ``(2 * self.num_dofs, self.num_dofs)``, respectively.
+        """
+        q, qd = jnp.split(y, 2)
+
+        if actuation_args is None:
+            u = None
+        elif len(actuation_args) == 1 or len(actuation_args) == 2:
+            u = actuation_args[0]
+        else:
+            raise ValueError("actuation_args must be a tuple of length 1 or 2.")
+
+        if u is None:
+            u = jnp.zeros((self.num_actuators,), dtype=q.dtype)
+
+        dyd_dy = self.forward_dynamics_state_jacobian(t, y, actuation_args)
+        dqdd_du, dqdd_dtau_ext = self.forward_dynamics_input_derivatives(q)
+
+        zeros_du = jnp.zeros((q.shape[0], u.shape[0]), dtype=q.dtype)
+        zeros_tau = jnp.zeros((q.shape[0], q.shape[0]), dtype=q.dtype)
+        dyd_du = jnp.concatenate([zeros_du, dqdd_du], axis=0)
+        dyd_dtau_ext = jnp.concatenate([zeros_tau, dqdd_dtau_ext], axis=0)
+
+        return dyd_dy, dyd_du, dyd_dtau_ext

--- a/src/soromox/utils/joint_motion_subspace.py
+++ b/src/soromox/utils/joint_motion_subspace.py
@@ -1,0 +1,467 @@
+__all__ = [
+    "joint_dSdq_qd",
+    "joint_motion_subspace_with_derivatives",
+]
+
+import jax.numpy as jnp
+from jax import Array, lax
+
+from soromox.utils.lie_algebra import se3
+from soromox.utils.numerics import safe_norm
+
+_THETA_SERIES_THRESHOLD = 1.0e-2
+
+
+def joint_motion_subspace_with_derivatives(
+    H, B_xi, xi_ref, q, qd, qdd, eps
+) -> tuple[Array, Array, Array, Array, Array, Array]:
+    """
+    Compute the joint transform, motion subspace, and derivatives.
+
+    This helper evaluates the constant-strain soft-joint motion subspace over
+    an interval of arclength "H". The strain field is assumed constant over
+    the interval and parameterized as "xi = B_xi @ q + xi_ref". The returned
+    matrices are expressed in the local body-frame convention used by the PCS
+    kinematic recursions.
+
+    Args:
+        H: Scalar interval length or local arclength over which the constant
+            strain is integrated.
+        B_xi: Strain basis matrix with shape "(6, num_dofs)".
+        xi_ref: Reference strain vector with shape "(6,)".
+        q: Generalized coordinates with shape "(num_dofs,)".
+        qd: Generalized velocities with shape "(num_dofs,)".
+        qdd: Generalized accelerations with shape "(num_dofs,)".
+        eps: Small positive tolerance used to avoid singular divisions. The
+            small-angle formulas switch branches at a fixed ``1e-2`` threshold.
+
+    Returns:
+        A tuple "(g, S, Sd, dSdq_qd, dSdq_qdd, dSddq_qd)".
+
+        - g: Transformation matrix over the interval, shape "(4, 4)".
+        - S: Joint motion subspace over the interval, shape "(6, num_dofs)".
+        - Sd: Time derivative of S induced by qd, shape "(6, num_dofs)".
+        - dSdq_qd: Directional derivative dS/dq contracted with qd, shape "(6, num_dofs)".
+        - dSdq_qdd: Directional derivative dS/dq contracted with qdd, shape "(6, num_dofs)".
+        - dSddq_qd: Directional derivative dSd/dq contracted with qd, shape "(6, num_dofs)".
+    """
+
+    I_theta = jnp.diag(jnp.array([1, 1, 1, 0, 0, 0]))
+    xi = B_xi @ q + xi_ref
+    Omega = H * xi
+    Z = H * B_xi
+    Omegad = Z @ qd
+
+    k = Omega[:3]
+    kd = Omegad[:3]
+    theta = jnp.maximum(safe_norm(Omega[:3]), eps)
+    thetad = (kd @ k) / theta
+
+    Omegahat = se3.hat(Omega)
+    Omegahatp2 = Omegahat @ Omegahat
+    Omegahatp3 = Omegahatp2 @ Omegahat
+
+    adjOmega = se3.small_adjoint(Omega)
+    adjOmegap2 = adjOmega @ adjOmega
+    adjOmegap3 = adjOmegap2 @ adjOmega
+    adjOmegap4 = adjOmegap3 @ adjOmega
+    adjOmegap = jnp.stack((adjOmega, adjOmegap2, adjOmegap3, adjOmegap4))
+
+    adjOmegad = se3.small_adjoint(Omegad)
+    adjOmegap2d = adjOmegad @ adjOmega + adjOmega @ adjOmegad
+    adjOmegap3d = adjOmegap2d @ adjOmega + adjOmegap2 @ adjOmegad
+    adjOmegap4d = adjOmegap3d @ adjOmega + adjOmegap3 @ adjOmegad
+    adjOmegapd = jnp.stack((adjOmegad, adjOmegap2d, adjOmegap3d, adjOmegap4d))
+
+    def _g_series_branch() -> tuple[Array, Array, Array, Array, Array, Array]:
+        # Keep the transform identical to the stable implementation used by
+        # the main PCS kinematics while using the small-angle derivative
+        # coefficients below.
+        g = se3.exp(Omega, eps=eps)
+        f = jnp.array([1 / 2, 1 / 6, 1 / 24, 1 / 120])
+        fd = jnp.zeros((4,))
+        fdd = jnp.zeros((4,))
+
+        T = (
+            jnp.eye(6)
+            + f[0] * adjOmegap[0]
+            + f[1] * adjOmegap[1]
+            + f[2] * adjOmegap[2]
+            + f[3] * adjOmegap[3]
+        )
+
+        Td = (
+            f[0] * adjOmegapd[0]
+            + f[1] * adjOmegapd[1]
+            + f[2] * adjOmegapd[2]
+            + f[3] * adjOmegapd[3]
+        )
+
+        return (f, fd, fdd, g, T, Td)
+
+    def _g_general_branch(
+        theta: Array,
+    ) -> tuple[Array, Array, Array, Array, Array, Array]:
+        tp2 = theta * theta
+        tp3 = tp2 * theta
+        tp4 = tp3 * theta
+        tp5 = tp4 * theta
+        tp6 = tp5 * theta
+        tp7 = tp6 * theta
+        costheta = jnp.cos(theta)
+        sintheta = jnp.sin(theta)
+
+        t1 = theta * sintheta
+        t2 = theta * costheta
+        t3 = -8 + (8 - tp2) * costheta + 5 * t1
+        t4 = -8 * theta + (15 - tp2) * sintheta - 7 * t2
+        t3d = 5 * sintheta + sintheta * (tp2 - 8) + 3 * theta * costheta
+        t4d = -8 + 5 * theta * sintheta + (15 - tp2) * costheta - 7 * costheta
+
+        f = jnp.stack(
+            (
+                (4 - 4 * costheta - t1) / (2 * tp2),
+                (4 * theta - 5 * sintheta + t2) / (2 * tp3),
+                (2 - 2 * costheta - t1) / (2 * tp4),
+                (2 * theta - 3 * sintheta + t2) / (2 * tp5),
+            )
+        )
+
+        fd = jnp.stack(
+            (
+                t3 / (2 * tp3),
+                t4 / (2 * tp4),
+                t3 / (2 * tp5),
+                t4 / (2 * tp6),
+            )
+        )
+
+        fdd = jnp.stack(
+            (
+                (theta * t3d - 3 * t3) / (2 * tp4),
+                (theta * t4d - 4 * t4) / (2 * tp5),
+                (theta * t3d - 5 * t3) / (2 * tp6),
+                (theta * t4d - 6 * t4) / (2 * tp7),
+            )
+        )
+
+        g = (
+            jnp.eye(4)
+            + Omegahat
+            + ((1 - costheta) / tp2) * Omegahatp2
+            + ((theta - sintheta) / tp3) * Omegahatp3
+        )
+
+        T = (
+            jnp.eye(6)
+            + f[0] * adjOmegap[0]
+            + f[1] * adjOmegap[1]
+            + f[2] * adjOmegap[2]
+            + f[3] * adjOmegap[3]
+        )
+
+        Td = (
+            fd[0] * thetad * adjOmegap[0]
+            + f[0] * adjOmegapd[0]
+            + fd[1] * thetad * adjOmegap[1]
+            + f[1] * adjOmegapd[1]
+            + fd[2] * thetad * adjOmegap[2]
+            + f[2] * adjOmegapd[2]
+            + fd[3] * thetad * adjOmegap[3]
+            + f[3] * adjOmegapd[3]
+        )
+
+        return (f, fd, fdd, g, T, Td)
+
+    f, fd, fdd, g, T, Td = lax.cond(
+        theta <= _THETA_SERIES_THRESHOLD,
+        lambda _: _g_series_branch(),
+        lambda _: _g_general_branch(theta),
+        operand=None,
+    )
+
+    S = T @ Z
+    Sd = Td @ Z
+    Zqdd = Z @ qdd
+
+    def _adjoint_power_or_eye(k: int) -> Array:
+        return jnp.eye(6) if k < 0 else adjOmegap[k]
+
+    def _sum_terms(terms) -> Array:
+        return jnp.sum(jnp.stack(terms), axis=0)
+
+    def _S_series_branch() -> tuple[Array, Array, Array]:
+        dSdq_qd_terms = []
+        dSdq_qdd_terms = []
+        dSddq_qd_terms = []
+        for r in range(4):
+            for u in range(1, r + 2):
+                adjOmegap1 = _adjoint_power_or_eye(u - 2)
+                adjOmegap2 = _adjoint_power_or_eye(r - u)
+
+                dSdq_qd_terms.append(
+                    -f[r] * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Omegad) @ Z)
+                )
+                dSdq_qdd_terms.append(
+                    -f[r] * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Zqdd) @ Z)
+                )
+
+                for p in range(1, u):
+                    adjOmegap3 = _adjoint_power_or_eye(p - 2)
+                    adjOmegap4 = _adjoint_power_or_eye(u - p - 2)
+
+                    dSddq_qd_terms.append(
+                        -f[r]
+                        * (
+                            adjOmegap3
+                            @ se3.small_adjoint(
+                                adjOmegap4 @ adjOmegapd[0] @ adjOmegap2 @ Omegad
+                            )
+                            @ Z
+                        )
+                    )
+
+                for p in range(1, r - u + 2):
+                    adjOmegap3 = _adjoint_power_or_eye(p - 2)
+                    adjOmegap4 = _adjoint_power_or_eye(r - u - p)
+
+                    dSddq_qd_terms.append(
+                        -f[r]
+                        * (
+                            adjOmegap1
+                            @ adjOmegapd[0]
+                            @ adjOmegap3
+                            @ se3.small_adjoint(adjOmegap4 @ Omegad)
+                            @ Z
+                        )
+                    )
+        return (
+            _sum_terms(dSdq_qd_terms),
+            _sum_terms(dSdq_qdd_terms),
+            _sum_terms(dSddq_qd_terms),
+        )
+
+    def _S_general_branch(theta: Array) -> tuple[Array, Array, Array]:
+        dSdq_qd_terms = []
+        dSdq_qdd_terms = []
+        dSddq_qd_terms = []
+        for r in range(4):
+            adjr = adjOmegap[r]
+            adjrd = adjOmegapd[r]
+
+            dSdq_qd_terms.append(
+                (1 / theta)
+                * fd[r]
+                * jnp.outer(
+                    adjr @ Omegad,
+                    Omega @ (I_theta @ Z),
+                )
+            )
+
+            dSdq_qdd_terms.append(
+                (1 / theta)
+                * fd[r]
+                * jnp.outer(
+                    adjr @ Zqdd,
+                    Omega @ (I_theta @ Z),
+                )
+            )
+
+            term1 = (1 / theta) * jnp.outer(
+                ((fdd[r] * thetad) * adjr + fd[r] * adjrd) @ Omegad,
+                Omega @ (I_theta @ Z),
+            )
+
+            term2 = (
+                (1 / theta)
+                * fd[r]
+                * jnp.outer(
+                    adjr @ Omegad, (Omegad - (thetad / theta) * Omega) @ (I_theta @ Z)
+                )
+            )
+
+            dSddq_qd_terms.extend([term1, term2])
+            for u in range(1, r + 2):
+                adjOmegap1 = _adjoint_power_or_eye(u - 2)
+                adjOmegap2 = _adjoint_power_or_eye(r - u)
+
+                dSdq_qd_terms.append(
+                    -f[r] * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Omegad) @ Z)
+                )
+                dSdq_qdd_terms.append(
+                    -f[r] * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Zqdd) @ Z)
+                )
+                dSddq_qd_terms.append(
+                    -fd[r]
+                    * thetad
+                    * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Omegad) @ Z)
+                )
+
+                for p in range(1, u):
+                    adjOmegap3 = _adjoint_power_or_eye(p - 2)
+                    adjOmegap4 = _adjoint_power_or_eye(u - p - 2)
+
+                    dSddq_qd_terms.append(
+                        -f[r]
+                        * (
+                            adjOmegap3
+                            @ se3.small_adjoint(
+                                adjOmegap4 @ adjOmegapd[0] @ adjOmegap2 @ Omegad
+                            )
+                            @ Z
+                        )
+                    )
+
+                for p in range(1, r - u + 2):
+                    adjOmegap3 = _adjoint_power_or_eye(p - 2)
+                    adjOmegap4 = _adjoint_power_or_eye(r - u - p)
+
+                    dSddq_qd_terms.append(
+                        -f[r]
+                        * (
+                            adjOmegap1
+                            @ adjOmegapd[0]
+                            @ adjOmegap3
+                            @ se3.small_adjoint(adjOmegap4 @ Omegad)
+                            @ Z
+                        )
+                    )
+
+        return (
+            _sum_terms(dSdq_qd_terms),
+            _sum_terms(dSdq_qdd_terms),
+            _sum_terms(dSddq_qd_terms),
+        )
+
+    dSdq_qd, dSdq_qdd, dSddq_qd = lax.cond(
+        theta <= _THETA_SERIES_THRESHOLD,
+        lambda _: _S_series_branch(),
+        lambda _: _S_general_branch(theta),
+        operand=None,
+    )
+
+    return (g, S, Sd, dSdq_qd, dSdq_qdd, dSddq_qd)
+
+
+def joint_dSdq_qd(H, B_xi, xi_ref, q, qd, eps) -> Array:
+    """
+    Compute only dS/dq contracted with qd.
+
+    Args:
+        H: Scalar interval length.
+        B_xi: Strain basis matrix, shape (6, num_dofs).
+        xi_ref: Reference strain vector, shape (6,).
+        q: Generalized coordinates, shape (num_dofs,).
+        qd: Generalized velocities, shape (num_dofs,).
+        eps: Small positive tolerance for the small-angle branch.
+
+    Returns:
+        dSdq_qd: Directional derivative dS/dq contracted with qd,
+            shape (6, num_dofs).
+    """
+
+    # Quantities required by both branches
+    xi = B_xi @ q + xi_ref
+    Omega = H * xi
+    Z = H * B_xi
+    Omegad = Z @ qd
+
+    theta = jnp.maximum(safe_norm(Omega[:3]), eps)
+
+    # Powers of ad_Omega
+    adjOmega = se3.small_adjoint(Omega)
+    adjOmegap2 = adjOmega @ adjOmega
+    adjOmegap3 = adjOmegap2 @ adjOmega
+    adjOmegap4 = adjOmegap3 @ adjOmega
+
+    adjOmegap = jnp.stack(
+        (
+            adjOmega,
+            adjOmegap2,
+            adjOmegap3,
+            adjOmegap4,
+        )
+    )
+
+    I6 = jnp.eye(6, dtype=Omega.dtype)
+
+    def _adjoint_power_or_eye(k: int) -> Array:
+        return I6 if k < 0 else adjOmegap[k]
+
+    def _series_branch(_: Array) -> Array:
+        f = jnp.array(
+            [1 / 2, 1 / 6, 1 / 24, 1 / 120],
+            dtype=Omega.dtype,
+        )
+
+        result = jnp.zeros_like(Z)
+
+        for r in range(4):
+            for u in range(1, r + 2):
+                adj1 = _adjoint_power_or_eye(u - 2)
+                adj2 = _adjoint_power_or_eye(r - u)
+
+                result = result - f[r] * (adj1 @ se3.small_adjoint(adj2 @ Omegad) @ Z)
+
+        return result
+
+    def _general_branch(theta: Array) -> Array:
+        tp2 = theta * theta
+        tp3 = tp2 * theta
+        tp4 = tp3 * theta
+        tp5 = tp4 * theta
+        tp6 = tp5 * theta
+
+        costheta = jnp.cos(theta)
+        sintheta = jnp.sin(theta)
+
+        t1 = theta * sintheta
+        t2 = theta * costheta
+
+        t3 = -8 + (8 - tp2) * costheta + 5 * t1
+        t4 = -8 * theta + (15 - tp2) * sintheta - 7 * t2
+
+        f = jnp.stack(
+            (
+                (4 - 4 * costheta - t1) / (2 * tp2),
+                (4 * theta - 5 * sintheta + t2) / (2 * tp3),
+                (2 - 2 * costheta - t1) / (2 * tp4),
+                (2 * theta - 3 * sintheta + t2) / (2 * tp5),
+            )
+        )
+
+        fd = jnp.stack(
+            (
+                t3 / (2 * tp3),
+                t4 / (2 * tp4),
+                t3 / (2 * tp5),
+                t4 / (2 * tp6),
+            )
+        )
+
+        rotational_projection = Omega[:3] @ Z[:3, :]
+
+        result = jnp.zeros_like(Z)
+
+        for r in range(4):
+            adjr = adjOmegap[r]
+
+            result = result + (fd[r] / theta) * jnp.outer(
+                adjr @ Omegad,
+                rotational_projection,
+            )
+
+            for u in range(1, r + 2):
+                adj1 = _adjoint_power_or_eye(u - 2)
+                adj2 = _adjoint_power_or_eye(r - u)
+
+                result = result - f[r] * (adj1 @ se3.small_adjoint(adj2 @ Omegad) @ Z)
+
+        return result
+
+    return lax.cond(
+        theta <= eps,
+        _series_branch,
+        _general_branch,
+        operand=theta,
+    )

--- a/src/soromox/utils/lie_algebra/se3.py
+++ b/src/soromox/utils/lie_algebra/se3.py
@@ -5,6 +5,7 @@ __all__ = [
     "small_adjoint",
     "small_adjoint_action",
     "coadjoint",
+    "coadjoint_bar",
     "adjoint",
     "adjoint_inverse",
     "left_jacobian",
@@ -715,6 +716,31 @@ def coadjoint(xi: Array) -> Array:
         angular-first dual vectors.
     """
     return -small_adjoint(xi).T
+
+
+def coadjoint_bar(dual: Array) -> Array:
+    r"""Return the twist Jacobian of the coadjoint action on ``dual``.
+
+    For a fixed spatial dual vector ``dual``, this matrix satisfies
+
+    .. math::
+
+        \operatorname{coadjoint}(\xi)\,dual
+        = \operatorname{coadjoint\_bar}(dual)\,\xi.
+
+    Args:
+        dual: Spatial dual vector with shape ``(6,)`` or ``(6, 1)`` in
+            ``[moment, force]`` order.
+
+    Returns:
+        Array with shape ``(6, 6)`` mapping an angular-first twist to the
+        corresponding coadjoint action on ``dual``.
+    """
+    dual = jnp.asarray(dual).reshape(-1)
+    moment_hat = so3.skew(dual[:3])
+    force_hat = so3.skew(dual[3:])
+    zero = jnp.zeros((3, 3), dtype=dual.dtype)
+    return -jnp.block([[moment_hat, force_hat], [force_hat, zero]])
 
 
 def coadjoint_action(xi: Array, dual: Array) -> Array:

--- a/tests/lie_algebra/test_se3.py
+++ b/tests/lie_algebra/test_se3.py
@@ -537,6 +537,17 @@ def test_coadjoint_action_se3_matches_matrix_product():
     assert_allclose(result, se3.coadjoint(xi) @ dual, rtol=RTOL, atol=ATOL)
 
 
+def test_coadjoint_bar_se3_matches_twist_jacobian():
+    xi = jnp.array([0.3, -0.5, 0.7, 1.1, -1.3, 1.7])
+    dual = jnp.array([-0.2, 0.4, -0.6, 0.8, -1.0, 1.2])
+
+    result = se3.coadjoint_bar(dual)
+    expected = jax.jacfwd(lambda xi_: se3.coadjoint_action(xi_, dual))(xi)
+
+    assert_allclose(result, expected, rtol=RTOL, atol=ATOL)
+    assert_allclose(result @ xi, se3.coadjoint_action(xi, dual), rtol=RTOL, atol=ATOL)
+
+
 def test_small_adjoint_action_se3_matches_matrix_product():
     xi = jnp.array([0.2, -0.4, 0.7, 1.1, -0.3, 0.5])
     eta = jnp.array([-0.6, 0.8, 0.1, -0.2, 0.9, 0.4])

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -895,8 +895,10 @@ def test_jacobian_and_time_derivative_bodyframe_abscissa_batched_matches_pointwi
     s_points = jnp.asarray(sample_arc_lengths(model), dtype=jnp.float64)
 
     for q, qd in ((zero_cfg, zero_vel), (q_random, qd_random)):
-        J_batch, Jd_batch = model.jacobian_and_time_derivative_bodyframe_abscissa_batched(
-            q, qd, s_points
+        J_batch, Jd_batch = (
+            model.jacobian_and_time_derivative_bodyframe_abscissa_batched(
+                q, qd, s_points
+            )
         )
 
         for idx, s_val in enumerate(s_points):
@@ -949,8 +951,10 @@ def test_jacobian_and_time_derivative_inertialframe_abscissa_batched_matches_poi
     s_points = jnp.asarray(sample_arc_lengths(model), dtype=jnp.float64)
 
     for q, qd in ((zero_cfg, zero_vel), (q_random, qd_random)):
-        J_batch, Jd_batch = model.jacobian_and_time_derivative_inertialframe_abscissa_batched(
-            q, qd, s_points
+        J_batch, Jd_batch = (
+            model.jacobian_and_time_derivative_inertialframe_abscissa_batched(
+                q, qd, s_points
+            )
         )
 
         for idx, s_val in enumerate(s_points):
@@ -1346,6 +1350,70 @@ def test_forward_dynamics_matches_manual_computation(num_segments: int):
         yd_expected = jnp.concatenate([qd, qdd_expected])
 
         assert_allclose(yd, yd_expected, rtol=RTOL, atol=ATOL)
+
+
+def test_inverse_dynamics_jacobian_passes_match_autodiff() -> None:
+    selector_per_segment = jnp.array(
+        [False, False, True, True, False, False],
+        dtype=bool,
+    )
+    model, _ = make_pcs(
+        num_segments=2,
+        num_gauss_points=2,
+        strain_selector=jnp.tile(selector_per_segment, 2),
+    )
+
+    key_q, key_qd, key_qdd, key_tau = jax.random.split(
+        jax.random.PRNGKey(7134),
+        4,
+    )
+    q = random_q(model, key_q, scale=0.08)
+    qd = random_q(model, key_qd, scale=0.06)
+    qdd = random_q(model, key_qdd, scale=0.1)
+    tau_ext = random_q(model, key_tau, scale=0.01)
+
+    def inverse_dynamics_force(q_: Array, qd_: Array, qdd_: Array) -> Array:
+        inertia, coriolis_qd, gravity = model.dynamics_terms(q_, qd_)
+        return inertia @ qdd_ + coriolis_qd + gravity
+
+    dID_dq, dID_dqd, dID_dqdd, _, _, _, _ = model.inverse_dynamics_backward_pass(
+        q, qd, qdd
+    )
+    expected_dID_dq = jacfwd(lambda q_: inverse_dynamics_force(q_, qd, qdd))(q)
+    expected_dID_dqd = jacfwd(lambda qd_: inverse_dynamics_force(q, qd_, qdd))(qd)
+    expected_dID_dqdd = jacfwd(lambda qdd_: inverse_dynamics_force(q, qd, qdd_))(qdd)
+
+    assert_allclose(dID_dq, expected_dID_dq, rtol=RTOL, atol=ATOL)
+    assert_allclose(dID_dqd, expected_dID_dqd, rtol=RTOL, atol=ATOL)
+    assert_allclose(dID_dqdd, expected_dID_dqdd, rtol=RTOL, atol=ATOL)
+
+    zero_q = jnp.zeros_like(q)
+    zero_results = model.inverse_dynamics_backward_pass(zero_q, qd, qdd)
+    zero_expected_dID_dq = jacfwd(lambda q_: inverse_dynamics_force(q_, qd, qdd))(
+        zero_q
+    )
+    zero_expected_dID_dqd = jacfwd(
+        lambda qd_: inverse_dynamics_force(zero_q, qd_, qdd)
+    )(qd)
+    assert_allclose(zero_results[0], zero_expected_dID_dq, rtol=RTOL, atol=ATOL)
+    assert_allclose(zero_results[1], zero_expected_dID_dqd, rtol=RTOL, atol=ATOL)
+
+    u = jnp.zeros((model.num_actuators,), dtype=q.dtype)
+    y = jnp.concatenate([q, qd])
+    state_jacobian = model.forward_dynamics_state_jacobian(
+        jnp.array(0.0),
+        y,
+        (u, tau_ext),
+    )
+    expected_state_jacobian = jacfwd(
+        lambda y_: model._forward_dynamics(0.0, y_, (u, tau_ext))
+    )(y)
+    assert_allclose(
+        state_jacobian,
+        expected_state_jacobian,
+        rtol=RTOL,
+        atol=ATOL,
+    )
 
 
 @pytest.mark.parametrize("num_segments", [1, 3])
@@ -1871,7 +1939,9 @@ def test_strain_basis_consistency_jacobians_and_time_derivatives(num_segments: i
     Jb_batch_small, Jbd_batch_small = reduced._J_Jd_local_abscissa_batched(
         q_small, qd_small, s_points
     )
-    Jb_batch_full, Jbd_batch_full = full._J_Jd_local_abscissa_batched(q_full, qd_full, s_points)
+    Jb_batch_full, Jbd_batch_full = full._J_Jd_local_abscissa_batched(
+        q_full, qd_full, s_points
+    )
     assert Jb_batch_small.shape == (s_points.shape[0], 6, n_full_strains)
     assert Jbd_batch_small.shape == (s_points.shape[0], 6, n_full_strains)
     assert Jb_batch_full.shape == (s_points.shape[0], 6, n_full_strains)

--- a/tools/benchmarks/pcs_custom_jvp_speed_test.py
+++ b/tools/benchmarks/pcs_custom_jvp_speed_test.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Compare PCS forward-dynamics derivatives with custom JVPs on and off.
+
+The benchmark separates the first-call compilation cost from steady-state
+execution time. Every timed call is synchronized with the active JAX device.
+Custom-JVP and pure-autodiff outputs are also compared for correctness.
+
+Example:
+    python tools/benchmarks/pcs_custom_jvp_speed_test.py \
+        --segment-counts 1 2 4 \
+        --setups full bending_extension axial threadlike \
+        --workloads state_jvp state_jacobian \
+        --repeats 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import statistics
+import time
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+from soromox.actuation import ThreadlikeActuator, ThreadlikeRouting  # noqa: E402
+from soromox.autodiff import set_custom_jvp_enabled  # noqa: E402
+from soromox.systems import PCS, LinkSpec, PCSStructure  # noqa: E402
+
+Array = jax.Array
+Tree = Any
+Workload = Callable[[Array, Array, Array], Tree]
+
+SETUPS = ("full", "bending_extension", "axial", "threadlike")
+WORKLOADS = ("primal", "state_jvp", "state_jacobian", "all_jacobians")
+
+
+def _strain_selector(setup: str, num_segments: int) -> Array | None:
+    if setup == "full":
+        return None
+    if setup in {"bending_extension", "threadlike"}:
+        per_segment = jnp.array([False, False, True, True, False, False])
+    elif setup == "axial":
+        per_segment = jnp.array([False, False, False, True, False, False])
+    else:
+        raise ValueError(f"Unknown setup: {setup}")
+    return jnp.tile(per_segment, num_segments)
+
+
+def _threadlike_actuator(num_segments: int) -> ThreadlikeActuator:
+    offsets = jnp.array([-0.01, 0.01])
+    routing = ThreadlikeRouting.linear(
+        intercept=jnp.stack(
+            [jnp.zeros_like(offsets), offsets, jnp.zeros_like(offsets)], axis=1
+        ),
+        slope=jnp.zeros((2, 3)),
+        start_segment_index=(0, 0),
+        end_segment_index=(num_segments - 1, num_segments - 1),
+    )
+    return ThreadlikeActuator.tendons(routing)
+
+
+def build_model(setup: str, num_segments: int, gauss_points: int) -> PCS:
+    """Build one benchmark PCS configuration."""
+    actuators = _threadlike_actuator(num_segments) if setup == "threadlike" else None
+    return PCS.from_links(
+        [
+            LinkSpec.circular(
+                length=0.1,
+                radius=0.02,
+                density=1070.0,
+                young_modulus=2.0e3,
+                shear_modulus=1.0e3,
+                material_damping_coefficient=1.0e-3,
+                reference_strain=[0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            )
+            for _ in range(num_segments)
+        ],
+        gravity=jnp.array([0.0, 0.0, -9.81]),
+        structure=PCSStructure(
+            num_gauss_points=gauss_points,
+            strain_selector=_strain_selector(setup, num_segments),
+        ),
+        actuators=actuators,
+    )
+
+
+def build_inputs(model: PCS) -> tuple[Array, Array, Array, Array]:
+    """Return state, state direction, actuator input, and external force."""
+    q = jnp.linspace(-0.025, 0.035, model.num_dofs)
+    qd = jnp.linspace(0.04, -0.03, model.num_dofs)
+    y = jnp.concatenate([q, qd])
+    y_direction = jnp.linspace(-0.2, 0.25, 2 * model.num_dofs)
+    u = jnp.linspace(0.05, 0.1, model.num_actuators)
+    tau_ext = jnp.linspace(-0.01, 0.015, model.num_dofs)
+    return y, y_direction, u, tau_ext
+
+
+def build_workload(model: PCS, workload: str, y_direction: Array) -> Workload:
+    """Create one public forward-dynamics derivative workload."""
+    t = jnp.array(0.0)
+
+    def dynamics(y: Array, u: Array, tau_ext: Array) -> Array:
+        return model.forward_dynamics(t, y, (u, tau_ext))
+
+    if workload == "primal":
+        return dynamics
+    if workload == "state_jvp":
+        return lambda y, u, tau_ext: jax.jvp(
+            lambda y_value: dynamics(y_value, u, tau_ext),
+            (y,),
+            (y_direction,),
+        )
+    if workload == "state_jacobian":
+        return lambda y, u, tau_ext: jax.jacfwd(
+            lambda y_value: dynamics(y_value, u, tau_ext)
+        )(y)
+    if workload == "all_jacobians":
+        return lambda y, u, tau_ext: jax.jacfwd(
+            dynamics,
+            argnums=(0, 1, 2),
+        )(y, u, tau_ext)
+    raise ValueError(f"Unknown workload: {workload}")
+
+
+def block_until_ready(tree: Tree) -> None:
+    """Synchronize every array leaf in a result PyTree."""
+    for leaf in jax.tree_util.tree_leaves(tree):
+        if hasattr(leaf, "block_until_ready"):
+            leaf.block_until_ready()
+
+
+def measure(
+    fn: Workload,
+    args: tuple[Array, Array, Array],
+    warmup_runs: int,
+    repeats: int,
+) -> tuple[float, float, Tree]:
+    """Return estimated compilation seconds, median execution seconds, output."""
+    compiled = jax.jit(fn)
+    start = time.perf_counter()
+    output = compiled(*args)
+    block_until_ready(output)
+    first_call = time.perf_counter() - start
+
+    for _ in range(warmup_runs):
+        output = compiled(*args)
+        block_until_ready(output)
+
+    samples = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        output = compiled(*args)
+        block_until_ready(output)
+        samples.append(time.perf_counter() - start)
+
+    execution = statistics.median(samples)
+    compilation = max(0.0, first_call - execution)
+    return compilation, execution, output
+
+
+def difference(reference: Tree, candidate: Tree) -> tuple[float, float]:
+    """Return maximum absolute and scale-normalized PyTree differences."""
+    reference_leaves, reference_tree = jax.tree_util.tree_flatten(reference)
+    candidate_leaves, candidate_tree = jax.tree_util.tree_flatten(candidate)
+    if reference_tree != candidate_tree:
+        return float("inf"), float("inf")
+
+    max_absolute = 0.0
+    max_relative = 0.0
+    for reference_leaf, candidate_leaf in zip(
+        reference_leaves, candidate_leaves, strict=True
+    ):
+        reference_array = jnp.asarray(reference_leaf)
+        candidate_array = jnp.asarray(candidate_leaf)
+        if reference_array.size == 0:
+            continue
+        absolute = float(jnp.max(jnp.abs(reference_array - candidate_array)))
+        scale = max(float(jnp.max(jnp.abs(reference_array))), 1.0e-12)
+        max_absolute = max(max_absolute, absolute)
+        max_relative = max(max_relative, absolute / scale)
+    return max_absolute, max_relative
+
+
+def run(args: argparse.Namespace) -> list[dict[str, Any]]:
+    """Execute every requested PCS custom-JVP benchmark pair."""
+    rows: list[dict[str, Any]] = []
+    device = jax.devices()[0]
+    print(
+        f"device={device.platform}:{getattr(device, 'device_kind', 'unknown')} "
+        f"x64={jax.config.x64_enabled} repeats={args.repeats}"
+    )
+    print(
+        "setup                 links dof workload          "
+        "off_ms    on_ms speedup compile_off compile_on  rel_error"
+    )
+
+    for setup in args.setups:
+        for num_segments in args.segment_counts:
+            model = build_model(setup, num_segments, args.gauss_points)
+            y, y_direction, u, tau_ext = build_inputs(model)
+            inputs = (y, u, tau_ext)
+
+            for workload in args.workloads:
+                measurements: dict[bool, tuple[float, float, Tree]] = {}
+                for enabled in (False, True):
+                    set_custom_jvp_enabled(enabled)
+                    jax.clear_caches()
+                    workload_fn = build_workload(model, workload, y_direction)
+                    measurements[enabled] = measure(
+                        workload_fn,
+                        inputs,
+                        args.warmup_runs,
+                        args.repeats,
+                    )
+
+                compile_off, execution_off, output_off = measurements[False]
+                compile_on, execution_on, output_on = measurements[True]
+                max_absolute, max_relative = difference(output_off, output_on)
+                if max_relative > args.correctness_rtol:
+                    raise AssertionError(
+                        "Custom-JVP output does not match pure autodiff: "
+                        f"setup={setup}, segments={num_segments}, "
+                        f"workload={workload}, max_relative={max_relative:.3e}, "
+                        f"limit={args.correctness_rtol:.3e}"
+                    )
+                speedup = execution_off / execution_on
+                row = {
+                    "setup": setup,
+                    "segment_count": num_segments,
+                    "dof": model.num_dofs,
+                    "gauss_points": args.gauss_points,
+                    "workload": workload,
+                    "custom_jvp_disabled_compile_s": compile_off,
+                    "custom_jvp_enabled_compile_s": compile_on,
+                    "custom_jvp_disabled_execution_s": execution_off,
+                    "custom_jvp_enabled_execution_s": execution_on,
+                    "speedup": speedup,
+                    "max_absolute_difference": max_absolute,
+                    "max_relative_difference": max_relative,
+                    "device": str(device),
+                }
+                rows.append(row)
+                print(
+                    f"{setup:21s} {num_segments:5d} {model.num_dofs:3d} "
+                    f"{workload:17s} {1e3 * execution_off:8.3f} "
+                    f"{1e3 * execution_on:8.3f} {speedup:7.2f}x "
+                    f"{compile_off:11.3f} {compile_on:10.3f} "
+                    f"{max_relative:10.3e}"
+                )
+
+    set_custom_jvp_enabled(True)
+    return rows
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line benchmark options."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--segment-counts", type=int, nargs="+", default=[1, 2, 4])
+    parser.add_argument("--setups", nargs="+", choices=SETUPS, default=list(SETUPS))
+    parser.add_argument(
+        "--workloads",
+        nargs="+",
+        choices=WORKLOADS,
+        default=["state_jvp", "state_jacobian"],
+    )
+    parser.add_argument("--gauss-points", type=int, default=3)
+    parser.add_argument("--warmup-runs", type=int, default=2)
+    parser.add_argument("--repeats", type=int, default=10)
+    parser.add_argument("--correctness-rtol", type=float, default=1.0e-5)
+    parser.add_argument("--csv", type=Path)
+    args = parser.parse_args(argv)
+    if any(count < 1 for count in args.segment_counts):
+        parser.error("--segment-counts values must be positive")
+    if args.gauss_points < 1:
+        parser.error("--gauss-points must be positive")
+    if args.warmup_runs < 0 or args.repeats < 1:
+        parser.error("warmup runs must be non-negative and repeats must be positive")
+    if args.correctness_rtol <= 0.0:
+        parser.error("--correctness-rtol must be positive")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the benchmark and optionally write its rows as CSV."""
+    args = parse_args(argv)
+    rows = run(args)
+    if args.csv is not None:
+        args.csv.parent.mkdir(parents=True, exist_ok=True)
+        with args.csv.open("w", newline="", encoding="utf-8") as stream:
+            writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"wrote {args.csv}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds analytical inverse- and forward-dynamics derivatives for spatial
PCS models and connects them to JAX through a hybrid custom JVP.

- Adds forward and backward inverse-dynamics Jacobian passes.
- Introduces a constant-strain joint motion-subspace helper and the SE(3)
  `coadjoint_bar` operator required by the wrench derivatives.
- Exposes inverse-dynamics, forward-dynamics, state, actuation-input, and
  external-force Jacobian helpers.
- Activates the existing global custom-JVP toggle for `PCS.forward_dynamics`.
  Inertial/Coriolis/gravity directions use the analytical passes, while
  actuator and passive-element force directions remain under JAX autodiff.
- Adds a synchronized benchmark covering full, reduced, axial, and threadlike
  PCS configurations over multiple segment counts.

## Implementation

### Analytical inverse-dynamics passes

The forward pass propagates interval kinematics and their configuration and
velocity derivatives in segment-major order. It uses the compact notation:

- `J = d(eta) / d(qd)`
- `Jdot = d(J) / dt`
- `R = d(eta) / d(q)`
- `A = d(etad) / d(q)`
- `Y = d(etad) / d(qd) = Jdot + R`

The backward pass recursively transports `F_res`, the resultant wrench from
the current interval and all downstream intervals, into the current base
frame. It simultaneously accumulates `dID_dq`, `dID_dqd`, and `dID_dqdd`;
the last quantity is the generalized inertia matrix.

Local motion-subspace terms are evaluated with `vmap`, followed by one ordered
forward scan and one ordered reverse scan. The implementation retains active
coordinate shapes and flattened interval storage to avoid assembling
full-strain intermediates.

### Hybrid forward-dynamics custom JVP

The existing `custom_jvp_enabled` setting is `True` by default but previously
did not affect `PCS.forward_dynamics`. The new rule differentiates the implicit
dynamics equation as

`M qdd_tangent = applied_force_tangent - dID_dq q_tangent - dID_dqd qd_tangent`.

The inverse-dynamics terms come from the analytical passes. The applied-force
direction is evaluated with a JVP through actuation, elasticity, damping, and
external generalized force. This preserves exact derivatives for
configuration-dependent threadlike actuators and passive elements without
materializing their full Jacobians. Disabling the global custom-JVP setting
retains the original complete-autodiff path.

### Supporting spatial algebra

`se3.coadjoint_bar(F)` returns the linear map satisfying
`coadjoint(xi) @ F == coadjoint_bar(F) @ xi`. The backward wrench recursion uses
this identity to differentiate the coadjoint momentum term without autodiff.

## Correctness

All values below are maximum scale-normalized errors in JAX FP64. The autodiff
reference differentiates the protected forward-dynamics primal directly, so it
does not pass through the custom JVP under test.

| Configuration | `dID/dq` | `dID/dqd` | `dID/dqdd` | State Jacobian |
| --- | ---: | ---: | ---: | ---: |
| One segment / full 6-DoF strain | 2.32e-10 | 2.42e-11 | 4.52e-14 | 2.44e-10 |
| Two segments / selected bending-extension strain | 3.76e-9 | 3.03e-12 | 4.52e-16 | 2.34e-9 |

Across the complete custom-JVP benchmark sweep, enabled and disabled outputs
agreed within `9.7e-7` relative error, including threadlike actuation. The
benchmark fails if the difference exceeds `1e-5`.

## Performance

Measurements use JAX FP64 on the CPU backend, three Gauss points per segment,
two synchronized warmups, and the median of ten synchronized calls. Each mode
is separately compiled after clearing JAX caches. `Speedup` is
`custom JVP disabled / custom JVP enabled`, so values above 1 favor the custom
JVP.

| Setup | Segments | DoFs | Workload | Disabled (ms) | Enabled (ms) | Speedup |
| --- | ---: | ---: | --- | ---: | ---: | ---: |
| Full strain | 1 | 6 | State Jacobian | 0.312 | 0.526 | 0.59x |
| Full strain | 2 | 12 | State Jacobian | 0.919 | 1.006 | 0.91x |
| Full strain | 4 | 24 | State Jacobian | 3.212 | 2.310 | 1.39x |
| Full strain | 8 | 48 | State Jacobian | 14.619 | 10.310 | 1.42x |
| Full strain | 4 | 24 | State + input Jacobians | 4.765 | 2.493 | 1.91x |
| Selected bending-extension | 4 | 8 | State Jacobian | 1.049 | 1.428 | 0.73x |
| Axial only | 4 | 4 | State Jacobian | 0.698 | 1.594 | 0.44x |
| Threadlike actuation | 4 | 8 | State Jacobian | 1.007 | 1.696 | 0.59x |

The custom rule benefits complete Jacobians once the full-strain model reaches
roughly 24 DoFs, and reaches 1.91x for the combined state/input Jacobians in the
measured four-segment case. It is slower for small or reduced-coordinate models
and for a single directional JVP because the analytical inverse-dynamics pass
constructs complete derivative matrices. Custom-JVP compilation is also about
3-4 seconds more expensive in these CPU measurements. The global toggle is
therefore retained as the explicit policy control rather than adding a
model-size heuristic.

## Validation

- Complete affected SE(3) and PCS suites: `173 passed`
- Focused PCS custom-JVP and inverse-dynamics regression selection: `5 passed`
- Ruff check and targeted formatting: passed
- `git diff --check`: passed
- Multi-configuration speed benchmark: completed with its correctness guard

## Scope and limitations

- The explicit elastic/damping/actuation derivative matrix helpers describe
  the base PCS constitutive model. The forward-dynamics custom JVP deliberately
  uses component-level autodiff directions so installed actuator and passive
  elements remain correct.
- The analytical pass currently builds full inverse-dynamics derivative
  matrices, so it is not intended as an optimization for a single JVP.
- Benchmark timings are CPU- and machine-specific; the benchmark file records
  the comparison procedure and can emit CSV for other devices.