### PR TITLE
Added tapered radii to ViserRenderer and fix lag in rendering

### DIFF
--- a/paper_results/secVc_model_based_control/configuration_space_comparison/code/render_configuration_space_comparison.py
+++ b/paper_results/secVc_model_based_control/configuration_space_comparison/code/render_configuration_space_comparison.py
@@ -265,7 +265,7 @@ def add_controller_visibility_selector(
             return
         points = make_tube_wire_segments(
             target_curves[frame_idx],
-            radius=renderer._robot_radius * TARGET_WIREFRAME_RADIUS_SCALE,
+            radius=float(np.mean(renderer._robot_radii)) * TARGET_WIREFRAME_RADIUS_SCALE,
             radial_segments=target_radial_segments,
         )
         color = target_wire_color(target_opacity)

--- a/paper_results/secVd_control_gain_optimization/code/render_control_gain_optimization_animations.py
+++ b/paper_results/secVd_control_gain_optimization/code/render_control_gain_optimization_animations.py
@@ -190,7 +190,7 @@ class SecVdTrackingRenderer(ViserRenderer):
         curve = self._target_curves[idx]
         points = make_tube_wire_segments(
             curve,
-            radius=self._robot_radius * TARGET_WIREFRAME_RADIUS_SCALE,
+            radius=float(np.mean(self._robot_radii)) * TARGET_WIREFRAME_RADIUS_SCALE,
         )
         if self._target_wire_handle is None:
             self._target_wire_handle = self._server.scene.add_line_segments(

--- a/src/soromox/rendering/umarm/viser_renderer.py
+++ b/src/soromox/rendering/umarm/viser_renderer.py
@@ -152,7 +152,7 @@ class UMArmViserRenderer(ViserRenderer):
         rod_radius = (
             float(np.max(rod_candidates))
             if rod_candidates.size
-            else float(self._robot_radius)
+            else float(np.mean(np.asarray(self._robot_radii)))
         )
         return ujoint_radius, rod_radius
 

--- a/src/soromox/rendering/viser_renderer.py
+++ b/src/soromox/rendering/viser_renderer.py
@@ -49,6 +49,7 @@ from soromox.rendering.base import BaseSoftRobotRenderer
 from soromox.rendering.camera_config import CameraConfig
 from soromox.rendering.color_config import RendererColorConfig, ensure_rgba
 from soromox.rendering.video_encoding import FFmpegVideoWriter, VideoEncodingConfig
+from soromox.systems.components import CrossSectionGeometry
 from soromox.systems.soft_robot import SoftRobot
 
 # =============================================================================
@@ -417,14 +418,25 @@ class ViserRenderer(BaseSoftRobotRenderer):
         if auto_start:
             self.start()
 
+    @staticmethod
+    def _effective_radius(geom_tag: int, dims: Array) -> float:
+        """Collapse a cross-section's dimensions into a single rendering radius."""
+        dims = np.asarray(dims, dtype=np.float64).reshape(-1)
+        if geom_tag == CrossSectionGeometry.CIRCULAR:
+            return float(dims[0])
+        if geom_tag == CrossSectionGeometry.RECTANGULAR:
+            return 0.5 * float(max(dims[0], dims[1]))
+        return float(max(dims[0], dims[1]))  # ELLIPTICAL
+
     def _get_robot_radii(self) -> Array:
-        """Get per-point robot radii for tapered visualization."""
+        """Get per-point effective robot radii for tapered visualization."""
         s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
         q_dummy = jnp.zeros(self.robot.num_dofs)
-        _, dims = jax.vmap(self.robot.cross_section_geometry, in_axes=(None, 0))(
-            q_dummy, s_ps
-        )
-        return dims[:, 0]
+        radii = [
+            self._effective_radius(*self.robot.cross_section_geometry(q_dummy, s))
+            for s in s_ps
+        ]
+        return jnp.array(radii)
 
     @property
     def is_3d(self) -> bool:

--- a/src/soromox/rendering/viser_renderer.py
+++ b/src/soromox/rendering/viser_renderer.py
@@ -398,8 +398,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
         self._backbone_cast_shadow = backbone_cast_shadow
         self._sphere_cast_shadow = sphere_cast_shadow
 
-        # Get robot radius for sizing
-        self._robot_radius = self._get_robot_radius()
+        # Get robot radii for sizing
         self._robot_radii = self._get_robot_radii()
 
         # Server and scene state
@@ -418,25 +417,14 @@ class ViserRenderer(BaseSoftRobotRenderer):
         if auto_start:
             self.start()
 
-    def _get_robot_radius(self) -> float:
-        """Get representative robot radius for visualization."""
-        if hasattr(self.robot, "r"):
-            r = self.robot.r
-            if hasattr(r, "__iter__"):
-                return float(np.mean(np.asarray(r)))
-            return float(r)
-        return 0.02  # Default radius
-
-    def _get_robot_radii(self):
+    def _get_robot_radii(self) -> Array:
         """Get per-point robot radii for tapered visualization."""
-        try:
-            s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
-            q_dummy = jnp.zeros(self.robot.num_dofs)
-            return jnp.array(
-                [self.robot.cross_section_geometry(q_dummy, s)[1][0] for s in s_ps]
-            )
-        except (AttributeError, NotImplementedError, TypeError, IndexError):
-            return jnp.full(self.num_points, self._robot_radius)
+        s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
+        q_dummy = jnp.zeros(self.robot.num_dofs)
+        _, dims = jax.vmap(self.robot.cross_section_geometry, in_axes=(None, 0))(
+            q_dummy, s_ps
+        )
+        return dims[:, 0]
 
     @property
     def is_3d(self) -> bool:
@@ -640,9 +628,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
                         (num_points, 4),
                     ).copy(),
                     batched_positions=np.asarray(curve, dtype=np.float32),
-                    batched_scales=np.full(
-                        num_points, self._robot_radius, dtype=np.float32
-                    ),
+                    batched_scales=np.asarray(self._robot_radii, dtype=np.float32),
                     batched_colors=colors,
                     batched_opacities=opacities,
                     wireframe=self._wireframe,

--- a/src/soromox/rendering/viser_renderer.py
+++ b/src/soromox/rendering/viser_renderer.py
@@ -200,23 +200,32 @@ def _oriented_tube_segment_mesh(
     p1: np.ndarray,
     frame0: np.ndarray,
     frame1: np.ndarray,
-    radius: float,
+    radius0: float,
+    radius1: float,
     sections: int,
     *,
     cap_end: bool = False,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return a tube segment whose endpoint rings use the FK material frames."""
     angles = np.linspace(0.0, 2.0 * np.pi, int(sections), endpoint=False)
-    local_offsets = np.stack(
+    local_offset0 = np.stack(
         [
             np.zeros_like(angles),
-            float(radius) * np.cos(angles),
-            float(radius) * np.sin(angles),
+            float(radius0) * np.cos(angles),
+            float(radius0) * np.sin(angles),
         ],
         axis=1,
     )
-    ring0 = np.asarray(p0) + local_offsets @ np.asarray(frame0).T
-    ring1 = np.asarray(p1) + local_offsets @ np.asarray(frame1).T
+    local_offset1 = np.stack(
+        [
+            np.zeros_like(angles),
+            float(radius1) * np.cos(angles),
+            float(radius1) * np.sin(angles),
+        ],
+        axis=1,
+    )
+    ring0 = np.asarray(p0) + local_offset0 @ np.asarray(frame0).T
+    ring1 = np.asarray(p1) + local_offset1 @ np.asarray(frame1).T
     vertex_groups = [ring0, ring1]
     if cap_end:
         vertex_groups.append(np.asarray(p1, dtype=np.float64).reshape(1, 3))
@@ -391,6 +400,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
 
         # Get robot radius for sizing
         self._robot_radius = self._get_robot_radius()
+        self._robot_radii = self._get_robot_radii()
 
         # Server and scene state
         self._server: viser.ViserServer | None = None
@@ -416,6 +426,17 @@ class ViserRenderer(BaseSoftRobotRenderer):
                 return float(np.mean(np.asarray(r)))
             return float(r)
         return 0.02  # Default radius
+
+    def _get_robot_radii(self):
+        """Get per-point robot radii for tapered visualization."""
+        try:
+            s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
+            q_dummy = jnp.zeros(self.robot.num_dofs)
+            return jnp.array(
+                [self.robot.cross_section_geometry(q_dummy, s)[1][0] for s in s_ps]
+            )
+        except (AttributeError, NotImplementedError, TypeError, IndexError):
+            return jnp.full(self.num_points, self._robot_radius)
 
     @property
     def is_3d(self) -> bool:
@@ -654,7 +675,8 @@ class ViserRenderer(BaseSoftRobotRenderer):
                             curve[pt_idx + 1],
                             robot_frames[pt_idx],
                             robot_frames[pt_idx + 1],
-                            self._robot_radius,
+                            self._robot_radii[pt_idx],
+                            self._robot_radii[pt_idx + 1],
                             self._cylinder_sections,
                             cap_end=pt_idx == num_points - 2,
                         )
@@ -720,7 +742,7 @@ class ViserRenderer(BaseSoftRobotRenderer):
             name=f"/robots/robot_{robot_idx}/base_plate",
             mesh=self._make_cylinder_trimesh(
                 length=self._base_plate_thickness,
-                radius=self._robot_radius * self._base_plate_radius_scale,
+                radius=self._robot_radii[0] * self._base_plate_radius_scale,
                 color=base_plate_color,
                 direction=None,  # Already Z-aligned
             ),
@@ -997,7 +1019,8 @@ class ViserRenderer(BaseSoftRobotRenderer):
                                 curve[seg_idx + 1],
                                 robot_frames[seg_idx],
                                 robot_frames[seg_idx + 1],
-                                self._robot_radius,
+                                self._robot_radii[seg_idx],
+                                self._robot_radii[seg_idx + 1],
                                 self._cylinder_sections,
                                 cap_end=seg_idx == num_points - 2,
                             )

--- a/src/soromox/rendering/viser_renderer.py
+++ b/src/soromox/rendering/viser_renderer.py
@@ -419,24 +419,25 @@ class ViserRenderer(BaseSoftRobotRenderer):
             self.start()
 
     @staticmethod
-    def _effective_radius(geom_tag: int, dims: Array) -> float:
-        """Collapse a cross-section's dimensions into a single rendering radius."""
-        dims = np.asarray(dims, dtype=np.float64).reshape(-1)
-        if geom_tag == CrossSectionGeometry.CIRCULAR:
-            return float(dims[0])
-        if geom_tag == CrossSectionGeometry.RECTANGULAR:
-            return 0.5 * float(max(dims[0], dims[1]))
-        return float(max(dims[0], dims[1]))  # ELLIPTICAL
+    def _effective_radii(tags: Array, dims: Array) -> Array:
+        """Collapse batched cross-section dimensions into per-point rendering radii."""
+        circular = dims[:, 0]
+        rectangular = 0.5 * jnp.maximum(dims[:, 0], dims[:, 1])
+        elliptical = jnp.maximum(dims[:, 0], dims[:, 1])
+        return jnp.where(
+            tags == CrossSectionGeometry.RECTANGULAR,
+            rectangular,
+            jnp.where(tags == CrossSectionGeometry.ELLIPTICAL, elliptical, circular),
+        )
 
     def _get_robot_radii(self) -> Array:
         """Get per-point effective robot radii for tapered visualization."""
         s_ps = jnp.linspace(0.0, self.L_max, self.num_points)
         q_dummy = jnp.zeros(self.robot.num_dofs)
-        radii = [
-            self._effective_radius(*self.robot.cross_section_geometry(q_dummy, s))
-            for s in s_ps
-        ]
-        return jnp.array(radii)
+        tags, dims = jax.vmap(self.robot.cross_section_geometry, in_axes=(None, 0))(
+            q_dummy, s_ps
+        )
+        return self._effective_radii(tags, dims)
 
     @property
     def is_3d(self) -> bool:

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -13,7 +13,6 @@ from soromox.actuation.threadlike import (
 )
 from soromox.systems.components import (
     ContinuumLinkParams,
-    CrossSectionGeometry,
     IsotropicMaterialParams,
 )
 from soromox.systems.gvs._assembly import assign_gvs_runtime_arrays
@@ -472,26 +471,29 @@ class GVS(SoftRobot):
         segment_idx, s_local = self.classify_segment(s)
         length_i = self.segment_lengths[segment_idx]
         x = safe_divide(s_local, length_i, self.global_eps)
-        cross_section_geometry_idx = self.cross_section_geometry_index[segment_idx]
-        cross_section_geometry_int = int(cross_section_geometry_idx)
-        if cross_section_geometry_int == CrossSectionGeometry.CIRCULAR:
+        tag = self.cross_section_geometry_index[segment_idx]
+
+        def circular(_):
             params = self.radius_params[segment_idx]
             radius = Link.interpolate_param(x, params[0], params[1])
-            tag = jnp.asarray(CrossSectionGeometry.CIRCULAR, dtype=jnp.int32)
-            return tag, jnp.array([radius])
-        if cross_section_geometry_int == CrossSectionGeometry.RECTANGULAR:
+            return jnp.array([radius, radius])
+
+        def rectangular(_):
             h_params = self.height_params[segment_idx]
             w_params = self.width_params[segment_idx]
             height = Link.interpolate_param(x, h_params[0], h_params[1])
             width = Link.interpolate_param(x, w_params[0], w_params[1])
-            tag = jnp.asarray(CrossSectionGeometry.RECTANGULAR, dtype=jnp.int32)
-            return tag, jnp.array([height, width])
-        a_params = self.semi_major_params[segment_idx]
-        b_params = self.semi_minor_params[segment_idx]
-        a_val = Link.interpolate_param(x, a_params[0], a_params[1])
-        b_val = Link.interpolate_param(x, b_params[0], b_params[1])
-        tag = jnp.asarray(CrossSectionGeometry.ELLIPTICAL, dtype=jnp.int32)
-        return tag, jnp.array([a_val, b_val])
+            return jnp.array([height, width])
+
+        def elliptical(_):
+            a_params = self.semi_major_params[segment_idx]
+            b_params = self.semi_minor_params[segment_idx]
+            a_val = Link.interpolate_param(x, a_params[0], a_params[1])
+            b_val = Link.interpolate_param(x, b_params[0], b_params[1])
+            return jnp.array([a_val, b_val])
+
+        dims = lax.switch(tag, [circular, rectangular, elliptical], None)
+        return tag.astype(jnp.int32), dims
 
     def _build_segment_i(
         self,

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -5398,6 +5398,7 @@ class GVS(SoftRobot):
 
         return jnp.sum(vmap(segment_lengths)(jnp.arange(self.num_segments)), axis=0)
 
+    @eqx.filter_jit
     def _threadlike_path_positions(
         self, q: Array, s: Array, routing: ThreadlikeRouting
     ) -> Array:

--- a/tests/rendering/test_viser_renderer.py
+++ b/tests/rendering/test_viser_renderer.py
@@ -18,6 +18,7 @@ class DummySpatialRobot:
     is_planar = False
     length = jnp.array(1.0)
     segment_length = jnp.array([1.0])
+    num_dofs = 0
 
     def __init__(self, base_pose: jnp.ndarray):
         self.base_pose = jnp.asarray(base_pose)
@@ -672,7 +673,7 @@ def test_viser_discrete_backbone_batches_positions_colors_and_robot_radius():
     assert_allclose(handle.batched_positions, curves[0], atol=1e-12)
     assert_allclose(
         handle.batched_scales,
-        np.full(2, renderer._robot_radius),
+        renderer._robot_radii,
         atol=1e-12,
     )
     assert_array_equal(handle.batched_colors, np.full((2, 3), 255))
@@ -761,7 +762,7 @@ def test_viser_swept_backbone_uses_material_frame_rings():
 
     first_ring = server.scene.simple_meshes[0].vertices[:8]
     assert_allclose(first_ring[:, 0], 0.0, atol=1e-7)
-    assert np.ptp(first_ring[:, 1]) > renderer._robot_radius
+    assert np.ptp(first_ring[:, 1]) > renderer._robot_radii[0]
 
 
 def test_viser_swept_body_owns_closed_tip_and_updates_atomically():
@@ -894,7 +895,8 @@ def test_viser_swept_batches_match_segment_geometry_across_animation_frames():
                     curves[0, frame_idx, segment_idx + 1],
                     frames[0, segment_idx],
                     frames[0, segment_idx + 1],
-                    renderer._robot_radius,
+                    renderer._robot_radii[segment_idx],
+                    renderer._robot_radii[segment_idx + 1],
                     renderer._cylinder_sections,
                     cap_end=segment_idx == curves.shape[2] - 2,
                 )

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1029,7 +1029,9 @@ def test_public_gvs_accessors_geometry_and_actuation_matrix() -> None:
         robot.radius_params[0, 1] - robot.radius_params[0, 0]
     )
     assert int(tag) == CrossSectionGeometry.CIRCULAR
-    assert_allclose(geom, jnp.array([expected_radius]), rtol=RTOL, atol=ATOL)
+    assert_allclose(
+        geom, jnp.array([expected_radius, expected_radius]), rtol=RTOL, atol=ATOL
+    )
 
     tag, geom = robot.cross_section_geometry(q, s_second)
     expected_width = robot.width_params[1, 0] + 0.25 * (


### PR DESCRIPTION
Adds per-point tapered radii to the tube-mesh backbone rendering in ViserRenderer, plus a fix for rendering lag cause by JAX jit/threading interaction. 