### PR TITLE
Tendon friction model for PCS systems

### DIFF
--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -18,12 +18,13 @@ The transmission model assumes that:
 - the routing is fixed in the material frame and depends only on arc length;
 - the actuator coordinate is determined by path length, scaled by a constant
   effective area for the pressure-chamber preset; and
-- each path carries one scalar work-conjugate effort, uniform along its route.
+- each path carries one scalar work-conjugate effort, attenuated along its
+  route only by the optional Capstan friction model described below.
 
 Consequently, configuration- or time-dependent rerouting, changes in chamber
-cross-section, along-path friction or slack, and internal actuator dynamics are
-outside the transmission model. Representing these effects requires an extended
-routing, transmission, or effort model.
+cross-section, path slack, and internal actuator dynamics are outside the
+transmission model. Representing these effects requires an extended routing,
+transmission, or effort model.
 
 Threadlike components require continuum segment topology and the host's native
 path-integration hooks. `PCS`, `PlanarPCS`, and `GVS` provide this contract.
@@ -165,13 +166,120 @@ coordinates = robot.actuator_coordinates(q)
 ```
 
 For tendons, `coordinates == -lengths`; for a pressure preset, coordinates are
-equivalent volumes. In every case,
+equivalent volumes. Without guide friction,
 `jax.jacrev(robot.actuator_coordinates)(q) == robot.actuation_matrix(q).T` up
-to quadrature tolerance.
+to quadrature tolerance. A nonzero friction coefficient breaks that identity by
+design, because the moment matrix then carries a transmission loss that path
+length does not; see [Guide friction](#guide-friction).
 
 PCS integrates the local path basis and performs the constant-strain projection
 once. GVS applies its strain basis inside the existing quadrature. The public
 behavior is common, while each host keeps its native evaluation path.
+
+## Guide friction
+
+By default a path transmits its effort undiminished along its whole route. Set
+`friction_coefficient` to model Coulomb friction against the guides the path
+runs through, following the force model of
+[Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3550846). A
+tendon threaded through spacer disks loses tension at every contact, and the
+loss at each contact obeys the classical Capstan (Euler) law
+\(T_{out} = T_{in}e^{-\mu\varphi}\), which depends on the accumulated turn
+\(\varphi\) alone and not on the guide radius.
+
+Taking the guide spacing to zero turns the product of per-contact losses into
+
+\[
+\eta(q, s) = e^{-\mu\Theta(q, s)}, \qquad
+\Theta(q, s) = \int_0^s \lVert\omega \times \hat{u}\rVert\,\mathrm{d}s'
+\]
+
+the fraction of the base effort that survives to arc length \(s\), with
+\(\hat{u}\) the unit routed-path tangent. Because \(\eta\) weights the integrand
+of the moment matrix rather than scaling its result, the distal part of a path
+contributes less than the proximal part:
+
+\[
+A_\mu(q) = B_\xi^\top \int_0^L \eta(q, s)\,\Phi(q, s)\,\mathrm{d}s
+\]
+
+\(\eta\) depends on the configuration only, so the actuation force stays linear
+in the effort and every controller keeps working. Since \(\eta \in (0, 1]\), the
+model can only ever remove effort, never add it, and a coefficient of zero
+reproduces the frictionless matrix exactly.
+
+The wrap density reduces to \(\lvert\kappa\rvert\) identically in the plane, for
+any offset and any strain. Under torsion it recovers the helix curvature of an
+off-axis path, so a twisted robot correctly reports a nonzero wrap angle.
+
+```python
+robot = PCS.from_links(
+    links,
+    structure=PCSStructure(num_gauss_points=5),
+    # a scalar shares one coefficient; pass shape (num_paths,) for per-path values
+    actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.2),
+)
+
+tau = robot.actuation_force(q, jnp.array([5.0, 0.0]))
+```
+
+`PCS` and `PlanarPCS` implement the wrap-angle model. `GVS` strain varies along
+arc length, so its wrap angle is not piecewise linear; it rejects a nonzero
+coefficient during construction with a descriptive `TypeError`.
+
+### Identifying the coefficient
+
+The coefficient is an ordinary dynamic leaf, so it is traceable and
+differentiable under `jit`:
+
+```python
+def with_friction(mu):
+    transmission = robot.actuators[0].params.transmission.replace(
+        friction_coefficient=mu
+    )
+    return robot.update_actuator_params(0, transmission=transmission)
+
+
+@jax.jit
+def loss(mu):
+    identified = with_friction(mu)
+    residual = (
+        identified.elastic_force(q_meas)
+        + identified.gravitational_force(q_meas)
+        - identified.actuation_force(q_meas, u_meas)
+    )
+    return jnp.sum(residual**2)
+
+
+value, grad = jax.value_and_grad(loss)(jnp.array(0.2))
+```
+
+Zero is a valid optimizer start, but \(\mathrm{d}A/\mathrm{d}\mu\) vanishes
+wherever \(\Theta = 0\), so a perfectly straight pose carries no information
+about \(\mu\). Set `wrap_angle_smoothing` on the host structure to replace
+\(\lvert\kappa\rvert\) with \(\sqrt{\kappa^2 + \epsilon^2}\) if the fit can
+approach a straight configuration. It never under-estimates the wrap angle and
+over-estimates it by at most \(\epsilon L\), and it also removes the \(C^0\)
+kink at zero curvature.
+
+### What changes at a nonzero coefficient
+
+- `moment_matrix` is no longer the transpose of the length gradient, so
+  `actuation_space` conversions that assume the identity do not apply.
+- The generalized actuation force has no potential: work around a closed
+  configuration loop at constant effort is nonzero and orientation dependent.
+- For a loaded passive path, `actuation_force(q, u)` is affine in `u` rather
+  than linear, and `actuation_force(q, 0)` is nonzero. Prefer
+  `actuation_force(q, u)` over `actuation_matrix(q) @ e` wherever passive
+  elements exist.
+- The moment matrix acquires a mild dependence on `num_gauss_points`, because
+  the attenuated integrand is no longer polynomial.
+- `path_lengths`, `path_velocities`, and `path_poses` are unchanged. They are
+  pure geometry at any coefficient.
+- The model assumes the effort drives the path. A back-driven path is still
+  modelled with the driving branch of Euler's law, so keep the passive
+  coefficient conservative or zero for long dynamic rollouts with
+  sign-changing path rates.
 
 ## Passive paths
 
@@ -196,7 +304,10 @@ robot = PCS(
 ```
 
 The passive element contributes to elastic force, damping, and elastic energy;
-it never consumes an active control channel.
+it never consumes an active control channel. A passive path may also declare a
+`friction_coefficient`, in which case part of its spring force becomes
+non-conservative and is applied through `actuation_force`; see
+[Guide friction](#guide-friction).
 
 ## Updating routing and actuator parameters
 

--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -168,7 +168,7 @@ coordinates = robot.actuator_coordinates(q)
 For tendons, `coordinates == -lengths`; for a pressure preset, coordinates are
 equivalent volumes. Without guide friction,
 `jax.jacrev(robot.actuator_coordinates)(q) == robot.actuation_matrix(q).T` up
-to quadrature tolerance. A nonzero friction coefficient breaks that identity by
+to quadrature tolerance. A lossy friction law breaks that identity by
 design, because the moment matrix then carries a transmission loss that path
 length does not; see [Guide friction](#guide-friction).
 
@@ -178,9 +178,21 @@ behavior is common, while each host keeps its native evaluation path.
 
 ## Guide friction
 
-By default a path transmits its effort undiminished along its whole route. Set
-`friction_coefficient` to model Coulomb friction against the guides the path
-runs through, following the force model of
+By default a path transmits its effort undiminished along its whole route. Pass
+a `friction=` law to model a transmission loss. The law is an object, so a new
+loss model needs no change to any host, and a third-party model needs no change
+to soromox.
+
+soromox ships three:
+
+| Law | Ratio | Hosts |
+|---|---|---|
+| `Frictionless` | \(1\) | all; the default |
+| `CapstanFriction` | \(e^{-\mu\Theta}\) | `PCS`, `PlanarPCS` |
+| `ExponentialLengthFriction` | \(e^{-ks}\) | all, including `GVS` |
+
+`CapstanFriction` models Coulomb friction against the guides a path runs
+through, following the force model of
 [Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3550846). A
 tendon threaded through spacer disks loses tension at every contact, and the
 loss at each contact obeys the classical Capstan (Euler) law
@@ -203,10 +215,11 @@ contributes less than the proximal part:
 A_\mu(q) = B_\xi^\top \int_0^L \eta(q, s)\,\Phi(q, s)\,\mathrm{d}s
 \]
 
-\(\eta\) depends on the configuration only, so the actuation force stays linear
-in the effort and every controller keeps working. Since \(\eta \in (0, 1]\), the
-model can only ever remove effort, never add it, and a coefficient of zero
-reproduces the frictionless matrix exactly.
+Every law obeys the same two rules. \(\eta\) depends on the configuration only,
+never on the effort, so the actuation force stays linear in the effort and every
+controller keeps working; and \(\eta \in (0, 1]\), so a law can only ever remove
+effort, never add it. The lossless default reproduces the frictionless matrix
+exactly and is skipped entirely, at no cost.
 
 The wrap density reduces to \(\lvert\kappa\rvert\) identically in the plane, for
 any offset and any strain. Under torsion it recovers the helix curvature of an
@@ -217,27 +230,39 @@ robot = PCS.from_links(
     links,
     structure=PCSStructure(num_gauss_points=5),
     # a scalar shares one coefficient; pass shape (num_paths,) for per-path values
-    actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.2),
+    actuators=ThreadlikeActuator.tendons(
+        routing, friction=CapstanFriction(coefficient=0.2)
+    ),
 )
 
 tau = robot.actuation_force(q, jnp.array([5.0, 0.0]))
 ```
 
-`PCS` and `PlanarPCS` implement the wrap-angle model. `GVS` strain varies along
-arc length, so its wrap angle is not piecewise linear; it rejects a nonzero
-coefficient during construction with a descriptive `TypeError`.
+`friction_coefficient=0.2` is kept as sugar for the same thing. Passing both it
+and `friction=` raises, because the two would silently disagree.
 
-### Identifying the coefficient
+A law declares what it needs, and a host refuses a law it cannot serve.
+`CapstanFriction` sets `requires_wrap_angle`, which `PCS` and `PlanarPCS`
+supply. `GVS` strain varies along arc length, so its wrap angle is not
+piecewise linear and it supplies none; it rejects a wrap-angle law during
+construction with a descriptive `TypeError`, at any coefficient including zero,
+because capability follows the law you install rather than the value you gave
+it. `ExponentialLengthFriction` reads only arc length, so it runs on `GVS` too.
 
-The coefficient is an ordinary dynamic leaf, so it is traceable and
+### Identifying a loss parameter
+
+Loss parameters are ordinary dynamic leaves, so they are traceable and
 differentiable under `jit`:
 
 ```python
 def with_friction(mu):
-    transmission = robot.actuators[0].params.transmission.replace(
-        friction_coefficient=mu
+    transmission = robot.actuators[0].params.transmission
+    return robot.update_actuator_params(
+        0,
+        transmission=transmission.replace(
+            friction=transmission.friction.replace(coefficient=mu)
+        ),
     )
-    return robot.update_actuator_params(0, transmission=transmission)
 
 
 @jax.jit
@@ -254,15 +279,64 @@ def loss(mu):
 value, grad = jax.value_and_grad(loss)(jnp.array(0.2))
 ```
 
-Zero is a valid optimizer start, but \(\mathrm{d}A/\mathrm{d}\mu\) vanishes
-wherever \(\Theta = 0\), so a perfectly straight pose carries no information
-about \(\mu\). Set `wrap_angle_smoothing` on the host structure to replace
+Swapping the law changes the parameter PyTree structure and so retraces, while
+replacing a value inside a law does not. Start identification from a lossy law
+at a zero parameter, `CapstanFriction(coefficient=0.0)`, rather than from
+`Frictionless()`. Zero is a valid optimizer start, but
+\(\mathrm{d}A/\mathrm{d}\mu\) vanishes wherever \(\Theta = 0\), so a perfectly
+straight pose carries no information about \(\mu\). Set `wrap_angle_smoothing` on the host structure to replace
 \(\lvert\kappa\rvert\) with \(\sqrt{\kappa^2 + \epsilon^2}\) if the fit can
 approach a straight configuration. It never under-estimates the wrap angle and
 over-estimates it by at most \(\epsilon L\), and it also removes the \(C^0\)
 kink at zero curvature.
 
-### What changes at a nonzero coefficient
+### Custom friction laws
+
+The hosts depend only on the law contract, not on the shipped models. A custom
+law supplies the parameters it needs, declares its requirements, and returns the
+surviving effort fraction per path:
+
+```python
+from soromox.actuation import ThreadlikeFriction
+
+
+class HyperbolicFriction(ThreadlikeFriction):
+    a: Array
+
+    def transmission_ratio(self, context):
+        return 1.0 / (1.0 + self.a * context.wrap_angle)
+
+
+actuator = ThreadlikeActuator.tendons(
+    routing, friction=HyperbolicFriction(a=jnp.asarray(0.5))
+)
+```
+
+The `context` is a `ThreadlikeQuadratureContext` describing the routed path at
+one quadrature node, batched over paths. Some of its fields mean the same thing
+on every host and some do not:
+
+| Field | Meaning | Portable |
+|---|---|---|
+| `arc_length` | backbone coordinate \(s\) | yes |
+| `segment_index` | segment containing the node | yes |
+| `offset`, `offset_derivative` | material-frame offset `(n, 3)` and its \(s\)-derivative | yes |
+| `tangent_norm` | routed-path stretch relative to the backbone | yes |
+| `active` | whether the node lies in each path's span | yes |
+| `unit_tangent` | normalized tangent, `(n, 2)` planar and `(n, 3)` spatial | no |
+| `strain` | `(n, 3)` planar and `(n, 6)` spatial | no |
+| `wrap_angle` | accumulated turn \(\Theta\), or `None` | only where supplied |
+
+A law reading only the portable fields runs unchanged on every host. A law
+reading `strain` or `unit_tangent` must document which host it targets.
+
+Set `requires_wrap_angle = False` if the law does not read `wrap_angle`, and the
+hosts will neither compute it nor refuse the law. Set `is_lossless = True` for a
+law that always returns one, and the hosts will skip it entirely. A law must
+keep its ratio in \((0, 1]\) and must not read the effort, which would make the
+actuation force nonlinear in the control.
+
+### What changes under a lossy law
 
 - `moment_matrix` is no longer the transpose of the length gradient, so
   `actuation_space` conversions that assume the identity do not apply.
@@ -305,7 +379,7 @@ robot = PCS(
 
 The passive element contributes to elastic force, damping, and elastic energy;
 it never consumes an active control channel. A passive path may also declare a
-`friction_coefficient`, in which case part of its spring force becomes
+`friction=` law, in which case part of its spring force becomes
 non-conservative and is applied through `actuation_force`; see
 [Guide friction](#guide-friction).
 

--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -185,11 +185,25 @@ to soromox.
 
 soromox ships three:
 
-| Law | Ratio | Hosts |
-|---|---|---|
-| `Frictionless` | \(1\) | all; the default |
-| `CapstanFriction` | \(e^{-\mu\Theta}\) | `PCS`, `PlanarPCS` |
-| `ExponentialLengthFriction` | \(e^{-ks}\) | all, including `GVS` |
+| Law | Ratio | Parameter | Hosts |
+|---|---|---|---|
+| `Frictionless` | \(1\) | none | all; the default |
+| `CapstanFriction` | \(e^{-\mu\Theta}\) | \(\mu\), Coulomb coefficient | `PCS`, `PlanarPCS` |
+| `ExponentialLengthFriction` | \(e^{-ks}\) | \(k\), per metre | all, including `GVS` |
+
+Both lossy laws solve the same tension ODE
+\(\mathrm{d}T/\mathrm{d}s = -\lambda(s)T\), whose solution is
+\(\eta = e^{-\int\lambda\,\mathrm{d}s}\). They differ only in where the normal
+load pressing the path against its guide comes from. Under `CapstanFriction`
+it is curvature-induced, \(N = Tw\), giving \(\lambda = \mu w\). Under
+`ExponentialLengthFriction` it comes from a snug sheath gripping in proportion
+to tension, \(N = cT\), giving a constant \(\lambda = \mu c = k\), so loss
+accrues with distance travelled rather than with turning.
+
+That makes \(k\) phenomenological in a way \(\mu\) is not: it lumps the
+friction coefficient together with the radial grip, so it has to be fitted
+rather than looked up. It suits a tendon in a close-fitting sheath or lumen,
+and because it never reads the wrap angle it is the one law `GVS` can host.
 
 `CapstanFriction` models Coulomb friction against the guides a path runs
 through, following the force model of

--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -19,7 +19,7 @@ The transmission model assumes that:
 - the actuator coordinate is determined by path length, scaled by a constant
   effective area for the pressure-chamber preset; and
 - each path carries one scalar work-conjugate effort, attenuated along its
-  route only by the optional Capstan friction model described below.
+  route by an optional friction model described below.
 
 Consequently, configuration- or time-dependent rerouting, changes in chamber
 cross-section, path slack, and internal actuator dynamics are outside the
@@ -168,76 +168,106 @@ coordinates = robot.actuator_coordinates(q)
 For tendons, `coordinates == -lengths`; for a pressure preset, coordinates are
 equivalent volumes. Without guide friction,
 `jax.jacrev(robot.actuator_coordinates)(q) == robot.actuation_matrix(q).T` up
-to quadrature tolerance. A lossy friction law breaks that identity by
-design, because the moment matrix then carries a transmission loss that path
-length does not; see [Guide friction](#guide-friction).
+to quadrature tolerance. A friction model breaks that identity by design,
+because the moment matrix then carries an attenuation that path length does
+not; see [Routing friction](#routing-friction).
 
-PCS integrates the local path basis and performs the constant-strain projection
+PCS integrates the local length gradient and performs the constant-strain projection
 once. GVS applies its strain basis inside the existing quadrature. The public
 behavior is common, while each host keeps its native evaluation path.
 
-## Guide friction
+## Routing friction
 
-By default a path transmits its effort undiminished along its whole route. Pass
-a `friction=` law to model a transmission loss. The law is an object, so a new
-loss model needs no change to any host, and a third-party model needs no change
-to soromox.
+Ideally, effort is transmitted undiminished along its route, from the motor
+until its attachment point. However, friction between the routing and the
+robot body is often non-negligible in real applications, and attenuates the
+effort along the path. It is possible to simulate this behavior via the
+`ThreadlikeFriction` model, which is installed on a `ThreadlikeTransmission`
+through the `friction=` keyword of `ThreadlikeActuator` and
+`ThreadlikeImpedance`.
+The current implemented models are the following:
 
-soromox ships three:
-
-| Law | Ratio | Parameter | Hosts |
+| Model | Ratio | Parameter | Hosts |
 |---|---|---|---|
-| `Frictionless` | \(1\) | none | all; the default |
-| `CapstanFriction` | \(e^{-\mu\Theta}\) | \(\mu\), Coulomb coefficient | `PCS`, `PlanarPCS` |
-| `ExponentialLengthFriction` | \(e^{-ks}\) | \(k\), per metre | all, including `GVS` |
+| `ThreadlikeFriction.frictionless()` | \(1\) | none | all; the default |
+| `ThreadlikeFriction.exponential_length(...)` | \(e^{-k\ell}\) | `rate` \(k\), per metre | all |
+| `ThreadlikeFriction.capstan(...)` | \(e^{-\mu\Theta}\) | `coefficient` \(\mu\), Coulomb; `eps` \(\epsilon\), per metre | `PCS`, `PlanarPCS` |
 
-Both lossy laws solve the same tension ODE
-\(\mathrm{d}T/\mathrm{d}s = -\lambda(s)T\), whose solution is
-\(\eta = e^{-\int\lambda\,\mathrm{d}s}\). They differ only in where the normal
-load pressing the path against its guide comes from. Under `CapstanFriction`
-it is curvature-induced, \(N = Tw\), giving \(\lambda = \mu w\). Under
-`ExponentialLengthFriction` it comes from a snug sheath gripping in proportion
-to tension, \(N = cT\), giving a constant \(\lambda = \mu c = k\), so loss
-accrues with distance travelled rather than with turning.
 
-That makes \(k\) phenomenological in a way \(\mu\) is not: it lumps the
-friction coefficient together with the radial grip, so it has to be fitted
-rather than looked up. It suits a tendon in a close-fitting sheath or lumen,
-and because it never reads the wrap angle it is the one law `GVS` can host.
+### Friction models
 
-`CapstanFriction` models Coulomb friction against the guides a path runs
-through, following the force model of
-[Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3550846). A
-tendon threaded through spacer disks loses tension at every contact, and the
-loss at each contact obeys the classical Capstan (Euler) law
-\(T_{out} = T_{in}e^{-\mu\varphi}\), which depends on the accumulated turn
-\(\varphi\) alone and not on the guide radius.
-
-Taking the guide spacing to zero turns the product of per-contact losses into
+The exponential length and Capstan models follow from the same tension balance along the routed path, with \(T\) the tension, \(\lambda\) the attenuation rate per unit arc length, and \(s_0\) the abscissa of the path anchor:
 
 \[
-\eta(q, s) = e^{-\mu\Theta(q, s)}, \qquad
-\Theta(q, s) = \int_0^s \lVert\omega \times \hat{u}\rVert\,\mathrm{d}s'
+\frac{\mathrm{d}T}{\mathrm{d}s} = -\lambda\,T,
+\qquad
+\eta(s) = \frac{T(s)}{T(s_0)} = \exp\!\left(-\int_{s_0}^{s}\lambda\,
+\mathrm{d}s'\right)
 \]
 
-the fraction of the base effort that survives to arc length \(s\), with
-\(\hat{u}\) the unit routed-path tangent. Because \(\eta\) weights the integrand
-of the moment matrix rather than scaling its result, the distal part of a path
-contributes less than the proximal part:
+They differ in the origin of the normal load \(N\) pressing the path against the
+body.
+
+**Configuration-independent friction.** A first approximation scales uniformly the tension along the path, \(N = cT\), so \(\lambda = \mu c \equiv k\) is
+constant and the attenuation depends only on the arc length \(\ell = s - s_0\)
+travelled from the anchor:
 
 \[
-A_\mu(q) = B_\xi^\top \int_0^L \eta(q, s)\,\Phi(q, s)\,\mathrm{d}s
+\eta(\ell) = e^{-k\ell}
 \]
 
-Every law obeys the same two rules. \(\eta\) depends on the configuration only,
-never on the effort, so the actuation force stays linear in the effort and every
-controller keeps working; and \(\eta \in (0, 1]\), so a law can only ever remove
-effort, never add it. The lossless default reproduces the frictionless matrix
-exactly and is skipped entirely, at no cost.
+**Configuration-dependent friction (Capstan).** The normal load is induced by
+the curvature of the path, \(N = Tk_p\), so \(\lambda = \mu k_p(q, s)\):
 
-The wrap density reduces to \(\lvert\kappa\rvert\) identically in the plane, for
-any offset and any strain. Under torsion it recovers the helix curvature of an
-off-axis path, so a twisted robot correctly reports a nonzero wrap angle.
+\[
+k_p(q, s) = \lVert\omega \times \hat{u}\rVert,
+\qquad
+\eta(q, s) = e^{-\mu\Theta(q, s)},
+\quad
+\Theta(q, s) = \int_{s_0}^{s} k_p(q, s')\,\mathrm{d}s'
+\]
+
+Here \(\omega\) is the angular strain, \(\hat{u}\) the unit routed-path tangent,
+and \(\Theta\) the wrap angle accumulated from the anchor. Since
+\(\mathrm{d}\hat{u}/\mathrm{d}s = \omega \times \hat{u}\), only the component of
+\(\omega\) orthogonal to \(\hat{u}\) contributes, so torsion about the axis of
+the path does not attenuate. In the plane \(k_p\) reduces to
+\(\lvert\kappa_z\rvert\); under torsion an off-axis path traces a helix, whose
+curvature \(k_p\) recovers.
+
+Because \(\Theta\) vanishes at a straight configuration, so does
+\(\partial\eta/\partial\mu\), and \(\mu\) is not identifiable there. The `eps`
+argument floors the curvature at \(\epsilon\), replacing \(k_p\) by
+\(\sqrt{k_p^2 + \epsilon^2}\). It never under-estimates \(\Theta\) and
+over-estimates it by at most \(\epsilon L\); the default \(\epsilon = 0\)
+reproduces the exact curvature.
+
+This model is the continuum limit of the discrete tendon force model of
+[Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3550846), in
+which the tendon passes through a finite set of spacer disks and each contact
+attenuates the tension by the classical Capstan (Euler) relation
+
+\[
+T_i = T_{i-1}\,e^{-\mu\varphi_i}
+\qquad\Longrightarrow\qquad
+T_n = T_0\,\exp\!\left(-\mu\sum_{i=1}^{n}\varphi_i\right)
+\]
+
+with \(\varphi_i\) the turn at the \(i\)-th contact, independent of the guide
+radius. As the disk spacing tends to zero at fixed total turning,
+\(\sum_i \varphi_i \to \Theta\) and the product recovers \(\eta\) above, which
+can then be evaluated at every quadrature node rather than at discrete guides.
+
+### Applying the friction
+
+\(\eta\) weights the integrand of the moment matrix rather than scaling its
+result, so the distal part of a path contributes less than the proximal part:
+
+\[
+A_\mu(q) = B_\xi^\top \int_0^L \eta(q, s)\,
+\frac{\partial\lVert t\rVert}{\partial\xi}(q, s)\,\mathrm{d}s
+\]
+
 
 ```python
 robot = PCS.from_links(
@@ -245,94 +275,54 @@ robot = PCS.from_links(
     structure=PCSStructure(num_gauss_points=5),
     # a scalar shares one coefficient; pass shape (num_paths,) for per-path values
     actuators=ThreadlikeActuator.tendons(
-        routing, friction=CapstanFriction(coefficient=0.2)
+        routing, friction=ThreadlikeFriction.capstan(coefficient=0.2)
     ),
 )
 
 tau = robot.actuation_force(q, jnp.array([5.0, 0.0]))
 ```
 
-`friction_coefficient=0.2` is kept as sugar for the same thing. Passing both it
-and `friction=` raises, because the two would silently disagree.
+### Custom friction models
 
-A law declares what it needs, and a host refuses a law it cannot serve.
-`CapstanFriction` sets `requires_wrap_angle`, which `PCS` and `PlanarPCS`
-supply. `GVS` strain varies along arc length, so its wrap angle is not
-piecewise linear and it supplies none; it rejects a wrap-angle law during
-construction with a descriptive `TypeError`, at any coefficient including zero,
-because capability follows the law you install rather than the value you gave
-it. `ExponentialLengthFriction` reads only arc length, so it runs on `GVS` too.
-
-### Identifying a loss parameter
-
-Loss parameters are ordinary dynamic leaves, so they are traceable and
-differentiable under `jit`:
+A model is a plain function of `(params, context)`, paired with its parameters by
+`ThreadlikeFriction`. The hosts depend only on that contract, not on the shipped
+models:
 
 ```python
-def with_friction(mu):
-    transmission = robot.actuators[0].params.transmission
-    return robot.update_actuator_params(
-        0,
-        transmission=transmission.replace(
-            friction=transmission.friction.replace(coefficient=mu)
-        ),
-    )
+from soromox.actuation import BaseThreadlikeFrictionParams, ThreadlikeFriction
 
 
-@jax.jit
-def loss(mu):
-    identified = with_friction(mu)
-    residual = (
-        identified.elastic_force(q_meas)
-        + identified.gravitational_force(q_meas)
-        - identified.actuation_force(q_meas, u_meas)
-    )
-    return jnp.sum(residual**2)
-
-
-value, grad = jax.value_and_grad(loss)(jnp.array(0.2))
-```
-
-Swapping the law changes the parameter PyTree structure and so retraces, while
-replacing a value inside a law does not. Start identification from a lossy law
-at a zero parameter, `CapstanFriction(coefficient=0.0)`, rather than from
-`Frictionless()`. Zero is a valid optimizer start, but
-\(\mathrm{d}A/\mathrm{d}\mu\) vanishes wherever \(\Theta = 0\), so a perfectly
-straight pose carries no information about \(\mu\). Set `wrap_angle_smoothing` on the host structure to replace
-\(\lvert\kappa\rvert\) with \(\sqrt{\kappa^2 + \epsilon^2}\) if the fit can
-approach a straight configuration. It never under-estimates the wrap angle and
-over-estimates it by at most \(\epsilon L\), and it also removes the \(C^0\)
-kink at zero curvature.
-
-### Custom friction laws
-
-The hosts depend only on the law contract, not on the shipped models. A custom
-law supplies the parameters it needs, declares its requirements, and returns the
-surviving effort fraction per path:
-
-```python
-from soromox.actuation import ThreadlikeFriction
-
-
-class HyperbolicFriction(ThreadlikeFriction):
+class HyperbolicFrictionParams(BaseThreadlikeFrictionParams):
     a: Array
 
-    def transmission_ratio(self, context):
-        return 1.0 / (1.0 + self.a * context.wrap_angle)
+
+def hyperbolic_transmission_ratio(params, context):
+    return 1.0 / (1.0 + params.a * context.wrap_angle)
 
 
 actuator = ThreadlikeActuator.tendons(
-    routing, friction=HyperbolicFriction(a=jnp.asarray(0.5))
+    routing,
+    friction=ThreadlikeFriction(
+        params=HyperbolicFrictionParams(a=jnp.asarray(0.5)),
+        ratio_fn=hyperbolic_transmission_ratio,
+        requires_wrap_angle=True,
+        is_frictionless=False,
+    ),
 )
 ```
 
+Parameters live in the transmission parameter tree, so they stay differentiable
+and replaceable; the model itself is static, so swapping it leads to retracing.
+This mirrors how `ThreadlikeRouting` pairs routing parameters with a static
+offset function.
+
 The `context` is a `ThreadlikeQuadratureContext` describing the routed path at
-one quadrature node, batched over paths. Some of its fields mean the same thing
-on every host and some do not:
+one quadrature node.
 
 | Field | Meaning | Portable |
 |---|---|---|
-| `arc_length` | backbone coordinate \(s\) | yes |
+| `abscissa` | backbone coordinate \(s\), from the robot base | yes |
+| `path_abscissa` | arc length travelled from this path's anchor | yes |
 | `segment_index` | segment containing the node | yes |
 | `offset`, `offset_derivative` | material-frame offset `(n, 3)` and its \(s\)-derivative | yes |
 | `tangent_norm` | routed-path stretch relative to the backbone | yes |
@@ -341,16 +331,14 @@ on every host and some do not:
 | `strain` | `(n, 3)` planar and `(n, 6)` spatial | no |
 | `wrap_angle` | accumulated turn \(\Theta\), or `None` | only where supplied |
 
-A law reading only the portable fields runs unchanged on every host. A law
-reading `strain` or `unit_tangent` must document which host it targets.
+Set `requires_wrap_angle=False` if the model does not read `wrap_angle`, and the
+hosts will neither compute it nor refuse the model. Set `is_frictionless=True`
+only
+for a model that always returns one, and the hosts will skip it entirely. A model
+must keep its ratio in \((0, 1]\) and must not read the effort, which would make
+the actuation force nonlinear in the control.
 
-Set `requires_wrap_angle = False` if the law does not read `wrap_angle`, and the
-hosts will neither compute it nor refuse the law. Set `is_lossless = True` for a
-law that always returns one, and the hosts will skip it entirely. A law must
-keep its ratio in \((0, 1]\) and must not read the effort, which would make the
-actuation force nonlinear in the control.
-
-### What changes under a lossy law
+### What changes under a friction model
 
 - `moment_matrix` is no longer the transpose of the length gradient, so
   `actuation_space` conversions that assume the identity do not apply.
@@ -363,7 +351,7 @@ actuation force nonlinear in the control.
 - The moment matrix acquires a mild dependence on `num_gauss_points`, because
   the attenuated integrand is no longer polynomial.
 - `path_lengths`, `path_velocities`, and `path_poses` are unchanged. They are
-  pure geometry at any coefficient.
+  pure geometry under any friction model.
 - The model assumes the effort drives the path. A back-driven path is still
   modelled with the driving branch of Euler's law, so keep the passive
   coefficient conservative or zero for long dynamic rollouts with
@@ -393,9 +381,9 @@ robot = PCS(
 
 The passive element contributes to elastic force, damping, and elastic energy;
 it never consumes an active control channel. A passive path may also declare a
-`friction=` law, in which case part of its spring force becomes
+`friction=` model, in which case part of its spring force becomes
 non-conservative and is applied through `actuation_force`; see
-[Guide friction](#guide-friction).
+[Routing friction](#routing-friction).
 
 ## Updating routing and actuator parameters
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -27,6 +27,17 @@ and include benchmark baseline and measurement context for performance claims.
 - Added `wrap_angle_smoothing` to `PCSStructure` and `PlanarPCSStructure`, which
   replaces `|kappa|` with `sqrt(kappa**2 + eps**2)` in the wrap-angle density so
   the friction coefficient stays identifiable near a straight configuration.
+- Made the threadlike transmission loss a pluggable `ThreadlikeFriction` model
+  chosen at construction through `friction=`, so a new loss law needs no host
+  change and a third-party law needs no soromox change. A law receives a
+  `ThreadlikeQuadratureContext` describing the routed path at one quadrature
+  node and returns the surviving effort fraction per path. `Frictionless` is the
+  default, `CapstanFriction` carries the Euler belt law, and
+  `ExponentialLengthFriction` applies a loss per unit arc length. See
+  [threadlike actuation](../api/actuation/threadlike.md#guide-friction).
+- Added `GVS` support for transmission-loss laws that do not need the wrap
+  angle, such as `ExponentialLengthFriction`. `GVS` strain varies along arc
+  length, so it still cannot supply the Capstan wrap angle.
 
 ### Changed
 
@@ -43,6 +54,17 @@ and include benchmark baseline and measurement context for performance claims.
   `sigma_x - d * kappa`. Planar routings must negate their `y` offsets to
   reproduce previous behavior, which is exactly equivalent when the routing
   slope is zero.
+- Replaced `ThreadlikeTransmissionParams.friction_coefficient` with `friction`,
+  which holds a `ThreadlikeFriction` law. The `friction_coefficient=` keyword is
+  kept as sugar for `CapstanFriction` on every preset and on
+  `ThreadlikeImpedance`, and passing it together with `friction=` raises.
+  Identification becomes
+  `transmission.replace(friction=transmission.friction.replace(coefficient=mu))`.
+- Made host support for a transmission loss depend on the law rather than on its
+  value: a wrap-angle law such as `CapstanFriction` is now refused on `GVS` at
+  any coefficient, including zero, where `friction_coefficient=0.0` was
+  previously accepted. Drop the argument or install
+  `ExponentialLengthFriction` instead.
 
 ### Performance
 
@@ -72,6 +94,10 @@ and include benchmark baseline and measurement context for performance claims.
 - Documented guide friction on the threadlike actuation page, replacing the
   paragraph that listed along-path friction as outside the transmission model,
   and recorded the invariants a nonzero coefficient deliberately breaks.
+- Documented the pluggable transmission-loss model, including which
+  quadrature-context fields are portable across hosts and which are host-shaped,
+  and added a custom friction law example alongside the existing custom routing
+  law example.
 
 ### Contributors
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -15,11 +15,34 @@ and include benchmark baseline and measurement context for performance claims.
 
 - Added renderer-neutral cross-section contours and loft construction, with a
   registration hook for extending both swept 3D renderers with new geometries.
+- Added opt-in Capstan guide friction to threadlike transmissions. A
+  `friction_coefficient` on `ThreadlikeActuator` and `ThreadlikeImpedance`
+  attenuates effort along a routed path as `exp(-mu * Theta(s))`, where `Theta`
+  is the accumulated turn of the path, instead of applying it uniformly. `PCS`
+  and `PlanarPCS` implement the wrap-angle model; `GVS` rejects a nonzero
+  coefficient during construction. The coefficient is a differentiable leaf and
+  can be identified under `jit`. Zero is the default and reproduces the
+  frictionless model exactly. See
+  [threadlike actuation](../api/actuation/threadlike.md#guide-friction).
+- Added `wrap_angle_smoothing` to `PCSStructure` and `PlanarPCSStructure`, which
+  replaces `|kappa|` with `sqrt(kappa**2 + eps**2)` in the wrap-angle density so
+  the friction coefficient stays identifiable near a straight configuration.
 
 ### Changed
 
 - Open3D and Viser swept backbones now preserve circular, elliptical, and
   rectangular cross-sections, including dimensions that vary with abscissa.
+- Replaced `ThreadlikeImpedanceParams.routing` with a nested
+  `transmission` field, so a passive routed path now carries a
+  `ThreadlikeTransmission` like its articulated counterpart. The
+  `ThreadlikeImpedance` constructor keeps its `routing=` keyword; direct
+  construction of `ThreadlikeImpedanceParams` and `update_params(routing=...)`
+  become `transmission=...`.
+- Corrected the planar routed-path offset sign, which used
+  `sigma_x + d * kappa` where `PlanarPCS` kinematics require
+  `sigma_x - d * kappa`. Planar routings must negate their `y` offsets to
+  reproduce previous behavior, which is exactly equivalent when the routing
+  slope is zero.
 
 ### Performance
 
@@ -39,8 +62,16 @@ and include benchmark baseline and measurement context for performance claims.
   shape-morphing funnel when adjacent links used different cross-sections.
 - Fixed Open3D swept meshes reusing the first endpoint cross-section at both
   ends, which previously rendered tapered profiles as piecewise-constant.
+- Fixed planar threadlike path lengths and moment arms disagreeing with `PCS`
+  and with the path positions the renderer draws. At `kappa = 10`, `L = 0.1`
+  and offset `0.02` the model reported `0.120` for a path whose rendered arc
+  length is `0.080`; planar and spatial hosts now agree exactly.
 
 ### Documentation
+
+- Documented guide friction on the threadlike actuation page, replacing the
+  paragraph that listed along-path friction as outside the transmission model,
+  and recorded the invariants a nonzero coefficient deliberately breaks.
 
 ### Contributors
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -15,29 +15,18 @@ and include benchmark baseline and measurement context for performance claims.
 
 - Added renderer-neutral cross-section contours and loft construction, with a
   registration hook for extending both swept 3D renderers with new geometries.
-- Added opt-in Capstan guide friction to threadlike transmissions. A
-  `friction_coefficient` on `ThreadlikeActuator` and `ThreadlikeImpedance`
-  attenuates effort along a routed path as `exp(-mu * Theta(s))`, where `Theta`
-  is the accumulated turn of the path, instead of applying it uniformly. `PCS`
-  and `PlanarPCS` implement the wrap-angle model; `GVS` rejects a nonzero
-  coefficient during construction. The coefficient is a differentiable leaf and
-  can be identified under `jit`. Zero is the default and reproduces the
-  frictionless model exactly. See
-  [threadlike actuation](../api/actuation/threadlike.md#guide-friction).
-- Added `wrap_angle_smoothing` to `PCSStructure` and `PlanarPCSStructure`, which
-  replaces `|kappa|` with `sqrt(kappa**2 + eps**2)` in the wrap-angle density so
-  the friction coefficient stays identifiable near a straight configuration.
-- Made the threadlike transmission loss a pluggable `ThreadlikeFriction` model
-  chosen at construction through `friction=`, so a new loss law needs no host
-  change and a third-party law needs no soromox change. A law receives a
-  `ThreadlikeQuadratureContext` describing the routed path at one quadrature
-  node and returns the surviving effort fraction per path. `Frictionless` is the
-  default, `CapstanFriction` carries the Euler belt law, and
-  `ExponentialLengthFriction` applies a loss per unit arc length. See
-  [threadlike actuation](../api/actuation/threadlike.md#guide-friction).
-- Added `GVS` support for transmission-loss laws that do not need the wrap
-  angle, such as `ExponentialLengthFriction`. `GVS` strain varies along arc
-  length, so it still cannot supply the Capstan wrap angle.
+- Added opt-in routing friction to threadlike transmissions, selected with
+  `friction=`. It weights the moment-matrix integrand, so the attenuation
+  accumulates from the path anchor rather than scaling the applied effort.
+  `ThreadlikeFriction.frictionless()` is the default,
+  `.capstan(coefficient=..., eps=...)` applies `exp(-mu * Theta)` with `Theta`
+  the integrated routed-path curvature floored at `eps`, which keeps the
+  coefficient identifiable near a straight configuration, and
+  `.exponential_length(rate=...)` a constant attenuation per unit arc length.
+  Parameters are differentiable leaves, identifiable under `jit`. A model is a
+  parameter container plus a static `ratio_fn`, so adding one needs no host
+  change. See
+  [threadlike actuation](../api/actuation/threadlike.md#routing-friction).
 
 ### Changed
 
@@ -54,17 +43,11 @@ and include benchmark baseline and measurement context for performance claims.
   `sigma_x - d * kappa`. Planar routings must negate their `y` offsets to
   reproduce previous behavior, which is exactly equivalent when the routing
   slope is zero.
-- Replaced `ThreadlikeTransmissionParams.friction_coefficient` with `friction`,
-  which holds a `ThreadlikeFriction` law. The `friction_coefficient=` keyword is
-  kept as sugar for `CapstanFriction` on every preset and on
-  `ThreadlikeImpedance`, and passing it together with `friction=` raises.
-  Identification becomes
-  `transmission.replace(friction=transmission.friction.replace(coefficient=mu))`.
-- Made host support for a transmission loss depend on the law rather than on its
-  value: a wrap-angle law such as `CapstanFriction` is now refused on `GVS` at
-  any coefficient, including zero, where `friction_coefficient=0.0` was
-  previously accepted. Drop the argument or install
-  `ExponentialLengthFriction` instead.
+- Made host support for friction depend on the installed model rather than on
+  its value. `PCS` and `PlanarPCS` supply the wrap angle; `GVS` strain varies
+  along arc length and does not, so it refuses a wrap-angle model at any
+  coefficient, zero included. Use `ThreadlikeFriction.exponential_length(...)`
+  there instead.
 
 ### Performance
 
@@ -91,13 +74,11 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Documentation
 
-- Documented guide friction on the threadlike actuation page, replacing the
-  paragraph that listed along-path friction as outside the transmission model,
-  and recorded the invariants a nonzero coefficient deliberately breaks.
-- Documented the pluggable transmission-loss model, including which
-  quadrature-context fields are portable across hosts and which are host-shaped,
-  and added a custom friction law example alongside the existing custom routing
-  law example.
+- Documented routing friction on the threadlike actuation page: the two
+  friction models and their derivation, the invariants a friction model
+  deliberately breaks, which quadrature-context fields are portable across
+  hosts, and a custom-model example alongside the existing custom routing one.
+  Replaced the paragraph that listed along-path friction as out of scope.
 
 ### Contributors
 

--- a/docs/user-guide/execution-devices-and-backends.md
+++ b/docs/user-guide/execution-devices-and-backends.md
@@ -165,25 +165,32 @@ Coriolis/centrifugal, and gravity terms together, call `dynamics_terms`.
 
 ### Threadlike actuation
 
-Built-in linear threadlike layouts have public Warp-native operands, FP64
-kernels, and allocation-free launchers for actuation matrices `(E, D, A)` and
-fused direct-effort forces `(E, D)`. These low-level APIs are always available
-from `soromox.execution.warp.pcs` and `.gvs` for Newton and other
-Warp-native integrations. They support multiple ordered threadlike actuator
-groups and every built-in modality.
+Built-in frictionless linear threadlike layouts have public Warp-native
+operands, FP64 kernels, and allocation-free launchers for actuation matrices
+`(E, D, A)` and fused direct-effort forces `(E, D)`. These low-level APIs are
+always available from `soromox.execution.warp.pcs` and `.gvs` for Newton and
+other Warp-native integrations. They support multiple ordered threadlike
+actuator groups and every built-in modality; non-frictionless
+`ThreadlikeFriction` models are not yet implemented by these kernels.
 
 For spatial `PCS`, `actuation_matrix` uses the Warp implementation when the GPU
-backend is selected. `PlanarPCS` and `GVS` actuation matrices, and all
-system-level `actuation_force` methods, use JAX. Passing `backend="warp"` for an
-unsupported system-level operation explains how to access the low-level
-Warp-native API. Passive threadlike impedance and actuator path coordinates
-also remain JAX operations.
+backend is selected and all active transmissions are frictionless. Installing
+a non-frictionless `ThreadlikeFriction` keeps the matrix on JAX under
+`backend="auto"`, while an explicit `backend="warp"` request raises an error.
+`PlanarPCS` and `GVS` actuation matrices, and all system-level
+`actuation_force` methods, use JAX. Passing `backend="warp"` for an unsupported
+system-level operation explains how to access the low-level Warp-native API.
+Passive threadlike impedance, non-conservative passive forces, and actuator
+path coordinates also remain JAX operations.
 
-When Warp dynamics is selected, eligible built-in linear threadlike actuation
-is fused with the dynamics evaluation. This fused path supports GVS on CPU and
-GPU, and PlanarPCS and PCS on GPU. Because `"auto"` selects JAX on CPU, CPU GVS
-fusion is used only when Warp is selected explicitly. Other actuation layouts
-use Warp dynamics and evaluate actuation with JAX.
+When Warp dynamics is selected, eligible built-in frictionless linear
+threadlike actuation is fused with the dynamics evaluation. The fused path is
+not used when an active transmission has a non-frictionless
+`ThreadlikeFriction` or a passive element contributes a non-conservative force;
+those models use Warp dynamics and evaluate actuation with JAX. Fusion supports
+GVS on CPU and GPU, and PlanarPCS and PCS on GPU. Because `"auto"` selects JAX
+on CPU, CPU GVS fusion is used only when Warp is selected explicitly. Other
+actuation layouts also use Warp dynamics and evaluate actuation with JAX.
 
 ## Model-level and per-call selection
 

--- a/src/soromox/actuation/__init__.py
+++ b/src/soromox/actuation/__init__.py
@@ -10,6 +10,13 @@ from .core import (
     PassiveElement,
     Transmission,
 )
+from .friction import (
+    CapstanFriction,
+    ExponentialLengthFriction,
+    Frictionless,
+    ThreadlikeFriction,
+    ThreadlikeQuadratureContext,
+)
 from .joint import (
     AffineJointTransmission,
     AffineJointTransmissionParams,
@@ -58,8 +65,13 @@ __all__ = [
     "ArticulatedMcKibbenTransmission",
     "ArticulatedMcKibbenTransmissionParams",
     "BaseThreadlikeRoutingParams",
+    "CapstanFriction",
+    "ExponentialLengthFriction",
+    "Frictionless",
     "LinearThreadlikeRoutingParams",
     "PassiveElement",
+    "ThreadlikeFriction",
+    "ThreadlikeQuadratureContext",
     "ThreadlikeActuator",
     "ThreadlikeActuatorParams",
     "ThreadlikeImpedance",

--- a/src/soromox/actuation/__init__.py
+++ b/src/soromox/actuation/__init__.py
@@ -11,11 +11,15 @@ from .core import (
     Transmission,
 )
 from .friction import (
-    CapstanFriction,
-    ExponentialLengthFriction,
-    Frictionless,
+    BaseThreadlikeFrictionParams,
+    CapstanFrictionParams,
+    ExponentialLengthFrictionParams,
+    FrictionlessParams,
     ThreadlikeFriction,
     ThreadlikeQuadratureContext,
+    capstan_transmission_ratio,
+    exponential_length_transmission_ratio,
+    frictionless_transmission_ratio,
 )
 from .joint import (
     AffineJointTransmission,
@@ -64,10 +68,11 @@ __all__ = [
     "ArticulatedMcKibbenActuatorParams",
     "ArticulatedMcKibbenTransmission",
     "ArticulatedMcKibbenTransmissionParams",
+    "BaseThreadlikeFrictionParams",
     "BaseThreadlikeRoutingParams",
-    "CapstanFriction",
-    "ExponentialLengthFriction",
-    "Frictionless",
+    "CapstanFrictionParams",
+    "ExponentialLengthFrictionParams",
+    "FrictionlessParams",
     "LinearThreadlikeRoutingParams",
     "PassiveElement",
     "ThreadlikeFriction",
@@ -80,6 +85,9 @@ __all__ = [
     "ThreadlikeTransmission",
     "ThreadlikeTransmissionParams",
     "Transmission",
+    "capstan_transmission_ratio",
+    "exponential_length_transmission_ratio",
+    "frictionless_transmission_ratio",
     "linear_threadlike_routing",
     "linear_threadlike_routing_derivative",
 ]

--- a/src/soromox/actuation/core.py
+++ b/src/soromox/actuation/core.py
@@ -168,6 +168,26 @@ class PassiveElement(eqx.Module):
         del robot
         return jnp.zeros((), dtype=q.dtype)
 
+    def nonconservative_force(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the part of this element's force that has no potential.
+
+        ``elastic_force`` is contracted to be the gradient of
+        ``elastic_energy``, so a force an element transmits but cannot derive
+        from a potential belongs here instead, keeping both contracts
+        truthful. ``SoftRobot.actuation_force`` applies the summed result, so
+        the total generalized force is unchanged by the split.
+
+        Args:
+            robot: Soft robot on which the element is installed.
+            q: Generalized coordinates of shape ``(robot.num_dofs,)``.
+
+        Returns:
+            tau_nc: Generalized force of shape ``(robot.num_dofs,)``, in the
+                same sign convention as :meth:`elastic_force`. Zero unless an
+                element overrides it.
+        """
+        return jnp.zeros((robot.num_dofs,), dtype=q.dtype)
+
 
 class Actuator(eqx.Module):
     """A transmission paired with an effort law and ordered channel metadata."""

--- a/src/soromox/actuation/core.py
+++ b/src/soromox/actuation/core.py
@@ -169,24 +169,7 @@ class PassiveElement(eqx.Module):
         return jnp.zeros((), dtype=q.dtype)
 
     def nonconservative_force(self, robot: SoftRobot, q: Array) -> Array:
-        """Return the part of this element's force that has no potential.
-
-        ``elastic_force`` is contracted to be the gradient of
-        ``elastic_energy``, so a force an element transmits but cannot derive
-        from a potential belongs here instead, keeping both contracts
-        truthful. ``SoftRobot.actuation_force`` applies the summed result, so
-        the total generalized force is unchanged by the split.
-
-        Args:
-            robot: Soft robot on which the element is installed.
-            q: Generalized coordinates of shape ``(robot.num_dofs,)``.
-
-        Returns:
-            tau_nc: Generalized force of shape ``(robot.num_dofs,)``, in the
-                same sign convention as :meth:`elastic_force`. Zero unless an
-                element overrides it.
-        """
-        return jnp.zeros((robot.num_dofs,), dtype=q.dtype)
+        return jnp.zeros((robot.num_velocities,), dtype=q.dtype)
 
 
 class Actuator(eqx.Module):

--- a/src/soromox/actuation/friction.py
+++ b/src/soromox/actuation/friction.py
@@ -212,16 +212,28 @@ class CapstanFriction(ThreadlikeFriction):
 class ExponentialLengthFriction(ThreadlikeFriction):
     """Loss accumulating with routed-path length rather than with turning.
 
-    ``eta(q, s) = exp(-rate * s)`` models drag a path accrues per unit length,
-    such as a sheath, a seal, or a lumen, independently of how the path bends.
-    It reads no host-shaped field and needs no wrap angle, so unlike
-    :class:`CapstanFriction` it runs on every threadlike host, ``GVS``
-    included.
+    Both shipped laws solve the same tension ODE ``dT/ds = -lambda(s) T``,
+    whose solution is ``eta = exp(-integral lambda ds)``. They differ only in
+    where the normal load pressing the path against its guide comes from.
+    :class:`CapstanFriction` takes it from curvature, ``N = T w``, giving
+    ``lambda = mu w``. This law takes it from a snug sheath that grips in
+    proportion to tension, ``N = c T``, giving a constant ``lambda = mu c``
+    and
+
+    ``eta(q, s) = exp(-rate * s)``
+
+    so loss accrues with distance travelled rather than with turning. It suits
+    a tendon in a close-fitting sheath or lumen. It reads no host-shaped field
+    and needs no wrap angle, so unlike :class:`CapstanFriction` it runs on
+    every threadlike host, ``GVS`` included.
 
     Attributes:
-        rate: Loss per unit arc length, in inverse metres, either a scalar
-            shared by the family or shaped ``(num_paths,)``. Zero reproduces
-            the frictionless transmission exactly.
+        rate: Loss per unit arc length ``mu c``, in inverse metres, either a
+            scalar shared by the family or shaped ``(num_paths,)``. Unlike a
+            Coulomb coefficient it is phenomenological: it lumps the friction
+            coefficient together with the radial grip and has to be fitted
+            rather than looked up. Zero reproduces the frictionless
+            transmission exactly.
     """
 
     rate: Array = eqx.field(default_factory=lambda: jnp.zeros((), dtype=jnp.float64))

--- a/src/soromox/actuation/friction.py
+++ b/src/soromox/actuation/friction.py
@@ -1,0 +1,247 @@
+"""Transmission-loss laws along threadlike routed paths.
+
+A threadlike transmission carries effort from the base of a routed path toward
+its tip. Guides, seals, and the surrounding material remove some of that effort
+before it reaches the backbone. A :class:`ThreadlikeFriction` model expresses
+how much survives, as a fraction ``eta(q, s)`` of the base effort, and the host
+folds that fraction into the arc-length quadrature that assembles the moment
+matrix.
+
+Because the fraction weights the integrand rather than scaling the result, the
+loss accumulates along the path: distal material contributes less than proximal
+material. The fraction depends on the configuration only, never on the effort,
+which keeps the generalized actuation force linear in the effort and every
+controller structurally unchanged.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, ClassVar
+
+import equinox as eqx
+from jax import Array
+from jax import numpy as jnp
+
+from soromox.systems.params import BaseSystemParams
+
+
+def validate_loss_parameter_shape(value: Any, count: int, name: str) -> None:
+    """Validate a per-path loss parameter shape without concretizing it.
+
+    Args:
+        value: Candidate loss parameter.
+        count: Number of routed paths in the family.
+        name: Field name used in the error message.
+
+    Raises:
+        ValueError: If the value is neither a scalar nor shaped ``(count,)``.
+    """
+    shape = jnp.asarray(value).shape
+    if shape not in ((), (count,)):
+        raise ValueError(
+            f"{name} must be a scalar or have shape ({count},), got {shape}."
+        )
+
+
+class ThreadlikeQuadratureContext(eqx.Module):
+    """Routed-path geometry at one arc-length quadrature node.
+
+    Instances are produced by the host inside its per-path ``vmap``, so every
+    array field carries a leading ``(num_paths,)`` axis.
+
+    Some fields mean the same thing on every host and some do not. A law that
+    reads only the host-agnostic fields runs unchanged on ``PlanarPCS``,
+    ``PCS``, and ``GVS``; a law that reads a host-shaped field must document
+    which host it targets.
+
+    Attributes:
+        arc_length: Backbone coordinate ``s`` of the node, in metres.
+            Host-agnostic.
+        segment_index: Index of the segment containing the node. Host-agnostic.
+        offset: Material-frame path offset of shape ``(num_paths, 3)``, ordered
+            ``[x, y, z]`` with local x along the backbone. Host-agnostic.
+        offset_derivative: Arc-length derivative of ``offset``, same shape.
+            Host-agnostic.
+        tangent_norm: Length of the routed-path tangent, ``(num_paths,)``. This
+            is the local stretch of the path relative to the backbone, so it is
+            the quantity a length-based loss integrates. Host-agnostic.
+        active: Whether the node lies inside each path's segment span, shape
+            ``(num_paths,)``. Host-agnostic.
+        unit_tangent: Normalized routed-path tangent. Host-shaped:
+            ``(num_paths, 2)`` in the plane and ``(num_paths, 3)`` in space.
+        strain: Segment strain at the node. Host-shaped: ``(num_paths, 3)``
+            ordered ``[kappa_z, sigma_x, sigma_y]`` in the plane, and
+            ``(num_paths, 6)`` ordered ``[omega, v]`` in space.
+        wrap_angle: Accumulated turn ``Theta`` of the routed path from the base
+            to this node, in radians, shape ``(num_paths,)``. ``None`` unless
+            the installed law sets ``requires_wrap_angle``, because computing
+            it costs the host extra work.
+
+    Note:
+        There is no path-count field. The host assembles the context inside a
+        ``vmap`` over paths, where a static count could not be set safely, so a
+        law that needs the count reads it from a batched field, for example
+        ``context.tangent_norm.shape[0]``.
+    """
+
+    arc_length: Array
+    segment_index: Array
+    offset: Array
+    offset_derivative: Array
+    tangent_norm: Array
+    active: Array
+    unit_tangent: Array
+    strain: Array
+    wrap_angle: Array | None = None
+
+    def with_wrap_angle(self, wrap_angle: Array) -> ThreadlikeQuadratureContext:
+        """Return a copy carrying the accumulated wrap angle.
+
+        The host builds the geometric fields inside its per-path ``vmap`` and
+        attaches the wrap angle afterwards, because the wrap density is
+        assembled once per segment rather than once per path.
+
+        Args:
+            wrap_angle: Accumulated turn of shape ``(num_paths,)``.
+
+        Returns:
+            context: A copy whose ``wrap_angle`` is populated.
+        """
+        return eqx.tree_at(
+            lambda context: context.wrap_angle,
+            self,
+            wrap_angle,
+            is_leaf=lambda leaf: leaf is None,
+        )
+
+
+class ThreadlikeFriction(BaseSystemParams):
+    """Fraction of routed-path effort that survives to a quadrature node.
+
+    Subclasses declare what they need from the host through the class
+    variables below, so a host computes only what the installed law reads and
+    can refuse a law it cannot serve.
+
+    Attributes:
+        is_lossless: Whether the law returns exactly one everywhere. Hosts skip
+            the friction path entirely when it is set, which keeps the default
+            bit-identical to the frictionless model at no cost.
+        requires_wrap_angle: Whether :meth:`transmission_ratio` reads
+            ``context.wrap_angle``. Hosts that cannot supply an exact
+            accumulated turn refuse such a law at construction.
+    """
+
+    is_lossless: ClassVar[bool] = False
+    requires_wrap_angle: ClassVar[bool] = True
+
+    @abstractmethod
+    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return the surviving effort fraction at one quadrature node.
+
+        Args:
+            context: Routed-path geometry at the node, batched over paths.
+
+        Returns:
+            eta: Surviving fraction of shape ``(num_paths,)``. Implementations
+                must stay within ``(0, 1]`` so a transmission can never
+                generate effort, and must not depend on the applied effort,
+                which would make the actuation force nonlinear in the control.
+        """
+        ...
+
+    def validate_for_paths(self, num_paths: int) -> None:
+        """Validate loss parameters against the routed-path count.
+
+        Args:
+            num_paths: Number of paths in the routing family.
+
+        Returns:
+            ``None``. Subclasses override this hook to check per-path shapes.
+            Implementations must be safe when leaves are JAX tracers.
+        """
+        del num_paths
+
+
+class Frictionless(ThreadlikeFriction):
+    """Ideal transmission that delivers the full effort to every node."""
+
+    is_lossless: ClassVar[bool] = True
+    requires_wrap_angle: ClassVar[bool] = False
+
+    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return ones, the identity of the weighted quadrature."""
+        return jnp.ones_like(context.tangent_norm)
+
+
+class CapstanFriction(ThreadlikeFriction):
+    """Coulomb guide friction following the Capstan (Euler) belt law.
+
+    A band drawn over a guide with total wrap angle ``phi`` transmits
+    ``exp(-mu * phi)`` of its input tension, independently of the guide radius.
+    Accumulating that loss over a continuum of guides gives
+
+    ``eta(q, s) = exp(-mu * Theta(q, s))``
+
+    with ``Theta`` the accumulated turn of the routed path. The law follows the
+    tendon force model of Feliu-Talegon, Alkayas, Adamu, Mathew and Renda,
+    "Actuation Reading Insights: Estimating Shape and Forces in Tendon-Driven
+    Slender Soft Robots", IEEE/ASME Transactions on Mechatronics 30(6), 2025.
+
+    Attributes:
+        coefficient: Coulomb coefficient between a path and its guides, either
+            a scalar shared by the family or shaped ``(num_paths,)``. Zero
+            reproduces the frictionless transmission exactly.
+    """
+
+    coefficient: Array = eqx.field(
+        default_factory=lambda: jnp.zeros((), dtype=jnp.float64)
+    )
+
+    requires_wrap_angle: ClassVar[bool] = True
+
+    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return the Capstan ratio ``exp(-mu * Theta)`` at the node."""
+        return jnp.exp(-jnp.asarray(self.coefficient) * context.wrap_angle)
+
+    def validate_for_paths(self, num_paths: int) -> None:
+        """Validate the coefficient shape against the routed-path count."""
+        validate_loss_parameter_shape(self.coefficient, num_paths, "coefficient")
+
+
+class ExponentialLengthFriction(ThreadlikeFriction):
+    """Loss accumulating with routed-path length rather than with turning.
+
+    ``eta(q, s) = exp(-rate * s)`` models drag a path accrues per unit length,
+    such as a sheath, a seal, or a lumen, independently of how the path bends.
+    It reads no host-shaped field and needs no wrap angle, so unlike
+    :class:`CapstanFriction` it runs on every threadlike host, ``GVS``
+    included.
+
+    Attributes:
+        rate: Loss per unit arc length, in inverse metres, either a scalar
+            shared by the family or shaped ``(num_paths,)``. Zero reproduces
+            the frictionless transmission exactly.
+    """
+
+    rate: Array = eqx.field(default_factory=lambda: jnp.zeros((), dtype=jnp.float64))
+
+    requires_wrap_angle: ClassVar[bool] = False
+
+    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return the length-decay ratio ``exp(-rate * s)`` at the node."""
+        return jnp.exp(-jnp.asarray(self.rate) * context.arc_length)
+
+    def validate_for_paths(self, num_paths: int) -> None:
+        """Validate the rate shape against the routed-path count."""
+        validate_loss_parameter_shape(self.rate, num_paths, "rate")
+
+
+__all__ = [
+    "CapstanFriction",
+    "ExponentialLengthFriction",
+    "Frictionless",
+    "ThreadlikeFriction",
+    "ThreadlikeQuadratureContext",
+    "validate_loss_parameter_shape",
+]

--- a/src/soromox/actuation/friction.py
+++ b/src/soromox/actuation/friction.py
@@ -1,23 +1,9 @@
-"""Transmission-loss laws along threadlike routed paths.
-
-A threadlike transmission carries effort from the base of a routed path toward
-its tip. Guides, seals, and the surrounding material remove some of that effort
-before it reaches the backbone. A :class:`ThreadlikeFriction` model expresses
-how much survives, as a fraction ``eta(q, s)`` of the base effort, and the host
-folds that fraction into the arc-length quadrature that assembles the moment
-matrix.
-
-Because the fraction weights the integrand rather than scaling the result, the
-loss accumulates along the path: distal material contributes less than proximal
-material. The fraction depends on the configuration only, never on the effort,
-which keeps the generalized actuation force linear in the effort and every
-controller structurally unchanged.
-"""
+"""Friction models along threadlike routed paths that attenuate the effort."""
 
 from __future__ import annotations
 
-from abc import abstractmethod
-from typing import Any, ClassVar
+from collections.abc import Callable
+from typing import Any, cast
 
 import equinox as eqx
 from jax import Array
@@ -26,12 +12,12 @@ from jax import numpy as jnp
 from soromox.systems.params import BaseSystemParams
 
 
-def validate_loss_parameter_shape(value: Any, count: int, name: str) -> None:
-    """Validate a per-path loss parameter shape without concretizing it.
+def validate_friction_parameter_shape(value: Any, count: int, name: str) -> None:
+    """Validate a per-path friction parameter shape.
 
     Args:
-        value: Candidate loss parameter.
-        count: Number of routed paths in the family.
+        value: Candidate friction parameter.
+        count: Number of routed paths.
         name: Field name used in the error message.
 
     Raises:
@@ -44,48 +30,53 @@ def validate_loss_parameter_shape(value: Any, count: int, name: str) -> None:
         )
 
 
+def validate_friction_parameter_values(value: Any, name: str) -> None:
+    """Validate that a friction parameter is finite and non-negative.
+
+    A negative or non-finite parameter pushes the transmission ratio outside
+    ``(0, 1]``, causing the transmission to generate effort.
+
+    Args:
+        value: Concrete friction parameter.
+        name: Field name used in the error message.
+
+    Raises:
+        ValueError: If the value is non-finite or negative.
+    """
+    array = jnp.asarray(value)
+    if not bool(jnp.all(jnp.isfinite(array))):
+        raise ValueError(f"{name} must be finite, got {array}.")
+    if bool(jnp.any(array < 0.0)):
+        raise ValueError(f"{name} must be non-negative, got {array}.")
+
+
 class ThreadlikeQuadratureContext(eqx.Module):
-    """Routed-path geometry at one arc-length quadrature node.
-
-    Instances are produced by the host inside its per-path ``vmap``, so every
-    array field carries a leading ``(num_paths,)`` axis.
-
-    Some fields mean the same thing on every host and some do not. A law that
-    reads only the host-agnostic fields runs unchanged on ``PlanarPCS``,
-    ``PCS``, and ``GVS``; a law that reads a host-shaped field must document
-    which host it targets.
+    """Routed-path geometry at one abscissa quadrature point.
 
     Attributes:
-        arc_length: Backbone coordinate ``s`` of the node, in metres.
-            Host-agnostic.
-        segment_index: Index of the segment containing the node. Host-agnostic.
+        abscissa: Backbone coordinate of the node from the robot base, in
+        metres.
+        path_abscissa: Arc-length covered along the span of each path from
+        the path anchor, in metres.
+        segment_index: Index of the segment containing the node.
         offset: Material-frame path offset of shape ``(num_paths, 3)``, ordered
-            ``[x, y, z]`` with local x along the backbone. Host-agnostic.
-        offset_derivative: Arc-length derivative of ``offset``, same shape.
-            Host-agnostic.
-        tangent_norm: Length of the routed-path tangent, ``(num_paths,)``. This
-            is the local stretch of the path relative to the backbone, so it is
-            the quantity a length-based loss integrates. Host-agnostic.
-        active: Whether the node lies inside each path's segment span, shape
-            ``(num_paths,)``. Host-agnostic.
+            ``[x, y, z]``.
+        offset_derivative: Arc-length derivative of ``offset``.
+        tangent_norm: Length of the routed-path tangent, ``(num_paths,)``.
+        active: True if the node lies inside the segment span of each path,
+            shape ``(num_paths,)``.
         unit_tangent: Normalized routed-path tangent. Host-shaped:
             ``(num_paths, 2)`` in the plane and ``(num_paths, 3)`` in space.
         strain: Segment strain at the node. Host-shaped: ``(num_paths, 3)``
             ordered ``[kappa_z, sigma_x, sigma_y]`` in the plane, and
             ``(num_paths, 6)`` ordered ``[omega, v]`` in space.
-        wrap_angle: Accumulated turn ``Theta`` of the routed path from the base
-            to this node, in radians, shape ``(num_paths,)``. ``None`` unless
-            the installed law sets ``requires_wrap_angle``, because computing
-            it costs the host extra work.
-
-    Note:
-        There is no path-count field. The host assembles the context inside a
-        ``vmap`` over paths, where a static count could not be set safely, so a
-        law that needs the count reads it from a batched field, for example
-        ``context.tangent_norm.shape[0]``.
+        wrap_angle: Routed-path curvature integrated from the path anchor to
+            the node, in radians, shape ``(num_paths,)``. ``None`` unless the
+            installed model sets ``requires_wrap_angle``.
     """
 
-    arc_length: Array
+    abscissa: Array
+    path_abscissa: Array
     segment_index: Array
     offset: Array
     offset_derivative: Array
@@ -98,12 +89,8 @@ class ThreadlikeQuadratureContext(eqx.Module):
     def with_wrap_angle(self, wrap_angle: Array) -> ThreadlikeQuadratureContext:
         """Return a copy carrying the accumulated wrap angle.
 
-        The host builds the geometric fields inside its per-path ``vmap`` and
-        attaches the wrap angle afterwards, because the wrap density is
-        assembled once per segment rather than once per path.
-
         Args:
-            wrap_angle: Accumulated turn of shape ``(num_paths,)``.
+            wrap_angle: Wrap angle of shape ``(num_paths,)``, in radians.
 
         Returns:
             context: A copy whose ``wrap_angle`` is populated.
@@ -116,144 +103,223 @@ class ThreadlikeQuadratureContext(eqx.Module):
         )
 
 
-class ThreadlikeFriction(BaseSystemParams):
-    """Fraction of routed-path effort that survives to a quadrature node.
+class BaseThreadlikeFrictionParams(BaseSystemParams):
+    """Base PyTree contract for threadlike friction parameters."""
 
-    Subclasses declare what they need from the host through the class
-    variables below, so a host computes only what the installed law reads and
-    can refuse a law it cannot serve.
-
-    Attributes:
-        is_lossless: Whether the law returns exactly one everywhere. Hosts skip
-            the friction path entirely when it is set, which keeps the default
-            bit-identical to the frictionless model at no cost.
-        requires_wrap_angle: Whether :meth:`transmission_ratio` reads
-            ``context.wrap_angle``. Hosts that cannot supply an exact
-            accumulated turn refuse such a law at construction.
-    """
-
-    is_lossless: ClassVar[bool] = False
-    requires_wrap_angle: ClassVar[bool] = True
-
-    @abstractmethod
-    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return the surviving effort fraction at one quadrature node.
-
-        Args:
-            context: Routed-path geometry at the node, batched over paths.
-
-        Returns:
-            eta: Surviving fraction of shape ``(num_paths,)``. Implementations
-                must stay within ``(0, 1]`` so a transmission can never
-                generate effort, and must not depend on the applied effort,
-                which would make the actuation force nonlinear in the control.
-        """
-        ...
-
-    def validate_for_paths(self, num_paths: int) -> None:
-        """Validate loss parameters against the routed-path count.
+    def validate_structure_compatibility(self, num_paths: int) -> None:
+        """Validate per-path friction parameter shapes against the path count.
 
         Args:
             num_paths: Number of paths in the routing family.
-
-        Returns:
-            ``None``. Subclasses override this hook to check per-path shapes.
-            Implementations must be safe when leaves are JAX tracers.
         """
         del num_paths
 
 
-class Frictionless(ThreadlikeFriction):
-    """Ideal transmission that delivers the full effort to every node."""
-
-    is_lossless: ClassVar[bool] = True
-    requires_wrap_angle: ClassVar[bool] = False
-
-    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return ones, the identity of the weighted quadrature."""
-        return jnp.ones_like(context.tangent_norm)
+class FrictionlessParams(BaseThreadlikeFrictionParams):
+    """Parameters of the ideal transmission. None."""
 
 
-class CapstanFriction(ThreadlikeFriction):
-    """Coulomb guide friction following the Capstan (Euler) belt law.
-
-    A band drawn over a guide with total wrap angle ``phi`` transmits
-    ``exp(-mu * phi)`` of its input tension, independently of the guide radius.
-    Accumulating that loss over a continuum of guides gives
-
-    ``eta(q, s) = exp(-mu * Theta(q, s))``
-
-    with ``Theta`` the accumulated turn of the routed path. The law follows the
-    tendon force model of Feliu-Talegon, Alkayas, Adamu, Mathew and Renda,
-    "Actuation Reading Insights: Estimating Shape and Forces in Tendon-Driven
-    Slender Soft Robots", IEEE/ASME Transactions on Mechatronics 30(6), 2025.
+class CapstanFrictionParams(BaseThreadlikeFrictionParams):
+    """Parameters of the Capstan (Euler) belt model.
 
     Attributes:
-        coefficient: Coulomb coefficient between a path and its guides, either
-            a scalar shared by the family or shaped ``(num_paths,)``. Zero
-            reproduces the frictionless transmission exactly.
+        coefficient: Coulomb coefficient between a routing and the robot, either
+            a scalar shared by the family or shaped ``(num_paths,)``.
+        eps: Curvature floor in radians per metre.
     """
 
     coefficient: Array = eqx.field(
         default_factory=lambda: jnp.zeros((), dtype=jnp.float64)
     )
+    eps: Array = eqx.field(default_factory=lambda: jnp.zeros((), dtype=jnp.float64))
 
-    requires_wrap_angle: ClassVar[bool] = True
+    def __check_init__(self) -> None:
+        self.validate_for_update()
 
-    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return the Capstan ratio ``exp(-mu * Theta)`` at the node."""
-        return jnp.exp(-jnp.asarray(self.coefficient) * context.wrap_angle)
-
-    def validate_for_paths(self, num_paths: int) -> None:
+    def validate_structure_compatibility(self, num_paths: int) -> None:
         """Validate the coefficient shape against the routed-path count."""
-        validate_loss_parameter_shape(self.coefficient, num_paths, "coefficient")
+        validate_friction_parameter_shape(self.coefficient, num_paths, "coefficient")
+
+    def validate_values(self) -> None:
+        """Validate eager Capstan parameter values."""
+        validate_friction_parameter_values(self.coefficient, "coefficient")
+        validate_friction_parameter_values(self.eps, "eps")
 
 
-class ExponentialLengthFriction(ThreadlikeFriction):
-    """Loss accumulating with routed-path length rather than with turning.
-
-    Both shipped laws solve the same tension ODE ``dT/ds = -lambda(s) T``,
-    whose solution is ``eta = exp(-integral lambda ds)``. They differ only in
-    where the normal load pressing the path against its guide comes from.
-    :class:`CapstanFriction` takes it from curvature, ``N = T w``, giving
-    ``lambda = mu w``. This law takes it from a snug sheath that grips in
-    proportion to tension, ``N = c T``, giving a constant ``lambda = mu c``
-    and
-
-    ``eta(q, s) = exp(-rate * s)``
-
-    so loss accrues with distance travelled rather than with turning. It suits
-    a tendon in a close-fitting sheath or lumen. It reads no host-shaped field
-    and needs no wrap angle, so unlike :class:`CapstanFriction` it runs on
-    every threadlike host, ``GVS`` included.
+class ExponentialLengthFrictionParams(BaseThreadlikeFrictionParams):
+    """Parameters of a configuration-independent friction proportional
+    to the routed-path length.
 
     Attributes:
-        rate: Loss per unit arc length ``mu c``, in inverse metres, either a
-            scalar shared by the family or shaped ``(num_paths,)``. Unlike a
-            Coulomb coefficient it is phenomenological: it lumps the friction
-            coefficient together with the radial grip and has to be fitted
-            rather than looked up. Zero reproduces the frictionless
-            transmission exactly.
+        rate: Attenuation per unit arc length, in inverse metres, either a scalar
+            shared by the family or shaped ``(num_paths,)``.
     """
 
     rate: Array = eqx.field(default_factory=lambda: jnp.zeros((), dtype=jnp.float64))
 
-    requires_wrap_angle: ClassVar[bool] = False
+    def __check_init__(self) -> None:
+        self.validate_for_update()
+
+    def validate_structure_compatibility(self, num_paths: int) -> None:
+        """Validate the rate shape against the routed-path count."""
+        validate_friction_parameter_shape(self.rate, num_paths, "rate")
+
+    def validate_values(self) -> None:
+        """Validate eager exponential-length parameter values."""
+        validate_friction_parameter_values(self.rate, "rate")
+
+
+def frictionless_transmission_ratio(
+    params: FrictionlessParams, context: ThreadlikeQuadratureContext
+) -> Array:
+    """Return ones, the identity of the weighted quadrature."""
+    del params
+    return jnp.ones_like(context.tangent_norm)
+
+
+def capstan_transmission_ratio(
+    params: CapstanFrictionParams, context: ThreadlikeQuadratureContext
+) -> Array:
+    """Return ``exp(-coefficient * wrap_angle)`` at the node."""
+    if context.wrap_angle is None:
+        raise ValueError(
+            "the Capstan law reads context.wrap_angle, which this host did not "
+            "supply. Declare requires_wrap_angle on the installed law."
+        )
+    return jnp.exp(-jnp.asarray(params.coefficient) * context.wrap_angle)
+
+
+def exponential_length_transmission_ratio(
+    params: ExponentialLengthFrictionParams, context: ThreadlikeQuadratureContext
+) -> Array:
+    """Return ``exp(-rate * path_abscissa)`` at the node."""
+    return jnp.exp(-jnp.asarray(params.rate) * context.path_abscissa)
+
+
+class ThreadlikeFriction(eqx.Module):
+    """Runtime friction model for a routed-path family.
+
+    Attributes:
+        params: Friction parameters.
+        ratio_fn: Model mapping ``(params, context)`` to the surviving fraction
+            of shape ``(num_paths,)``.
+        requires_wrap_angle: True if ``ratio_fn`` reads ``context.wrap_angle``.
+        is_frictionless: True if the law returns exactly one everywhere.
+    """
+
+    params: BaseThreadlikeFrictionParams = eqx.field(default_factory=FrictionlessParams)
+    ratio_fn: Callable = eqx.field(static=True, default=frictionless_transmission_ratio)
+    requires_wrap_angle: bool = eqx.field(static=True, default=False)
+    is_frictionless: bool = eqx.field(static=True, default=True)
+
+    def __check_init__(self) -> None:
+        if (
+            self.is_frictionless
+            and self.ratio_fn is not frictionless_transmission_ratio
+        ):
+            raise ValueError(
+                "is_frictionless=True requires frictionless_transmission_ratio. "
+                "A friction model requires is_frictionless=False."
+            )
+
+    @classmethod
+    def frictionless(cls) -> ThreadlikeFriction:
+        """Build the ideal transmission."""
+        return cls()
+
+    @classmethod
+    def capstan(cls, *, coefficient: Any = 0.0, eps: Any = 0.0) -> ThreadlikeFriction:
+        """Build the Capstan belt model.
+
+        Args:
+            coefficient: Coulomb coefficient, scalar or shaped ``(num_paths,)``.
+            eps: Curvature floor in radians per metre.
+
+        Returns:
+            friction: Capstan model.
+        """
+        return cls(
+            params=CapstanFrictionParams(
+                coefficient=jnp.asarray(coefficient), eps=jnp.asarray(eps)
+            ),
+            ratio_fn=capstan_transmission_ratio,
+            requires_wrap_angle=True,
+            is_frictionless=False,
+        )
+
+    @classmethod
+    def exponential_length(cls, *, rate: Any = 0.0) -> ThreadlikeFriction:
+        """Build the length-decay model.
+
+        Args:
+            rate: Attenuation per unit arc length, scalar or ``(num_paths,)``.
+
+        Returns:
+            friction: Length-decay law.
+        """
+        return cls(
+            params=ExponentialLengthFrictionParams(rate=jnp.asarray(rate)),
+            ratio_fn=exponential_length_transmission_ratio,
+            requires_wrap_angle=False,
+            is_frictionless=False,
+        )
 
     def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return the length-decay ratio ``exp(-rate * s)`` at the node."""
-        return jnp.exp(-jnp.asarray(self.rate) * context.arc_length)
+        """Return the transmission ratio at one quadrature node.
 
-    def validate_for_paths(self, num_paths: int) -> None:
-        """Validate the rate shape against the routed-path count."""
-        validate_loss_parameter_shape(self.rate, num_paths, "rate")
+        Args:
+            context: Routed-path geometry at the node, batched over paths.
+
+        Returns:
+            transmission_ratio: shape ``(num_paths,)``.
+        """
+        return self.ratio_fn(self.params, context)
+
+    def with_params(self, params: BaseThreadlikeFrictionParams) -> ThreadlikeFriction:
+        """Return a copy carrying replacement friction parameters."""
+        if not isinstance(params, BaseThreadlikeFrictionParams):
+            raise TypeError("params must be BaseThreadlikeFrictionParams.")
+        if type(params) is not type(self.params):
+            raise TypeError(
+                "friction params must keep their type; got "
+                f"{type(params).__name__} for an installed "
+                f"{type(self.params).__name__} model."
+            )
+        params.validate_for_update()
+        return ThreadlikeFriction(
+            params=params,
+            ratio_fn=self.ratio_fn,
+            requires_wrap_angle=self.requires_wrap_angle,
+            is_frictionless=self.is_frictionless,
+        )
+
+    def update_params(self, **updates: Any) -> ThreadlikeFriction:
+        """Return a copy with replaced friction parameter leaves."""
+        return self.with_params(
+            cast(BaseThreadlikeFrictionParams, self.params.replace(**updates))
+        )
+
+
+def validate_friction_for_robot(friction: ThreadlikeFriction, robot) -> None:
+    if friction.is_frictionless or not friction.requires_wrap_angle:
+        return
+    if not callable(getattr(robot, "_threadlike_path_curvature", None)):
+        raise TypeError(
+            f"{type(robot).__name__} does not support the threadlike wrap-angle model."
+        )
 
 
 __all__ = [
-    "CapstanFriction",
-    "ExponentialLengthFriction",
-    "Frictionless",
+    "BaseThreadlikeFrictionParams",
+    "CapstanFrictionParams",
+    "ExponentialLengthFrictionParams",
+    "FrictionlessParams",
     "ThreadlikeFriction",
     "ThreadlikeQuadratureContext",
-    "validate_loss_parameter_shape",
+    "capstan_transmission_ratio",
+    "exponential_length_transmission_ratio",
+    "frictionless_transmission_ratio",
+    "validate_friction_for_robot",
+    "validate_friction_parameter_shape",
+    "validate_friction_parameter_values",
 ]

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -18,6 +18,16 @@ from .core import (
     PassiveElement,
     Transmission,
 )
+from .friction import (
+    CapstanFriction,
+    Frictionless,
+    ThreadlikeFriction,
+)
+
+# Sentinel distinguishing "caller passed nothing" from an explicit friction
+# law, so the deprecated friction_coefficient sugar can be rejected when both
+# spellings are supplied.
+_UNSET: Any = object()
 
 ThreadlikeKind = Literal["tendon", "push_rod", "muscle", "pneumatic", "generic"]
 
@@ -101,49 +111,64 @@ def _channel_array(value: Any, count: int, name: str) -> Array:
     return array
 
 
-def _zero_friction_coefficient() -> Array:
-    """Return the frictionless default Capstan coefficient.
+def _resolve_friction(
+    friction: ThreadlikeFriction | None,
+    friction_coefficient: Any,
+) -> ThreadlikeFriction:
+    """Resolve the two spellings of a transmission-loss law into one model.
 
-    A zero *scalar*, not a ``(0,)`` array: consumers replace this leaf inside
-    differentiated closures, and a per-path default would change leaf shape on
-    the first replacement and force a retrace. It is also not ``None``, because
-    ``BaseSystemParams.replace`` reaches fields through ``eqx.tree_at`` and JAX
-    treats ``None`` as an empty subtree.
+    ``friction_coefficient`` is retained sugar for the common Capstan case and
+    builds a :class:`CapstanFriction`. Supplying both spellings is a mistake
+    rather than a merge, because the two would silently disagree.
+
+    Args:
+        friction: Explicit transmission-loss law, or ``None`` for the default.
+        friction_coefficient: Capstan coefficient sugar, or ``_UNSET``.
+
+    Returns:
+        model: The law to install. Defaults to :class:`Frictionless`.
+
+    Raises:
+        TypeError: If ``friction`` is not a :class:`ThreadlikeFriction`.
+        ValueError: If both spellings are supplied.
     """
-    return jnp.zeros((), dtype=jnp.float64)
-
-
-def _validate_friction_shape(value: Any, count: int, name: str) -> None:
-    """Validate a Capstan coefficient shape without concretizing its value."""
-    shape = jnp.asarray(value).shape
-    if shape not in ((), (count,)):
-        raise ValueError(
-            f"{name} must be a scalar or have shape ({count},), got {shape}."
+    if friction_coefficient is not _UNSET:
+        if friction is not None:
+            raise ValueError(
+                "Pass either friction= or friction_coefficient=, not both. "
+                "friction_coefficient is sugar for "
+                "CapstanFriction(coefficient=...)."
+            )
+        return CapstanFriction(coefficient=jnp.asarray(friction_coefficient))
+    if friction is None:
+        return Frictionless()
+    if not isinstance(friction, ThreadlikeFriction):
+        raise TypeError(
+            "friction must be a ThreadlikeFriction instance, got "
+            f"{type(friction).__name__}."
         )
+    return friction
 
 
-def _broadcast_friction(value: Any, count: int) -> Array:
-    """Broadcast a scalar or batched Capstan coefficient to one entry per path."""
-    return jnp.broadcast_to(jnp.asarray(value), (count,))
+def _validate_friction_for_robot(friction: ThreadlikeFriction, robot) -> None:
+    """Reject a transmission-loss law the host cannot serve.
 
-
-def _validate_friction_for_robot(friction_coefficient: Any, robot) -> None:
-    """Reject a nonzero Capstan coefficient on a host with no wrap-angle model.
-
-    The transmission ratio needs the accumulated turn of the routed path, which
-    only a host implementing ``_threadlike_wrap_density`` can supply. Hosts
-    without it silently ignore the coefficient, so a nonzero value is refused
-    here rather than being dropped. This runs only when the coefficient is
-    concrete, through the tracer guard in ``validate_for_robot``.
+    A law reading the accumulated turn of the routed path needs a host that
+    implements ``_threadlike_wrap_density``. Hosts without it would silently
+    ignore the law, so it is refused here rather than dropped. Laws that read
+    only host-agnostic geometry, such as a length-based loss, are accepted
+    everywhere. This runs only on concrete values, through the tracer guard in
+    ``validate_for_robot``.
     """
-    if not bool(jnp.any(jnp.asarray(friction_coefficient) != 0.0)):
+    if friction.is_lossless or not friction.requires_wrap_angle:
         return
     if not callable(getattr(robot, "_threadlike_wrap_density", None)):
         raise TypeError(
             f"{type(robot).__name__} does not implement the threadlike "
-            "wrap-angle model, so a nonzero friction_coefficient cannot be "
-            "honoured. Install the component on PCS or PlanarPCS, or leave the "
-            "coefficient at zero."
+            f"wrap-angle model, so {type(friction).__name__} cannot be "
+            "honoured. Install the component on PCS or PlanarPCS, or choose a "
+            "law that does not require the wrap angle, such as "
+            "ExponentialLengthFriction."
         )
 
 
@@ -379,20 +404,24 @@ class ThreadlikeRouting(eqx.Module):
 
 
 class ThreadlikeTransmissionParams(BaseSystemParams):
-    """Routing parameters, work-coordinate scale, and guide friction per path.
+    """Routing parameters, work-coordinate scale, and the transmission loss.
 
-    ``friction_coefficient`` is the Capstan coefficient between a path and its
-    guides. Effort applied at the base is transmitted to arc length ``s``
-    through ``exp(-mu * Theta(q, s))``, where ``Theta`` is the accumulated turn
-    of the routed path, so the loss builds up along the path instead of scaling
-    the input. It is either a scalar shared by every path of the family or
-    batched with shape ``(num_paths,)``. Zero is the default and reproduces the
-    frictionless transmission exactly.
+    ``friction`` is the law describing how much of the effort applied at the
+    base of a path survives to arc length ``s``. It weights the integrand of
+    the moment matrix, so a loss accumulates along the path instead of scaling
+    the input. The default :class:`~soromox.actuation.friction.Frictionless`
+    delivers the full effort everywhere and reproduces the frictionless
+    transmission exactly.
+
+    Swapping the law changes the parameter PyTree structure and so triggers a
+    retrace; replacing a value inside a law does not. Identification should
+    therefore start from a lossy law at a zero parameter, such as
+    ``CapstanFriction(coefficient=0.0)``, rather than from ``Frictionless()``.
     """
 
     routing: BaseThreadlikeRoutingParams
     coordinate_scale: Array
-    friction_coefficient: Array = eqx.field(default_factory=_zero_friction_coefficient)
+    friction: ThreadlikeFriction = eqx.field(default_factory=Frictionless)
 
     def __check_init__(self) -> None:
         self.validate_for_update()
@@ -406,15 +435,18 @@ class ThreadlikeTransmissionParams(BaseSystemParams):
                 "coordinate_scale must have shape "
                 f"({self.routing.num_paths},), got {scale.shape}."
             )
-        _validate_friction_shape(
-            self.friction_coefficient,
-            self.routing.num_paths,
-            "friction_coefficient",
-        )
+        if not isinstance(self.friction, ThreadlikeFriction):
+            raise TypeError(
+                "friction must be a ThreadlikeFriction instance, got "
+                f"{type(self.friction).__name__}."
+            )
+        self.friction.validate_structure()
+        self.friction.validate_for_paths(self.routing.num_paths)
 
     def validate_values(self) -> None:
-        """Validate eager nested routing values."""
+        """Validate eager nested routing and transmission-loss values."""
         self.routing.validate_values()
+        self.friction.validate_values()
 
 
 class ThreadlikeTransmission(Transmission):
@@ -454,13 +486,13 @@ class ThreadlikeTransmission(Transmission):
         )
 
     @property
-    def friction_coefficient(self) -> Array:
-        """Capstan coefficient of each path, broadcast to ``(num_channels,)``."""
-        return _broadcast_friction(self.params.friction_coefficient, self.num_channels)
+    def friction(self) -> ThreadlikeFriction:
+        """Transmission-loss law installed on this path family."""
+        return self.params.friction
 
     def moment_matrix(self, robot, q: Array) -> Array:
         raw_matrix = robot._threadlike_moment_matrix(
-            q, self.routing, friction_coefficient=self.friction_coefficient
+            q, self.routing, friction=self.friction
         )
         return raw_matrix * self.params.coordinate_scale[None, :]
 
@@ -591,7 +623,8 @@ class ThreadlikeActuator(Actuator):
         lower_bounds: Array | float = 0.0,
         upper_bounds: Array | float = jnp.inf,
         labels: tuple[str, ...] | None = None,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         count = routing.num_paths
@@ -601,7 +634,7 @@ class ThreadlikeActuator(Actuator):
                 coordinate_scale=_channel_array(
                     coordinate_scale, count, "coordinate_scale"
                 ),
-                friction_coefficient=jnp.asarray(friction_coefficient),
+                friction=_resolve_friction(friction, friction_coefficient),
             ),
             lower_bounds=_channel_array(lower_bounds, count, "lower_bounds"),
             upper_bounds=_channel_array(upper_bounds, count, "upper_bounds"),
@@ -623,7 +656,8 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -634,6 +668,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="tendon_tension",
             labels=labels,
+            friction=friction,
             friction_coefficient=friction_coefficient,
         )
 
@@ -643,7 +678,8 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -654,6 +690,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="rod_compression",
             labels=labels,
+            friction=friction,
             friction_coefficient=friction_coefficient,
         )
 
@@ -663,7 +700,8 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -674,6 +712,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="muscle_tension",
             labels=labels,
+            friction=friction,
             friction_coefficient=friction_coefficient,
         )
 
@@ -684,7 +723,8 @@ class ThreadlikeActuator(Actuator):
         *,
         effective_areas: Array,
         labels: tuple[str, ...] | None = None,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -697,6 +737,7 @@ class ThreadlikeActuator(Actuator):
             unit="Pa",
             label_prefix="chamber_pressure",
             labels=labels,
+            friction=friction,
             friction_coefficient=friction_coefficient,
         )
 
@@ -737,9 +778,7 @@ class ThreadlikeActuator(Actuator):
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.transmission.routing, robot)
-        _validate_friction_for_robot(
-            self.params.transmission.friction_coefficient, robot
-        )
+        _validate_friction_for_robot(self.params.transmission.friction, robot)
 
     def _robot_value_validation_tree(self):
         # The friction coefficient must be part of this subtree: validate_for_robot
@@ -747,7 +786,7 @@ class ThreadlikeActuator(Actuator):
         # routing would otherwise let the eager value checks run on a tracer.
         return (
             self.transmission.routing.params,
-            self.params.transmission.friction_coefficient,
+            self.params.transmission.friction,
         )
 
     def path_lengths(self, robot, q: Array) -> Array:
@@ -812,7 +851,8 @@ class ThreadlikeImpedance(PassiveElement):
         stiffness: Array,
         damping: Array,
         rest_length: Array,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
         name: str = "passive_threadlike",
     ) -> None:
         routing = ThreadlikeActuator._normalize_routing(routing)
@@ -821,7 +861,7 @@ class ThreadlikeImpedance(PassiveElement):
             transmission=ThreadlikeTransmissionParams(
                 routing=routing.params,
                 coordinate_scale=jnp.ones((count,)),
-                friction_coefficient=jnp.asarray(friction_coefficient),
+                friction=_resolve_friction(friction, friction_coefficient),
             ),
             stiffness=_channel_array(stiffness, count, "stiffness"),
             damping=_channel_array(damping, count, "damping"),
@@ -845,7 +885,7 @@ class ThreadlikeImpedance(PassiveElement):
             stiffness=params.stiffness,
             damping=params.damping,
             rest_length=params.rest_length,
-            friction_coefficient=params.transmission.friction_coefficient,
+            friction=params.transmission.friction,
             name=name,
         )
 
@@ -876,16 +916,14 @@ class ThreadlikeImpedance(PassiveElement):
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.routing, robot)
-        _validate_friction_for_robot(
-            self.params.transmission.friction_coefficient, robot
-        )
+        _validate_friction_for_robot(self.params.transmission.friction, robot)
 
     def _robot_value_validation_tree(self):
         # See ThreadlikeActuator._robot_value_validation_tree: the coefficient
         # belongs here so a traced value is detected by validate_for_robot.
         return (
             self.routing.params,
-            self.params.transmission.friction_coefficient,
+            self.params.transmission.friction,
         )
 
     def path_lengths(self, robot, q: Array) -> Array:

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -101,6 +101,52 @@ def _channel_array(value: Any, count: int, name: str) -> Array:
     return array
 
 
+def _zero_friction_coefficient() -> Array:
+    """Return the frictionless default Capstan coefficient.
+
+    A zero *scalar*, not a ``(0,)`` array: consumers replace this leaf inside
+    differentiated closures, and a per-path default would change leaf shape on
+    the first replacement and force a retrace. It is also not ``None``, because
+    ``BaseSystemParams.replace`` reaches fields through ``eqx.tree_at`` and JAX
+    treats ``None`` as an empty subtree.
+    """
+    return jnp.zeros((), dtype=jnp.float64)
+
+
+def _validate_friction_shape(value: Any, count: int, name: str) -> None:
+    """Validate a Capstan coefficient shape without concretizing its value."""
+    shape = jnp.asarray(value).shape
+    if shape not in ((), (count,)):
+        raise ValueError(
+            f"{name} must be a scalar or have shape ({count},), got {shape}."
+        )
+
+
+def _broadcast_friction(value: Any, count: int) -> Array:
+    """Broadcast a scalar or batched Capstan coefficient to one entry per path."""
+    return jnp.broadcast_to(jnp.asarray(value), (count,))
+
+
+def _validate_friction_for_robot(friction_coefficient: Any, robot) -> None:
+    """Reject a nonzero Capstan coefficient on a host with no wrap-angle model.
+
+    The transmission ratio needs the accumulated turn of the routed path, which
+    only a host implementing ``_threadlike_wrap_density`` can supply. Hosts
+    without it silently ignore the coefficient, so a nonzero value is refused
+    here rather than being dropped. This runs only when the coefficient is
+    concrete, through the tracer guard in ``validate_for_robot``.
+    """
+    if not bool(jnp.any(jnp.asarray(friction_coefficient) != 0.0)):
+        return
+    if not callable(getattr(robot, "_threadlike_wrap_density", None)):
+        raise TypeError(
+            f"{type(robot).__name__} does not implement the threadlike "
+            "wrap-angle model, so a nonzero friction_coefficient cannot be "
+            "honoured. Install the component on PCS or PlanarPCS, or leave the "
+            "coefficient at zero."
+        )
+
+
 def _path_vector_array(value: Any, name: str, *, count: int | None = None) -> Array:
     """Normalize material-frame vectors to shape ``(num_paths, 3)``."""
     array = jnp.asarray(value)
@@ -333,10 +379,20 @@ class ThreadlikeRouting(eqx.Module):
 
 
 class ThreadlikeTransmissionParams(BaseSystemParams):
-    """Routing parameters and constant work-coordinate scale per path."""
+    """Routing parameters, work-coordinate scale, and guide friction per path.
+
+    ``friction_coefficient`` is the Capstan coefficient between a path and its
+    guides. Effort applied at the base is transmitted to arc length ``s``
+    through ``exp(-mu * Theta(q, s))``, where ``Theta`` is the accumulated turn
+    of the routed path, so the loss builds up along the path instead of scaling
+    the input. It is either a scalar shared by every path of the family or
+    batched with shape ``(num_paths,)``. Zero is the default and reproduces the
+    frictionless transmission exactly.
+    """
 
     routing: BaseThreadlikeRoutingParams
     coordinate_scale: Array
+    friction_coefficient: Array = eqx.field(default_factory=_zero_friction_coefficient)
 
     def __check_init__(self) -> None:
         self.validate_for_update()
@@ -350,6 +406,11 @@ class ThreadlikeTransmissionParams(BaseSystemParams):
                 "coordinate_scale must have shape "
                 f"({self.routing.num_paths},), got {scale.shape}."
             )
+        _validate_friction_shape(
+            self.friction_coefficient,
+            self.routing.num_paths,
+            "friction_coefficient",
+        )
 
     def validate_values(self) -> None:
         """Validate eager nested routing values."""
@@ -392,15 +453,32 @@ class ThreadlikeTransmission(Transmission):
             q, self.routing
         )
 
+    @property
+    def friction_coefficient(self) -> Array:
+        """Capstan coefficient of each path, broadcast to ``(num_channels,)``."""
+        return _broadcast_friction(self.params.friction_coefficient, self.num_channels)
+
     def moment_matrix(self, robot, q: Array) -> Array:
-        raw_matrix = robot._threadlike_moment_matrix(q, self.routing)
+        raw_matrix = robot._threadlike_moment_matrix(
+            q, self.routing, friction_coefficient=self.friction_coefficient
+        )
         return raw_matrix * self.params.coordinate_scale[None, :]
+
+    def kinematic_matrix(self, robot, q: Array) -> Array:
+        """Return the frictionless length gradient ``(dl/dq).T`` of the paths.
+
+        This is the exact geometric Jacobian at any friction coefficient,
+        because path length is pure geometry. It coincides with
+        :meth:`moment_matrix` only when the coefficient is zero and the
+        coordinate scale is one.
+        """
+        return robot._threadlike_moment_matrix(q, self.routing)
 
     def path_lengths(self, robot, q: Array) -> Array:
         return robot._threadlike_path_lengths(q, self.routing)
 
     def path_velocities(self, robot, q: Array, qd: Array) -> Array:
-        return robot._threadlike_moment_matrix(q, self.routing).T @ qd
+        return self.kinematic_matrix(robot, q).T @ qd
 
     def path_poses(self, robot, q: Array, s: Array) -> Array:
         return robot._threadlike_path_positions(q, s, self.routing)
@@ -513,6 +591,7 @@ class ThreadlikeActuator(Actuator):
         lower_bounds: Array | float = 0.0,
         upper_bounds: Array | float = jnp.inf,
         labels: tuple[str, ...] | None = None,
+        friction_coefficient: Array | float = 0.0,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         count = routing.num_paths
@@ -522,6 +601,7 @@ class ThreadlikeActuator(Actuator):
                 coordinate_scale=_channel_array(
                     coordinate_scale, count, "coordinate_scale"
                 ),
+                friction_coefficient=jnp.asarray(friction_coefficient),
             ),
             lower_bounds=_channel_array(lower_bounds, count, "lower_bounds"),
             upper_bounds=_channel_array(upper_bounds, count, "upper_bounds"),
@@ -543,6 +623,7 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
+        friction_coefficient: Array | float = 0.0,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -553,6 +634,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="tendon_tension",
             labels=labels,
+            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -561,6 +643,7 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
+        friction_coefficient: Array | float = 0.0,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -571,6 +654,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="rod_compression",
             labels=labels,
+            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -579,6 +663,7 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
+        friction_coefficient: Array | float = 0.0,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -589,6 +674,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="muscle_tension",
             labels=labels,
+            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -598,6 +684,7 @@ class ThreadlikeActuator(Actuator):
         *,
         effective_areas: Array,
         labels: tuple[str, ...] | None = None,
+        friction_coefficient: Array | float = 0.0,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -610,6 +697,7 @@ class ThreadlikeActuator(Actuator):
             unit="Pa",
             label_prefix="chamber_pressure",
             labels=labels,
+            friction_coefficient=friction_coefficient,
         )
 
     @property
@@ -649,9 +737,18 @@ class ThreadlikeActuator(Actuator):
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.transmission.routing, robot)
+        _validate_friction_for_robot(
+            self.params.transmission.friction_coefficient, robot
+        )
 
     def _robot_value_validation_tree(self):
-        return self.transmission.routing.params
+        # The friction coefficient must be part of this subtree: validate_for_robot
+        # uses it to detect tracers, and a traced coefficient alongside concrete
+        # routing would otherwise let the eager value checks run on a tracer.
+        return (
+            self.transmission.routing.params,
+            self.params.transmission.friction_coefficient,
+        )
 
     def path_lengths(self, robot, q: Array) -> Array:
         return self.transmission.path_lengths(robot, q)
@@ -664,9 +761,15 @@ class ThreadlikeActuator(Actuator):
 
 
 class ThreadlikeImpedanceParams(BaseSystemParams):
-    """Spring-damper parameters for passive routed paths."""
+    """Spring-damper parameters for passive routed paths.
 
-    routing: BaseThreadlikeRoutingParams
+    The routed path is described by a nested ``transmission``, matching
+    ``ArticulatedTendonImpedanceParams``, so guide friction is declared in one
+    place for active and passive paths alike. Its coordinate scale is one,
+    because a passive path's natural coordinate is its raw length.
+    """
+
+    transmission: ThreadlikeTransmissionParams
     stiffness: Array
     damping: Array
     rest_length: Array
@@ -674,10 +777,15 @@ class ThreadlikeImpedanceParams(BaseSystemParams):
     def __check_init__(self) -> None:
         self.validate_for_update()
 
+    @property
+    def routing(self) -> BaseThreadlikeRoutingParams:
+        """Routing parameters of the passive paths."""
+        return self.transmission.routing
+
     def validate_structure(self) -> None:
         """Validate threadlike impedance parameter structure."""
-        self.routing.validate_structure()
-        count = self.routing.num_paths
+        self.transmission.validate_structure()
+        count = self.transmission.routing.num_paths
         for name in ("stiffness", "damping", "rest_length"):
             value = jnp.asarray(getattr(self, name))
             if value.shape != (count,):
@@ -686,15 +794,15 @@ class ThreadlikeImpedanceParams(BaseSystemParams):
                 )
 
     def validate_values(self) -> None:
-        """Validate eager nested threadlike routing values."""
-        self.routing.validate_values()
+        """Validate eager nested threadlike transmission values."""
+        self.transmission.validate_values()
 
 
 class ThreadlikeImpedance(PassiveElement):
     """Passive spring-damper mechanics along fixed threadlike paths."""
 
     _params: ThreadlikeImpedanceParams
-    routing: ThreadlikeRouting
+    _transmission: ThreadlikeTransmission
     name: str = eqx.field(static=True)
 
     def __init__(
@@ -704,17 +812,24 @@ class ThreadlikeImpedance(PassiveElement):
         stiffness: Array,
         damping: Array,
         rest_length: Array,
+        friction_coefficient: Array | float = 0.0,
         name: str = "passive_threadlike",
     ) -> None:
         routing = ThreadlikeActuator._normalize_routing(routing)
         count = routing.num_paths
         self._params = ThreadlikeImpedanceParams(
-            routing=routing.params,
+            transmission=ThreadlikeTransmissionParams(
+                routing=routing.params,
+                coordinate_scale=jnp.ones((count,)),
+                friction_coefficient=jnp.asarray(friction_coefficient),
+            ),
             stiffness=_channel_array(stiffness, count, "stiffness"),
             damping=_channel_array(damping, count, "damping"),
             rest_length=_channel_array(rest_length, count, "rest_length"),
         )
-        self.routing = routing
+        self._transmission = ThreadlikeTransmission(
+            self._params.transmission, routing=routing
+        )
         self.name = name
 
     @classmethod
@@ -726,10 +841,11 @@ class ThreadlikeImpedance(PassiveElement):
         routing: ThreadlikeRouting,
     ) -> ThreadlikeImpedance:
         return cls(
-            routing=routing.with_params(params.routing),
+            routing=routing.with_params(params.transmission.routing),
             stiffness=params.stiffness,
             damping=params.damping,
             rest_length=params.rest_length,
+            friction_coefficient=params.transmission.friction_coefficient,
             name=name,
         )
 
@@ -737,10 +853,21 @@ class ThreadlikeImpedance(PassiveElement):
     def params(self) -> ThreadlikeImpedanceParams:
         return self._params
 
+    @property
+    def transmission(self) -> ThreadlikeTransmission:
+        return self._transmission
+
+    @property
+    def routing(self) -> ThreadlikeRouting:
+        """Runtime routing object of the passive paths."""
+        return self._transmission.routing
+
     def with_params(self, params: BaseSystemParams) -> ThreadlikeImpedance:
         if not isinstance(params, ThreadlikeImpedanceParams):
             raise TypeError("params must be ThreadlikeImpedanceParams.")
-        self.params.routing.assert_same_topology(params.routing)
+        self.params.transmission.routing.assert_same_topology(
+            params.transmission.routing
+        )
         params.validate_for_update()
         return self._from_params(params, name=self.name, routing=self.routing)
 
@@ -749,35 +876,83 @@ class ThreadlikeImpedance(PassiveElement):
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.routing, robot)
+        _validate_friction_for_robot(
+            self.params.transmission.friction_coefficient, robot
+        )
 
     def _robot_value_validation_tree(self):
-        return self.routing.params
+        # See ThreadlikeActuator._robot_value_validation_tree: the coefficient
+        # belongs here so a traced value is detected by validate_for_robot.
+        return (
+            self.routing.params,
+            self.params.transmission.friction_coefficient,
+        )
 
     def path_lengths(self, robot, q: Array) -> Array:
         """Return the raw lengths of the passive routed paths."""
-        return robot._threadlike_path_lengths(q, self.routing)
+        return self._transmission.path_lengths(robot, q)
 
     def path_velocities(self, robot, q: Array, qd: Array) -> Array:
         """Return the raw length rates of the passive routed paths."""
-        return self._length_jacobian(robot, q) @ qd
+        return self._transmission.path_velocities(robot, q, qd)
 
     def path_poses(self, robot, q: Array, s: Array) -> Array:
         """Return passive routed-path positions at backbone coordinate ``s``."""
-        return robot._threadlike_path_positions(q, s, self.routing)
+        return self._transmission.path_poses(robot, q, s)
 
     def _length_jacobian(self, robot, q: Array) -> Array:
-        return robot._threadlike_moment_matrix(q, self.routing).T
+        """Return the exact kinematic length Jacobian ``dl/dq``.
+
+        Path length is pure geometry, so this is exact at any friction
+        coefficient. The friction-weighted force transmission is
+        :meth:`_transmission_matrix`.
+        """
+        return self._transmission.kinematic_matrix(robot, q).T
+
+    def _transmission_matrix(self, robot, q: Array) -> Array:
+        """Return the Capstan-weighted force transmission map of the paths."""
+        return self._transmission.moment_matrix(robot, q)
 
     def elastic_force(self, robot, q: Array) -> Array:
+        """Return the conservative part of the passive path force.
+
+        This uses the exact kinematic Jacobian, so it stays exactly the
+        gradient of :meth:`elastic_energy` at any friction coefficient. The
+        remainder that friction stops from reaching the backbone is reported by
+        :meth:`nonconservative_force`.
+        """
         lengths = self.path_lengths(robot, q)
         jacobian = self._length_jacobian(robot, q)
         return jacobian.T @ (
             self.params.stiffness * (lengths - self.params.rest_length)
         )
 
-    def damping_matrix(self, robot, q: Array) -> Array:
+    def nonconservative_force(self, robot, q: Array) -> Array:
+        """Return the part of the spring force that friction makes non-potential.
+
+        Guide friction attenuates the spring force transmitted to the backbone
+        without changing the energy stored in the spring, so the transmitted
+        force is not the gradient of anything. Splitting it off keeps
+        :meth:`elastic_force` conservative and the host's ``elastic_energy``
+        custom JVP truthful. It is zero when the friction coefficient is zero.
+        """
+        lengths = self.path_lengths(robot, q)
+        transmission = self._transmission_matrix(robot, q)
         jacobian = self._length_jacobian(robot, q)
-        return jacobian.T @ (self.params.damping[:, None] * jacobian)
+        return (transmission - jacobian.T) @ (
+            self.params.stiffness * (lengths - self.params.rest_length)
+        )
+
+    def damping_matrix(self, robot, q: Array) -> Array:
+        """Return the passive damping contribution of the routed paths.
+
+        Both sides use the Capstan-weighted transmission map, which keeps the
+        result symmetric positive semi-definite and therefore dissipative at
+        any friction coefficient. Reading the rate through the exact Jacobian
+        instead would make the matrix indefinite.
+        """
+        matrix = self._transmission_matrix(robot, q)
+        return matrix @ (self.params.damping[:, None] * matrix.T)
 
     def elastic_energy(self, robot, q: Array) -> Array:
         delta = self.path_lengths(robot, q) - self.params.rest_length

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -19,15 +19,11 @@ from .core import (
     Transmission,
 )
 from .friction import (
-    CapstanFriction,
-    Frictionless,
+    BaseThreadlikeFrictionParams,
+    FrictionlessParams,
     ThreadlikeFriction,
+    validate_friction_for_robot,
 )
-
-# Sentinel distinguishing "caller passed nothing" from an explicit friction
-# law, so the deprecated friction_coefficient sugar can be rejected when both
-# spellings are supplied.
-_UNSET: Any = object()
 
 ThreadlikeKind = Literal["tendon", "push_rod", "muscle", "pneumatic", "generic"]
 
@@ -111,65 +107,13 @@ def _channel_array(value: Any, count: int, name: str) -> Array:
     return array
 
 
-def _resolve_friction(
-    friction: ThreadlikeFriction | None,
-    friction_coefficient: Any,
-) -> ThreadlikeFriction:
-    """Resolve the two spellings of a transmission-loss law into one model.
-
-    ``friction_coefficient`` is retained sugar for the common Capstan case and
-    builds a :class:`CapstanFriction`. Supplying both spellings is a mistake
-    rather than a merge, because the two would silently disagree.
-
-    Args:
-        friction: Explicit transmission-loss law, or ``None`` for the default.
-        friction_coefficient: Capstan coefficient sugar, or ``_UNSET``.
-
-    Returns:
-        model: The law to install. Defaults to :class:`Frictionless`.
-
-    Raises:
-        TypeError: If ``friction`` is not a :class:`ThreadlikeFriction`.
-        ValueError: If both spellings are supplied.
-    """
-    if friction_coefficient is not _UNSET:
-        if friction is not None:
-            raise ValueError(
-                "Pass either friction= or friction_coefficient=, not both. "
-                "friction_coefficient is sugar for "
-                "CapstanFriction(coefficient=...)."
-            )
-        return CapstanFriction(coefficient=jnp.asarray(friction_coefficient))
-    if friction is None:
-        return Frictionless()
-    if not isinstance(friction, ThreadlikeFriction):
+def _normalize_friction(friction: Any) -> ThreadlikeFriction | None:
+    if friction is not None and not isinstance(friction, ThreadlikeFriction):
         raise TypeError(
             "friction must be a ThreadlikeFriction instance, got "
             f"{type(friction).__name__}."
         )
     return friction
-
-
-def _validate_friction_for_robot(friction: ThreadlikeFriction, robot) -> None:
-    """Reject a transmission-loss law the host cannot serve.
-
-    A law reading the accumulated turn of the routed path needs a host that
-    implements ``_threadlike_wrap_density``. Hosts without it would silently
-    ignore the law, so it is refused here rather than dropped. Laws that read
-    only host-agnostic geometry, such as a length-based loss, are accepted
-    everywhere. This runs only on concrete values, through the tracer guard in
-    ``validate_for_robot``.
-    """
-    if friction.is_lossless or not friction.requires_wrap_angle:
-        return
-    if not callable(getattr(robot, "_threadlike_wrap_density", None)):
-        raise TypeError(
-            f"{type(robot).__name__} does not implement the threadlike "
-            f"wrap-angle model, so {type(friction).__name__} cannot be "
-            "honoured. Install the component on PCS or PlanarPCS, or choose a "
-            "law that does not require the wrap angle, such as "
-            "ExponentialLengthFriction."
-        )
 
 
 def _path_vector_array(value: Any, name: str, *, count: int | None = None) -> Array:
@@ -404,24 +348,15 @@ class ThreadlikeRouting(eqx.Module):
 
 
 class ThreadlikeTransmissionParams(BaseSystemParams):
-    """Routing parameters, work-coordinate scale, and the transmission loss.
-
-    ``friction`` is the law describing how much of the effort applied at the
-    base of a path survives to arc length ``s``. It weights the integrand of
-    the moment matrix, so a loss accumulates along the path instead of scaling
-    the input. The default :class:`~soromox.actuation.friction.Frictionless`
-    delivers the full effort everywhere and reproduces the frictionless
-    transmission exactly.
-
-    Swapping the law changes the parameter PyTree structure and so triggers a
-    retrace; replacing a value inside a law does not. Identification should
-    therefore start from a lossy law at a zero parameter, such as
-    ``CapstanFriction(coefficient=0.0)``, rather than from ``Frictionless()``.
+    """Routing parameters, constant work-coordinate scale per path, and
+    friction paramters.
     """
 
     routing: BaseThreadlikeRoutingParams
     coordinate_scale: Array
-    friction: ThreadlikeFriction = eqx.field(default_factory=Frictionless)
+    friction: BaseThreadlikeFrictionParams = eqx.field(
+        default_factory=FrictionlessParams
+    )
 
     def __check_init__(self) -> None:
         self.validate_for_update()
@@ -435,16 +370,16 @@ class ThreadlikeTransmissionParams(BaseSystemParams):
                 "coordinate_scale must have shape "
                 f"({self.routing.num_paths},), got {scale.shape}."
             )
-        if not isinstance(self.friction, ThreadlikeFriction):
+        if not isinstance(self.friction, BaseThreadlikeFrictionParams):
             raise TypeError(
-                "friction must be a ThreadlikeFriction instance, got "
+                "friction must be a BaseThreadlikeFrictionParams instance, got "
                 f"{type(self.friction).__name__}."
             )
         self.friction.validate_structure()
-        self.friction.validate_for_paths(self.routing.num_paths)
+        self.friction.validate_structure_compatibility(self.routing.num_paths)
 
     def validate_values(self) -> None:
-        """Validate eager nested routing and transmission-loss values."""
+        """Validate eager nested routing and friction values."""
         self.routing.validate_values()
         self.friction.validate_values()
 
@@ -454,12 +389,14 @@ class ThreadlikeTransmission(Transmission):
 
     params: ThreadlikeTransmissionParams
     routing: ThreadlikeRouting
+    friction: ThreadlikeFriction
 
     def __init__(
         self,
         params: ThreadlikeTransmissionParams,
         *,
         routing: ThreadlikeRouting | None = None,
+        friction: ThreadlikeFriction | None = None,
     ) -> None:
         if not isinstance(params, ThreadlikeTransmissionParams):
             raise TypeError("params must be ThreadlikeTransmissionParams.")
@@ -475,6 +412,16 @@ class ThreadlikeTransmission(Transmission):
         else:
             routing = routing.with_params(params.routing)
         self.routing = routing
+        if friction is None:
+            if not isinstance(params.friction, FrictionlessParams):
+                raise TypeError(
+                    "friction params require their matching "
+                    "ThreadlikeFriction runtime object."
+                )
+            friction = ThreadlikeFriction()
+        else:
+            friction = friction.with_params(params.friction)
+        self.friction = friction
 
     @property
     def num_channels(self) -> int:
@@ -485,11 +432,6 @@ class ThreadlikeTransmission(Transmission):
             q, self.routing
         )
 
-    @property
-    def friction(self) -> ThreadlikeFriction:
-        """Transmission-loss law installed on this path family."""
-        return self.params.friction
-
     def moment_matrix(self, robot, q: Array) -> Array:
         raw_matrix = robot._threadlike_moment_matrix(
             q, self.routing, friction=self.friction
@@ -497,13 +439,7 @@ class ThreadlikeTransmission(Transmission):
         return raw_matrix * self.params.coordinate_scale[None, :]
 
     def kinematic_matrix(self, robot, q: Array) -> Array:
-        """Return the frictionless length gradient ``(dl/dq).T`` of the paths.
-
-        This is the exact geometric Jacobian at any friction coefficient,
-        because path length is pure geometry. It coincides with
-        :meth:`moment_matrix` only when the coefficient is zero and the
-        coordinate scale is one.
-        """
+        """Return the frictionless length gradient ``(dl/dq).T`` of the paths."""
         return robot._threadlike_moment_matrix(q, self.routing)
 
     def path_lengths(self, robot, q: Array) -> Array:
@@ -522,7 +458,9 @@ class ThreadlikeTransmission(Transmission):
             raise TypeError("params must be ThreadlikeTransmissionParams.")
         self.params.routing.assert_same_topology(params.routing)
         params.validate_for_update()
-        return ThreadlikeTransmission(params, routing=self.routing)
+        return ThreadlikeTransmission(
+            params, routing=self.routing, friction=self.friction
+        )
 
     def update_params(self, **updates: Any) -> ThreadlikeTransmission:
         return self.with_params(self.params.replace(**updates))
@@ -569,6 +507,7 @@ class ThreadlikeActuator(Actuator):
         *,
         params: ThreadlikeActuatorParams,
         routing: ThreadlikeRouting | None = None,
+        friction: ThreadlikeFriction | None = None,
         labels: tuple[str, ...],
         units: str | tuple[str, ...],
         name: str,
@@ -580,7 +519,7 @@ class ThreadlikeActuator(Actuator):
             raise ValueError("labels must contain one entry per threadlike path.")
         self._params = params
         self._transmission = ThreadlikeTransmission(
-            params.transmission, routing=routing
+            params.transmission, routing=routing, friction=friction
         )
         self._effort_model = DirectEffort()
         self._metadata = ActuatorMetadata(
@@ -624,9 +563,9 @@ class ThreadlikeActuator(Actuator):
         upper_bounds: Array | float = jnp.inf,
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
+        friction = _normalize_friction(friction)
         count = routing.num_paths
         params = ThreadlikeActuatorParams(
             transmission=ThreadlikeTransmissionParams(
@@ -634,7 +573,9 @@ class ThreadlikeActuator(Actuator):
                 coordinate_scale=_channel_array(
                     coordinate_scale, count, "coordinate_scale"
                 ),
-                friction=_resolve_friction(friction, friction_coefficient),
+                friction=(
+                    friction.params if friction is not None else FrictionlessParams()
+                ),
             ),
             lower_bounds=_channel_array(lower_bounds, count, "lower_bounds"),
             upper_bounds=_channel_array(upper_bounds, count, "upper_bounds"),
@@ -644,6 +585,7 @@ class ThreadlikeActuator(Actuator):
         return cls(
             params=params,
             routing=routing,
+            friction=friction,
             labels=labels,
             units=unit,
             name=name,
@@ -657,7 +599,6 @@ class ThreadlikeActuator(Actuator):
         *,
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -669,7 +610,6 @@ class ThreadlikeActuator(Actuator):
             label_prefix="tendon_tension",
             labels=labels,
             friction=friction,
-            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -679,7 +619,6 @@ class ThreadlikeActuator(Actuator):
         *,
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -691,7 +630,6 @@ class ThreadlikeActuator(Actuator):
             label_prefix="rod_compression",
             labels=labels,
             friction=friction,
-            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -701,7 +639,6 @@ class ThreadlikeActuator(Actuator):
         *,
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -713,7 +650,6 @@ class ThreadlikeActuator(Actuator):
             label_prefix="muscle_tension",
             labels=labels,
             friction=friction,
-            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -724,7 +660,6 @@ class ThreadlikeActuator(Actuator):
         effective_areas: Array,
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -738,7 +673,6 @@ class ThreadlikeActuator(Actuator):
             label_prefix="chamber_pressure",
             labels=labels,
             friction=friction,
-            friction_coefficient=friction_coefficient,
         )
 
     @property
@@ -767,6 +701,7 @@ class ThreadlikeActuator(Actuator):
         return ThreadlikeActuator(
             params=params,
             routing=self.transmission.routing,
+            friction=self.transmission.friction,
             labels=self.metadata.labels,
             units=self.metadata.units,
             name=self.name,
@@ -778,12 +713,9 @@ class ThreadlikeActuator(Actuator):
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.transmission.routing, robot)
-        _validate_friction_for_robot(self.params.transmission.friction, robot)
+        validate_friction_for_robot(self.transmission.friction, robot)
 
     def _robot_value_validation_tree(self):
-        # The friction coefficient must be part of this subtree: validate_for_robot
-        # uses it to detect tracers, and a traced coefficient alongside concrete
-        # routing would otherwise let the eager value checks run on a tracer.
         return (
             self.transmission.routing.params,
             self.params.transmission.friction,
@@ -800,13 +732,7 @@ class ThreadlikeActuator(Actuator):
 
 
 class ThreadlikeImpedanceParams(BaseSystemParams):
-    """Spring-damper parameters for passive routed paths.
-
-    The routed path is described by a nested ``transmission``, matching
-    ``ArticulatedTendonImpedanceParams``, so guide friction is declared in one
-    place for active and passive paths alike. Its coordinate scale is one,
-    because a passive path's natural coordinate is its raw length.
-    """
+    """Spring-damper parameters for passive routed paths."""
 
     transmission: ThreadlikeTransmissionParams
     stiffness: Array
@@ -852,23 +778,25 @@ class ThreadlikeImpedance(PassiveElement):
         damping: Array,
         rest_length: Array,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
         name: str = "passive_threadlike",
     ) -> None:
         routing = ThreadlikeActuator._normalize_routing(routing)
+        friction = _normalize_friction(friction)
         count = routing.num_paths
         self._params = ThreadlikeImpedanceParams(
             transmission=ThreadlikeTransmissionParams(
                 routing=routing.params,
                 coordinate_scale=jnp.ones((count,)),
-                friction=_resolve_friction(friction, friction_coefficient),
+                friction=(
+                    friction.params if friction is not None else FrictionlessParams()
+                ),
             ),
             stiffness=_channel_array(stiffness, count, "stiffness"),
             damping=_channel_array(damping, count, "damping"),
             rest_length=_channel_array(rest_length, count, "rest_length"),
         )
         self._transmission = ThreadlikeTransmission(
-            self._params.transmission, routing=routing
+            self._params.transmission, routing=routing, friction=friction
         )
         self.name = name
 
@@ -879,13 +807,14 @@ class ThreadlikeImpedance(PassiveElement):
         *,
         name: str,
         routing: ThreadlikeRouting,
+        friction: ThreadlikeFriction,
     ) -> ThreadlikeImpedance:
         return cls(
             routing=routing.with_params(params.transmission.routing),
             stiffness=params.stiffness,
             damping=params.damping,
             rest_length=params.rest_length,
-            friction=params.transmission.friction,
+            friction=friction.with_params(params.transmission.friction),
             name=name,
         )
 
@@ -909,18 +838,21 @@ class ThreadlikeImpedance(PassiveElement):
             params.transmission.routing
         )
         params.validate_for_update()
-        return self._from_params(params, name=self.name, routing=self.routing)
+        return self._from_params(
+            params,
+            name=self.name,
+            routing=self.routing,
+            friction=self._transmission.friction,
+        )
 
     def validate_structure_for_robot(self, robot) -> None:
         _validate_routing_structure_for_robot(self.routing, robot)
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.routing, robot)
-        _validate_friction_for_robot(self.params.transmission.friction, robot)
+        validate_friction_for_robot(self.transmission.friction, robot)
 
     def _robot_value_validation_tree(self):
-        # See ThreadlikeActuator._robot_value_validation_tree: the coefficient
-        # belongs here so a traced value is detected by validate_for_robot.
         return (
             self.routing.params,
             self.params.transmission.friction,
@@ -939,26 +871,13 @@ class ThreadlikeImpedance(PassiveElement):
         return self._transmission.path_poses(robot, q, s)
 
     def _length_jacobian(self, robot, q: Array) -> Array:
-        """Return the exact kinematic length Jacobian ``dl/dq``.
-
-        Path length is pure geometry, so this is exact at any friction
-        coefficient. The friction-weighted force transmission is
-        :meth:`_transmission_matrix`.
-        """
         return self._transmission.kinematic_matrix(robot, q).T
 
     def _transmission_matrix(self, robot, q: Array) -> Array:
-        """Return the Capstan-weighted force transmission map of the paths."""
         return self._transmission.moment_matrix(robot, q)
 
     def elastic_force(self, robot, q: Array) -> Array:
-        """Return the conservative part of the passive path force.
-
-        This uses the exact kinematic Jacobian, so it stays exactly the
-        gradient of :meth:`elastic_energy` at any friction coefficient. The
-        remainder that friction stops from reaching the backbone is reported by
-        :meth:`nonconservative_force`.
-        """
+        """Return the conservative part of the passive path force."""
         lengths = self.path_lengths(robot, q)
         jacobian = self._length_jacobian(robot, q)
         return jacobian.T @ (
@@ -966,14 +885,7 @@ class ThreadlikeImpedance(PassiveElement):
         )
 
     def nonconservative_force(self, robot, q: Array) -> Array:
-        """Return the part of the spring force that friction makes non-potential.
-
-        Guide friction attenuates the spring force transmitted to the backbone
-        without changing the energy stored in the spring, so the transmitted
-        force is not the gradient of anything. Splitting it off keeps
-        :meth:`elastic_force` conservative and the host's ``elastic_energy``
-        custom JVP truthful. It is zero when the friction coefficient is zero.
-        """
+        """Return the part of the spring force that friction makes non-potential."""
         lengths = self.path_lengths(robot, q)
         transmission = self._transmission_matrix(robot, q)
         jacobian = self._length_jacobian(robot, q)
@@ -982,13 +894,6 @@ class ThreadlikeImpedance(PassiveElement):
         )
 
     def damping_matrix(self, robot, q: Array) -> Array:
-        """Return the passive damping contribution of the routed paths.
-
-        Both sides use the Capstan-weighted transmission map, which keeps the
-        result symmetric positive semi-definite and therefore dissipative at
-        any friction coefficient. Reading the rate through the exact Jacobian
-        instead would make the matrix indefinite.
-        """
         matrix = self._transmission_matrix(robot, q)
         return matrix @ (self.params.damping[:, None] * matrix.T)
 

--- a/src/soromox/execution/dispatch.py
+++ b/src/soromox/execution/dispatch.py
@@ -122,7 +122,7 @@ def dispatch_actuation_matrix(
     if configured == "warp" and not eligible:
         raise NotImplementedError(
             f"Warp {capabilities.family_name} actuation_matrix requires only "
-            "built-in linear ThreadlikeActuator transmissions."
+            "built-in frictionless linear ThreadlikeActuator transmissions."
         )
     if configured == "warp" and eligible and not capabilities.matrix_enabled:
         raise NotImplementedError(
@@ -174,7 +174,8 @@ def dispatch_actuation_force(
     if configured == "warp" and not eligible:
         raise NotImplementedError(
             f"Warp {capabilities.family_name} actuation_force requires only "
-            "built-in linear ThreadlikeActuator transmissions with DirectEffort."
+            "built-in frictionless linear ThreadlikeActuator transmissions with "
+            "DirectEffort and no non-conservative passive forces."
         )
     if configured == "warp" and eligible and not capabilities.force_enabled:
         raise NotImplementedError(

--- a/src/soromox/execution/warp/actuation/threadlike.py
+++ b/src/soromox/execution/warp/actuation/threadlike.py
@@ -6,7 +6,7 @@ import equinox as eqx
 import jax.numpy as jnp
 from jax import Array
 
-from soromox.actuation.core import DirectEffort
+from soromox.actuation.core import DirectEffort, PassiveElement
 from soromox.actuation.threadlike import (
     LinearThreadlikeRoutingParams,
     ThreadlikeActuator,
@@ -68,7 +68,7 @@ class LinearThreadlikeActuationData(eqx.Module):
 
 
 def _uses_builtin_linear_routing(actuator) -> bool:
-    """Return whether one actuator has the exact built-in linear runtime."""
+    """Return whether one actuator has the exact frictionless linear runtime."""
 
     if not isinstance(actuator, ThreadlikeActuator):
         return False
@@ -77,21 +77,41 @@ def _uses_builtin_linear_routing(actuator) -> bool:
         isinstance(routing.params, LinearThreadlikeRoutingParams)
         and routing.offset_fn is linear_threadlike_routing
         and routing.derivative_fn is linear_threadlike_routing_derivative
+        and actuator.transmission.friction.is_frictionless
+    )
+
+
+def _has_nonconservative_passive_force(element) -> bool:
+    """Return whether a passive element contributes outside an elastic potential."""
+
+    transmission = getattr(element, "transmission", None)
+    friction = getattr(transmission, "friction", None)
+    if friction is not None:
+        return not friction.is_frictionless
+    return (
+        type(element).nonconservative_force is not PassiveElement.nonconservative_force
     )
 
 
 def supports_linear_threadlike_matrix(model) -> bool:
-    """Return whether all active transmission columns have Warp-linear routing."""
+    """Return whether every active column has frictionless Warp-linear routing."""
 
     actuators = tuple(getattr(model, "actuators", ()))
     return bool(actuators) and all(_uses_builtin_linear_routing(a) for a in actuators)
 
 
 def supports_linear_threadlike_force(model) -> bool:
-    """Return whether the matrix may be fused with direct actuator controls."""
+    """Return whether frictionless direct controls may use the fused Warp force."""
 
-    return supports_linear_threadlike_matrix(model) and all(
-        type(actuator.effort_model) is DirectEffort for actuator in model.actuators
+    return (
+        supports_linear_threadlike_matrix(model)
+        and all(
+            type(actuator.effort_model) is DirectEffort for actuator in model.actuators
+        )
+        and not any(
+            _has_nonconservative_passive_force(element)
+            for element in getattr(model, "passive_elements", ())
+        )
     )
 
 

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -7,6 +7,10 @@ import jax.numpy as jnp
 from jax import Array, lax, vmap
 
 from soromox.actuation.core import Actuator, PassiveElement
+from soromox.actuation.friction import (
+    ThreadlikeFriction,
+    ThreadlikeQuadratureContext,
+)
 from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
     ThreadlikeRouting,
@@ -5841,7 +5845,7 @@ class GVS(SoftRobot):
             self, q, u, qd, backend=backend, capabilities=GVS_ACTUATION
         )
 
-    def _threadlike_local_basis(
+    def _threadlike_local_geometry(
         self,
         routing: ThreadlikeRouting,
         path_params: BaseThreadlikeRoutingParams,
@@ -5851,8 +5855,15 @@ class GVS(SoftRobot):
         s: Array,
         segment_index: Array,
         point_index: Array,
-    ) -> Array:
-        """Return one spatial routed-path length gradient density."""
+    ) -> ThreadlikeQuadratureContext:
+        """Return one routed-path geometry at a GVS quadrature node.
+
+        Returns:
+            context: Node geometry for one path. ``wrap_angle`` is never
+                populated: GVS strain varies along the arc length, so the
+                accumulated turn is not piecewise linear and would need its own
+                cumulative quadrature.
+        """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
         )
@@ -5861,33 +5872,48 @@ class GVS(SoftRobot):
         if self.scale_rotational_basis_by_length:
             basis = basis.at[:3, :].divide(length)
         strain = basis @ q_link + self.xi_ref_Xs[segment_index, point_index]
-        offset = jnp.append(routing.offset(path_params, s), 1.0)
-        derivative = jnp.append(routing.derivative(path_params, s), 1.0)
-        tangent_unnormalized = (derivative + se3.hat(strain) @ offset)[:-1]
-        tangent = safe_normalize(tangent_unnormalized, eps=self.global_eps)
-        local = jnp.hstack([so3.skew(offset[:-1]) @ tangent, tangent])
-        return active * local
+        offset = routing.offset(path_params, s)
+        offset_derivative = routing.derivative(path_params, s)
+        homogeneous_offset = jnp.append(offset, 1.0)
+        homogeneous_derivative = jnp.append(offset_derivative, 1.0)
+        tangent = (homogeneous_derivative + se3.hat(strain) @ homogeneous_offset)[:-1]
+        return ThreadlikeQuadratureContext(
+            arc_length=jnp.asarray(s),
+            segment_index=jnp.asarray(segment_index),
+            offset=offset,
+            offset_derivative=offset_derivative,
+            tangent_norm=safe_norm(tangent),
+            active=active,
+            unit_tangent=safe_normalize(tangent, eps=self.global_eps),
+            strain=strain,
+        )
+
+    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return one routed-path length gradient density in the GVS basis."""
+        tangent = context.unit_tangent
+        local = jnp.hstack([so3.skew(context.offset) @ tangent, tangent])
+        return context.active * local
 
     def _threadlike_moment_matrix(
         self,
         q: Array,
         routing: ThreadlikeRouting,
-        friction_coefficient: Array | None = None,
+        friction: ThreadlikeFriction | None = None,
     ) -> Array:
-        """Integrate raw routed-length moment arms in the native GVS basis.
+        """Integrate routed-length moment arms in the native GVS basis.
 
         GVS strain varies along the arc length, so the Capstan wrap angle is
-        not piecewise linear and would need its own cumulative quadrature. The
-        wrap-angle model is therefore not implemented for this host and
-        ``friction_coefficient`` is ignored; installing a threadlike component
-        carrying a nonzero coefficient on a GVS robot is refused at
-        construction instead of being silently dropped.
+        not piecewise linear and would need its own cumulative quadrature. This
+        host therefore supplies no ``wrap_angle``, and a law requiring one is
+        refused at construction rather than silently dropped. Laws reading only
+        host-agnostic geometry, such as a length-based loss, are honoured here
+        exactly as on the PCS hosts.
         """
-        del friction_coefficient
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
+        lossy = friction is not None and not friction.is_lossless
         q_gathered = self._min_size_gathered(q)
 
         def segment_matrix(segment_index: Array) -> Array:
@@ -5900,10 +5926,10 @@ class GVS(SoftRobot):
                     self.segment_end_positions[segment_index]
                     + self.integration_points[segment_index, point_index] * length
                 )
-                local = vmap(
-                    self._threadlike_local_basis,
+                context = vmap(
+                    self._threadlike_local_geometry,
                     in_axes=(None, 0, 0, 0, None, None, None, None),
-                    out_axes=1,
+                    out_axes=0,
                 )(
                     routing,
                     params,
@@ -5914,6 +5940,9 @@ class GVS(SoftRobot):
                     segment_index,
                     point_index,
                 )
+                local = vmap(self._threadlike_local_basis, out_axes=1)(context)
+                if lossy:
+                    local = local * friction.transmission_ratio(context)[None, :]
                 basis = self.B_Xs[segment_index, point_index]
                 if self.scale_rotational_basis_by_length:
                     basis = basis.at[:3, :].divide(length)

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -5868,8 +5868,22 @@ class GVS(SoftRobot):
         local = jnp.hstack([so3.skew(offset[:-1]) @ tangent, tangent])
         return active * local
 
-    def _threadlike_moment_matrix(self, q: Array, routing: ThreadlikeRouting) -> Array:
-        """Integrate raw routed-length moment arms in the native GVS basis."""
+    def _threadlike_moment_matrix(
+        self,
+        q: Array,
+        routing: ThreadlikeRouting,
+        friction_coefficient: Array | None = None,
+    ) -> Array:
+        """Integrate raw routed-length moment arms in the native GVS basis.
+
+        GVS strain varies along the arc length, so the Capstan wrap angle is
+        not piecewise linear and would need its own cumulative quadrature. The
+        wrap-angle model is therefore not implemented for this host and
+        ``friction_coefficient`` is ignored; installing a threadlike component
+        carrying a nonzero coefficient on a GVS robot is refused at
+        construction instead of being silently dropped.
+        """
+        del friction_coefficient
         params = routing.params
         count = params.num_paths
         if count == 0:

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -5859,13 +5859,15 @@ class GVS(SoftRobot):
         """Return one routed-path geometry at a GVS quadrature node.
 
         Returns:
-            context: Node geometry for one path. ``wrap_angle`` is never
-                populated: GVS strain varies along the arc length, so the
-                accumulated turn is not piecewise linear and would need its own
-                cumulative quadrature.
+            context: Node geometry for one path.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
+        )
+        path_abscissa = jnp.clip(
+            jnp.asarray(s) - self.segment_end_positions[start_segment_index],
+            0.0,
+            self.segment_end_positions[-1],
         )
         basis = self.B_Xs[segment_index, point_index]
         length = self.segment_lengths[segment_index]
@@ -5878,7 +5880,8 @@ class GVS(SoftRobot):
         homogeneous_derivative = jnp.append(offset_derivative, 1.0)
         tangent = (homogeneous_derivative + se3.hat(strain) @ homogeneous_offset)[:-1]
         return ThreadlikeQuadratureContext(
-            arc_length=jnp.asarray(s),
+            abscissa=jnp.asarray(s),
+            path_abscissa=path_abscissa,
             segment_index=jnp.asarray(segment_index),
             offset=offset,
             offset_derivative=offset_derivative,
@@ -5888,8 +5891,17 @@ class GVS(SoftRobot):
             strain=strain,
         )
 
-    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return one routed-path length gradient density in the GVS basis."""
+    def _threadlike_local_length_gradient(
+        self, context: ThreadlikeQuadratureContext
+    ) -> Array:
+        """Return one routed-path length gradient density in the GVS basis.
+
+        Args:
+            context: Node geometry.
+
+        Returns:
+            length_gradient_density: Shape ``(6,)``.
+        """
         tangent = context.unit_tangent
         local = jnp.hstack([so3.skew(context.offset) @ tangent, tangent])
         return context.active * local
@@ -5900,20 +5912,12 @@ class GVS(SoftRobot):
         routing: ThreadlikeRouting,
         friction: ThreadlikeFriction | None = None,
     ) -> Array:
-        """Integrate routed-length moment arms in the native GVS basis.
-
-        GVS strain varies along the arc length, so the Capstan wrap angle is
-        not piecewise linear and would need its own cumulative quadrature. This
-        host therefore supplies no ``wrap_angle``, and a law requiring one is
-        refused at construction rather than silently dropped. Laws reading only
-        host-agnostic geometry, such as a length-based loss, are honoured here
-        exactly as on the PCS hosts.
-        """
+        """Integrate routed-length moment arms in the native GVS basis."""
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
-        lossy = friction is not None and not friction.is_lossless
+        has_friction = friction is not None and not friction.is_frictionless
         q_gathered = self._min_size_gathered(q)
 
         def segment_matrix(segment_index: Array) -> Array:
@@ -5940,8 +5944,10 @@ class GVS(SoftRobot):
                     segment_index,
                     point_index,
                 )
-                local = vmap(self._threadlike_local_basis, out_axes=1)(context)
-                if lossy:
+                local = vmap(self._threadlike_local_length_gradient, out_axes=1)(
+                    context
+                )
+                if has_friction:
                     local = local * friction.transmission_ratio(context)[None, :]
                 basis = self.B_Xs[segment_index, point_index]
                 if self.scale_rotational_basis_by_length:

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -125,7 +125,6 @@ class PCS(SoftRobot):
     scale_rotational_basis_by_length: bool = eqx.field(static=True)
     backend: ExecutionBackend = eqx.field(static=True)
     backend_params: PCSBackendParams = eqx.field(static=True)
-    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
     xi_ref: Array  # Reference configuration strain
     B_xi_unscaled: Array  # Unscaled strain basis matrix
@@ -364,12 +363,6 @@ class PCS(SoftRobot):
         self.scale_rotational_basis_by_length = bool(
             structure.scale_rotational_basis_by_length
         )
-        self.wrap_angle_smoothing = float(structure.wrap_angle_smoothing)
-        if self.wrap_angle_smoothing < 0.0:
-            raise ValueError(
-                "wrap_angle_smoothing must be non-negative, got "
-                f"{self.wrap_angle_smoothing}."
-            )
 
         # Number of segments
         num_segments = int(params.link.length.shape[0])
@@ -3117,9 +3110,6 @@ class PCS(SoftRobot):
     ) -> ThreadlikeQuadratureContext:
         """Return one spatial routed-path geometry at a quadrature node.
 
-        The routed tangent is ``v + omega x r + r'``, assembled here in
-        homogeneous coordinates.
-
         Args:
             segment_index: Index of the segment containing the node.
             strain: Segment strain of shape ``(6,)``.
@@ -3131,11 +3121,14 @@ class PCS(SoftRobot):
 
         Returns:
             context: Node geometry for one path, consumed by
-                :meth:`_threadlike_local_basis` and by the installed
-                transmission-loss law.
+                :meth:`_threadlike_local_length_gradient` and by the installed
+                friction model.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
+        )
+        path_abscissa = jnp.clip(
+            jnp.asarray(s) - self.L_cum[start_segment_index], 0.0, self.L_cum[-1]
         )
         offset = routing.offset(path_params, s)
         offset_derivative = routing.derivative(path_params, s)
@@ -3143,7 +3136,8 @@ class PCS(SoftRobot):
         homogeneous_derivative = jnp.append(offset_derivative, 1.0)
         tangent = (homogeneous_derivative + se3.hat(strain) @ homogeneous_offset)[:-1]
         return ThreadlikeQuadratureContext(
-            arc_length=jnp.asarray(s),
+            abscissa=jnp.asarray(s),
+            path_abscissa=path_abscissa,
             segment_index=jnp.asarray(segment_index),
             offset=offset,
             offset_derivative=offset_derivative,
@@ -3153,81 +3147,98 @@ class PCS(SoftRobot):
             strain=strain,
         )
 
-    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return one spatial routed-path length gradient density.
+    def _threadlike_local_length_gradient(
+        self, context: ThreadlikeQuadratureContext
+    ) -> Array:
+        """Return one spatial routed-path length gradient density, ``d|t|/dxi``.
 
         Args:
-            context: Node geometry from :meth:`_threadlike_local_geometry`.
+            context: Node geometry.
 
         Returns:
-            phi: Length-gradient density of shape ``(6,)``.
+            length_gradient_density: Shape ``(6,)``.
         """
         tangent = context.unit_tangent
         basis = jnp.hstack([so3.skew(context.offset) @ tangent, tangent])
         return context.active * basis
 
-    def _threadlike_wrap_density(
+    def _threadlike_path_curvature(
         self, strains: Array, routing: ThreadlikeRouting
     ) -> Array:
-        """Return the Capstan wrap-angle density of each segment and path.
+        """Return the curvature of each routed path in each segment.
 
-        The density is ``|omega x u_hat|``, the turning rate of the routed path
-        tangent with its material-frame rotation dropped. Torsion contributes
-        whenever the path is off-axis: for a constant offset at radius ``rho``
-        under pure twist ``kx`` it evaluates to ``kx**2 rho / nu``, the
-        curvature of the resulting helix. In a planar configuration the angular
-        strain is perpendicular to the unit tangent and it reduces to
-        ``|kappa|`` identically, which is what makes the planar and spatial
-        hosts agree.
+        The curvature is ``|omega x u_hat|``, the rate at which the routed-path
+        tangent turns per metre of backbone. Only the component of the angular
+        strain perpendicular to the tangent contributes, so torsion about the
+        axis of the path does not. An off-axis path under twist traces a helix,
+        and this recovers that curvature of the helix.
 
-        The offset is evaluated at the segment midpoint, so the density is
+        The offset is evaluated at the segment midpoint, so the curvature is
         exact for constant-offset routing and first order in the routing slope
         otherwise, matching the accuracy of the dropped material-frame term.
 
         Args:
             strains: Segment strains of shape ``(num_segments, 6)``.
-            routing: Routed-path family whose tangents set the density.
+            routing: Routed-path family whose tangents set the curvature.
 
         Returns:
-            w: Wrap-angle density of shape ``(num_segments, num_paths)``, in
-                radians per metre.
+            path_curvature: Shape ``(num_segments, num_paths)``, in radians per
+                metre.
         """
         params = routing.params
         midpoints = 0.5 * (self.L_cum[:-1] + self.L_cum[1:])
 
-        def density_segment(segment_index: Array, s: Array) -> Array:
+        def curvature_segment(segment_index: Array, s: Array) -> Array:
             strain = strains[segment_index]
             angular = strain[:3]
 
-            def density_path(path_params: BaseThreadlikeRoutingParams) -> Array:
+            def curvature_path(path_params: BaseThreadlikeRoutingParams) -> Array:
                 offset = jnp.append(routing.offset(path_params, s), 1.0)
                 derivative = jnp.append(routing.derivative(path_params, s), 1.0)
                 tangent = (derivative + se3.hat(strain) @ offset)[:-1]
                 unit = safe_normalize(tangent, eps=self.global_eps)
                 return safe_norm(jnp.cross(angular, unit))
 
-            return vmap(density_path)(params)
+            return vmap(curvature_path)(params)
 
-        density = vmap(density_segment)(jnp.arange(self.num_segments), midpoints)
-        if self.wrap_angle_smoothing == 0.0:
-            return density
-        return jnp.sqrt(density**2 + self.wrap_angle_smoothing**2)
+        return vmap(curvature_segment)(jnp.arange(self.num_segments), midpoints)
 
-    def _threadlike_wrap_angle(self, density: Array, s: Array) -> Array:
-        """Accumulate the wrap angle of each path from the base up to ``s``.
+    def _threadlike_safe_wrap_angle(
+        self,
+        path_curvature: Array,
+        s: Array,
+        start_segment_index: Array,
+        eps: Array,
+    ) -> Array:
+        """Integrate path curvature from each path anchor up to ``s``.
 
-        The density is piecewise constant, so the accumulated angle is
-        piecewise linear in ``s`` and therefore exact at every quadrature node.
+        Segments before a path anchor contribute nothing, because the path
+        has not turned there yet. ``safe_norm`` floors the curvature at
+        ``eps`` to keep a Capstan coefficient identifiable near a straight
+        configuration; its zero tangent at the origin reproduces the exact
+        curvature at ``eps == 0`` with a finite gradient, which a plain
+        ``sqrt`` would not.
 
         Args:
-            density: Wrap density of shape ``(num_segments, num_paths)``.
-            s: Scalar arc-length coordinate.
+            path_curvature: Shape ``(num_segments, num_paths)``.
+            s: Scalar abscissa coordinate.
+            start_segment_index: First segment of each path, ``(num_paths,)``.
+            eps: Curvature floor in radians per metre.
 
         Returns:
-            Theta: Accumulated wrap angle of shape ``(num_paths,)``, in radians.
+            wrap_angle: Shape ``(num_paths,)``, in radians.
         """
+        floored = safe_norm(
+            jnp.stack(
+                [path_curvature, jnp.broadcast_to(eps, path_curvature.shape)],
+                axis=-1,
+            ),
+            axis=-1,
+        )
         arc_in_segment = jnp.clip(jnp.asarray(s) - self.L_cum[:-1], 0.0, self.L)
-        return arc_in_segment @ density
+        segments = jnp.arange(self.num_segments)
+        spanned = segments[:, None] >= jnp.asarray(start_segment_index)[None, :]
+        return (spanned * floored * arc_in_segment[:, None]).sum(axis=0)
 
     def _threadlike_moment_matrix(
         self,
@@ -3237,17 +3248,11 @@ class PCS(SoftRobot):
     ) -> Array:
         """Integrate routed-length moment arms in the PCS strain basis.
 
-        When a lossy ``friction`` law is installed, its transmission ratio
-        weights the local basis inside the arc-length integral, because a
-        transmission loss accumulates along the path rather than scaling the
-        applied effort. A lossless law is skipped entirely and reproduces the
-        frictionless matrix exactly.
-
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
             routing: Routed-path family to integrate.
-            friction: Optional transmission-loss law. ``None`` or any law whose
-                ``is_lossless`` is set skips the weighting entirely.
+            friction: Optional friction model. ``None`` or any model whose
+                ``is_frictionless`` is set skips the weighting entirely.
 
         Returns:
             A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
@@ -3258,10 +3263,10 @@ class PCS(SoftRobot):
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 6))
 
-        lossy = friction is not None and not friction.is_lossless
-        wrap_density = None
-        if lossy and friction.requires_wrap_angle:
-            wrap_density = self._threadlike_wrap_density(strains, routing)
+        has_friction = friction is not None and not friction.is_frictionless
+        path_curvature = None
+        if has_friction and friction.requires_wrap_angle:
+            path_curvature = self._threadlike_path_curvature(strains, routing)
 
         def segment_matrix(segment_index: Array) -> Array:
             points, weights = scale_gaussian_quadrature(
@@ -3285,13 +3290,20 @@ class PCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
-                basis = vmap(self._threadlike_local_basis, out_axes=1)(context)
+                basis = vmap(self._threadlike_local_length_gradient, out_axes=1)(
+                    context
+                )
                 weighted = weights[point_index] * basis
-                if not lossy:
+                if not has_friction:
                     return weighted
-                if wrap_density is not None:
+                if path_curvature is not None:
                     context = context.with_wrap_angle(
-                        self._threadlike_wrap_angle(wrap_density, points[point_index])
+                        self._threadlike_safe_wrap_angle(
+                            path_curvature,
+                            points[point_index],
+                            params.start_segment_index_array,
+                            getattr(friction.params, "eps", 0.0),
+                        )
                     )
                 return weighted * friction.transmission_ratio(context)[None, :]
 

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -121,6 +121,7 @@ class PCS(SoftRobot):
     scale_rotational_basis_by_length: bool = eqx.field(static=True)
     backend: ExecutionBackend = eqx.field(static=True)
     backend_params: PCSBackendParams = eqx.field(static=True)
+    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
     xi_ref: Array  # Reference configuration strain
     B_xi_unscaled: Array  # Unscaled strain basis matrix
@@ -359,6 +360,12 @@ class PCS(SoftRobot):
         self.scale_rotational_basis_by_length = bool(
             structure.scale_rotational_basis_by_length
         )
+        self.wrap_angle_smoothing = float(structure.wrap_angle_smoothing)
+        if self.wrap_angle_smoothing < 0.0:
+            raise ValueError(
+                "wrap_angle_smoothing must be non-negative, got "
+                f"{self.wrap_angle_smoothing}."
+            )
 
         # Number of segments
         num_segments = int(params.link.length.shape[0])
@@ -3115,13 +3122,102 @@ class PCS(SoftRobot):
         basis = jnp.hstack([so3.skew(offset[:-1]) @ tangent, tangent])
         return active * basis
 
-    def _threadlike_moment_matrix(self, q: Array, routing: ThreadlikeRouting) -> Array:
-        """Integrate raw routed-length moment arms in the PCS strain basis."""
+    def _threadlike_wrap_density(
+        self, strains: Array, routing: ThreadlikeRouting
+    ) -> Array:
+        """Return the Capstan wrap-angle density of each segment and path.
+
+        The density is ``|omega x u_hat|``, the turning rate of the routed path
+        tangent with its material-frame rotation dropped. Torsion contributes
+        whenever the path is off-axis: for a constant offset at radius ``rho``
+        under pure twist ``kx`` it evaluates to ``kx**2 rho / nu``, the
+        curvature of the resulting helix. In a planar configuration the angular
+        strain is perpendicular to the unit tangent and it reduces to
+        ``|kappa|`` identically, which is what makes the planar and spatial
+        hosts agree.
+
+        The offset is evaluated at the segment midpoint, so the density is
+        exact for constant-offset routing and first order in the routing slope
+        otherwise, matching the accuracy of the dropped material-frame term.
+
+        Args:
+            strains: Segment strains of shape ``(num_segments, 6)``.
+            routing: Routed-path family whose tangents set the density.
+
+        Returns:
+            w: Wrap-angle density of shape ``(num_segments, num_paths)``, in
+                radians per metre.
+        """
+        params = routing.params
+        midpoints = 0.5 * (self.L_cum[:-1] + self.L_cum[1:])
+
+        def density_segment(segment_index: Array, s: Array) -> Array:
+            strain = strains[segment_index]
+            angular = strain[:3]
+
+            def density_path(path_params: BaseThreadlikeRoutingParams) -> Array:
+                offset = jnp.append(routing.offset(path_params, s), 1.0)
+                derivative = jnp.append(routing.derivative(path_params, s), 1.0)
+                tangent = (derivative + se3.hat(strain) @ offset)[:-1]
+                unit = safe_normalize(tangent, eps=self.global_eps)
+                return safe_norm(jnp.cross(angular, unit))
+
+            return vmap(density_path)(params)
+
+        density = vmap(density_segment)(jnp.arange(self.num_segments), midpoints)
+        if self.wrap_angle_smoothing == 0.0:
+            return density
+        return jnp.sqrt(density**2 + self.wrap_angle_smoothing**2)
+
+    def _threadlike_wrap_angle(self, density: Array, s: Array) -> Array:
+        """Accumulate the wrap angle of each path from the base up to ``s``.
+
+        The density is piecewise constant, so the accumulated angle is
+        piecewise linear in ``s`` and therefore exact at every quadrature node.
+
+        Args:
+            density: Wrap density of shape ``(num_segments, num_paths)``.
+            s: Scalar arc-length coordinate.
+
+        Returns:
+            Theta: Accumulated wrap angle of shape ``(num_paths,)``, in radians.
+        """
+        arc_in_segment = jnp.clip(jnp.asarray(s) - self.L_cum[:-1], 0.0, self.L)
+        return arc_in_segment @ density
+
+    def _threadlike_moment_matrix(
+        self,
+        q: Array,
+        routing: ThreadlikeRouting,
+        friction_coefficient: Array | None = None,
+    ) -> Array:
+        """Integrate routed-length moment arms in the PCS strain basis.
+
+        When a ``friction_coefficient`` is supplied, the Capstan transmission
+        ratio ``exp(-mu * Theta(s))`` weights the local basis inside the
+        arc-length integral, because guide friction accumulates along the path
+        rather than scaling the applied effort. A zero coefficient reproduces
+        the frictionless matrix exactly.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+            routing: Routed-path family to integrate.
+            friction_coefficient: Optional Capstan coefficient, scalar or one
+                entry per path. ``None`` skips the weighting entirely.
+
+        Returns:
+            A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
+        """
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 6))
+
+        mu = None
+        if friction_coefficient is not None:
+            mu = jnp.broadcast_to(jnp.asarray(friction_coefficient), (count,))
+            wrap_density = self._threadlike_wrap_density(strains, routing)
 
         def segment_matrix(segment_index: Array) -> Array:
             points, weights = scale_gaussian_quadrature(
@@ -3145,7 +3241,13 @@ class PCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
-                return weights[point_index] * basis
+                weighted = weights[point_index] * basis
+                if mu is None:
+                    return weighted
+                transmission_ratio = jnp.exp(
+                    -mu * self._threadlike_wrap_angle(wrap_density, points[point_index])
+                )
+                return weighted * transmission_ratio[None, :]
 
             return jnp.sum(
                 vmap(point_matrix)(jnp.arange(self.num_integration_points)), axis=0

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -8,6 +8,10 @@ from jax import Array, jvp, lax, vmap
 from jax import numpy as jnp
 
 from soromox.actuation.core import Actuator, PassiveElement
+from soromox.actuation.friction import (
+    ThreadlikeFriction,
+    ThreadlikeQuadratureContext,
+)
 from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
     ThreadlikeRouting,
@@ -3101,7 +3105,7 @@ class PCS(SoftRobot):
             self, q, u, qd, backend=backend, capabilities=PCS_ACTUATION
         )
 
-    def _threadlike_local_basis(
+    def _threadlike_local_geometry(
         self,
         segment_index: Array,
         strain: Array,
@@ -3110,17 +3114,57 @@ class PCS(SoftRobot):
         path_params: BaseThreadlikeRoutingParams,
         start_segment_index: Array,
         end_segment_index: Array,
-    ) -> Array:
-        """Return one spatial routed-path length gradient density."""
+    ) -> ThreadlikeQuadratureContext:
+        """Return one spatial routed-path geometry at a quadrature node.
+
+        The routed tangent is ``v + omega x r + r'``, assembled here in
+        homogeneous coordinates.
+
+        Args:
+            segment_index: Index of the segment containing the node.
+            strain: Segment strain of shape ``(6,)``.
+            s: Backbone coordinate of the node.
+            routing: Routed-path family being integrated.
+            path_params: Parameters of the single path.
+            start_segment_index: First segment the path spans.
+            end_segment_index: Last segment the path spans.
+
+        Returns:
+            context: Node geometry for one path, consumed by
+                :meth:`_threadlike_local_basis` and by the installed
+                transmission-loss law.
+        """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
         )
-        offset = jnp.append(routing.offset(path_params, s), 1.0)
-        offset_derivative = jnp.append(routing.derivative(path_params, s), 1.0)
-        tangent_unnormalized = (offset_derivative + se3.hat(strain) @ offset)[:-1]
-        tangent = safe_normalize(tangent_unnormalized, eps=self.global_eps)
-        basis = jnp.hstack([so3.skew(offset[:-1]) @ tangent, tangent])
-        return active * basis
+        offset = routing.offset(path_params, s)
+        offset_derivative = routing.derivative(path_params, s)
+        homogeneous_offset = jnp.append(offset, 1.0)
+        homogeneous_derivative = jnp.append(offset_derivative, 1.0)
+        tangent = (homogeneous_derivative + se3.hat(strain) @ homogeneous_offset)[:-1]
+        return ThreadlikeQuadratureContext(
+            arc_length=jnp.asarray(s),
+            segment_index=jnp.asarray(segment_index),
+            offset=offset,
+            offset_derivative=offset_derivative,
+            tangent_norm=safe_norm(tangent),
+            active=active,
+            unit_tangent=safe_normalize(tangent, eps=self.global_eps),
+            strain=strain,
+        )
+
+    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return one spatial routed-path length gradient density.
+
+        Args:
+            context: Node geometry from :meth:`_threadlike_local_geometry`.
+
+        Returns:
+            phi: Length-gradient density of shape ``(6,)``.
+        """
+        tangent = context.unit_tangent
+        basis = jnp.hstack([so3.skew(context.offset) @ tangent, tangent])
+        return context.active * basis
 
     def _threadlike_wrap_density(
         self, strains: Array, routing: ThreadlikeRouting
@@ -3189,21 +3233,21 @@ class PCS(SoftRobot):
         self,
         q: Array,
         routing: ThreadlikeRouting,
-        friction_coefficient: Array | None = None,
+        friction: ThreadlikeFriction | None = None,
     ) -> Array:
         """Integrate routed-length moment arms in the PCS strain basis.
 
-        When a ``friction_coefficient`` is supplied, the Capstan transmission
-        ratio ``exp(-mu * Theta(s))`` weights the local basis inside the
-        arc-length integral, because guide friction accumulates along the path
-        rather than scaling the applied effort. A zero coefficient reproduces
-        the frictionless matrix exactly.
+        When a lossy ``friction`` law is installed, its transmission ratio
+        weights the local basis inside the arc-length integral, because a
+        transmission loss accumulates along the path rather than scaling the
+        applied effort. A lossless law is skipped entirely and reproduces the
+        frictionless matrix exactly.
 
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
             routing: Routed-path family to integrate.
-            friction_coefficient: Optional Capstan coefficient, scalar or one
-                entry per path. ``None`` skips the weighting entirely.
+            friction: Optional transmission-loss law. ``None`` or any law whose
+                ``is_lossless`` is set skips the weighting entirely.
 
         Returns:
             A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
@@ -3214,9 +3258,9 @@ class PCS(SoftRobot):
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 6))
 
-        mu = None
-        if friction_coefficient is not None:
-            mu = jnp.broadcast_to(jnp.asarray(friction_coefficient), (count,))
+        lossy = friction is not None and not friction.is_lossless
+        wrap_density = None
+        if lossy and friction.requires_wrap_angle:
             wrap_density = self._threadlike_wrap_density(strains, routing)
 
         def segment_matrix(segment_index: Array) -> Array:
@@ -3228,10 +3272,10 @@ class PCS(SoftRobot):
             )
 
             def point_matrix(point_index: Array) -> Array:
-                basis = vmap(
-                    self._threadlike_local_basis,
+                context = vmap(
+                    self._threadlike_local_geometry,
                     in_axes=(None, None, None, None, 0, 0, 0),
-                    out_axes=1,
+                    out_axes=0,
                 )(
                     segment_index,
                     strains[segment_index],
@@ -3241,13 +3285,15 @@ class PCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
+                basis = vmap(self._threadlike_local_basis, out_axes=1)(context)
                 weighted = weights[point_index] * basis
-                if mu is None:
+                if not lossy:
                     return weighted
-                transmission_ratio = jnp.exp(
-                    -mu * self._threadlike_wrap_angle(wrap_density, points[point_index])
-                )
-                return weighted * transmission_ratio[None, :]
+                if wrap_density is not None:
+                    context = context.with_wrap_angle(
+                        self._threadlike_wrap_angle(wrap_density, points[point_index])
+                    )
+                return weighted * friction.transmission_ratio(context)[None, :]
 
             return jnp.sum(
                 vmap(point_matrix)(jnp.arange(self.num_integration_points)), axis=0

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -2977,17 +2977,26 @@ class PlanarPCS(SoftRobot):
         start_segment_index: Array,
         end_segment_index: Array,
     ) -> Array:
+        """Return one planar routed-path length gradient density.
+
+        The offset is measured along the local ``+y`` axis, so a path at
+        positive offset lies on the inside of a positive-curvature bend and
+        shortens as that bend increases. Differentiating the routed position
+        ``p + d Rot(theta) e_y`` gives ``(sigma_x - d kappa)`` along the tangent
+        and ``(sigma_y + d')`` along the normal, which is what the spatial host
+        obtains from ``v + omega x r + r'``.
+        """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
         )
         offset = routing.offset(path_params, s)[1]
         offset_derivative = routing.derivative(path_params, s)[1]
-        axial = strain[1] + offset * strain[0]
+        axial = strain[1] - offset * strain[0]
         shear = strain[2] + offset_derivative
         norm = safe_norm(jnp.stack([axial, shear]))
         axial_ratio = safe_divide(axial, norm, self.global_eps)
         shear_ratio = safe_divide(shear, norm, self.global_eps)
-        return active * jnp.asarray([offset * axial_ratio, axial_ratio, shear_ratio])
+        return active * jnp.asarray([-offset * axial_ratio, axial_ratio, shear_ratio])
 
     def _threadlike_moment_matrix(self, q: Array, routing: ThreadlikeRouting) -> Array:
         """Integrate raw routed-length moment arms in the planar PCS basis."""
@@ -3059,7 +3068,7 @@ class PlanarPCS(SoftRobot):
                     offset = routing.offset(path_params, s)[1]
                     derivative = routing.derivative(path_params, s)[1]
                     axial = (
-                        strains[segment_index, 1] + offset * strains[segment_index, 0]
+                        strains[segment_index, 1] - offset * strains[segment_index, 0]
                     )
                     shear = strains[segment_index, 2] + derivative
                     return active * safe_norm(jnp.stack([axial, shear]))

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -8,6 +8,10 @@ from jax import Array, jvp, lax, vmap
 from jax import numpy as jnp
 
 from soromox.actuation.core import Actuator, PassiveElement
+from soromox.actuation.friction import (
+    ThreadlikeFriction,
+    ThreadlikeQuadratureContext,
+)
 from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
     ThreadlikeRouting,
@@ -2974,7 +2978,7 @@ class PlanarPCS(SoftRobot):
             capabilities=PLANAR_PCS_ACTUATION,
         )
 
-    def _threadlike_local_basis(
+    def _threadlike_local_geometry(
         self,
         segment_index: Array,
         strain: Array,
@@ -2983,8 +2987,8 @@ class PlanarPCS(SoftRobot):
         path_params: BaseThreadlikeRoutingParams,
         start_segment_index: Array,
         end_segment_index: Array,
-    ) -> Array:
-        """Return one planar routed-path length gradient density.
+    ) -> ThreadlikeQuadratureContext:
+        """Return one planar routed-path geometry at a quadrature node.
 
         The offset is measured along the local ``+y`` axis, so a path at
         positive offset lies on the inside of a positive-curvature bend and
@@ -2992,18 +2996,61 @@ class PlanarPCS(SoftRobot):
         ``p + d Rot(theta) e_y`` gives ``(sigma_x - d kappa)`` along the tangent
         and ``(sigma_y + d')`` along the normal, which is what the spatial host
         obtains from ``v + omega x r + r'``.
+
+        Args:
+            segment_index: Index of the segment containing the node.
+            strain: Segment strain of shape ``(3,)``.
+            s: Backbone coordinate of the node.
+            routing: Routed-path family being integrated.
+            path_params: Parameters of the single path.
+            start_segment_index: First segment the path spans.
+            end_segment_index: Last segment the path spans.
+
+        Returns:
+            context: Node geometry for one path, consumed by
+                :meth:`_threadlike_local_basis` and by the installed
+                transmission-loss law.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
         )
-        offset = routing.offset(path_params, s)[1]
-        offset_derivative = routing.derivative(path_params, s)[1]
-        axial = strain[1] - offset * strain[0]
-        shear = strain[2] + offset_derivative
+        offset = routing.offset(path_params, s)
+        offset_derivative = routing.derivative(path_params, s)
+        axial = strain[1] - offset[1] * strain[0]
+        shear = strain[2] + offset_derivative[1]
         norm = safe_norm(jnp.stack([axial, shear]))
-        axial_ratio = safe_divide(axial, norm, self.global_eps)
-        shear_ratio = safe_divide(shear, norm, self.global_eps)
-        return active * jnp.asarray([-offset * axial_ratio, axial_ratio, shear_ratio])
+        unit_tangent = jnp.stack(
+            [
+                safe_divide(axial, norm, self.global_eps),
+                safe_divide(shear, norm, self.global_eps),
+            ]
+        )
+        return ThreadlikeQuadratureContext(
+            arc_length=jnp.asarray(s),
+            segment_index=jnp.asarray(segment_index),
+            offset=offset,
+            offset_derivative=offset_derivative,
+            tangent_norm=norm,
+            active=active,
+            unit_tangent=unit_tangent,
+            strain=strain,
+        )
+
+    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return one planar routed-path length gradient density.
+
+        Args:
+            context: Node geometry from :meth:`_threadlike_local_geometry`.
+
+        Returns:
+            phi: Length-gradient density of shape ``(3,)``.
+        """
+        offset = context.offset[1]
+        axial_ratio = context.unit_tangent[0]
+        shear_ratio = context.unit_tangent[1]
+        return context.active * jnp.asarray(
+            [-offset * axial_ratio, axial_ratio, shear_ratio]
+        )
 
     def _threadlike_wrap_density(self, strains: Array) -> Array:
         """Return the Capstan wrap-angle density of each segment.
@@ -3049,21 +3096,21 @@ class PlanarPCS(SoftRobot):
         self,
         q: Array,
         routing: ThreadlikeRouting,
-        friction_coefficient: Array | None = None,
+        friction: ThreadlikeFriction | None = None,
     ) -> Array:
         """Integrate routed-length moment arms in the planar PCS basis.
 
-        When a ``friction_coefficient`` is supplied, the Capstan transmission
-        ratio ``exp(-mu * Theta(s))`` weights the local basis inside the
-        arc-length integral, because guide friction accumulates along the path
-        rather than scaling the applied effort. A zero coefficient reproduces
-        the frictionless matrix exactly.
+        When a lossy ``friction`` law is installed, its transmission ratio
+        weights the local basis inside the arc-length integral, because a
+        transmission loss accumulates along the path rather than scaling the
+        applied effort. A lossless law is skipped entirely and reproduces the
+        frictionless matrix exactly.
 
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
             routing: Routed-path family to integrate.
-            friction_coefficient: Optional Capstan coefficient, scalar or one
-                entry per path. ``None`` skips the weighting entirely.
+            friction: Optional transmission-loss law. ``None`` or any law whose
+                ``is_lossless`` is set skips the weighting entirely.
 
         Returns:
             A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
@@ -3074,9 +3121,9 @@ class PlanarPCS(SoftRobot):
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 3))
 
-        mu = None
-        if friction_coefficient is not None:
-            mu = jnp.broadcast_to(jnp.asarray(friction_coefficient), (count,))
+        lossy = friction is not None and not friction.is_lossless
+        wrap_density = None
+        if lossy and friction.requires_wrap_angle:
             wrap_density = self._threadlike_wrap_density(strains)
 
         def segment_matrix(segment_index: Array) -> Array:
@@ -3088,10 +3135,10 @@ class PlanarPCS(SoftRobot):
             )
 
             def point_matrix(point_index: Array) -> Array:
-                basis = vmap(
-                    self._threadlike_local_basis,
+                context = vmap(
+                    self._threadlike_local_geometry,
                     in_axes=(None, None, None, None, 0, 0, 0),
-                    out_axes=1,
+                    out_axes=0,
                 )(
                     segment_index,
                     strains[segment_index],
@@ -3101,13 +3148,22 @@ class PlanarPCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
+                basis = vmap(self._threadlike_local_basis, out_axes=1)(context)
                 weighted = weights[point_index] * basis
-                if mu is None:
+                if not lossy:
                     return weighted
-                transmission_ratio = jnp.exp(
-                    -mu * self._threadlike_wrap_angle(wrap_density, points[point_index])
-                )
-                return weighted * transmission_ratio[None, :]
+                if wrap_density is not None:
+                    # The planar wrap angle is path-independent, so broadcast it
+                    # to one entry per path before the law consumes it.
+                    context = context.with_wrap_angle(
+                        jnp.broadcast_to(
+                            self._threadlike_wrap_angle(
+                                wrap_density, points[point_index]
+                            ),
+                            (count,),
+                        )
+                    )
+                return weighted * friction.transmission_ratio(context)[None, :]
 
             return jnp.sum(
                 vmap(point_matrix)(jnp.arange(self.num_integration_points)), axis=0

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -130,7 +130,6 @@ class PlanarPCS(SoftRobot):
     )
     _segment_dof_ends: tuple[int, ...] = eqx.field(static=True, default=())
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
-    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
     xi_ref: Array | None = eqx.field(default=None)  # Reference configuration strain
     B_xi_unscaled: Array | None = eqx.field(
@@ -357,12 +356,6 @@ class PlanarPCS(SoftRobot):
         self.scale_rotational_basis_by_length = bool(
             structure.scale_rotational_basis_by_length
         )
-        self.wrap_angle_smoothing = float(structure.wrap_angle_smoothing)
-        if self.wrap_angle_smoothing < 0.0:
-            raise ValueError(
-                "wrap_angle_smoothing must be non-negative, got "
-                f"{self.wrap_angle_smoothing}."
-            )
 
         # Number of segments
         num_segments = int(params.link.length.shape[0])
@@ -3008,11 +3001,14 @@ class PlanarPCS(SoftRobot):
 
         Returns:
             context: Node geometry for one path, consumed by
-                :meth:`_threadlike_local_basis` and by the installed
-                transmission-loss law.
+                :meth:`_threadlike_local_length_gradient` and by the installed
+                friction model.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
+        )
+        path_abscissa = jnp.clip(
+            jnp.asarray(s) - self.L_cum[start_segment_index], 0.0, self.L_cum[-1]
         )
         offset = routing.offset(path_params, s)
         offset_derivative = routing.derivative(path_params, s)
@@ -3026,7 +3022,8 @@ class PlanarPCS(SoftRobot):
             ]
         )
         return ThreadlikeQuadratureContext(
-            arc_length=jnp.asarray(s),
+            abscissa=jnp.asarray(s),
+            path_abscissa=path_abscissa,
             segment_index=jnp.asarray(segment_index),
             offset=offset,
             offset_derivative=offset_derivative,
@@ -3036,14 +3033,16 @@ class PlanarPCS(SoftRobot):
             strain=strain,
         )
 
-    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return one planar routed-path length gradient density.
+    def _threadlike_local_length_gradient(
+        self, context: ThreadlikeQuadratureContext
+    ) -> Array:
+        """Return one planar routed-path length gradient density, ``d|t|/dxi``.
 
         Args:
-            context: Node geometry from :meth:`_threadlike_local_geometry`.
+            context: Node geometry.
 
         Returns:
-            phi: Length-gradient density of shape ``(3,)``.
+            length_gradient_density: Shape ``(3,)``.
         """
         offset = context.offset[1]
         axial_ratio = context.unit_tangent[0]
@@ -3052,45 +3051,58 @@ class PlanarPCS(SoftRobot):
             [-offset * axial_ratio, axial_ratio, shear_ratio]
         )
 
-    def _threadlike_wrap_density(self, strains: Array) -> Array:
-        """Return the Capstan wrap-angle density of each segment.
+    def _threadlike_path_curvature(self, strains: Array) -> Array:
+        """Return the curvature of the routed paths in each segment,
+        ``|omega x u_hat|``.
 
-        The density is ``|omega x u_hat|``, the turning rate of the routed path
-        tangent with its material-frame rotation dropped. In the plane the
-        angular strain is perpendicular to the in-plane unit tangent, so this
-        reduces to ``|kappa|`` identically, for any routing offset and any
-        strain, and is therefore shared by every path.
+        In the plane the angular strain is perpendicular to the in-plane unit
+        tangent, so this reduces to ``|kappa|`` identically, for any routing
+        offset and any strain, and is therefore shared by every path.
 
         Args:
             strains: Segment strains of shape ``(num_segments, 3)``.
 
         Returns:
-            w: Wrap-angle density per segment, shape ``(num_segments,)``, in
-                radians per metre.
+            path_curvature: Shape ``(num_segments,)``, in radians per metre.
         """
-        density = jnp.abs(strains[:, 0])
-        if self.wrap_angle_smoothing == 0.0:
-            return density
-        return jnp.sqrt(density**2 + self.wrap_angle_smoothing**2)
+        return jnp.abs(strains[:, 0])
 
-    def _threadlike_wrap_angle(self, density: Array, s: Array) -> Array:
-        """Accumulate the wrap angle from the base up to ``s``.
+    def _threadlike_safe_wrap_angle(
+        self,
+        path_curvature: Array,
+        s: Array,
+        start_segment_index: Array,
+        eps: Array,
+    ) -> Array:
+        """Integrate path curvature from each path anchor up to ``s``.
 
-        The density is piecewise constant, so the accumulated angle is
-        piecewise linear in ``s`` and therefore exact at every quadrature node.
+        Segments before a path anchor contribute nothing, because the path
+        has not turned there yet. ``safe_norm`` floors the curvature at
+        ``eps`` to keep a Capstan coefficient identifiable near a straight
+        configuration; its zero tangent at the origin reproduces the exact
+        curvature at ``eps == 0`` with a finite gradient, which a plain
+        ``sqrt`` would not.
 
         Args:
-            density: Per-segment wrap density of shape ``(num_segments,)``.
-            s: Arc-length coordinate, scalar or shape ``(num_points,)``.
+            path_curvature: Per-segment curvature of shape ``(num_segments,)``.
+            s: Scalar abscissa coordinate.
+            start_segment_index: First segment of each path, ``(num_paths,)``.
+            eps: Curvature floor in radians per metre.
 
         Returns:
-            Theta: Accumulated wrap angle in radians, matching the shape of
-                ``s``.
+            wrap_angle: Shape ``(num_paths,)``, in radians.
         """
-        arc_in_segment = jnp.clip(
-            jnp.asarray(s)[..., None] - self.L_cum[:-1], 0.0, self.L
+        floored = safe_norm(
+            jnp.stack(
+                [path_curvature, jnp.broadcast_to(eps, path_curvature.shape)],
+                axis=-1,
+            ),
+            axis=-1,
         )
-        return jnp.sum(density * arc_in_segment, axis=-1)
+        arc_in_segment = jnp.clip(jnp.asarray(s) - self.L_cum[:-1], 0.0, self.L)
+        segments = jnp.arange(self.num_segments)
+        spanned = segments[None, :] >= jnp.asarray(start_segment_index)[:, None]
+        return (spanned * (floored * arc_in_segment)[None, :]).sum(axis=-1)
 
     def _threadlike_moment_matrix(
         self,
@@ -3100,17 +3112,10 @@ class PlanarPCS(SoftRobot):
     ) -> Array:
         """Integrate routed-length moment arms in the planar PCS basis.
 
-        When a lossy ``friction`` law is installed, its transmission ratio
-        weights the local basis inside the arc-length integral, because a
-        transmission loss accumulates along the path rather than scaling the
-        applied effort. A lossless law is skipped entirely and reproduces the
-        frictionless matrix exactly.
-
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
             routing: Routed-path family to integrate.
-            friction: Optional transmission-loss law. ``None`` or any law whose
-                ``is_lossless`` is set skips the weighting entirely.
+            friction: Optional friction model.
 
         Returns:
             A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
@@ -3121,10 +3126,10 @@ class PlanarPCS(SoftRobot):
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 3))
 
-        lossy = friction is not None and not friction.is_lossless
-        wrap_density = None
-        if lossy and friction.requires_wrap_angle:
-            wrap_density = self._threadlike_wrap_density(strains)
+        has_friction = friction is not None and not friction.is_frictionless
+        path_curvature = None
+        if has_friction and friction.requires_wrap_angle:
+            path_curvature = self._threadlike_path_curvature(strains)
 
         def segment_matrix(segment_index: Array) -> Array:
             points, weights = scale_gaussian_quadrature(
@@ -3148,19 +3153,19 @@ class PlanarPCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
-                basis = vmap(self._threadlike_local_basis, out_axes=1)(context)
-                weighted = weights[point_index] * basis
-                if not lossy:
+                gradient = vmap(self._threadlike_local_length_gradient, out_axes=1)(
+                    context
+                )
+                weighted = weights[point_index] * gradient
+                if not has_friction:
                     return weighted
-                if wrap_density is not None:
-                    # The planar wrap angle is path-independent, so broadcast it
-                    # to one entry per path before the law consumes it.
+                if path_curvature is not None:
                     context = context.with_wrap_angle(
-                        jnp.broadcast_to(
-                            self._threadlike_wrap_angle(
-                                wrap_density, points[point_index]
-                            ),
-                            (count,),
+                        self._threadlike_safe_wrap_angle(
+                            path_curvature,
+                            points[point_index],
+                            params.start_segment_index_array,
+                            getattr(friction.params, "eps", 0.0),
                         )
                     )
                 return weighted * friction.transmission_ratio(context)[None, :]

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -126,6 +126,7 @@ class PlanarPCS(SoftRobot):
     )
     _segment_dof_ends: tuple[int, ...] = eqx.field(static=True, default=())
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
+    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
     xi_ref: Array | None = eqx.field(default=None)  # Reference configuration strain
     B_xi_unscaled: Array | None = eqx.field(
@@ -352,6 +353,12 @@ class PlanarPCS(SoftRobot):
         self.scale_rotational_basis_by_length = bool(
             structure.scale_rotational_basis_by_length
         )
+        self.wrap_angle_smoothing = float(structure.wrap_angle_smoothing)
+        if self.wrap_angle_smoothing < 0.0:
+            raise ValueError(
+                "wrap_angle_smoothing must be non-negative, got "
+                f"{self.wrap_angle_smoothing}."
+            )
 
         # Number of segments
         num_segments = int(params.link.length.shape[0])
@@ -2998,13 +3005,79 @@ class PlanarPCS(SoftRobot):
         shear_ratio = safe_divide(shear, norm, self.global_eps)
         return active * jnp.asarray([-offset * axial_ratio, axial_ratio, shear_ratio])
 
-    def _threadlike_moment_matrix(self, q: Array, routing: ThreadlikeRouting) -> Array:
-        """Integrate raw routed-length moment arms in the planar PCS basis."""
+    def _threadlike_wrap_density(self, strains: Array) -> Array:
+        """Return the Capstan wrap-angle density of each segment.
+
+        The density is ``|omega x u_hat|``, the turning rate of the routed path
+        tangent with its material-frame rotation dropped. In the plane the
+        angular strain is perpendicular to the in-plane unit tangent, so this
+        reduces to ``|kappa|`` identically, for any routing offset and any
+        strain, and is therefore shared by every path.
+
+        Args:
+            strains: Segment strains of shape ``(num_segments, 3)``.
+
+        Returns:
+            w: Wrap-angle density per segment, shape ``(num_segments,)``, in
+                radians per metre.
+        """
+        density = jnp.abs(strains[:, 0])
+        if self.wrap_angle_smoothing == 0.0:
+            return density
+        return jnp.sqrt(density**2 + self.wrap_angle_smoothing**2)
+
+    def _threadlike_wrap_angle(self, density: Array, s: Array) -> Array:
+        """Accumulate the wrap angle from the base up to ``s``.
+
+        The density is piecewise constant, so the accumulated angle is
+        piecewise linear in ``s`` and therefore exact at every quadrature node.
+
+        Args:
+            density: Per-segment wrap density of shape ``(num_segments,)``.
+            s: Arc-length coordinate, scalar or shape ``(num_points,)``.
+
+        Returns:
+            Theta: Accumulated wrap angle in radians, matching the shape of
+                ``s``.
+        """
+        arc_in_segment = jnp.clip(
+            jnp.asarray(s)[..., None] - self.L_cum[:-1], 0.0, self.L
+        )
+        return jnp.sum(density * arc_in_segment, axis=-1)
+
+    def _threadlike_moment_matrix(
+        self,
+        q: Array,
+        routing: ThreadlikeRouting,
+        friction_coefficient: Array | None = None,
+    ) -> Array:
+        """Integrate routed-length moment arms in the planar PCS basis.
+
+        When a ``friction_coefficient`` is supplied, the Capstan transmission
+        ratio ``exp(-mu * Theta(s))`` weights the local basis inside the
+        arc-length integral, because guide friction accumulates along the path
+        rather than scaling the applied effort. A zero coefficient reproduces
+        the frictionless matrix exactly.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+            routing: Routed-path family to integrate.
+            friction_coefficient: Optional Capstan coefficient, scalar or one
+                entry per path. ``None`` skips the weighting entirely.
+
+        Returns:
+            A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
+        """
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 3))
+
+        mu = None
+        if friction_coefficient is not None:
+            mu = jnp.broadcast_to(jnp.asarray(friction_coefficient), (count,))
+            wrap_density = self._threadlike_wrap_density(strains)
 
         def segment_matrix(segment_index: Array) -> Array:
             points, weights = scale_gaussian_quadrature(
@@ -3028,7 +3101,13 @@ class PlanarPCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
-                return weights[point_index] * basis
+                weighted = weights[point_index] * basis
+                if mu is None:
+                    return weighted
+                transmission_ratio = jnp.exp(
+                    -mu * self._threadlike_wrap_angle(wrap_density, points[point_index])
+                )
+                return weighted * transmission_ratio[None, :]
 
             return jnp.sum(
                 vmap(point_matrix)(jnp.arange(self.num_integration_points)), axis=0

--- a/src/soromox/systems/pcs/structures.py
+++ b/src/soromox/systems/pcs/structures.py
@@ -57,11 +57,23 @@ class PCSStructure(eqx.Module):
             ``None`` activates every strain coordinate.
         scale_rotational_basis_by_length: Whether rotational strain coordinates
             are normalized by their link length.
+        wrap_angle_smoothing: Regularizer for the threadlike Capstan wrap
+            angle, in radians per metre. It replaces ``|kappa|`` by
+            ``sqrt(kappa**2 + wrap_angle_smoothing**2)``, which makes the
+            transmission ratio smooth across a straight segment instead of
+            merely continuous, and keeps a friction coefficient identifiable
+            at a straight configuration. It never under-estimates the wrap
+            angle and over-estimates it by at most
+            ``wrap_angle_smoothing * sum(length)``. It is static because it is
+            a numerical choice rather than a physical parameter, so it is
+            neither differentiated nor identified. The default reproduces the
+            exact ``|kappa|``.
     """
 
     num_gauss_points: int = eqx.field(static=True, default=5)
     strain_selector: Array | None = None
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
+    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
 
 class PlanarPCSStructure(eqx.Module):
@@ -73,11 +85,23 @@ class PlanarPCSStructure(eqx.Module):
             ``None`` activates every strain coordinate.
         scale_rotational_basis_by_length: Whether the rotational strain
             coordinate is normalized by its link length.
+        wrap_angle_smoothing: Regularizer for the threadlike Capstan wrap
+            angle, in radians per metre. It replaces ``|kappa|`` by
+            ``sqrt(kappa**2 + wrap_angle_smoothing**2)``, which makes the
+            transmission ratio smooth across a straight segment instead of
+            merely continuous, and keeps a friction coefficient identifiable
+            at a straight configuration. It never under-estimates the wrap
+            angle and over-estimates it by at most
+            ``wrap_angle_smoothing * sum(length)``. It is static because it is
+            a numerical choice rather than a physical parameter, so it is
+            neither differentiated nor identified. The default reproduces the
+            exact ``|kappa|``.
     """
 
     num_gauss_points: int = eqx.field(static=True, default=5)
     strain_selector: Array | None = None
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
+    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
 
 class PlanarHSAStructure(eqx.Module):

--- a/src/soromox/systems/pcs/structures.py
+++ b/src/soromox/systems/pcs/structures.py
@@ -57,23 +57,11 @@ class PCSStructure(eqx.Module):
             ``None`` activates every strain coordinate.
         scale_rotational_basis_by_length: Whether rotational strain coordinates
             are normalized by their link length.
-        wrap_angle_smoothing: Regularizer for the threadlike Capstan wrap
-            angle, in radians per metre. It replaces ``|kappa|`` by
-            ``sqrt(kappa**2 + wrap_angle_smoothing**2)``, which makes the
-            transmission ratio smooth across a straight segment instead of
-            merely continuous, and keeps a friction coefficient identifiable
-            at a straight configuration. It never under-estimates the wrap
-            angle and over-estimates it by at most
-            ``wrap_angle_smoothing * sum(length)``. It is static because it is
-            a numerical choice rather than a physical parameter, so it is
-            neither differentiated nor identified. The default reproduces the
-            exact ``|kappa|``.
     """
 
     num_gauss_points: int = eqx.field(static=True, default=5)
     strain_selector: Array | None = None
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
-    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
 
 class PlanarPCSStructure(eqx.Module):
@@ -85,23 +73,11 @@ class PlanarPCSStructure(eqx.Module):
             ``None`` activates every strain coordinate.
         scale_rotational_basis_by_length: Whether the rotational strain
             coordinate is normalized by its link length.
-        wrap_angle_smoothing: Regularizer for the threadlike Capstan wrap
-            angle, in radians per metre. It replaces ``|kappa|`` by
-            ``sqrt(kappa**2 + wrap_angle_smoothing**2)``, which makes the
-            transmission ratio smooth across a straight segment instead of
-            merely continuous, and keeps a friction coefficient identifiable
-            at a straight configuration. It never under-estimates the wrap
-            angle and over-estimates it by at most
-            ``wrap_angle_smoothing * sum(length)``. It is static because it is
-            a numerical choice rather than a physical parameter, so it is
-            neither differentiated nor identified. The default reproduces the
-            exact ``|kappa|``.
     """
 
     num_gauss_points: int = eqx.field(static=True, default=5)
     strain_selector: Array | None = None
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
-    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
 
 class PlanarHSAStructure(eqx.Module):

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -2594,15 +2594,32 @@ class SoftRobot(DynamicalSystem):
         split and no system implementation needs to be modified.
 
         Args:
-            q: Generalized coordinates of shape ``(num_dofs,)``.
+            q: Generalized coordinates of shape ``(num_coordinates,)``.
 
         Returns:
             tau_nc: Non-conservative passive generalized force of shape
-                ``(num_dofs,)``, in the same sign convention as
+                ``(num_velocities,)``, in the same sign convention as
                 :meth:`elastic_force`. A robot whose passive elements are all
                 conservative returns zeros.
         """
-        force = jnp.zeros((self.num_dofs,), dtype=q.dtype)
+        if self.floating_base:
+            total_input = q.shape[-1] == self.num_coordinates
+            q_internal = (
+                self.split_configuration(q)[1]
+                if total_input
+                else self._check_trailing_dimension(
+                    "q_internal", q, self.num_internal_dofs
+                )
+            )
+            internal = self._fixed_base_robot_at_pose().passive_nonconservative_force(
+                q_internal
+            )
+            return (
+                jnp.pad(internal, (self.num_base_velocities, 0))
+                if total_input
+                else internal
+            )
+        force = jnp.zeros((self.num_velocities,), dtype=q.dtype)
         for element in self.passive_elements:
             force = force + element.nonconservative_force(self, q)
         return force

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -2428,7 +2428,7 @@ class SoftRobot(DynamicalSystem):
             qd=qd,
             actuation_matrix=actuation_matrix,
         )
-        return actuation_matrix @ effort
+        return actuation_matrix @ effort - self.passive_nonconservative_force(q)
 
     def actuation_force(
         self,
@@ -2446,6 +2446,13 @@ class SoftRobot(DynamicalSystem):
         then maps those efforts to generalized forces as
 
         ``tau_u = A(q) @ e``.
+
+        Any non-conservative passive force is subtracted here as well, because
+        it has no potential and therefore cannot be carried by
+        :meth:`elastic_force`. It is independent of ``u``, so with such an
+        element installed the returned force is affine in ``u`` rather than
+        linear and ``actuation_force(q, 0)`` is nonzero. Prefer this method
+        over ``actuation_matrix(q) @ e`` wherever passive elements exist.
 
         Args:
             q: Generalized coordinates of shape (num_coordinates,).
@@ -2575,6 +2582,30 @@ class SoftRobot(DynamicalSystem):
         for element in self.passive_elements:
             energy = energy + element.elastic_energy(self, q)
         return energy
+
+    def passive_nonconservative_force(self, q: Array) -> Array:
+        """
+        Return the installed passive elements' non-conservative generalized force.
+
+        This is the part of the passive force that is not the gradient of any
+        potential and therefore cannot live in :meth:`elastic_force` without
+        breaking its energy contract. It is applied through
+        :meth:`actuation_force`, so the total dynamics is unchanged by the
+        split and no system implementation needs to be modified.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+
+        Returns:
+            tau_nc: Non-conservative passive generalized force of shape
+                ``(num_dofs,)``, in the same sign convention as
+                :meth:`elastic_force`. A robot whose passive elements are all
+                conservative returns zeros.
+        """
+        force = jnp.zeros((self.num_dofs,), dtype=q.dtype)
+        for element in self.passive_elements:
+            force = force + element.nonconservative_force(self, q)
+        return force
 
     # -----------------------------------------
     # Energy methods

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -486,12 +486,22 @@ def test_coordinate_jacobian_equals_moment_matrix_transpose(factory):
 
 
 @pytest.mark.parametrize(
-    ("factory", "axial_index"),
-    [(_spatial_pcs, 3), (_planar_pcs, 1), (_gvs, 3)],
+    ("factory", "axial_index", "friction_coefficient"),
+    [
+        (_spatial_pcs, 3, 0.0),
+        (_spatial_pcs, 3, 0.7),
+        (_planar_pcs, 1, 0.0),
+        (_planar_pcs, 1, 0.7),
+        (_gvs, 3, 0.0),  # GVS refuses a nonzero coefficient at construction
+    ],
 )
-def test_collapsed_threadlike_tangent_has_finite_reverse_mode(factory, axial_index):
+def test_collapsed_threadlike_tangent_has_finite_reverse_mode(
+    factory, axial_index, friction_coefficient
+):
     """Cover normalization and path density at an exactly zero routing tangent."""
-    actuator = ThreadlikeActuator.tendons(_routing(count=1))
+    actuator = ThreadlikeActuator.tendons(
+        _routing(count=1), friction_coefficient=friction_coefficient
+    )
     robot = factory(actuators=actuator)
     q = jnp.zeros(robot.num_internal_dofs).at[axial_index].set(-1.0)
 

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -142,12 +142,13 @@ def _updated_threadlike_component_params(actuator, passive):
     updated_actuator = actuator_params.replace(transmission=actuator_transmission)
 
     passive_params = passive.params
-    passive_routing = passive_params.routing.replace(
-        intercept=1.01 * passive_params.routing.intercept,
-        slope=1.02 * passive_params.routing.slope,
+    passive_routing = passive_params.transmission.routing.replace(
+        intercept=1.01 * passive_params.transmission.routing.intercept,
+        slope=1.02 * passive_params.transmission.routing.slope,
     )
+    passive_transmission = passive_params.transmission.replace(routing=passive_routing)
     updated_passive = passive_params.replace(
-        routing=passive_routing,
+        transmission=passive_transmission,
         stiffness=1.03 * passive_params.stiffness,
         damping=1.04 * passive_params.damping,
         rest_length=1.01 * passive_params.rest_length,
@@ -382,11 +383,11 @@ def test_direct_effort_skips_unused_threadlike_state(monkeypatch):
     calls = {"moment_matrix": 0}
     original_moment_matrix = PCS._threadlike_moment_matrix
 
-    def counted_moment_matrix(self, q, routing):
+    def counted_moment_matrix(self, q, routing, friction_coefficient=None):
         calls["moment_matrix"] += 1
         return original_moment_matrix(self, q, routing)
 
-    def unexpected_path_lengths(self, q, routing):
+    def unexpected_path_lengths(self, q, routing, friction_coefficient=None):
         del self, q, routing
         raise AssertionError("DirectEffort must not evaluate actuator coordinates.")
 
@@ -434,11 +435,11 @@ def test_state_dependent_effort_reuses_generalized_force_moment_matrix(monkeypat
     original_moment_matrix = PCS._threadlike_moment_matrix
     original_path_lengths = PCS._threadlike_path_lengths
 
-    def counted_moment_matrix(self, q, routing):
+    def counted_moment_matrix(self, q, routing, friction_coefficient=None):
         calls["moment_matrix"] += 1
         return original_moment_matrix(self, q, routing)
 
-    def counted_path_lengths(self, q, routing):
+    def counted_path_lengths(self, q, routing, friction_coefficient=None):
         calls["path_lengths"] += 1
         return original_path_lengths(self, q, routing)
 

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -16,7 +16,9 @@ from system_param_builders import (
 
 from soromox.actuation import (
     BaseThreadlikeRoutingParams,
+    CapstanFriction,
     EffortModel,
+    ExponentialLengthFriction,
     IdentityActuator,
     IdentityTransmission,
     ThreadlikeActuator,
@@ -383,11 +385,11 @@ def test_direct_effort_skips_unused_threadlike_state(monkeypatch):
     calls = {"moment_matrix": 0}
     original_moment_matrix = PCS._threadlike_moment_matrix
 
-    def counted_moment_matrix(self, q, routing, friction_coefficient=None):
+    def counted_moment_matrix(self, q, routing, friction=None):
         calls["moment_matrix"] += 1
         return original_moment_matrix(self, q, routing)
 
-    def unexpected_path_lengths(self, q, routing, friction_coefficient=None):
+    def unexpected_path_lengths(self, q, routing, friction=None):
         del self, q, routing
         raise AssertionError("DirectEffort must not evaluate actuator coordinates.")
 
@@ -435,11 +437,11 @@ def test_state_dependent_effort_reuses_generalized_force_moment_matrix(monkeypat
     original_moment_matrix = PCS._threadlike_moment_matrix
     original_path_lengths = PCS._threadlike_path_lengths
 
-    def counted_moment_matrix(self, q, routing, friction_coefficient=None):
+    def counted_moment_matrix(self, q, routing, friction=None):
         calls["moment_matrix"] += 1
         return original_moment_matrix(self, q, routing)
 
-    def counted_path_lengths(self, q, routing, friction_coefficient=None):
+    def counted_path_lengths(self, q, routing, friction=None):
         calls["path_lengths"] += 1
         return original_path_lengths(self, q, routing)
 
@@ -486,22 +488,22 @@ def test_coordinate_jacobian_equals_moment_matrix_transpose(factory):
 
 
 @pytest.mark.parametrize(
-    ("factory", "axial_index", "friction_coefficient"),
+    ("factory", "axial_index", "friction"),
     [
-        (_spatial_pcs, 3, 0.0),
-        (_spatial_pcs, 3, 0.7),
-        (_planar_pcs, 1, 0.0),
-        (_planar_pcs, 1, 0.7),
-        (_gvs, 3, 0.0),  # GVS refuses a nonzero coefficient at construction
+        (_spatial_pcs, 3, None),
+        (_spatial_pcs, 3, CapstanFriction(coefficient=0.7)),
+        (_planar_pcs, 1, None),
+        (_planar_pcs, 1, CapstanFriction(coefficient=0.7)),
+        # GVS supplies no wrap angle, so it hosts only wrap-angle-free laws.
+        (_gvs, 3, None),
+        (_gvs, 3, ExponentialLengthFriction(rate=3.0)),
     ],
 )
 def test_collapsed_threadlike_tangent_has_finite_reverse_mode(
-    factory, axial_index, friction_coefficient
+    factory, axial_index, friction
 ):
     """Cover normalization and path density at an exactly zero routing tangent."""
-    actuator = ThreadlikeActuator.tendons(
-        _routing(count=1), friction_coefficient=friction_coefficient
-    )
+    actuator = ThreadlikeActuator.tendons(_routing(count=1), friction=friction)
     robot = factory(actuators=actuator)
     q = jnp.zeros(robot.num_internal_dofs).at[axial_index].set(-1.0)
 

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -16,12 +16,11 @@ from system_param_builders import (
 
 from soromox.actuation import (
     BaseThreadlikeRoutingParams,
-    CapstanFriction,
     EffortModel,
-    ExponentialLengthFriction,
     IdentityActuator,
     IdentityTransmission,
     ThreadlikeActuator,
+    ThreadlikeFriction,
     ThreadlikeImpedance,
     ThreadlikeRouting,
 )
@@ -491,12 +490,12 @@ def test_coordinate_jacobian_equals_moment_matrix_transpose(factory):
     ("factory", "axial_index", "friction"),
     [
         (_spatial_pcs, 3, None),
-        (_spatial_pcs, 3, CapstanFriction(coefficient=0.7)),
+        (_spatial_pcs, 3, ThreadlikeFriction.capstan(coefficient=0.7)),
         (_planar_pcs, 1, None),
-        (_planar_pcs, 1, CapstanFriction(coefficient=0.7)),
+        (_planar_pcs, 1, ThreadlikeFriction.capstan(coefficient=0.7)),
         # GVS supplies no wrap angle, so it hosts only wrap-angle-free laws.
         (_gvs, 3, None),
-        (_gvs, 3, ExponentialLengthFriction(rate=3.0)),
+        (_gvs, 3, ThreadlikeFriction.exponential_length(rate=3.0)),
     ],
 )
 def test_collapsed_threadlike_tangent_has_finite_reverse_mode(

--- a/tests/actuation/test_threadlike_friction.py
+++ b/tests/actuation/test_threadlike_friction.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-"""Capstan guide friction on threadlike transmissions."""
+"""Guide friction on threadlike transmissions, and the pluggable loss model."""
 
 import jax
 import pytest
@@ -7,6 +7,7 @@ import pytest
 jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp
+from jax import Array
 from numpy.testing import assert_allclose
 from system_param_builders import (
     pcs_params,
@@ -15,7 +16,15 @@ from system_param_builders import (
     spatial_base_pose,
 )
 
-from soromox.actuation import ThreadlikeActuator, ThreadlikeImpedance, ThreadlikeRouting
+from soromox.actuation import (
+    CapstanFriction,
+    ExponentialLengthFriction,
+    Frictionless,
+    ThreadlikeActuator,
+    ThreadlikeFriction,
+    ThreadlikeImpedance,
+    ThreadlikeRouting,
+)
 from soromox.autodiff import custom_jvp_mode
 from soromox.systems import (
     GVS,
@@ -565,3 +574,204 @@ def test_gvs_rejects_nonzero_friction():
 
     with pytest.raises(TypeError, match="wrap-angle model"):
         _gvs(actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.3))
+
+
+# ---------------------------------------------------------------------------
+# The pluggable transmission-loss model
+# ---------------------------------------------------------------------------
+
+
+class _HyperbolicFriction(ThreadlikeFriction):
+    """A law defined entirely outside soromox, to pin the extension point."""
+
+    a: Array
+
+    def transmission_ratio(self, context):
+        return 1.0 / (1.0 + self.a * context.wrap_angle)
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial])
+def test_default_is_lossless_and_bit_identical(factory):
+    """The shipped default delivers full effort and costs nothing."""
+    routing = _routing([0.02, -0.015])
+    q = jnp.linspace(-0.01, 0.04, factory().num_dofs)
+
+    default = factory(actuators=ThreadlikeActuator.tendons(routing))
+    explicit = factory(
+        actuators=ThreadlikeActuator.tendons(routing, friction=Frictionless())
+    )
+    assert Frictionless.is_lossless
+    assert not Frictionless.requires_wrap_angle
+    assert jnp.array_equal(default.actuation_matrix(q), explicit.actuation_matrix(q))
+    assert isinstance(default.actuators[0].params.transmission.friction, Frictionless)
+
+
+def test_capstan_object_matches_coefficient_sugar():
+    """The two spellings of a Capstan law must not diverge."""
+    routing = _routing([0.02])
+    q = jnp.array([6.0, 0.0, 0.0])
+
+    sugar = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.4)
+    )
+    obj = _planar(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=CapstanFriction(coefficient=0.4)
+        )
+    )
+    assert jnp.array_equal(sugar.actuation_matrix(q), obj.actuation_matrix(q))
+
+    with pytest.raises(ValueError, match="not both"):
+        ThreadlikeActuator.tendons(
+            routing, friction=CapstanFriction(coefficient=0.1), friction_coefficient=0.2
+        )
+    with pytest.raises(TypeError, match="ThreadlikeFriction"):
+        ThreadlikeActuator.tendons(routing, friction="capstan")
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial])
+def test_length_friction_matches_closed_form(factory):
+    """A per-length loss integrates to its own analytic mean over a segment."""
+    rate, length = 3.0, 0.1
+    routing = _routing([0.02])
+    q = jnp.zeros((factory().num_dofs,)).at[0].set(4.0)
+
+    frictionless = factory(actuators=ThreadlikeActuator.tendons(routing))
+    attenuated = factory(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ExponentialLengthFriction(rate=rate)
+        )
+    )
+    decay = rate * length
+    expected = (1.0 - jnp.exp(-decay)) / decay
+
+    reference = frictionless.actuation_matrix(q)
+    row = int(jnp.argmax(jnp.abs(reference[:, 0])))
+    assert_allclose(
+        attenuated.actuation_matrix(q)[row, 0],
+        expected * reference[row, 0],
+        rtol=1e-8,
+    )
+
+
+def test_length_friction_runs_on_gvs():
+    """GVS hosts a wrap-angle-free law, and still refuses a Capstan law."""
+    routing = _routing([0.02])
+    q = jnp.zeros((_gvs().num_dofs,)).at[0].set(3.0)
+
+    frictionless = _gvs(actuators=ThreadlikeActuator.tendons(routing))
+    attenuated = _gvs(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ExponentialLengthFriction(rate=4.0)
+        )
+    )
+    reference = jnp.abs(frictionless.actuation_matrix(q))
+    weighted = jnp.abs(attenuated.actuation_matrix(q))
+    assert jnp.all(weighted <= reference + 1e-15)
+    assert jnp.max(reference - weighted) > 1e-6
+
+    with pytest.raises(TypeError, match="wrap-angle model"):
+        _gvs(
+            actuators=ThreadlikeActuator.tendons(
+                routing, friction=CapstanFriction(coefficient=0.3)
+            )
+        )
+
+
+def test_custom_friction_model_needs_no_soromox_change():
+    """A third-party law installs through the public contract alone."""
+    routing = _routing([0.02])
+    q = jnp.array([6.0, 0.0, 0.0])
+
+    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    custom = _planar(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=_HyperbolicFriction(a=jnp.asarray(0.5))
+        )
+    )
+    reference = frictionless.actuation_matrix(q)
+    weighted = custom.actuation_matrix(q)
+
+    assert jnp.all(jnp.abs(weighted) <= jnp.abs(reference) + 1e-15)
+    assert jnp.max(jnp.abs(reference - weighted)) > 1e-6
+    # The law is not Capstan, so it must not coincide with one.
+    capstan = _planar(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=CapstanFriction(coefficient=0.5)
+        )
+    ).actuation_matrix(q)
+    assert jnp.max(jnp.abs(weighted - capstan)) > 1e-6
+
+
+def test_model_is_traceable_and_identifiable():
+    """Loss parameters stay differentiable leaves under jit, for any law."""
+    routing = _routing([0.02, -0.015])
+    q = jnp.array([4.0, 0.02, -0.01])
+    u = jnp.array([2.0, 1.0])
+
+    def loss_for(build, value):
+        # The robot is built once outside the trace; only the loss parameter is
+        # traced, which is how a law is identified in practice.
+        robot = _planar(
+            actuators=ThreadlikeActuator.tendons(routing, friction=build(value))
+        )
+
+        @jax.jit
+        def loss(parameter):
+            transmission = robot.actuators[0].params.transmission
+            identified = robot.update_actuator_params(
+                0, transmission=transmission.replace(friction=build(parameter))
+            )
+            return jnp.sum(identified.actuation_force(q, u) ** 2)
+
+        return jax.value_and_grad(loss)(jnp.asarray(value))
+
+    for build, value in (
+        (lambda p: CapstanFriction(coefficient=p), 0.3),
+        (lambda p: ExponentialLengthFriction(rate=p), 2.0),
+        (lambda p: _HyperbolicFriction(a=p), 0.4),
+    ):
+        magnitude, gradient = loss_for(build, value)
+        assert jnp.isfinite(magnitude) and jnp.isfinite(gradient)
+        assert jnp.abs(gradient) > 0.0
+
+
+def test_context_fields_agree_across_hosts():
+    """Host-agnostic context fields must match, so portable laws are portable."""
+    routing = _routing([0.02, -0.015])
+    planar = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    spatial = _spatial(actuators=ThreadlikeActuator.tendons(routing))
+
+    curvature, axial, shear = 5.0, 0.02, -0.01
+    planar_strain = jnp.array([curvature, 1.0 + axial, shear])
+    spatial_strain = jnp.array([0.0, 0.0, curvature, 1.0 + axial, shear, 0.0])
+    arc_length = 0.06
+    path_routing = planar.actuators[0].transmission.routing
+
+    def geometry(robot, strain):
+        return jax.vmap(
+            robot._threadlike_local_geometry,
+            in_axes=(None, None, None, None, 0, 0, 0),
+            out_axes=0,
+        )(
+            jnp.asarray(0),
+            strain,
+            jnp.asarray(arc_length),
+            path_routing,
+            path_routing.params,
+            path_routing.params.start_segment_index_array,
+            path_routing.params.end_segment_index_array,
+        )
+
+    planar_context = geometry(planar, planar_strain)
+    spatial_context = geometry(spatial, spatial_strain)
+
+    for field in ("arc_length", "offset", "offset_derivative", "tangent_norm"):
+        assert_allclose(
+            getattr(planar_context, field),
+            getattr(spatial_context, field),
+            rtol=1e-9,
+            atol=1e-12,
+            err_msg=f"host-agnostic field {field} disagrees",
+        )
+    assert jnp.array_equal(planar_context.active, spatial_context.active)

--- a/tests/actuation/test_threadlike_friction.py
+++ b/tests/actuation/test_threadlike_friction.py
@@ -139,11 +139,15 @@ def _settle(robot, u, iterations=30):
     return q
 
 
-def _with_friction(robot, friction_coefficient):
-    transmission = robot.actuators[0].params.transmission.replace(
-        friction_coefficient=friction_coefficient
+def _with_friction(robot, coefficient):
+    """Return a copy of ``robot`` whose Capstan coefficient is ``coefficient``."""
+    transmission = robot.actuators[0].params.transmission
+    return robot.update_actuator_params(
+        0,
+        transmission=transmission.replace(
+            friction=transmission.friction.replace(coefficient=coefficient)
+        ),
     )
-    return robot.update_actuator_params(0, transmission=transmission)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/actuation/test_threadlike_friction.py
+++ b/tests/actuation/test_threadlike_friction.py
@@ -1,0 +1,563 @@
+# ruff: noqa: E402
+"""Capstan guide friction on threadlike transmissions."""
+
+import jax
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+from numpy.testing import assert_allclose
+from system_param_builders import (
+    pcs_params,
+    planar_base_pose,
+    planar_pcs_params,
+    spatial_base_pose,
+)
+
+from soromox.actuation import ThreadlikeActuator, ThreadlikeImpedance, ThreadlikeRouting
+from soromox.autodiff import custom_jvp_mode
+from soromox.systems import (
+    GVS,
+    PCS,
+    GVSSegment,
+    JointSpec,
+    LinkSpec,
+    PCSStructure,
+    PlanarPCS,
+    StrainBasisSpec,
+)
+from soromox.systems.pcs import PlanarPCSStructure
+
+# Pull that bends the reference robot by a few radians per metre.
+TENSION = 0.03
+
+
+def _planar(
+    *,
+    num_segments=1,
+    actuators=None,
+    passive_elements=(),
+    wrap_angle_smoothing=0.0,
+    num_gauss_points=5,
+    gravity=jnp.zeros((2,)),
+):
+    body = planar_pcs_params(
+        base_pose=planar_base_pose(),
+        length=jnp.full((num_segments,), 0.1),
+        radius=jnp.full((num_segments,), 0.02),
+        density=jnp.full((num_segments,), 1000.0),
+        gravity=gravity,
+        young_modulus=jnp.full((num_segments,), 1e3),
+        shear_modulus=jnp.full((num_segments,), 5e2),
+        damping_matrix=1e-3 * jnp.eye(3 * num_segments),
+    )
+    return PlanarPCS(
+        body,
+        PlanarPCSStructure(
+            num_gauss_points=num_gauss_points,
+            wrap_angle_smoothing=wrap_angle_smoothing,
+        ),
+        actuators=actuators,
+        passive_elements=passive_elements,
+    )
+
+
+def _spatial(*, num_segments=1, actuators=None, wrap_angle_smoothing=0.0):
+    body = pcs_params(
+        base_pose=spatial_base_pose(),
+        length=jnp.full((num_segments,), 0.1),
+        radius=jnp.full((num_segments,), 0.02),
+        density=jnp.full((num_segments,), 1000.0),
+        gravity=jnp.zeros((3,)),
+        young_modulus=jnp.full((num_segments,), 1e3),
+        shear_modulus=jnp.full((num_segments,), 5e2),
+        damping_matrix=1e-3 * jnp.eye(6 * num_segments),
+    )
+    return PCS(
+        body,
+        PCSStructure(num_gauss_points=5, wrap_angle_smoothing=wrap_angle_smoothing),
+        actuators=actuators,
+    )
+
+
+def _gvs(*, actuators=None):
+    segment = GVSSegment(
+        link=LinkSpec.circular(
+            young_modulus=3e5,
+            shear_modulus=3e5 / 2.9,
+            density=1300.0,
+            material_damping_coefficient=1e4,
+            length=0.1,
+            radius=0.015,
+            reference_strain=[0, 0, 0, 1, 0, 0],
+        ),
+        joint=JointSpec(type="fixed"),
+        basis=StrainBasisSpec(
+            type="monomial",
+            strain_selector=[1, 1, 1, 1, 0, 0],
+            basis_order=[0, 0, 0, 0, 0, 0],
+        ),
+        num_gauss_points=5,
+    )
+    return GVS.from_segments([segment], gravity=jnp.zeros((3,)), actuators=actuators)
+
+
+def _routing(offsets, *, num_segments=1):
+    count = len(offsets)
+    zeros = jnp.zeros((count,))
+    return ThreadlikeRouting.linear(
+        intercept=jnp.stack((zeros, jnp.asarray(offsets), zeros), axis=-1),
+        start_segment_index=(0,) * count,
+        end_segment_index=(num_segments - 1,) * count,
+    )
+
+
+def _impedance(routing, friction_coefficient=0.0):
+    return ThreadlikeImpedance(
+        routing=routing,
+        stiffness=jnp.array([50.0, 30.0]),
+        damping=jnp.array([0.3, 0.2]),
+        rest_length=jnp.array([0.09, 0.1]),
+        friction_coefficient=friction_coefficient,
+    )
+
+
+def _settle(robot, u, iterations=30):
+    """Return the static equilibrium reached by Newton iteration from rest."""
+
+    def residual(q):
+        return (
+            robot.elastic_force(q)
+            + robot.gravitational_force(q)
+            - robot.actuation_force(q, u)
+        )
+
+    q = jnp.zeros((robot.num_dofs,))
+    for _ in range(iterations):
+        q = q - jnp.linalg.solve(jax.jacobian(residual)(q), residual(q))
+    return q
+
+
+def _with_friction(robot, friction_coefficient):
+    transmission = robot.actuators[0].params.transmission.replace(
+        friction_coefficient=friction_coefficient
+    )
+    return robot.update_actuator_params(0, transmission=transmission)
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial])
+def test_zero_friction_is_bit_identical(factory):
+    routing = _routing([0.02, -0.015])
+    plain = factory(actuators=ThreadlikeActuator.tendons(routing))
+    zero = factory(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.0)
+    )
+    q = jnp.linspace(-0.01, 0.04, plain.num_dofs)
+    assert jnp.array_equal(plain.actuation_matrix(q), zero.actuation_matrix(q))
+
+
+def test_capstan_matches_closed_form():
+    """Attenuation follows the Euler belt law and compounds along the arc."""
+    mu, kappa, length = 0.3, 8.0, 0.1
+    routing = _routing([0.02])
+    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    attenuated = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=mu)
+    )
+    q = jnp.array([kappa, 0.0, 0.0])
+    wrap = mu * kappa * length
+    expected = (1.0 - jnp.exp(-wrap)) / wrap
+    axial_row = 1
+    assert_allclose(
+        attenuated.actuation_matrix(q)[axial_row],
+        expected * frictionless.actuation_matrix(q)[axial_row],
+        rtol=1e-8,
+    )
+
+    # Segment-averaged transmission decreases monotonically toward the tip.
+    num_segments = 3
+    span = _routing([0.02], num_segments=num_segments)
+    chain_0 = _planar(
+        num_segments=num_segments, actuators=ThreadlikeActuator.tendons(span)
+    )
+    chain_mu = _planar(
+        num_segments=num_segments,
+        actuators=ThreadlikeActuator.tendons(span, friction_coefficient=0.4),
+    )
+    q_chain = jnp.zeros((chain_0.num_dofs,)).at[::3].set(jnp.array([6.0, 9.0, 12.0]))
+    rows = jnp.arange(num_segments) * 3 + axial_row
+    ratio = (
+        chain_mu.actuation_matrix(q_chain)[rows, 0]
+        / chain_0.actuation_matrix(q_chain)[rows, 0]
+    )
+    assert jnp.all(ratio[1:] < ratio[:-1])
+    assert jnp.all((ratio > 0.0) & (ratio <= 1.0))
+
+
+def test_torsion_wrap_matches_helix_curvature():
+    """An off-axis path under pure torsion wraps at the helix curvature."""
+    radius, torsion = 0.02, 5.0
+    routing = _routing([radius])
+    robot = _spatial(actuators=ThreadlikeActuator.tendons(routing))
+    q = jnp.zeros((robot.num_dofs,)).at[0].set(torsion)
+    strains = robot.strain(q).reshape((robot.num_segments, 6))
+
+    density = robot._threadlike_wrap_density(
+        strains, robot.actuators[0].transmission.routing
+    )
+    chord = jnp.sqrt(1.0 + (torsion * radius) ** 2)
+    assert_allclose(density, jnp.full_like(density, torsion**2 * radius / chord))
+
+
+# ---------------------------------------------------------------------------
+# Energy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("actuator_friction", "passive_friction"),
+    [(0.0, 0.0), (0.6, 0.0), (0.0, 0.6), (0.6, 0.6)],
+)
+def test_energy_rate_matches_actuation_and_damping_power(
+    actuator_friction, passive_friction
+):
+    """The robot-side energy budget stays exact at any friction coefficient."""
+    routing = _routing([0.02, -0.015])
+    robot = _planar(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction_coefficient=actuator_friction
+        ),
+        passive_elements=(_impedance(routing, passive_friction),),
+        gravity=jnp.array([0.0, -9.81]),
+    )
+    q = jnp.array([4.0, 0.02, -0.01])
+    qd = jnp.array([0.7, -0.3, 0.5])
+    u = jnp.array([3.0, 1.5])
+
+    state_rate = robot.forward_dynamics(0.0, jnp.concatenate([q, qd]), (u,))
+    qdd = state_rate[robot.num_dofs :]
+
+    def energy(q_, qd_):
+        return robot.kinetic_energy(q_, qd_) + robot.potential_energy(q_)
+
+    energy_rate = jax.grad(energy, 0)(q, qd) @ qd + jax.grad(energy, 1)(q, qd) @ qdd
+    power = qd @ robot.actuation_force(q, u, qd=qd) - qd @ robot.damping_matrix(q) @ qd
+    assert_allclose(energy_rate, power, rtol=1e-9, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("preset", "u", "qd_sign"),
+    [
+        (ThreadlikeActuator.tendons, 4.0, 1.0),
+        (ThreadlikeActuator.tendons, -4.0, -1.0),
+        (ThreadlikeActuator.push_rods, 4.0, -1.0),
+    ],
+)
+def test_driving_effort_dissipates_for_pull_and_push(preset, u, qd_sign):
+    """Guides absorb power whenever the effort drives the path, either way."""
+    routing = _routing([0.02])
+    robot = _planar(actuators=preset(routing, friction_coefficient=0.5))
+    transmission = robot.actuators[0].transmission
+    q = jnp.array([7.0, 0.0, 0.0])
+    qd = jnp.array([qd_sign, 0.0, 0.0])
+    effort = jnp.array([u])
+
+    scale = transmission.params.coordinate_scale
+    supplied = jnp.sum(
+        effort * scale * (transmission.kinematic_matrix(robot, q).T @ qd)
+    )
+    delivered = qd @ (transmission.moment_matrix(robot, q) @ effort)
+
+    assert supplied > 0.0  # the effort drives the path in this direction
+    assert delivered > 0.0
+    assert delivered < supplied
+    assert supplied - delivered > 0.0
+
+
+def test_closed_loop_work_is_nonzero_and_orientation_dependent():
+    """Friction admits no actuation potential, so loop work does not vanish."""
+    routing = _routing([0.02])
+    effort = jnp.array([2.0])
+
+    def loop_work(robot, orientation, num_points=2000):
+        angle = orientation * jnp.linspace(0.0, 2.0 * jnp.pi, num_points)
+        path = jnp.stack(
+            [
+                5.0 + 4.0 * jnp.cos(angle),
+                0.05 * jnp.sin(angle),
+                jnp.zeros_like(angle),
+            ],
+            axis=-1,
+        )
+        force = jax.vmap(lambda q: robot.actuation_matrix(q) @ effort)(path)
+        midpoint = 0.5 * (force[1:] + force[:-1])
+        return jnp.sum(midpoint * jnp.diff(path, axis=0))
+
+    attenuated = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.8)
+    )
+    forward = loop_work(attenuated, 1.0)
+    assert jnp.abs(forward) > 1e-4
+    assert_allclose(loop_work(attenuated, -1.0), -forward, rtol=1e-6)
+
+    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    assert jnp.abs(loop_work(frictionless, 1.0)) < 1e-12
+
+
+@pytest.mark.parametrize("passive_friction", [0.0, 1.0])
+def test_passive_friction_is_the_only_unactuated_energy_source(passive_friction):
+    """An unactuated robot decays monotonically only at zero passive friction."""
+    routing = _routing([0.02, -0.015], num_segments=2)
+    robot = _planar(
+        num_segments=2,
+        passive_elements=(_impedance(routing, passive_friction),),
+        gravity=jnp.array([0.0, -9.81]),
+    )
+    control = jnp.zeros((robot.num_actuators,))
+    key = jax.random.PRNGKey(3)
+
+    def energy_rate(index):
+        keys = jax.random.split(jax.random.fold_in(key, index))
+        q = 4.0 * jax.random.normal(keys[0], (robot.num_dofs,))
+        qd = jax.random.normal(keys[1], (robot.num_dofs,))
+        return (
+            qd @ robot.actuation_force(q, control, qd=qd)
+            - qd @ robot.damping_matrix(q) @ qd
+        )
+
+    rates = jax.vmap(energy_rate)(jnp.arange(200))
+    if passive_friction == 0.0:
+        assert jnp.all(rates <= 0.0)
+    else:
+        assert jnp.any(rates > 0.0)
+
+
+def test_passive_damping_is_psd_under_friction():
+    """The chosen congruence stays dissipative where the rejected form does not."""
+    routing = _routing([0.02, -0.015], num_segments=2)
+    passive = _impedance(routing, 1.2)
+    robot = _planar(num_segments=2, passive_elements=(passive,))
+    q = jnp.array([6.0, 0.02, -0.01, 10.0, 0.02, -0.01])
+
+    damping = passive.damping_matrix(robot, q)
+    assert_allclose(damping, damping.T, atol=1e-18)
+    assert jnp.min(jnp.linalg.eigvalsh(damping)) > -1e-15
+
+    # The rejected A_mu D A_0^T reads the rate through the exact Jacobian.
+    transmission = passive._transmission_matrix(robot, q)
+    jacobian = passive._length_jacobian(robot, q).T
+    rejected = transmission @ (passive.params.damping[:, None] * jacobian.T)
+    symmetric = 0.5 * (rejected + rejected.T)
+    direction = jnp.linalg.eigh(symmetric)[1][:, 0]
+
+    assert direction @ rejected @ direction < 0.0  # would inject energy
+    assert direction @ damping @ direction > 0.0
+
+
+def test_passive_split_preserves_energy_gradient_and_total_dynamics():
+    """Splitting the spring force changes bookkeeping, not physics."""
+    routing = _routing([0.02, -0.015], num_segments=2)
+    passive = _impedance(routing, 0.8)
+    robot = _planar(num_segments=2, passive_elements=(passive,))
+    q = jnp.array([5.0, 0.02, -0.01, -3.0, 0.01, 0.02])
+
+    extension = passive.path_lengths(robot, q) - passive.params.rest_length
+    transmitted = passive._transmission_matrix(robot, q) @ (
+        passive.params.stiffness * extension
+    )
+    assert_allclose(
+        transmitted,
+        passive.elastic_force(robot, q) + passive.nonconservative_force(robot, q),
+        atol=1e-15,
+    )
+
+    for enabled in (True, False):
+        with custom_jvp_mode(enabled):
+            assert_allclose(
+                jax.grad(robot.elastic_energy)(q),
+                robot.elastic_force(q),
+                rtol=1e-9,
+                atol=1e-14,
+            )
+
+
+def test_push_and_pull_share_the_same_transmission_ratio():
+    """The ratio depends on the configuration only, never on the effort."""
+    routing = _routing([0.02])
+    tendon = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.7)
+    )
+    push_rod = _planar(
+        actuators=ThreadlikeActuator.push_rods(routing, friction_coefficient=0.7)
+    )
+    q = jnp.array([6.0, 0.01, 0.0])
+    assert_allclose(
+        tendon.actuation_matrix(q), -push_rod.actuation_matrix(q), atol=1e-18
+    )
+
+
+# ---------------------------------------------------------------------------
+# Planar routed-path offset sign
+# ---------------------------------------------------------------------------
+
+
+def test_pulled_tendon_shortens_and_bends_toward_its_own_side():
+    """A pulled tendon must shorten and curve the backbone onto its own side."""
+    robot = _planar(actuators=ThreadlikeActuator.tendons(_routing([0.02, -0.02])))
+    actuator = robot.actuators[0]
+    rest = 0.1
+
+    q_first = _settle(robot, jnp.array([TENSION, 0.0]))
+    first = actuator.path_lengths(robot, q_first)
+    assert q_first[0] > 0.0
+    assert first[0] < rest < first[1]
+
+    q_second = _settle(robot, jnp.array([0.0, TENSION]))
+    second = actuator.path_lengths(robot, q_second)
+    assert_allclose(q_second[0], -q_first[0], rtol=1e-9)
+    assert_allclose(second, first[::-1], rtol=1e-9)
+
+    q_push = _settle(robot, jnp.array([-TENSION, 0.0]))
+    pushed = actuator.path_lengths(robot, q_push)
+    assert q_push[0] < 0.0
+    assert pushed[0] > rest > pushed[1]
+
+
+def test_planar_path_length_matches_rendered_path():
+    """Path length must equal the arc length of the curve the renderer draws."""
+    robot = _planar(actuators=ThreadlikeActuator.tendons(_routing([0.02])))
+    actuator = robot.actuators[0]
+    q = jnp.array([10.0, 0.0, 0.0])
+
+    samples = jnp.linspace(0.0, float(jnp.sum(robot.L)), 20001)
+    positions = jax.vmap(lambda s: actuator.path_poses(robot, q, s))(samples)
+    polyline = jnp.sum(jnp.linalg.norm(jnp.diff(positions[:, 0], axis=0), axis=-1))
+
+    assert_allclose(actuator.path_lengths(robot, q), jnp.array([0.08]), rtol=1e-6)
+    assert_allclose(polyline, 0.08, rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Invariants and autodiff
+# ---------------------------------------------------------------------------
+
+
+def test_friction_breaks_length_gradient_identity():
+    """Friction deliberately severs moment_matrix from the length gradient."""
+    routing = _routing([0.02, -0.015])
+    q = jnp.array([4.0, 0.02, -0.01])
+
+    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    assert_allclose(
+        jax.jacrev(frictionless.actuator_coordinates)(q),
+        frictionless.actuation_matrix(q).T,
+        rtol=2e-7,
+        atol=2e-9,
+    )
+
+    attenuated = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.6)
+    )
+    gap = (
+        jax.jacrev(attenuated.actuator_coordinates)(q)
+        - attenuated.actuation_matrix(q).T
+    )
+    assert jnp.max(jnp.abs(gap)) > 1e-3
+
+
+def test_friction_coefficient_is_traceable_and_identifiable():
+    """The coefficient stays a differentiable leaf under jit."""
+    routing = _routing([0.02, -0.015])
+    robot = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.2)
+    )
+    q = jnp.array([4.0, 0.02, -0.01])
+    u = jnp.array([2.0, 1.0])
+
+    @jax.jit
+    def loss(friction_coefficient):
+        identified = _with_friction(robot, friction_coefficient)
+        return jnp.sum(identified.actuation_force(q, u) ** 2)
+
+    for start in (0.0, 0.35):
+        value, gradient = jax.value_and_grad(loss)(jnp.asarray(start))
+        assert jnp.isfinite(value) and jnp.isfinite(gradient)
+        assert jnp.abs(gradient) > 0.0
+
+    per_path = jax.grad(loss)(jnp.array([0.1, 0.4]))
+    assert per_path.shape == (2,)
+    assert jnp.all(jnp.isfinite(per_path)) and jnp.all(per_path != 0.0)
+
+
+@pytest.mark.parametrize("wrap_angle_smoothing", [0.0, 0.1])
+def test_friction_gradients_are_finite_at_singular_states(wrap_angle_smoothing):
+    """The |kappa| kink at a straight backbone must not produce NaNs."""
+    robot = _planar(
+        wrap_angle_smoothing=wrap_angle_smoothing,
+        actuators=ThreadlikeActuator.tendons(
+            _routing([0.02]), friction_coefficient=0.3
+        ),
+    )
+    straight = jnp.zeros((robot.num_dofs,))
+
+    assert jnp.isfinite(jax.jacrev(robot.actuation_matrix)(straight)).all()
+    assert jnp.isfinite(jax.jacrev(robot.actuator_coordinates)(straight)).all()
+
+    def matrix_norm(friction_coefficient):
+        identified = _with_friction(robot, friction_coefficient)
+        return jnp.sum(identified.actuation_matrix(straight) ** 2)
+
+    sensitivity = jax.grad(matrix_norm)(jnp.asarray(0.3))
+    assert jnp.isfinite(sensitivity)
+    # Smoothing is what makes the coefficient identifiable at a straight pose.
+    if wrap_angle_smoothing == 0.0:
+        assert sensitivity == 0.0
+    else:
+        assert jnp.abs(sensitivity) > 0.0
+
+
+def test_wrap_angle_smoothing_bias_is_bounded_and_removes_the_kink():
+    """Smoothing only ever over-estimates the wrap angle, by at most eps * L."""
+    q = jnp.array([3.0, 0.0, 0.0, -2.0, 0.0, 0.0])
+    exact = _planar(num_segments=2)
+    total_length = float(jnp.sum(exact.L))
+    reference = exact._threadlike_wrap_angle(
+        exact._threadlike_wrap_density(exact.strain(q).reshape((2, 3))), total_length
+    )
+
+    for smoothing in (0.0, 0.05, 0.4):
+        smoothed = _planar(num_segments=2, wrap_angle_smoothing=smoothing)
+        angle = smoothed._threadlike_wrap_angle(
+            smoothed._threadlike_wrap_density(smoothed.strain(q).reshape((2, 3))),
+            total_length,
+        )
+        assert angle >= reference
+        assert angle - reference <= smoothing * total_length + 1e-12
+
+    routing = _routing([0.02])
+    plain = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.5)
+    )
+    unsmoothed = _planar(
+        wrap_angle_smoothing=0.0,
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.5),
+    )
+    q_single = jnp.array([3.0, 0.0, 0.0])
+    assert jnp.array_equal(
+        plain.actuation_matrix(q_single), unsmoothed.actuation_matrix(q_single)
+    )
+
+
+def test_gvs_rejects_nonzero_friction():
+    """GVS strain varies along s, so the piecewise-linear wrap angle is invalid."""
+    routing = _routing([0.02])
+    _gvs(actuators=ThreadlikeActuator.tendons(routing))  # zero stays allowed
+
+    with pytest.raises(TypeError, match="wrap-angle model"):
+        _gvs(actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.3))

--- a/tests/actuation/test_threadlike_friction.py
+++ b/tests/actuation/test_threadlike_friction.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-"""Guide friction on threadlike transmissions, and the pluggable loss model."""
+"""Guide friction on threadlike transmissions, and the pluggable model."""
 
 import jax
 import pytest
@@ -17,13 +17,15 @@ from system_param_builders import (
 )
 
 from soromox.actuation import (
-    CapstanFriction,
-    ExponentialLengthFriction,
-    Frictionless,
+    BaseThreadlikeFrictionParams,
+    CapstanFrictionParams,
+    ExponentialLengthFrictionParams,
+    FrictionlessParams,
     ThreadlikeActuator,
     ThreadlikeFriction,
     ThreadlikeImpedance,
     ThreadlikeRouting,
+    capstan_transmission_ratio,
 )
 from soromox.autodiff import custom_jvp_mode
 from soromox.systems import (
@@ -47,12 +49,10 @@ def _planar(
     num_segments=1,
     actuators=None,
     passive_elements=(),
-    wrap_angle_smoothing=0.0,
     num_gauss_points=5,
     gravity=jnp.zeros((2,)),
 ):
     body = planar_pcs_params(
-        base_pose=planar_base_pose(),
         length=jnp.full((num_segments,), 0.1),
         radius=jnp.full((num_segments,), 0.02),
         density=jnp.full((num_segments,), 1000.0),
@@ -63,18 +63,15 @@ def _planar(
     )
     return PlanarPCS(
         body,
-        PlanarPCSStructure(
-            num_gauss_points=num_gauss_points,
-            wrap_angle_smoothing=wrap_angle_smoothing,
-        ),
+        PlanarPCSStructure(num_gauss_points=num_gauss_points),
+        base_pose=planar_base_pose(),
         actuators=actuators,
         passive_elements=passive_elements,
     )
 
 
-def _spatial(*, num_segments=1, actuators=None, wrap_angle_smoothing=0.0):
+def _spatial(*, num_segments=1, actuators=None):
     body = pcs_params(
-        base_pose=spatial_base_pose(),
         length=jnp.full((num_segments,), 0.1),
         radius=jnp.full((num_segments,), 0.02),
         density=jnp.full((num_segments,), 1000.0),
@@ -85,7 +82,8 @@ def _spatial(*, num_segments=1, actuators=None, wrap_angle_smoothing=0.0):
     )
     return PCS(
         body,
-        PCSStructure(num_gauss_points=5, wrap_angle_smoothing=wrap_angle_smoothing),
+        PCSStructure(num_gauss_points=5),
+        base_pose=spatial_base_pose(),
         actuators=actuators,
     )
 
@@ -122,13 +120,46 @@ def _routing(offsets, *, num_segments=1):
     )
 
 
-def _impedance(routing, friction_coefficient=0.0):
+def _anchored_routing(offset, *, start, end):
+    """One path anchored at segment ``start`` and ending at segment ``end``."""
+    return ThreadlikeRouting.linear(
+        intercept=jnp.array([[0.0, offset, 0.0]]),
+        start_segment_index=(start,),
+        end_segment_index=(end,),
+    )
+
+
+def _geometry(robot, path_routing, q, *, s, segment_index):
+    """Evaluate the quadrature context of every path at one node."""
+    strains = robot.strain(q).reshape((robot.num_segments, -1))
+    params = path_routing.params
+    return jax.vmap(
+        robot._threadlike_local_geometry,
+        in_axes=(None, None, None, None, 0, 0, 0),
+        out_axes=0,
+    )(
+        jnp.asarray(segment_index),
+        strains[segment_index],
+        jnp.asarray(s),
+        path_routing,
+        params,
+        params.start_segment_index_array,
+        params.end_segment_index_array,
+    )
+
+
+def _bend_index(factory):
+    """Index of the bending strain within one segment, per host."""
+    return 0 if factory is _planar else 2
+
+
+def _impedance(routing, coefficient=0.0):
     return ThreadlikeImpedance(
         routing=routing,
         stiffness=jnp.array([50.0, 30.0]),
         damping=jnp.array([0.3, 0.2]),
         rest_length=jnp.array([0.09, 0.1]),
-        friction_coefficient=friction_coefficient,
+        friction=ThreadlikeFriction.capstan(coefficient=coefficient),
     )
 
 
@@ -142,7 +173,7 @@ def _settle(robot, u, iterations=30):
             - robot.actuation_force(q, u)
         )
 
-    q = jnp.zeros((robot.num_dofs,))
+    q = jnp.zeros((robot.num_coordinates,))
     for _ in range(iterations):
         q = q - jnp.linalg.solve(jax.jacobian(residual)(q), residual(q))
     return q
@@ -159,6 +190,17 @@ def _with_friction(robot, coefficient):
     )
 
 
+def _with_eps(robot, eps):
+    """Return a copy of ``robot`` whose Capstan curvature floor is ``eps``."""
+    transmission = robot.actuators[0].params.transmission
+    return robot.update_actuator_params(
+        0,
+        transmission=transmission.replace(
+            friction=transmission.friction.replace(eps=eps)
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Model
 # ---------------------------------------------------------------------------
@@ -169,9 +211,11 @@ def test_zero_friction_is_bit_identical(factory):
     routing = _routing([0.02, -0.015])
     plain = factory(actuators=ThreadlikeActuator.tendons(routing))
     zero = factory(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.0)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.0)
+        )
     )
-    q = jnp.linspace(-0.01, 0.04, plain.num_dofs)
+    q = jnp.linspace(-0.01, 0.04, plain.num_coordinates)
     assert jnp.array_equal(plain.actuation_matrix(q), zero.actuation_matrix(q))
 
 
@@ -181,7 +225,9 @@ def test_capstan_matches_closed_form():
     routing = _routing([0.02])
     frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
     attenuated = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=mu)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=mu)
+        )
     )
     q = jnp.array([kappa, 0.0, 0.0])
     wrap = mu * kappa * length
@@ -201,9 +247,13 @@ def test_capstan_matches_closed_form():
     )
     chain_mu = _planar(
         num_segments=num_segments,
-        actuators=ThreadlikeActuator.tendons(span, friction_coefficient=0.4),
+        actuators=ThreadlikeActuator.tendons(
+            span, friction=ThreadlikeFriction.capstan(coefficient=0.4)
+        ),
     )
-    q_chain = jnp.zeros((chain_0.num_dofs,)).at[::3].set(jnp.array([6.0, 9.0, 12.0]))
+    q_chain = (
+        jnp.zeros((chain_0.num_coordinates,)).at[::3].set(jnp.array([6.0, 9.0, 12.0]))
+    )
     rows = jnp.arange(num_segments) * 3 + axial_row
     ratio = (
         chain_mu.actuation_matrix(q_chain)[rows, 0]
@@ -213,19 +263,32 @@ def test_capstan_matches_closed_form():
     assert jnp.all((ratio > 0.0) & (ratio <= 1.0))
 
 
-def test_torsion_wrap_matches_helix_curvature():
-    """An off-axis path under pure torsion wraps at the helix curvature."""
-    radius, torsion = 0.02, 5.0
+def test_path_curvature_is_the_curvature_of_the_routed_path():
+    """``|omega x u_hat|`` must be the curvature the routed path traces."""
+    radius, torsion, bend = 0.02, 5.0, 7.0
     routing = _routing([radius])
-    robot = _spatial(actuators=ThreadlikeActuator.tendons(routing))
-    q = jnp.zeros((robot.num_dofs,)).at[0].set(torsion)
-    strains = robot.strain(q).reshape((robot.num_segments, 6))
+    spatial = _spatial(actuators=ThreadlikeActuator.tendons(routing))
+    path_routing = spatial.actuators[0].transmission.routing
 
-    density = robot._threadlike_wrap_density(
-        strains, robot.actuators[0].transmission.routing
-    )
+    def spatial_curvature(q):
+        strains = spatial.strain(q).reshape((spatial.num_segments, 6))
+        return spatial._threadlike_path_curvature(strains, path_routing)
+
+    # Under pure torsion an off-axis path traces a helix.
+    helix = spatial_curvature(jnp.zeros((spatial.num_coordinates,)).at[0].set(torsion))
     chord = jnp.sqrt(1.0 + (torsion * radius) ** 2)
-    assert_allclose(density, jnp.full_like(density, torsion**2 * radius / chord))
+    assert_allclose(helix, jnp.full_like(helix, torsion**2 * radius / chord))
+
+    # In a planar configuration it reduces to |kappa_z| for any offset, which
+    # is what makes the planar and spatial hosts agree.
+    reduced = spatial_curvature(jnp.zeros((spatial.num_coordinates,)).at[2].set(bend))
+    planar = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    planar_q = jnp.zeros((planar.num_coordinates,)).at[0].set(bend)
+    planar_curvature = planar._threadlike_path_curvature(
+        planar.strain(planar_q).reshape((planar.num_segments, 3))
+    )
+    assert_allclose(reduced, jnp.full_like(reduced, bend), rtol=1e-9)
+    assert_allclose(planar_curvature, jnp.full_like(planar_curvature, bend), rtol=1e-9)
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +307,7 @@ def test_energy_rate_matches_actuation_and_damping_power(
     routing = _routing([0.02, -0.015])
     robot = _planar(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction_coefficient=actuator_friction
+            routing, friction=ThreadlikeFriction.capstan(coefficient=actuator_friction)
         ),
         passive_elements=(_impedance(routing, passive_friction),),
         gravity=jnp.array([0.0, -9.81]),
@@ -254,7 +317,7 @@ def test_energy_rate_matches_actuation_and_damping_power(
     u = jnp.array([3.0, 1.5])
 
     state_rate = robot.forward_dynamics(0.0, jnp.concatenate([q, qd]), (u,))
-    qdd = state_rate[robot.num_dofs :]
+    qdd = state_rate[robot.num_coordinates :]
 
     def energy(q_, qd_):
         return robot.kinetic_energy(q_, qd_) + robot.potential_energy(q_)
@@ -275,7 +338,9 @@ def test_energy_rate_matches_actuation_and_damping_power(
 def test_driving_effort_dissipates_for_pull_and_push(preset, u, qd_sign):
     """Guides absorb power whenever the effort drives the path, either way."""
     routing = _routing([0.02])
-    robot = _planar(actuators=preset(routing, friction_coefficient=0.5))
+    robot = _planar(
+        actuators=preset(routing, friction=ThreadlikeFriction.capstan(coefficient=0.5))
+    )
     transmission = robot.actuators[0].transmission
     q = jnp.array([7.0, 0.0, 0.0])
     qd = jnp.array([qd_sign, 0.0, 0.0])
@@ -313,7 +378,9 @@ def test_closed_loop_work_is_nonzero_and_orientation_dependent():
         return jnp.sum(midpoint * jnp.diff(path, axis=0))
 
     attenuated = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.8)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.8)
+        )
     )
     forward = loop_work(attenuated, 1.0)
     assert jnp.abs(forward) > 1e-4
@@ -337,8 +404,8 @@ def test_passive_friction_is_the_only_unactuated_energy_source(passive_friction)
 
     def energy_rate(index):
         keys = jax.random.split(jax.random.fold_in(key, index))
-        q = 4.0 * jax.random.normal(keys[0], (robot.num_dofs,))
-        qd = jax.random.normal(keys[1], (robot.num_dofs,))
+        q = 4.0 * jax.random.normal(keys[0], (robot.num_coordinates,))
+        qd = jax.random.normal(keys[1], (robot.num_velocities,))
         return (
             qd @ robot.actuation_force(q, control, qd=qd)
             - qd @ robot.damping_matrix(q) @ qd
@@ -349,6 +416,31 @@ def test_passive_friction_is_the_only_unactuated_energy_source(passive_friction)
         assert jnp.all(rates <= 0.0)
     else:
         assert jnp.any(rates > 0.0)
+
+
+def test_floating_passive_nonconservative_force_has_zero_base_prefix():
+    """Passive routing friction acts only on the internal material coordinates."""
+
+    routing = _routing([0.02, -0.015])
+    fixed = _planar(passive_elements=(_impedance(routing, coefficient=0.6),))
+    floating = PlanarPCS(
+        params=fixed.params,
+        structure=PlanarPCSStructure(num_gauss_points=fixed.num_gauss_points),
+        passive_elements=fixed.passive_elements,
+        floating_base=True,
+        backend="jax",
+    )
+    q_internal = jnp.array([4.0, 0.02, -0.01])
+    q = floating.pack_configuration(
+        q_internal,
+        base_pose=jnp.array([0.3, 0.1, -0.2]),
+    )
+    expected = fixed.passive_nonconservative_force(q_internal)
+    actual = floating.passive_nonconservative_force(q)
+
+    assert_allclose(actual[: floating.num_base_velocities], 0.0, atol=0.0)
+    assert_allclose(actual[floating.num_base_velocities :], expected)
+    assert_allclose(floating.passive_nonconservative_force(q_internal), expected)
 
 
 def test_passive_damping_is_psd_under_friction():
@@ -404,10 +496,14 @@ def test_push_and_pull_share_the_same_transmission_ratio():
     """The ratio depends on the configuration only, never on the effort."""
     routing = _routing([0.02])
     tendon = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.7)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.7)
+        )
     )
     push_rod = _planar(
-        actuators=ThreadlikeActuator.push_rods(routing, friction_coefficient=0.7)
+        actuators=ThreadlikeActuator.push_rods(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.7)
+        )
     )
     q = jnp.array([6.0, 0.01, 0.0])
     assert_allclose(
@@ -475,7 +571,9 @@ def test_friction_breaks_length_gradient_identity():
     )
 
     attenuated = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.6)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.6)
+        )
     )
     gap = (
         jax.jacrev(attenuated.actuator_coordinates)(q)
@@ -484,18 +582,20 @@ def test_friction_breaks_length_gradient_identity():
     assert jnp.max(jnp.abs(gap)) > 1e-3
 
 
-def test_friction_coefficient_is_traceable_and_identifiable():
+def test_capstan_coefficient_is_traceable_and_identifiable():
     """The coefficient stays a differentiable leaf under jit."""
     routing = _routing([0.02, -0.015])
     robot = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.2)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.2)
+        )
     )
     q = jnp.array([4.0, 0.02, -0.01])
     u = jnp.array([2.0, 1.0])
 
     @jax.jit
-    def loss(friction_coefficient):
-        identified = _with_friction(robot, friction_coefficient)
+    def loss(coefficient):
+        identified = _with_friction(robot, coefficient)
         return jnp.sum(identified.actuation_force(q, u) ** 2)
 
     for start in (0.0, 0.35):
@@ -508,58 +608,68 @@ def test_friction_coefficient_is_traceable_and_identifiable():
     assert jnp.all(jnp.isfinite(per_path)) and jnp.all(per_path != 0.0)
 
 
-@pytest.mark.parametrize("wrap_angle_smoothing", [0.0, 0.1])
-def test_friction_gradients_are_finite_at_singular_states(wrap_angle_smoothing):
+@pytest.mark.parametrize("eps", [0.0, 0.1])
+def test_friction_gradients_are_finite_at_singular_states(eps):
     """The |kappa| kink at a straight backbone must not produce NaNs."""
     robot = _planar(
-        wrap_angle_smoothing=wrap_angle_smoothing,
         actuators=ThreadlikeActuator.tendons(
-            _routing([0.02]), friction_coefficient=0.3
+            _routing([0.02]),
+            friction=ThreadlikeFriction.capstan(coefficient=0.3, eps=eps),
         ),
     )
-    straight = jnp.zeros((robot.num_dofs,))
+    straight = jnp.zeros((robot.num_coordinates,))
 
     assert jnp.isfinite(jax.jacrev(robot.actuation_matrix)(straight)).all()
     assert jnp.isfinite(jax.jacrev(robot.actuator_coordinates)(straight)).all()
 
-    def matrix_norm(friction_coefficient):
-        identified = _with_friction(robot, friction_coefficient)
+    def matrix_norm(coefficient):
+        identified = _with_friction(robot, coefficient)
         return jnp.sum(identified.actuation_matrix(straight) ** 2)
 
     sensitivity = jax.grad(matrix_norm)(jnp.asarray(0.3))
     assert jnp.isfinite(sensitivity)
-    # Smoothing is what makes the coefficient identifiable at a straight pose.
-    if wrap_angle_smoothing == 0.0:
+    # The curvature floor is what makes the coefficient identifiable straight.
+    if eps == 0.0:
         assert sensitivity == 0.0
-    else:
-        assert jnp.abs(sensitivity) > 0.0
+        return
+    assert jnp.abs(sensitivity) > 0.0
+
+    # The floor is itself a traced leaf, so it can be fitted alongside.
+    def floor_norm(value):
+        return jnp.sum(_with_eps(robot, value).actuation_matrix(straight) ** 2)
+
+    floor_sensitivity = jax.grad(floor_norm)(jnp.asarray(eps))
+    assert jnp.isfinite(floor_sensitivity) and jnp.abs(floor_sensitivity) > 0.0
 
 
-def test_wrap_angle_smoothing_bias_is_bounded_and_removes_the_kink():
-    """Smoothing only ever over-estimates the wrap angle, by at most eps * L."""
+def test_curvature_floor_bias_is_bounded_and_removes_the_kink():
+    """The floor only ever over-estimates the wrap angle, by at most eps * L."""
     q = jnp.array([3.0, 0.0, 0.0, -2.0, 0.0, 0.0])
-    exact = _planar(num_segments=2)
-    total_length = float(jnp.sum(exact.L))
-    reference = exact._threadlike_wrap_angle(
-        exact._threadlike_wrap_density(exact.strain(q).reshape((2, 3))), total_length
+    robot = _planar(num_segments=2)
+    total_length = float(jnp.sum(robot.L))
+    starts = jnp.zeros((1,), dtype=jnp.int32)
+    curvature = robot._threadlike_path_curvature(robot.strain(q).reshape((2, 3)))
+    reference = robot._threadlike_safe_wrap_angle(
+        curvature, total_length, starts, jnp.asarray(0.0)
     )
 
-    for smoothing in (0.0, 0.05, 0.4):
-        smoothed = _planar(num_segments=2, wrap_angle_smoothing=smoothing)
-        angle = smoothed._threadlike_wrap_angle(
-            smoothed._threadlike_wrap_density(smoothed.strain(q).reshape((2, 3))),
-            total_length,
+    for eps in (0.0, 0.05, 0.4):
+        angle = robot._threadlike_safe_wrap_angle(
+            curvature, total_length, starts, jnp.asarray(eps)
         )
-        assert angle >= reference
-        assert angle - reference <= smoothing * total_length + 1e-12
+        assert jnp.all(angle >= reference)
+        assert jnp.all(angle - reference <= eps * total_length + 1e-12)
 
     routing = _routing([0.02])
     plain = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.5)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.5)
+        )
     )
     unsmoothed = _planar(
-        wrap_angle_smoothing=0.0,
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.5),
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.5, eps=0.0)
+        ),
     )
     q_single = jnp.array([3.0, 0.0, 0.0])
     assert jnp.array_equal(
@@ -573,73 +683,100 @@ def test_gvs_rejects_nonzero_friction():
     _gvs(actuators=ThreadlikeActuator.tendons(routing))  # zero stays allowed
 
     with pytest.raises(TypeError, match="wrap-angle model"):
-        _gvs(actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.3))
+        _gvs(
+            actuators=ThreadlikeActuator.tendons(
+                routing, friction=ThreadlikeFriction.capstan(coefficient=0.3)
+            )
+        )
 
 
 # ---------------------------------------------------------------------------
-# The pluggable transmission-loss model
+# The pluggable friction model
 # ---------------------------------------------------------------------------
 
 
-class _HyperbolicFriction(ThreadlikeFriction):
-    """A law defined entirely outside soromox, to pin the extension point."""
+class _HyperbolicFrictionParams(BaseThreadlikeFrictionParams):
+    """Parameters of a law defined entirely outside soromox."""
 
     a: Array
 
-    def transmission_ratio(self, context):
-        return 1.0 / (1.0 + self.a * context.wrap_angle)
+
+def _hyperbolic_transmission_ratio(params, context):
+    """A law defined entirely outside soromox, to pin the extension point."""
+    return 1.0 / (1.0 + params.a * context.wrap_angle)
+
+
+def _hyperbolic(a):
+    return ThreadlikeFriction(
+        params=_HyperbolicFrictionParams(a=jnp.asarray(a)),
+        ratio_fn=_hyperbolic_transmission_ratio,
+        requires_wrap_angle=True,
+        is_frictionless=False,
+    )
 
 
 @pytest.mark.parametrize("factory", [_planar, _spatial])
-def test_default_is_lossless_and_bit_identical(factory):
+def test_default_is_frictionless_and_bit_identical(factory):
     """The shipped default delivers full effort and costs nothing."""
     routing = _routing([0.02, -0.015])
-    q = jnp.linspace(-0.01, 0.04, factory().num_dofs)
+    q = jnp.linspace(-0.01, 0.04, factory().num_coordinates)
 
     default = factory(actuators=ThreadlikeActuator.tendons(routing))
     explicit = factory(
-        actuators=ThreadlikeActuator.tendons(routing, friction=Frictionless())
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.frictionless()
+        )
     )
-    assert Frictionless.is_lossless
-    assert not Frictionless.requires_wrap_angle
+    assert ThreadlikeFriction.frictionless().is_frictionless
+    assert not ThreadlikeFriction.frictionless().requires_wrap_angle
     assert jnp.array_equal(default.actuation_matrix(q), explicit.actuation_matrix(q))
-    assert isinstance(default.actuators[0].params.transmission.friction, Frictionless)
+    assert isinstance(
+        default.actuators[0].params.transmission.friction, FrictionlessParams
+    )
 
 
-def test_capstan_object_matches_coefficient_sugar():
-    """The two spellings of a Capstan law must not diverge."""
+def test_params_and_law_stay_paired():
+    """The params leaf and the runtime law must not drift apart."""
     routing = _routing([0.02])
     q = jnp.array([6.0, 0.0, 0.0])
 
-    sugar = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.4)
-    )
-    obj = _planar(
+    robot = _planar(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction=CapstanFriction(coefficient=0.4)
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.4)
         )
     )
-    assert jnp.array_equal(sugar.actuation_matrix(q), obj.actuation_matrix(q))
+    transmission = robot.actuators[0].transmission
+    assert isinstance(transmission.params.friction, CapstanFrictionParams)
+    assert transmission.friction.params is transmission.params.friction
 
-    with pytest.raises(ValueError, match="not both"):
-        ThreadlikeActuator.tendons(
-            routing, friction=CapstanFriction(coefficient=0.1), friction_coefficient=0.2
+    # Replacing a value keeps the installed law.
+    replaced = _with_friction(robot, jnp.asarray(0.4))
+    assert replaced.actuators[0].transmission.friction.ratio_fn is (
+        transmission.friction.ratio_fn
+    )
+    assert jnp.array_equal(robot.actuation_matrix(q), replaced.actuation_matrix(q))
+
+    # Swapping the params type behind an installed law is refused, as is
+    # installing anything that is not a law.
+    with pytest.raises(TypeError, match="keep their type"):
+        transmission.friction.with_params(
+            ExponentialLengthFrictionParams(rate=jnp.asarray(1.0))
         )
-    with pytest.raises(TypeError, match="ThreadlikeFriction"):
+    with pytest.raises(TypeError):
         ThreadlikeActuator.tendons(routing, friction="capstan")
 
 
 @pytest.mark.parametrize("factory", [_planar, _spatial])
 def test_length_friction_matches_closed_form(factory):
-    """A per-length loss integrates to its own analytic mean over a segment."""
+    """A per-length friction integrates to its analytic mean over a segment."""
     rate, length = 3.0, 0.1
     routing = _routing([0.02])
-    q = jnp.zeros((factory().num_dofs,)).at[0].set(4.0)
+    q = jnp.zeros((factory().num_coordinates,)).at[0].set(4.0)
 
     frictionless = factory(actuators=ThreadlikeActuator.tendons(routing))
     attenuated = factory(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction=ExponentialLengthFriction(rate=rate)
+            routing, friction=ThreadlikeFriction.exponential_length(rate=rate)
         )
     )
     decay = rate * length
@@ -657,12 +794,12 @@ def test_length_friction_matches_closed_form(factory):
 def test_length_friction_runs_on_gvs():
     """GVS hosts a wrap-angle-free law, and still refuses a Capstan law."""
     routing = _routing([0.02])
-    q = jnp.zeros((_gvs().num_dofs,)).at[0].set(3.0)
+    q = jnp.zeros((_gvs().num_coordinates,)).at[0].set(3.0)
 
     frictionless = _gvs(actuators=ThreadlikeActuator.tendons(routing))
     attenuated = _gvs(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction=ExponentialLengthFriction(rate=4.0)
+            routing, friction=ThreadlikeFriction.exponential_length(rate=4.0)
         )
     )
     reference = jnp.abs(frictionless.actuation_matrix(q))
@@ -673,7 +810,7 @@ def test_length_friction_runs_on_gvs():
     with pytest.raises(TypeError, match="wrap-angle model"):
         _gvs(
             actuators=ThreadlikeActuator.tendons(
-                routing, friction=CapstanFriction(coefficient=0.3)
+                routing, friction=ThreadlikeFriction.capstan(coefficient=0.3)
             )
         )
 
@@ -685,9 +822,7 @@ def test_custom_friction_model_needs_no_soromox_change():
 
     frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
     custom = _planar(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=_HyperbolicFriction(a=jnp.asarray(0.5))
-        )
+        actuators=ThreadlikeActuator.tendons(routing, friction=_hyperbolic(0.5))
     )
     reference = frictionless.actuation_matrix(q)
     weighted = custom.actuation_matrix(q)
@@ -697,20 +832,20 @@ def test_custom_friction_model_needs_no_soromox_change():
     # The law is not Capstan, so it must not coincide with one.
     capstan = _planar(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction=CapstanFriction(coefficient=0.5)
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.5)
         )
     ).actuation_matrix(q)
     assert jnp.max(jnp.abs(weighted - capstan)) > 1e-6
 
 
 def test_model_is_traceable_and_identifiable():
-    """Loss parameters stay differentiable leaves under jit, for any law."""
+    """Friction parameters stay differentiable leaves under jit, for any model."""
     routing = _routing([0.02, -0.015])
     q = jnp.array([4.0, 0.02, -0.01])
     u = jnp.array([2.0, 1.0])
 
     def loss_for(build, value):
-        # The robot is built once outside the trace; only the loss parameter is
+        # The robot is built once outside the trace; only the friction parameter
         # traced, which is how a law is identified in practice.
         robot = _planar(
             actuators=ThreadlikeActuator.tendons(routing, friction=build(value))
@@ -720,16 +855,17 @@ def test_model_is_traceable_and_identifiable():
         def loss(parameter):
             transmission = robot.actuators[0].params.transmission
             identified = robot.update_actuator_params(
-                0, transmission=transmission.replace(friction=build(parameter))
+                0,
+                transmission=transmission.replace(friction=build(parameter).params),
             )
             return jnp.sum(identified.actuation_force(q, u) ** 2)
 
         return jax.value_and_grad(loss)(jnp.asarray(value))
 
     for build, value in (
-        (lambda p: CapstanFriction(coefficient=p), 0.3),
-        (lambda p: ExponentialLengthFriction(rate=p), 2.0),
-        (lambda p: _HyperbolicFriction(a=p), 0.4),
+        (lambda p: ThreadlikeFriction.capstan(coefficient=p), 0.3),
+        (lambda p: ThreadlikeFriction.exponential_length(rate=p), 2.0),
+        (lambda p: _hyperbolic(p), 0.4),
     ):
         magnitude, gradient = loss_for(build, value)
         assert jnp.isfinite(magnitude) and jnp.isfinite(gradient)
@@ -745,7 +881,7 @@ def test_context_fields_agree_across_hosts():
     curvature, axial, shear = 5.0, 0.02, -0.01
     planar_strain = jnp.array([curvature, 1.0 + axial, shear])
     spatial_strain = jnp.array([0.0, 0.0, curvature, 1.0 + axial, shear, 0.0])
-    arc_length = 0.06
+    abscissa = 0.06
     path_routing = planar.actuators[0].transmission.routing
 
     def geometry(robot, strain):
@@ -756,7 +892,7 @@ def test_context_fields_agree_across_hosts():
         )(
             jnp.asarray(0),
             strain,
-            jnp.asarray(arc_length),
+            jnp.asarray(abscissa),
             path_routing,
             path_routing.params,
             path_routing.params.start_segment_index_array,
@@ -766,7 +902,13 @@ def test_context_fields_agree_across_hosts():
     planar_context = geometry(planar, planar_strain)
     spatial_context = geometry(spatial, spatial_strain)
 
-    for field in ("arc_length", "offset", "offset_derivative", "tangent_norm"):
+    for field in (
+        "abscissa",
+        "path_abscissa",
+        "offset",
+        "offset_derivative",
+        "tangent_norm",
+    ):
         assert_allclose(
             getattr(planar_context, field),
             getattr(spatial_context, field),
@@ -775,3 +917,129 @@ def test_context_fields_agree_across_hosts():
             err_msg=f"host-agnostic field {field} disagrees",
         )
     assert jnp.array_equal(planar_context.active, spatial_context.active)
+
+
+@pytest.mark.parametrize(
+    ("build", "field"),
+    [
+        (lambda v: CapstanFrictionParams(coefficient=jnp.asarray(v)), "coefficient"),
+        (lambda v: CapstanFrictionParams(eps=jnp.asarray(v)), "eps"),
+        (lambda v: ExponentialLengthFrictionParams(rate=jnp.asarray(v)), "rate"),
+    ],
+)
+@pytest.mark.parametrize("value", [-1.0, jnp.nan, jnp.inf])
+def test_friction_parameters_reject_negative_and_non_finite_values(build, field, value):
+    """A ratio outside (0, 1] would let a transmission generate effort."""
+    with pytest.raises(ValueError, match=field):
+        build(value)
+
+
+def test_friction_parameters_reject_a_wrong_per_path_shape():
+    """A per-path parameter must carry one entry per routed path."""
+    with pytest.raises(ValueError, match="coefficient"):
+        ThreadlikeActuator.tendons(
+            _routing([0.02, -0.015]),
+            friction=ThreadlikeFriction.capstan(coefficient=jnp.zeros((3,))),
+        )
+
+
+def test_a_friction_model_may_not_claim_to_be_frictionless():
+    """is_frictionless skips the model, so a friction model must not set it."""
+    with pytest.raises(ValueError, match="is_frictionless"):
+        ThreadlikeFriction(
+            params=CapstanFrictionParams(coefficient=jnp.asarray(0.3)),
+            ratio_fn=capstan_transmission_ratio,
+            requires_wrap_angle=True,
+            is_frictionless=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Friction accumulates from the path anchor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial])
+def test_friction_is_measured_from_the_path_anchor(factory):
+    """A path anchored mid-robot must not pay for what happens below it."""
+    robot = factory(num_segments=3)
+    anchored = _anchored_routing(0.02, start=1, end=2)
+    path_routing = ThreadlikeActuator.tendons(anchored).transmission.routing
+    starts = anchored.params.start_segment_index_array
+    anchor, tip = float(robot.L_cum[1]), float(jnp.sum(robot.L))
+
+    # Bend only the first segment, which the path does not span.
+    q = jnp.zeros((robot.num_coordinates,)).at[_bend_index(factory)].set(9.0)
+    strains = robot.strain(q).reshape((robot.num_segments, -1))
+    curvature = (
+        robot._threadlike_path_curvature(strains)
+        if factory is _planar
+        else robot._threadlike_path_curvature(strains, anchored)
+    )
+
+    # The wrap angle ignores that turning,
+    anchored_angle = robot._threadlike_safe_wrap_angle(
+        curvature, tip, starts, jnp.asarray(0.0)
+    )
+    assert_allclose(anchored_angle, jnp.zeros_like(anchored_angle), atol=1e-12)
+    # which the same pose measured from the robot base does not.
+    base_angle = robot._threadlike_safe_wrap_angle(
+        curvature, tip, jnp.zeros_like(starts), jnp.asarray(0.0)
+    )
+    assert jnp.all(base_angle > 1e-3)
+
+    # The traversed length is anchor-relative too, so a length law transmits in
+    # full at the anchor and decays only beyond it.
+    at_anchor = _geometry(robot, path_routing, q, s=anchor, segment_index=1)
+    assert_allclose(
+        at_anchor.path_abscissa, jnp.zeros_like(at_anchor.path_abscissa), atol=1e-12
+    )
+    ratio = ThreadlikeFriction.exponential_length(rate=5.0).transmission_ratio(
+        at_anchor
+    )
+    assert_allclose(ratio, jnp.ones_like(ratio), rtol=1e-12)
+
+    travelled = 0.03
+    beyond = _geometry(robot, path_routing, q, s=anchor + travelled, segment_index=1)
+    assert_allclose(
+        beyond.path_abscissa, jnp.full_like(beyond.path_abscissa, travelled)
+    )
+    # while the backbone coordinate still counts from the robot base.
+    assert_allclose(beyond.abscissa, jnp.full_like(beyond.abscissa, anchor + travelled))
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial])
+def test_capstan_friction_is_unaffected_by_curvature_before_the_anchor(factory):
+    """Attenuation of a mid-robot path must not depend on the segments below."""
+    anchored = _anchored_routing(0.02, start=1, end=2)
+    frictional = factory(
+        num_segments=3,
+        actuators=ThreadlikeActuator.tendons(
+            anchored, friction=ThreadlikeFriction.capstan(coefficient=0.6)
+        ),
+    )
+    reference = factory(num_segments=3, actuators=ThreadlikeActuator.tendons(anchored))
+    per_segment, bend = frictional.num_internal_dofs // 3, _bend_index(factory)
+
+    def attenuation(base_curvature):
+        # Bend the two segments the path spans, so it is genuinely attenuated,
+        # and vary only the curvature of the segment below its anchor.
+        q = (
+            jnp.zeros((frictional.num_coordinates,))
+            .at[bend]
+            .set(base_curvature)
+            .at[per_segment + bend]
+            .set(8.0)
+            .at[2 * per_segment + bend]
+            .set(-6.0)
+        )
+        reference_matrix = reference.actuation_matrix(q)
+        carried = jnp.abs(reference_matrix) > 1e-9
+        return frictional.actuation_matrix(q)[carried] / reference_matrix[carried]
+
+    straight_below = attenuation(0.0)
+    bent_below = attenuation(11.0)
+    assert straight_below.size > 0
+    # The path is attenuated, but by its own turning only.
+    assert jnp.all(straight_below < 1.0)
+    assert_allclose(straight_below, bent_below, rtol=1e-9, atol=1e-12)

--- a/tests/execution/warp/actuation/test_threadlike.py
+++ b/tests/execution/warp/actuation/test_threadlike.py
@@ -8,8 +8,17 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from soromox.actuation import ThreadlikeActuator, ThreadlikeRouting
+from soromox.actuation import (
+    ThreadlikeActuator,
+    ThreadlikeFriction,
+    ThreadlikeImpedance,
+    ThreadlikeRouting,
+)
 from soromox.execution.warp import loader
+from soromox.execution.warp.actuation.threadlike import (
+    supports_linear_threadlike_force,
+    supports_linear_threadlike_matrix,
+)
 from soromox.execution.warp.gvs.actuation.operands import (
     GVSThreadlikeOperands,
     GVSThreadlikeShapes,
@@ -693,6 +702,56 @@ def test_public_gate_uses_only_benchmark_qualified_warp_paths(family: str) -> No
             model.actuation_matrix(q, backend="warp")
     with pytest.raises(NotImplementedError, match="low-level Warp-native"):
         model.actuation_force(q, controls, backend="warp")
+
+
+def test_warp_gate_rejects_unimplemented_active_friction() -> None:
+    """Keep frictional matrices and forces on the differentiable JAX path."""
+
+    base = _build_system("pcs", 2, 4)
+    actuator = ThreadlikeActuator.tendons(
+        _routing(2, 4, planar=False),
+        friction=ThreadlikeFriction.exponential_length(rate=2.0),
+    )
+    model = _rebuild_with_actuators(base, actuator)
+    q = jnp.zeros((model.num_coordinates,))
+    controls = jnp.ones((model.num_actuators,))
+
+    assert not supports_linear_threadlike_matrix(model)
+    assert not supports_linear_threadlike_force(model)
+    with pytest.raises(NotImplementedError, match="frictionless"):
+        model.actuation_matrix(q, backend="warp")
+    with pytest.raises(NotImplementedError, match="frictionless"):
+        model.actuation_force(q, controls, backend="warp")
+
+
+def test_warp_force_gate_rejects_nonconservative_passive_friction() -> None:
+    """Prevent fused Warp force evaluation from dropping passive friction."""
+
+    base = _build_system("pcs", 2, 4)
+    routing = _routing(2, 4, planar=False)
+
+    def rebuild(friction):
+        passive = ThreadlikeImpedance(
+            routing=routing,
+            stiffness=jnp.ones((4,)),
+            damping=jnp.ones((4,)),
+            rest_length=jnp.full((4,), 0.2),
+            friction=friction,
+        )
+        return PCS(
+            params=base.params,
+            structure=PCSStructure(num_gauss_points=base.num_gauss_points),
+            base_pose=base.fixed_base_pose,
+            actuators=base.actuators,
+            passive_elements=(passive,),
+            backend="jax",
+        )
+
+    conservative = rebuild(None)
+    nonconservative = rebuild(ThreadlikeFriction.exponential_length(rate=2.0))
+    assert supports_linear_threadlike_matrix(nonconservative)
+    assert supports_linear_threadlike_force(conservative)
+    assert not supports_linear_threadlike_force(nonconservative)
 
 
 def test_pcs_explicit_warp_matrix_uses_warp_on_cpu(

--- a/tests/systems/test_pcs_2d_vs_3d_coherence.py
+++ b/tests/systems/test_pcs_2d_vs_3d_coherence.py
@@ -10,6 +10,7 @@ from system_param_builders import (
     spatial_base_pose,
 )
 
+from soromox.actuation import ThreadlikeActuator, ThreadlikeRouting
 from soromox.systems import PCS, PCSStructure, PlanarPCS, PlanarPCSStructure
 from soromox.utils.tolerance import Tolerance
 
@@ -24,7 +25,7 @@ NUM_RANDOM_SAMPLES = 5
 
 
 def make_planar_model(
-    num_segments: int, total_length: float = TOTAL_LENGTH
+    num_segments: int, total_length: float = TOTAL_LENGTH, actuators=None
 ) -> PlanarPCS:
     segment_length = total_length / num_segments
     L = segment_length * jnp.ones((num_segments,))
@@ -45,10 +46,13 @@ def make_planar_model(
         params=params,
         structure=PlanarPCSStructure(num_gauss_points=3),
         base_pose=planar_base_pose(),
+        actuators=actuators,
     )
 
 
-def make_spatial_model(num_segments: int, total_length: float = TOTAL_LENGTH) -> PCS:
+def make_spatial_model(
+    num_segments: int, total_length: float = TOTAL_LENGTH, actuators=None
+) -> PCS:
     segment_length = total_length / num_segments
     L = segment_length * jnp.ones((num_segments,))
     diag_entries = (
@@ -69,6 +73,7 @@ def make_spatial_model(num_segments: int, total_length: float = TOTAL_LENGTH) ->
         params=params,
         structure=PCSStructure(num_gauss_points=3),
         base_pose=spatial_base_pose(),
+        actuators=actuators,
     )
 
 
@@ -434,3 +439,41 @@ def test_forward_dynamics_coherence(num_segments):
 if __name__ == "__main__":
     # run pytest with activated stdout
     pytest.main([__file__])
+
+
+@pytest.mark.parametrize("num_segments", [1, 2, 3])
+@pytest.mark.parametrize("friction_coefficient", [0.0, 0.7])
+def test_threadlike_actuation_coherence(num_segments, friction_coefficient):
+    """The planar and spatial hosts must route and attenuate identically."""
+    routing = ThreadlikeRouting.linear(
+        intercept=jnp.array([[0.0, 2e-2, 0.0], [0.0, -1.5e-2, 0.0]]),
+        start_segment_index=(0, 0),
+        end_segment_index=(num_segments - 1,) * 2,
+    )
+
+    def tendons(coefficient):
+        return ThreadlikeActuator.tendons(routing, friction_coefficient=coefficient)
+
+    planar = make_planar_model(num_segments, actuators=tendons(friction_coefficient))
+    spatial = make_spatial_model(num_segments, actuators=tendons(friction_coefficient))
+
+    q_planar = jnp.concatenate(
+        [jnp.array([4.0 + 2.0 * seg, 2e-2, -1e-2]) for seg in range(num_segments)]
+    )
+    q_spatial = lift_planar_configuration(planar, spatial, q_planar)
+    indices = spatial_planar_indices(num_segments)
+
+    planar_matrix = planar.actuation_matrix(q_planar)
+    assert_allclose(
+        planar_matrix,
+        spatial.actuation_matrix(q_spatial)[indices],
+        rtol=RTOL,
+        atol=ATOL,
+    )
+
+    if friction_coefficient > 0.0:
+        frictionless = make_planar_model(num_segments, actuators=tendons(0.0))
+        attenuated = jnp.abs(planar_matrix)
+        reference = jnp.abs(frictionless.actuation_matrix(q_planar))
+        assert jnp.all(attenuated <= reference + ATOL)
+        assert jnp.max(reference - attenuated) > 1e-4

--- a/tests/systems/test_pcs_2d_vs_3d_coherence.py
+++ b/tests/systems/test_pcs_2d_vs_3d_coherence.py
@@ -10,7 +10,11 @@ from system_param_builders import (
     spatial_base_pose,
 )
 
-from soromox.actuation import ThreadlikeActuator, ThreadlikeRouting
+from soromox.actuation import (
+    ThreadlikeActuator,
+    ThreadlikeFriction,
+    ThreadlikeRouting,
+)
 from soromox.systems import PCS, PCSStructure, PlanarPCS, PlanarPCSStructure
 from soromox.utils.tolerance import Tolerance
 
@@ -442,8 +446,8 @@ if __name__ == "__main__":
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-@pytest.mark.parametrize("friction_coefficient", [0.0, 0.7])
-def test_threadlike_actuation_coherence(num_segments, friction_coefficient):
+@pytest.mark.parametrize("coefficient", [0.0, 0.7])
+def test_threadlike_actuation_coherence(num_segments, coefficient):
     """The planar and spatial hosts must route and attenuate identically."""
     routing = ThreadlikeRouting.linear(
         intercept=jnp.array([[0.0, 2e-2, 0.0], [0.0, -1.5e-2, 0.0]]),
@@ -451,11 +455,13 @@ def test_threadlike_actuation_coherence(num_segments, friction_coefficient):
         end_segment_index=(num_segments - 1,) * 2,
     )
 
-    def tendons(coefficient):
-        return ThreadlikeActuator.tendons(routing, friction_coefficient=coefficient)
+    def tendons(value):
+        return ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=value)
+        )
 
-    planar = make_planar_model(num_segments, actuators=tendons(friction_coefficient))
-    spatial = make_spatial_model(num_segments, actuators=tendons(friction_coefficient))
+    planar = make_planar_model(num_segments, actuators=tendons(coefficient))
+    spatial = make_spatial_model(num_segments, actuators=tendons(coefficient))
 
     q_planar = jnp.concatenate(
         [jnp.array([4.0 + 2.0 * seg, 2e-2, -1e-2]) for seg in range(num_segments)]
@@ -471,7 +477,7 @@ def test_threadlike_actuation_coherence(num_segments, friction_coefficient):
         atol=ATOL,
     )
 
-    if friction_coefficient > 0.0:
+    if coefficient > 0.0:
         frictionless = make_planar_model(num_segments, actuators=tendons(0.0))
         attenuated = jnp.abs(planar_matrix)
         reference = jnp.abs(frictionless.actuation_matrix(q_planar))


### PR DESCRIPTION
## Summary

Threadlike transmissions currently deliver effort undiminished along a routed path. This adds an opt-in transmission loss, expressed as a first-class model object chosen at construction, so a new loss law needs no change to any host and a third-party law needs no change to soromox.

Three laws ship: `Frictionless` (the default), `CapstanFriction`, and `ExponentialLengthFriction`. Everything is inert at the default, which is skipped entirely and reproduces the frictionless result bit for bit.

The PR also corrects a pre-existing sign error in the planar routed-path offset. That fix lands whether or not guide friction is adopted: it changes results for any existing planar threadlike routing, and it is what allows the planar and spatial hosts to be checked against each other for the first time.

---

# Part I — Theory

## Reference model

Guide friction is the dominant unmodelled loss in a tendon-driven continuum robot, and the term that separates commanded tension from delivered tension during identification. The frictionless limit soromox implements today is the special case of the force model in

> D. Feliu-Talegon, A. Y. Alkayas, Y. A. Adamu, A. T. Mathew and F. Renda, "Actuation Reading Insights: Estimating Shape and Forces in Tendon-Driven Slender Soft Robots," *IEEE/ASME Transactions on Mechatronics*, 30(6), 7878-7888, 2025.

There a tendon runs from a motorized capstan through holes in a chain of spacer disks. Each disk contact involves Coulomb friction against the bushing, so the tension is not uniform along the tendon, and the loss at each contact is quantified with the classical Capstan equation. This PR adds the friction term that model carries and soromox currently drops.

Guide friction is not one law, though. It depends on how the path is held: a tendon through spacer disks loses tension where it turns, while a tendon in a close-fitting sheath loses it with distance travelled. Hard-coding either would have to be undone to add the other, so the law is a replaceable object from the outset.

## Derivation

### Step 1 — the classical Capstan (Euler) law

A flexible band drawn over a fixed cylinder with total wrap angle $\varphi$ and Coulomb coefficient $\mu$ transmits

$$
T_{out} = T_{in} e^{-\mu\varphi}
$$

when the input end is the driving end. The result is independent of the drum radius: only the accumulated turn of the band matters. That single fact is what the whole model rests on.

### Step 2 — the rigid guide chain

Thread a tendon through $N$ discrete guides at points $p_k$. Between guides the tendon is straight, with chord length $\nu_k$ and unit vector $u_k$; at guide $k$ it turns by $\varphi_k$. Applying step 1 at each guide and accumulating,

$$
T_{k+1} = T_k e^{-\mu\varphi_k}
\qquad\Longrightarrow\qquad
T_k = T_0 e^{-\mu\sum_j^{k-1}\varphi_j}
$$

The force the tendon applies to the body at guide $k$ is the resultant of the two adjacent spans, $f_k = -T_k u_k + T_{k+1}u_{k+1}$. Taking virtual work and summing by parts, with a fixed base $\delta p_0 = 0$,

$$
\delta W = \sum_k f_k\cdot\delta p_k
= -\sum_k T_k u_k\cdot(\delta p_k - \delta p_{k-1})
= -\sum_k T_k \delta\nu_k
$$

This step needs no assumption whatsoever on the $T_k$, which is the crux of the design: the friction reaction is already contained in $T_k \neq T_{k+1}$, so nothing has to be subtracted afterwards. The friction load belongs inside the actuation matrix, not beside it.

### Step 3 — the continuum limit

Let the guide spacing go to zero. The sums become integrals over the backbone coordinate $s$, and the accumulated turn becomes

$$
\Theta(q, s) = \int_0^s \lVert\omega\times\hat u\rVert \mathrm{d}s'
$$

Define the transmission ratio $\eta(q, s) = e^{-\mu\Theta(q, s)}$, the fraction of the effort applied at the base that survives to arc length $s$, so that $T(s) = e \eta(q,s)$ for a base effort $e$. It equals one at the base and decays monotonically toward the tip.

For one path, $r(s)$ is the material-frame offset and the local tangent is $t = v + \omega\times r + r'$. With $\nu = \lVert t\rVert$ and $\hat u = t/\nu$, the length-gradient density is $\Phi = \partial\nu/\partial\xi = [ r\times\hat u\ ;\ \hat u ]$, and substituting $\delta\xi = B_\xi \delta q$ gives

$$
A_\eta(q) = B_\xi^\top\!\int_0^L \eta(q, s) \Phi(q, s) \mathrm{d}s
$$

At $\mu = 0$ this is $A_0 = (\partial\ell/\partial q)^\top$, today's implementation, so the model is a strict generalization. The scalar $\eta$ multiplies the whole basis, moment row included: the moment arm needs no separate treatment.

### Step 4 — one ODE, two laws

Steps 1 to 3 are the curvature-driven case. Both shipped laws in fact solve the same tension ODE along the path,

$$
\frac{\mathrm{d}T}{\mathrm{d}s} = -\lambda(q, s) T
\qquad\Longrightarrow\qquad
\eta = e^{-\int_0^s \lambda \mathrm{d}s'}
$$

and differ only in where the normal load pressing the path against its guide comes from. `CapstanFriction` takes it from curvature, $N = Tw$ with $w = \lVert\omega\times\hat u\rVert$, giving $\lambda = \mu w$ and $\eta = e^{-\mu\Theta}$. `ExponentialLengthFriction` takes it from a sheath gripping in proportion to tension, $N = cT$, giving a constant $\lambda = \mu c = k$ and $\eta = e^{-ks}$, so loss accrues with distance rather than with turning.

That makes $k$ phenomenological in a way $\mu$ is not: it lumps the friction coefficient with the radial grip, so it must be fitted rather than looked up. It suits a tendon in a close-fitting sheath or lumen, and because it never reads the wrap angle it is the one law `GVS` can host.

Every law must satisfy two rules. $\eta$ depends on the configuration only, never on the effort, so the actuation force stays linear in the effort and every existing controller keeps working; and $\eta \in (0, 1]$, so a law can only remove effort, never add it.

## Wrap-angle density

$\hat T = R\hat u$ gives $\mathrm{d}\hat T/\mathrm{d}s = R(\omega\times\hat u + \hat u')$, so the exact density is $\lVert\omega\times\hat u + \hat u'\rVert$. The implementation drops $\hat u'$, which is first order in shear-strain times routing-slope and identically zero at constant offset, leaving $w = \lVert\omega\times\hat u\rVert$.

In the plane, $\omega = (0,0,\kappa)$ is perpendicular to the in-plane unit tangent, so $w = \lvert\kappa\rvert$ identically, for any offset and any strain. Under pure torsion $\omega = (k_x,0,0)$ at offset radius $\rho$ gives $w = k_x^2\rho/\nu$ with $\nu = \sqrt{1 + k_x^2\rho^2}$, exactly the helix curvature of the resulting path converted from per-tendon-length to per-$s$. An off-axis path under pure torsion does wrap its guides, and this term captures it.

Since $\omega$ is constant per PCS segment, $w$ is piecewise constant and $\Theta$ is piecewise linear, therefore exact at every quadrature node with no nested quadrature and no added error. Planar $w$ is path-independent; spatial $w$ depends on $\hat u$ and so is per path.

### Wrap-angle smoothing

A static `wrap_angle_smoothing` $\epsilon$ on the host structure replaces $\lvert\kappa\rvert$ by $\sqrt{\kappa^2 + \epsilon^2}$. It never under-estimates the wrap angle and over-estimates it by at most $\epsilon L$, so $\eta$ stays in $(0, 1]$, and $\epsilon = 0$ reproduces the exact $\lvert\kappa\rvert$ bit for bit.

It exists for identification. With the exact $\lvert\kappa\rvert$ a straight configuration has $\Theta = 0$, which makes $\mathrm{d}A/\mathrm{d}\mu$ a clean zero, indistinguishable from a converged fit. A nonzero $\epsilon$ gives $\Theta > 0$ even when straight, and also removes the $C^0$ kink on every $\kappa_i = 0$ hyperplane.

## Effect on the energy of the system

With a loss installed the equations of motion read

$$
M\ddot q + C\dot q + \frac{\partial U_g}{\partial q} + \frac{\partial U_{el}}{\partial q} + D(q)\dot q = \tau_u,
\qquad
\tau_u = A_\eta e - (A_\eta - A_0)K \Delta\ell
$$

where $e$ is the work-conjugate effort the effort model produces from the control, $\Delta\ell$ is the passive-path extension, and $K$ the diagonal passive stiffness.

### The robot-side budget stays exact

`elastic_force` keeps only the conservative half of the passive force, so it remains exactly $\partial U_{el}/\partial q$ and

$$
\frac{\mathrm{d}}{\mathrm{d}t}(T + U) = \dot q\cdot\tau_u - \dot q^\top D\dot q
$$

holds verbatim under any law. A transmission loss does not add a dissipation term to the robot; it changes what $\tau_u$ is. This is the headline invariant, and it holds to $10^{-16}$ for all four combinations of actuator and passive coefficients.

### Why the passive force is split

`elastic_force` is wired by a custom JVP to be the gradient of `elastic_energy`. The attenuated spring force is the gradient of nothing: differentiating $A_\eta e$ picks up a per-node outer product $(\partial\eta/\partial\xi)(\partial\nu/\partial\xi)^\top$ whose antisymmetric part is generically nonzero, because $\partial\eta/\partial\xi$ lies in the bending channel alone while $\partial\nu/\partial\xi$ has every component, so the two never cancel. Carrying the attenuated force in `elastic_force` would make `jax.grad(elastic_energy)` disagree with a finite difference of that same function: a silent wrong gradient, unrepairable by redefining the energy. Hence

$$
\tau_{pt} = \underbrace{A_0K \Delta\ell}_{\text{conservative}} + \underbrace{(A_\eta - A_0)K \Delta\ell}_{\text{non-conservative}}
$$

with the first term in `elastic_force` and the second applied through `actuation_force`. The split is bookkeeping: the total force, and the trajectory, are unchanged.

### Where the dissipation goes

Power supplied at the path input is $P_{in} = e s_c (A_0^\top\dot q)$, using the true kinematics; power delivered to the backbone is $P_{out} = \dot q\cdot A_\eta e$. The difference

$$
P_{guides} = e s_c (A_0 - A_\eta)^\top\dot q,
\qquad
A_0 - A_\eta = B_\xi^\top\!\int_0^L (1 - \eta) \Phi \mathrm{d}s
$$

is absorbed by the guides, with $1 - \eta \ge 0$ pointwise. It is not a $D$ term, because it is configuration-rate dependent rather than velocity-quadratic.

### Why the passive damper uses the weighted map on both sides

The damper force conjugate to the path rate admits two forms. Reading the rate through the exact Jacobian, $A_\eta D A_0^\top$, is indefinite: for a single path it is $d (a_\eta\cdot\dot q)(a_0\cdot\dot q)$, negative wherever the two projections disagree in sign, so the damper would inject energy and break passivity. On a two-segment robot the symmetric part of that form has a measured eigenvalue of $-2.2\times10^{-4}$ where the chosen form gives $+1.2\times10^{-4}$.

$A_\eta D A_\eta^\top$ is a congruence transform of a PSD diagonal, hence symmetric positive semi-definite under any law. It is also the physical reading: the damper acts in the weighted work-conjugate coordinate, precisely the one in which $e\cdot\dot y_a = \dot q\cdot\tau_u$. Unlike `elastic_force`, damping carries no energy-gradient contract, so it needs no split.

### Pulling and pushing

$\eta$ is a function of the configuration alone, so both driving directions share the same ratio and $\tau_u$ stays linear in $e$.

Pulling a tendon, $s_c u < 0$, drives the configuration down the routed-length gradient: the backbone bends toward the tendon and compresses, and because $\eta$ decays with arc length the distal nodes are down-weighted, the load shifts proximally, and the tip deflects less than in the frictionless case. Pushing, whether a tendon at $u < 0$ or a push rod at $u > 0$, has $s_c u > 0$: the path lengthens and the backbone bends away from it, while the same $\eta$ still down-weights the distal nodes, because $\eta$ cannot depend on the effort. Both signs flip together in $P_{guides}$, so pushing through curved guides dissipates exactly as pulling does.

### What the model does not cover

Both cases above assume the effort drives the path. When the robot's own motion pays the path out against the effort, $e s_c \dot\ell < 0$ and $P_{guides}$ turns negative: the model appears to return energy. Euler's law gives $e^{-\mu\Theta}$ only when the input end drives and $e^{+\mu\Theta}$ when the load back-drives, whereas $\eta$ always takes the driving branch. Two consequences follow, both pinned by tests.

Work around a closed configuration loop at constant effort is nonzero and orientation dependent, so no actuation potential exists: a loss is intrinsically non-conservative. And the passive remainder is not sign-definite, so at a nonzero passive coefficient an unactuated robot no longer loses energy monotonically, because a back-driven passive path is still modelled as driven. At a zero passive coefficient monotone decay is restored.

The effect is bounded, since $\lvert\eta\Phi\rvert \le \lvert\Phi\rvert$ pointwise: the model never transmits more than the frictionless integrand and cannot manufacture energy without limit. A slip-aware variant would need $\eta$ to depend on $\mathrm{sign}(A_0^\top\dot q)$, which makes $\tau_u$ non-smooth in $\dot q$ and destroys linearity in $e$; that is a different contract and belongs in a subclass. In practice: for quasi-static and identification work the effort drives throughout and the model is exact; for long dynamic rollouts with sign-changing path rates, keep the passive coefficient conservative or zero.

## Pre-existing defect: the planar routed-path offset sign

Independent of friction, and verified against the repo's own kinematics rather than assumed.

`PlanarPCS` defines the backbone by $p' = \mathrm{Rot}(\theta)[\sigma_x, \sigma_y]$ with $\theta' = \kappa$, and places the routed path at $p + d \mathrm{Rot}(\theta)e_y$. Differentiating, $\mathrm{d}(\mathrm{Rot}(\theta)e_y)/\mathrm{d}s = -\kappa \mathrm{Rot}(\theta)e_x$, so

$$
p_d'(s) = (\sigma_x - d\kappa) T + (\sigma_y + d') N
$$

The implementation used $\sigma_x + d\kappa$, with a moment row of matching sign. The spatial host derives the correct expression from $v + \omega\times r + r'$, so planar disagreed with spatial, and planar contradicted its own `_threadlike_path_positions`, which the renderer draws from.

It was not even self-consistent: the axial term matched an offset of $-d$ while the shear term matched $+d$. The two coincide only when $d' = 0$, which is every current test and example, which is why it survived. At $\kappa = 10$, $L = 0.1$, $d = 0.02$ the model returned $0.120$ for a path whose rendered arc length is $0.080$. Both hosts now return $0.080$ and agree to $10^{-17}$.

---

# Part II — Implementation

## The law contract

A law is an object, so the hosts depend on a contract rather than on a formula.

```python
class ThreadlikeFriction(BaseSystemParams):
    is_lossless: ClassVar[bool] = False
    requires_wrap_angle: ClassVar[bool] = True

    @abstractmethod
    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
        """Return the surviving effort fraction per path, shape (num_paths,)."""
```

Subclassing `BaseSystemParams` rather than a bare `eqx.Module` supplies `replace`, `validate_structure`, `validate_values`, and the tracer-safe `validate_for_update` a law needs anyway, and makes it a normal parameter subtree that `eqx.tree_at` reaches for identification.

The class variables are how a host serves only what a law reads. `is_lossless` lets a host skip the friction path entirely, which is what keeps the default free. `requires_wrap_angle` lets a host refuse a law it cannot serve.

| Law | Ratio | Parameter | Hosts |
|---|---|---|---|
| `Frictionless` | $1$ | none | all; the default |
| `CapstanFriction` | $e^{-\mu\Theta}$ | $\mu$, Coulomb coefficient | `PCS`, `PlanarPCS` |
| `ExponentialLengthFriction` | $e^{-ks}$ | $k$, per metre | all, including `GVS` |

## The quadrature context

`ThreadlikeQuadratureContext` carries the routed-path geometry at one quadrature node, batched over paths. Some fields mean the same thing on every host and some do not, which decides whether a law is portable.

| Field | Meaning | Portable |
|---|---|---|
| `arc_length` | backbone coordinate $s$ | yes |
| `segment_index` | segment containing the node | yes |
| `offset`, `offset_derivative` | material-frame offset and its $s$-derivative | yes |
| `tangent_norm` | routed-path stretch relative to the backbone | yes |
| `active` | whether the node lies in each path's span | yes |
| `unit_tangent` | normalized tangent, 2-vector planar and 3-vector spatial | no |
| `strain` | 3-vector planar and 6-vector spatial | no |
| `wrap_angle` | accumulated turn $\Theta$, or `None` | only where supplied |

`wrap_angle` is populated only when the installed law sets `requires_wrap_angle`, so the default path costs nothing.

## Files

| File | Change |
|---|---|
| `src/soromox/actuation/friction.py` | new: the law contract, the context, and the three laws |
| `src/soromox/actuation/threadlike.py` | `friction` on the transmission params, presets, impedance, host validation |
| `src/soromox/systems/pcs/planar_pcs.py`, `pcs.py` | geometry and basis split, weighted quadrature, wrap-angle density |
| `src/soromox/systems/gvs/core.py` | same split; accepts wrap-angle-free laws |
| `src/soromox/systems/pcs/structures.py` | `wrap_angle_smoothing` |
| `src/soromox/actuation/core.py`, `src/soromox/systems/soft_robot.py` | the non-conservative passive force |

Each host previously computed the routed geometry inside `_threadlike_local_basis` and discarded everything but the basis. That method is split into a geometry step that builds the context and a basis step that consumes it, so a law reads geometry the host already had rather than recomputing it. The per-path `vmap` already present in the moment matrix batches the context for free, which is exactly the shape `transmission_ratio` must return.

`ThreadlikeImpedance` now holds a `ThreadlikeTransmission`, matching `ArticulatedTendonImpedance`, so the law is declared in one place instead of duplicated onto the impedance parameters.

Host support follows the law, not its value. `PCS` and `PlanarPCS` supply the wrap angle. `GVS` strain varies along arc length, so its wrap angle is not piecewise linear and it supplies none, but it hosts wrap-angle-free laws.

## Opting in

```python
robot = PCS.from_links(
    links,
    structure=PCSStructure(num_gauss_points=5),
    actuators=ThreadlikeActuator.tendons(
        routing, friction=CapstanFriction(coefficient=0.2)
    ),
)

tau = robot.actuation_force(q, jnp.array([5.0, 0.0]))
```

`friction_coefficient=0.2` is kept as sugar for the same thing. Passing both it and `friction=` raises, because the two would silently disagree.

A custom law needs no change to soromox:

```python
class HyperbolicFriction(ThreadlikeFriction):
    a: Array

    def transmission_ratio(self, context):
        return 1.0 / (1.0 + self.a * context.wrap_angle)
```

## Identifying a loss parameter

Loss parameters are ordinary dynamic leaves, so they are traceable and differentiable under `jit`.

```python
@jax.jit
def loss(mu):
    transmission = robot.actuators[0].params.transmission
    identified = robot.update_actuator_params(
        0,
        transmission=transmission.replace(
            friction=transmission.friction.replace(coefficient=mu)
        ),
    )
    residual = (
        identified.elastic_force(q_meas)
        + identified.gravitational_force(q_meas)
        - identified.actuation_force(q_meas, u_meas)
    )
    return jnp.sum(residual**2)


value, grad = jax.value_and_grad(loss)(jnp.array(0.2))
```

The nesting matches the routing idiom already in the repo: one level through a sibling field of `ThreadlikeTransmissionParams`. Swapping the law changes the parameter PyTree structure and so retraces, while replacing a value inside a law does not, so identification should start from `CapstanFriction(coefficient=0.0)` rather than from `Frictionless()`. Note also that $\mathrm{d}A/\mathrm{d}\mu$ vanishes wherever $\Theta = 0$, so set `wrap_angle_smoothing` if the fit can approach a straight pose.

## Migration

- Planar routings must negate their `y` offsets to reproduce previous behaviour. The two are exactly equivalent when the routing slope is zero, which covers every existing test and example.
- `ThreadlikeTransmissionParams.friction_coefficient` becomes `friction`, holding the law.
- `ThreadlikeImpedanceParams.routing` becomes `transmission.routing`. The `ThreadlikeImpedance` constructor keeps its `routing=` keyword.
- A wrap-angle law is refused on `GVS` at any coefficient, including zero, where `friction_coefficient=0.0` was previously accepted. `GVS` supplies no wrap angle for the law to read, and substituting $\Theta = 0$ would silently ignore the law rather than report that it cannot be served. Drop the argument or install `ExponentialLengthFriction`.

---

# Part III — Verification

## Invariants

All hold exactly at the lossless default.

| Invariant | Under a lossy law |
|---|---|
| `moment_matrix == jacrev(coordinates).T` | broken by design; assumed by `coordinate_transformations/actuation_space.py` |
| `ThreadlikeImpedance._length_jacobian == jacrev(path_lengths)` | preserved; it passes no law |
| an actuation potential exists | broken, provably |
| `elastic_force == grad(elastic_energy)` and the energy custom JVPs | preserved; only the conservative half stays |
| $\mathrm{d}(T+U)/\mathrm{d}t = \dot q\cdot\tau_u - \dot q^\top D\dot q$ | preserved under any law |
| `actuation_force(q, 0) == 0` | broken for a loaded passive path; affine in $u$, not linear |
| total dynamics unchanged by the passive split | preserved |
| unactuated energy decreases monotonically | preserved at zero passive coefficient; broken above it |
| added passive damping symmetric PSD | preserved by the $A_\eta D A_\eta^\top$ choice |
| Gauss exactness for constant routing | broken; $A$ becomes mildly `num_gauss_points` dependent |
| $A(q)$ is $C^1$ | $C^0$ by default; `wrap_angle_smoothing` restores smoothness |
| backward pass finite at a collapsed tangent | preserved |
| $\tau = A(q)e$ linear in $e$ | preserved; every controller keeps working |
| `path_lengths`, `path_positions` | unchanged; pure geometry |

## Test coverage

Model, in `tests/actuation/test_threadlike_friction.py`: the Capstan ratio matches the closed form $(1 - e^{-\mu\kappa L})/(\mu\kappa L)$ to $10^{-8}$ and the per-segment ratio decreases monotonically toward the tip; the torsion wrap density matches the helix curvature $k_x^2\rho/\nu$ exactly; the length law matches its own closed form on both PCS hosts and runs on `GVS`, where a Capstan law is still refused.

Energy: the budget identity holds to $10^{-16}$ for all four combinations of actuator and passive coefficients; guide dissipation is positive whenever the effort drives the path, for a pulled tendon and a push rod alike; closed-loop work at constant effort is nonzero and orientation dependent, and vanishes at the default; passive damping is PSD including along the direction that makes the rejected form indefinite; `elastic_force` equals `grad(elastic_energy)` in both `custom_jvp` modes and the split leaves `forward_dynamics` unchanged.

Extension point: a law defined inside the test file installs through the public contract alone, and is asserted to differ from `CapstanFriction`, so a law that accidentally reduced to Capstan cannot pass while appearing to prove extensibility. The host-agnostic context fields are compared between `PlanarPCS` and `PCS`, which is what makes a portable law portable.

Sign fix: a settled two-tendon `PlanarPCS` bends toward the pulled tendon and shortens it, mirrors under the opposite pull, and lengthens it under a push; the analytic path length matches the densely sampled rendered polyline; and planar and spatial moment matrices agree at both zero and nonzero coefficients.

## Validation

866 tests across every file referencing a symbol this PR touches, with no failures.

| Scope | Result |
|---|---|
| `tests/actuation` | 87 passed |
| `test_pcs`, `test_planar_pcs`, 2D/3D coherence, lengths, pressure, shared components | 359 passed |
| `test_actuation_space_dynamics`, `tests/control`, `test_gvs`, articulated, McKibben, defaults, `paper_results` actuation | 420 passed |

```bash
uv run ruff format --check src tests examples   # clean
uv run ruff check src tests examples            # clean
uv run --extra docs zensical build --clean      # no issues found
```

Two source-level probes were applied and reverted, to confirm the tests fail for the right reasons. Forcing the transmission ratio to one fails every friction-dependent test while the lossless and smoothing tests keep passing. Collapsing the conservative split is caught by the `custom_jvp_mode(False)` branch, where real autodiff of the energy disagrees with `elastic_force` by 67 percent.

## Documentation

The `Guide friction` section of the threadlike actuation page is written around the law object, with a `Custom friction laws` subsection mirroring the existing `Custom routing laws` example and a table marking each context field portable or host-shaped. The changelog records the additions, the migration, and the documentation change.

## Scope and follow-up

- Laws whose ratio depends on the effort or on the sign of the path rate, such as a slip-aware Capstan or a tension-dependent loss, are out of scope. Both break the linearity of $\tau = A(q)e$ that every controller in the repo assumes. The quadrature context carries neither effort nor velocity, so the interface cannot express them by accident.
- The Capstan law is not extended to `GVS`. Its wrap angle needs a cumulative quadrature because strain varies along arc length.
- Tendon slack is not modelled. A tendon at negative effort pushes rather than going slack; `push_rods` remains the modality for pushing.
- Cost: the friction path adds one `abs`, `clip` and `sum` over segments plus one `exp` per quadrature node, and is skipped entirely at the default.
