### PR TITLE
Optimize floating-base kinematics composition

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -16,8 +16,8 @@ and include benchmark baseline and measurement context for performance claims.
 - Added optional floating-base configurations and dynamics across all system
   families, with runtime planar or quaternion base poses, unequal configuration
   and velocity dimensions, world-frame base velocities and wrenches, JAX
-  support for every model, and specialized Warp execution for `GVS`, `PCS`,
-  and `PlanarPCS`; see
+  support for every model, vectorized JAX floating-frame Jacobian composition,
+  and specialized Warp execution for `GVS`, `PCS`, and `PlanarPCS`; see
   [Floating-base systems](../user-guide/floating-base-systems.md).
 - Added fused Warp forward-kinematics and inertial-Jacobian execution for
   `GVS`, `PCS`, and `PlanarPCS`, including spatial, environment, and combined
@@ -75,11 +75,22 @@ and include benchmark baseline and measurement context for performance claims.
   GVS JVP/VJP improved 1.51–2.35×/1.19–1.38× and PCS improved
   4.07–6.97×/3.06–5.03×. Directional measurements used Warp 1.16.0, five
   warmups, and medians of seven runs with 20 synchronized iterations each;
-  see [PR #191](https://github.com/tud-phi/soromox/pull/191).
+  see [PR #191](https://github.com/tud-phi/soromox/pull/191). Optimizing the
+  floating-frame adapter further improved isolated CUDA dense-Jacobian
+  composition by 5.96–54.7×, pose composition by 2.18–3.47×, JVP composition
+  by 1.86–3.25×, and VJP composition by 1.13–1.80× across 1–256 environments
+  and 64 abscissae. Direct JAX CPU composition improved 1.06–1.70× across
+  1–1024 abscissae, and the complete four-segment PCS pose-plus-Jacobian call
+  improved 1.16× at 64 abscissae. These FP64 measurements used the same JAX
+  and Warp versions, one pinned Intel Core Ultra 9 285K core for JAX, and an
+  RTX 5090 for Warp.
 - Accelerated batched FP64 continuum dynamics on an RTX 5090 with Warp. For
   four-segment models at batch 256, order-1 GVS dynamics terms improved 3.02×
   (2.224 to 0.735 ms) and forward dynamics 2.40× (2.482 to 1.034 ms), while
   five-point PlanarPCS and PCS forward dynamics improved 2.21× and 1.66×.
+  Reusing each normalized floating-root rotation across velocity and gravity
+  products additionally reduced one-segment floating PCS and GVS dynamics-term
+  runtimes by 3.2–6.2% across batches 1 and 256.
   Warp is not a CPU optimization: single-environment order-5/9-point GVS terms
   were 2.46× slower (0.587 to 1.445 ms), so `backend="auto"` selects JAX on CPU;
   see [PR #177](https://github.com/tud-phi/soromox/pull/177).

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -25,7 +25,9 @@ and include benchmark baseline and measurement context for performance claims.
   Allocation-free matrix-free launchers additionally evaluate
   `J(q, s) @ qd` and `sum_s J(q, s).T @ wrench_s` directly, reuse caller-owned
   boundary-pose state, and compose planar or spatial floating-base products
-  without materializing sample Jacobians.
+  without materializing sample Jacobians. Shared Warp quaternion, `SO(2)`,
+  `SO(3)`, `SE(2)`, and `SE(3)` helpers centralize rotation actions, stable
+  constant-strain operators, and exponential transforms across these paths.
 - Added optional Warp dynamics backends for `GVS`, `PCS`, and `PlanarPCS`,
   including automatic GPU selection, arbitrary positive PCS quadrature counts,
   JAX-routed differentiation, typed `GVSBackendParams` and `PCSBackendParams`

--- a/src/soromox/execution/warp/common/floating_base.py
+++ b/src/soromox/execution/warp/common/floating_base.py
@@ -5,88 +5,11 @@ from __future__ import annotations
 
 import warp as wp
 
+from soromox.execution.warp.common.rotations import (
+    _quaternion_rotation_transpose_entry,
+)
+
 wp.set_module_options({"enable_backward": False})
-
-
-@wp.func
-def _planar_rotation_transpose_entry(
-    theta: wp.float64, row: int, column: int
-) -> wp.float64:
-    """Return one entry of the transpose of a planar rotation.
-
-    Args:
-        theta: World-frame base orientation.
-        row: Requested matrix row.
-        column: Requested matrix column.
-
-    Returns:
-        Entry ``(row, column)`` of ``R(theta).T``.
-    """
-    cosine = wp.cos(theta)
-    sine = wp.sin(theta)
-    value = wp.float64(0.0)
-    if row == 0 and column == 0 or row == 1 and column == 1:
-        value = cosine
-    elif row == 0 and column == 1:
-        value = sine
-    elif row == 1 and column == 0:
-        value = -sine
-    return value
-
-
-@wp.func
-def _quaternion_rotation_transpose_entry(
-    base_pose: wp.array2d[wp.float64], environment: int, row: int, column: int
-) -> wp.float64:
-    """Return one normalized quaternion rotation-transpose entry.
-
-    Args:
-        base_pose: Batched scalar-last quaternion poses with shape ``(E, 7)``.
-        environment: Environment row in ``base_pose``.
-        row: Requested matrix row.
-        column: Requested matrix column.
-
-    Returns:
-        Entry ``(row, column)`` of the normalized quaternion rotation
-        transpose. A zero runtime quaternion follows the trace-safe JAX path
-        and maps to identity.
-    """
-    x = base_pose[environment, 0]
-    y = base_pose[environment, 1]
-    z = base_pose[environment, 2]
-    w = base_pose[environment, 3]
-    norm_sq = w * w + x * x + y * y + z * z
-    if norm_sq <= wp.float64(0.0):
-        value = wp.float64(0.0)
-        if row == column:
-            value = wp.float64(1.0)
-        return value
-    inverse_norm = wp.float64(1.0) / wp.sqrt(norm_sq)
-    w *= inverse_norm
-    x *= inverse_norm
-    y *= inverse_norm
-    z *= inverse_norm
-
-    value = wp.float64(0.0)
-    if row == 0 and column == 0:
-        value = wp.float64(1.0) - wp.float64(2.0) * (y * y + z * z)
-    elif row == 0 and column == 1:
-        value = wp.float64(2.0) * (x * y + w * z)
-    elif row == 0 and column == 2:
-        value = wp.float64(2.0) * (x * z - w * y)
-    elif row == 1 and column == 0:
-        value = wp.float64(2.0) * (x * y - w * z)
-    elif row == 1 and column == 1:
-        value = wp.float64(1.0) - wp.float64(2.0) * (x * x + z * z)
-    elif row == 1 and column == 2:
-        value = wp.float64(2.0) * (y * z + w * x)
-    elif row == 2 and column == 0:
-        value = wp.float64(2.0) * (x * z + w * y)
-    elif row == 2 and column == 1:
-        value = wp.float64(2.0) * (y * z - w * x)
-    elif row == 2 and column == 2:
-        value = wp.float64(1.0) - wp.float64(2.0) * (x * x + y * y)
-    return value
 
 
 @wp.func
@@ -151,8 +74,6 @@ def launch_prepend_zeros(
 
 
 __all__ = [
-    "_planar_rotation_transpose_entry",
-    "_quaternion_rotation_transpose_entry",
     "_spatial_root_jacobian_entry",
     "launch_prepend_zeros",
 ]

--- a/src/soromox/execution/warp/common/floating_kinematics.py
+++ b/src/soromox/execution/warp/common/floating_kinematics.py
@@ -9,6 +9,10 @@ from soromox.execution.warp.common.rotations import (
     _quaternion_rotation_matrix,
     _quaternion_rotation_transpose_entry,
 )
+from soromox.execution.warp.common.so2 import (
+    _rotate_vector,
+    _rotation_matrix,
+)
 
 wp.set_module_options({"enable_backward": False})
 
@@ -401,28 +405,25 @@ def _compose_planar_poses_and_twists_kernel(
 
     environment, sample = wp.tid()
     theta = base_pose[environment, 0]
-    cosine = wp.cos(theta)
-    sine = wp.sin(theta)
-    relative_x = relative_pose[environment, sample, 1]
-    relative_y = relative_pose[environment, sample, 2]
-    radius_x = cosine * relative_x - sine * relative_y
-    radius_y = sine * relative_x + cosine * relative_y
+    rotation = _rotation_matrix(theta)
+    radius = rotation * wp.vec2d(
+        relative_pose[environment, sample, 1],
+        relative_pose[environment, sample, 2],
+    )
+    internal_linear = rotation * wp.vec2d(
+        internal_twist[environment, sample, 1],
+        internal_twist[environment, sample, 2],
+    )
     angular = base_velocity[environment, 0]
     poses[environment, sample, 0] = theta + relative_pose[environment, sample, 0]
-    poses[environment, sample, 1] = base_pose[environment, 1] + radius_x
-    poses[environment, sample, 2] = base_pose[environment, 2] + radius_y
+    poses[environment, sample, 1] = base_pose[environment, 1] + radius[0]
+    poses[environment, sample, 2] = base_pose[environment, 2] + radius[1]
     twists[environment, sample, 0] = angular + internal_twist[environment, sample, 0]
     twists[environment, sample, 1] = (
-        base_velocity[environment, 1]
-        - angular * radius_y
-        + cosine * internal_twist[environment, sample, 1]
-        - sine * internal_twist[environment, sample, 2]
+        base_velocity[environment, 1] - angular * radius[1] + internal_linear[0]
     )
     twists[environment, sample, 2] = (
-        base_velocity[environment, 2]
-        + angular * radius_x
-        + sine * internal_twist[environment, sample, 1]
-        + cosine * internal_twist[environment, sample, 2]
+        base_velocity[environment, 2] + angular * radius[0] + internal_linear[1]
     )
 
 
@@ -450,23 +451,26 @@ def _compose_planar_wrench_vjp_kernel(
 
     environment, sample = wp.tid()
     theta = base_pose[environment, 0]
-    cosine = wp.cos(theta)
-    sine = wp.sin(theta)
-    relative_x = relative_pose[environment, sample, 1]
-    relative_y = relative_pose[environment, sample, 2]
-    radius_x = cosine * relative_x - sine * relative_y
-    radius_y = sine * relative_x + cosine * relative_y
+    rotation = _rotation_matrix(theta)
+    radius = rotation * wp.vec2d(
+        relative_pose[environment, sample, 1],
+        relative_pose[environment, sample, 2],
+    )
     moment = inertial_wrenches[environment, sample, 0]
     force_x = inertial_wrenches[environment, sample, 1]
     force_y = inertial_wrenches[environment, sample, 2]
+    relative_force = wp.vec2d(
+        rotation[0, 0] * force_x + rotation[1, 0] * force_y,
+        rotation[0, 1] * force_x + rotation[1, 1] * force_y,
+    )
     relative_wrenches[environment, sample, 0] = moment
-    relative_wrenches[environment, sample, 1] = cosine * force_x + sine * force_y
-    relative_wrenches[environment, sample, 2] = -sine * force_x + cosine * force_y
+    relative_wrenches[environment, sample, 1] = relative_force[0]
+    relative_wrenches[environment, sample, 2] = relative_force[1]
     wp.atomic_add(
         base_generalized_force,
         environment,
         0,
-        moment + radius_x * force_y - radius_y * force_x,
+        moment + radius[0] * force_y - radius[1] * force_x,
     )
     wp.atomic_add(base_generalized_force, environment, 1, force_x)
     wp.atomic_add(base_generalized_force, environment, 2, force_y)
@@ -480,13 +484,16 @@ def _compose_planar_poses_kernel(
 ):
     environment, sample = wp.tid()
     theta = base_pose[environment, 0]
-    cosine = wp.cos(theta)
-    sine = wp.sin(theta)
-    x = relative_pose[environment, sample, 1]
-    y = relative_pose[environment, sample, 2]
+    radius = _rotate_vector(
+        theta,
+        wp.vec2d(
+            relative_pose[environment, sample, 1],
+            relative_pose[environment, sample, 2],
+        ),
+    )
     output[environment, sample, 0] = theta + relative_pose[environment, sample, 0]
-    output[environment, sample, 1] = base_pose[environment, 1] + cosine * x - sine * y
-    output[environment, sample, 2] = base_pose[environment, 2] + sine * x + cosine * y
+    output[environment, sample, 1] = base_pose[environment, 1] + radius[0]
+    output[environment, sample, 2] = base_pose[environment, 2] + radius[1]
 
 
 @wp.kernel(enable_backward=False)
@@ -498,20 +505,19 @@ def _compose_planar_jacobians_kernel(
 ):
     environment, sample = wp.tid()
     theta = base_pose[environment, 0]
-    cosine = wp.cos(theta)
-    sine = wp.sin(theta)
-    x_relative = relative_pose[environment, sample, 1]
-    y_relative = relative_pose[environment, sample, 2]
-    rx = cosine * x_relative - sine * y_relative
-    ry = sine * x_relative + cosine * y_relative
+    rotation = _rotation_matrix(theta)
+    radius = rotation * wp.vec2d(
+        relative_pose[environment, sample, 1],
+        relative_pose[environment, sample, 2],
+    )
 
     output[environment, sample, 0, 0] = wp.float64(1.0)
     output[environment, sample, 0, 1] = wp.float64(0.0)
     output[environment, sample, 0, 2] = wp.float64(0.0)
-    output[environment, sample, 1, 0] = -ry
+    output[environment, sample, 1, 0] = -radius[1]
     output[environment, sample, 1, 1] = wp.float64(1.0)
     output[environment, sample, 1, 2] = wp.float64(0.0)
-    output[environment, sample, 2, 0] = rx
+    output[environment, sample, 2, 0] = radius[0]
     output[environment, sample, 2, 1] = wp.float64(0.0)
     output[environment, sample, 2, 2] = wp.float64(1.0)
 
@@ -520,14 +526,12 @@ def _compose_planar_jacobians_kernel(
         output[environment, sample, 0, 3 + column] = internal[
             environment, sample, 0, column
         ]
-        output[environment, sample, 1, 3 + column] = (
-            cosine * internal[environment, sample, 1, column]
-            - sine * internal[environment, sample, 2, column]
+        internal_linear = rotation * wp.vec2d(
+            internal[environment, sample, 1, column],
+            internal[environment, sample, 2, column],
         )
-        output[environment, sample, 2, 3 + column] = (
-            sine * internal[environment, sample, 1, column]
-            + cosine * internal[environment, sample, 2, column]
-        )
+        output[environment, sample, 1, 3 + column] = internal_linear[0]
+        output[environment, sample, 2, 3 + column] = internal_linear[1]
         column += 1
 
 

--- a/src/soromox/execution/warp/common/floating_kinematics.py
+++ b/src/soromox/execution/warp/common/floating_kinematics.py
@@ -5,21 +5,12 @@ from __future__ import annotations
 
 import warp as wp
 
-from soromox.execution.warp.common.floating_base import (
+from soromox.execution.warp.common.rotations import (
+    _quaternion_rotation_matrix,
     _quaternion_rotation_transpose_entry,
 )
 
 wp.set_module_options({"enable_backward": False})
-
-
-@wp.func
-def _spatial_base_rotation_entry(
-    base_pose: wp.array2d[wp.float64], environment: int, row: int, column: int
-) -> wp.float64:
-    """Return one normalized runtime base-rotation entry."""
-    return _quaternion_rotation_transpose_entry(
-        base_pose, environment, column, row
-    )
 
 
 @wp.kernel(enable_backward=False)
@@ -29,6 +20,7 @@ def _compose_spatial_poses_kernel(
     output: wp.array4d[wp.float64],
 ):
     environment, sample = wp.tid()
+    rotation = _quaternion_rotation_matrix(base_pose, environment)
     row = int(0)
     while row < 3:
         column = int(0)
@@ -36,18 +28,19 @@ def _compose_spatial_poses_kernel(
             value = wp.float64(0.0)
             inner = int(0)
             while inner < 3:
-                value += _spatial_base_rotation_entry(
-                    base_pose, environment, row, inner
-                ) * relative_pose[environment, sample, inner, column]
+                value += (
+                    rotation[row, inner]
+                    * relative_pose[environment, sample, inner, column]
+                )
                 inner += 1
             output[environment, sample, row, column] = value
             column += 1
         position = base_pose[environment, 4 + row]
         inner = int(0)
         while inner < 3:
-            position += _spatial_base_rotation_entry(
-                base_pose, environment, row, inner
-            ) * relative_pose[environment, sample, inner, 3]
+            position += (
+                rotation[row, inner] * relative_pose[environment, sample, inner, 3]
+            )
             inner += 1
         output[environment, sample, row, 3] = position
         row += 1
@@ -66,20 +59,15 @@ def _compose_spatial_jacobians_kernel(
     output: wp.array4d[wp.float64],
 ):
     environment, sample = wp.tid()
+    rotation = _quaternion_rotation_matrix(base_pose, environment)
     rx = wp.float64(0.0)
     ry = wp.float64(0.0)
     rz = wp.float64(0.0)
     inner = int(0)
     while inner < 3:
-        rx += _spatial_base_rotation_entry(
-            base_pose, environment, 0, inner
-        ) * relative_pose[environment, sample, inner, 3]
-        ry += _spatial_base_rotation_entry(
-            base_pose, environment, 1, inner
-        ) * relative_pose[environment, sample, inner, 3]
-        rz += _spatial_base_rotation_entry(
-            base_pose, environment, 2, inner
-        ) * relative_pose[environment, sample, inner, 3]
+        rx += rotation[0, inner] * relative_pose[environment, sample, inner, 3]
+        ry += rotation[1, inner] * relative_pose[environment, sample, inner, 3]
+        rz += rotation[2, inner] * relative_pose[environment, sample, inner, 3]
         inner += 1
 
     row = int(0)
@@ -87,10 +75,7 @@ def _compose_spatial_jacobians_kernel(
         column = int(0)
         while column < 6:
             value = wp.float64(0.0)
-            if (
-                (row < 3 and column < 3 or row >= 3 and column >= 3)
-                and row == column
-            ):
+            if (row < 3 and column < 3 or row >= 3 and column >= 3) and row == column:
                 value = wp.float64(1.0)
             elif row == 3 and column == 1:
                 value = rz
@@ -111,18 +96,105 @@ def _compose_spatial_jacobians_kernel(
             value = wp.float64(0.0)
             inner = int(0)
             while inner < 3:
-                value += _spatial_base_rotation_entry(
-                    base_pose, environment, row % 3, inner
-                ) * internal[
-                    environment,
-                    sample,
-                    (0 if row < 3 else 3) + inner,
-                    internal_column,
-                ]
+                value += (
+                    rotation[row % 3, inner]
+                    * internal[
+                        environment,
+                        sample,
+                        (0 if row < 3 else 3) + inner,
+                        internal_column,
+                    ]
+                )
                 inner += 1
             output[environment, sample, row, 6 + internal_column] = value
             internal_column += 1
         row += 1
+
+
+@wp.kernel(enable_backward=False)
+def _compose_spatial_jacobians_tiled_kernel(
+    base_pose: wp.array2d[wp.float64],
+    relative_pose: wp.array4d[wp.float64],
+    internal: wp.array4d[wp.float64],
+    output: wp.array4d[wp.float64],
+):
+    """Compose one floating spatial Jacobian cooperatively per sample.
+
+    Args:
+        base_pose: Batched scalar-last quaternion poses with shape ``(E, 7)``.
+        relative_pose: Base-relative transforms with shape ``(E, N, 4, 4)``.
+        internal: Base-frame internal Jacobians with shape ``(E, N, 6, D)``.
+        output: World-frame augmented Jacobians with shape
+            ``(E, N, 6, D + 6)``.
+
+    Returns:
+        None. ``output`` is updated in place by one cooperative block for each
+        environment-sample pair.
+    """
+    work_item, lane = wp.tid()
+    sample_count = relative_pose.shape[1]
+    environment = work_item // sample_count
+    sample = work_item - environment * sample_count
+    rotation = wp.tile_zeros(shape=(9,), dtype=wp.float64, storage="shared")
+    position = wp.tile_zeros(shape=(3,), dtype=wp.float64, storage="shared")
+
+    rotation_entry = wp.float64(0.0)
+    if lane < 9:
+        rotation_row = lane // 3
+        rotation_column = lane - 3 * rotation_row
+        rotation_entry = _quaternion_rotation_transpose_entry(
+            base_pose, environment, rotation_column, rotation_row
+        )
+    wp.tile_scatter_masked(rotation, lane, rotation_entry, lane < 9)
+
+    position_entry = wp.float64(0.0)
+    if lane < 3:
+        inner = int(0)
+        while inner < 3:
+            position_entry += (
+                rotation[3 * lane + inner]
+                * relative_pose[environment, sample, inner, 3]
+            )
+            inner += 1
+    wp.tile_scatter_masked(position, lane, position_entry, lane < 3)
+
+    entry = lane
+    column_count = output.shape[3]
+    while entry < 6 * column_count:
+        row = entry // column_count
+        column = entry - row * column_count
+        value = wp.float64(0.0)
+        if column < 6:
+            if row == column and (row < 3 and column < 3 or row >= 3 and column >= 3):
+                value = wp.float64(1.0)
+            elif row == 3 and column == 1:
+                value = position[2]
+            elif row == 3 and column == 2:
+                value = -position[1]
+            elif row == 4 and column == 0:
+                value = -position[2]
+            elif row == 4 and column == 2:
+                value = position[0]
+            elif row == 5 and column == 0:
+                value = position[1]
+            elif row == 5 and column == 1:
+                value = -position[0]
+        else:
+            internal_column = column - 6
+            inner = int(0)
+            while inner < 3:
+                value += (
+                    rotation[3 * (row % 3) + inner]
+                    * internal[
+                        environment,
+                        sample,
+                        (0 if row < 3 else 3) + inner,
+                        internal_column,
+                    ]
+                )
+                inner += 1
+        output[environment, sample, row, column] = value
+        entry += wp.block_dim()
 
 
 @wp.kernel(enable_backward=False)
@@ -150,20 +222,15 @@ def _compose_spatial_poses_and_twists_kernel(
     """
 
     environment, sample = wp.tid()
+    rotation = _quaternion_rotation_matrix(base_pose, environment)
     rx = wp.float64(0.0)
     ry = wp.float64(0.0)
     rz = wp.float64(0.0)
     inner = int(0)
     while inner < 3:
-        rx += _spatial_base_rotation_entry(
-            base_pose, environment, 0, inner
-        ) * relative_pose[environment, sample, inner, 3]
-        ry += _spatial_base_rotation_entry(
-            base_pose, environment, 1, inner
-        ) * relative_pose[environment, sample, inner, 3]
-        rz += _spatial_base_rotation_entry(
-            base_pose, environment, 2, inner
-        ) * relative_pose[environment, sample, inner, 3]
+        rx += rotation[0, inner] * relative_pose[environment, sample, inner, 3]
+        ry += rotation[1, inner] * relative_pose[environment, sample, inner, 3]
+        rz += rotation[2, inner] * relative_pose[environment, sample, inner, 3]
         inner += 1
     radius = wp.vec3d(rx, ry, rz)
     base_angular = wp.vec3d(
@@ -184,13 +251,16 @@ def _compose_spatial_poses_and_twists_kernel(
             value = wp.float64(0.0)
             inner = int(0)
             while inner < 3:
-                value += _spatial_base_rotation_entry(
-                    base_pose, environment, row, inner
-                ) * relative_pose[environment, sample, inner, column]
+                value += (
+                    rotation[row, inner]
+                    * relative_pose[environment, sample, inner, column]
+                )
                 inner += 1
             poses[environment, sample, row, column] = value
             column += 1
-        poses[environment, sample, row, 3] = base_pose[environment, 4 + row] + radius[row]
+        poses[environment, sample, row, 3] = (
+            base_pose[environment, 4 + row] + radius[row]
+        )
         row += 1
     column = int(0)
     while column < 3:
@@ -205,11 +275,9 @@ def _compose_spatial_poses_and_twists_kernel(
         linear = point_velocity[row]
         inner = int(0)
         while inner < 3:
-            rotation = _spatial_base_rotation_entry(
-                base_pose, environment, row, inner
-            )
-            angular += rotation * internal_twist[environment, sample, inner]
-            linear += rotation * internal_twist[environment, sample, 3 + inner]
+            rotation_entry = rotation[row, inner]
+            angular += rotation_entry * internal_twist[environment, sample, inner]
+            linear += rotation_entry * internal_twist[environment, sample, 3 + inner]
             inner += 1
         twists[environment, sample, row] = angular
         twists[environment, sample, 3 + row] = linear
@@ -239,14 +307,15 @@ def _compose_spatial_wrench_vjp_kernel(
     """
 
     environment, sample = wp.tid()
+    rotation = _quaternion_rotation_matrix(base_pose, environment)
     radius = wp.vec3d()
     row = int(0)
     while row < 3:
         inner = int(0)
         while inner < 3:
-            radius[row] += _spatial_base_rotation_entry(
-                base_pose, environment, row, inner
-            ) * relative_pose[environment, sample, inner, 3]
+            radius[row] += (
+                rotation[row, inner] * relative_pose[environment, sample, inner, 3]
+            )
             inner += 1
         row += 1
     moment = wp.vec3d(
@@ -266,11 +335,9 @@ def _compose_spatial_wrench_vjp_kernel(
         relative_force = wp.float64(0.0)
         inner = int(0)
         while inner < 3:
-            rotation = _spatial_base_rotation_entry(
-                base_pose, environment, inner, row
-            )
-            relative_moment += rotation * moment[inner]
-            relative_force += rotation * force[inner]
+            rotation_entry = rotation[inner, row]
+            relative_moment += rotation_entry * moment[inner]
+            relative_force += rotation_entry * force[inner]
             inner += 1
         relative_wrenches[environment, sample, row] = relative_moment
         relative_wrenches[environment, sample, 3 + row] = relative_force
@@ -344,9 +411,7 @@ def _compose_planar_poses_and_twists_kernel(
     poses[environment, sample, 0] = theta + relative_pose[environment, sample, 0]
     poses[environment, sample, 1] = base_pose[environment, 1] + radius_x
     poses[environment, sample, 2] = base_pose[environment, 2] + radius_y
-    twists[environment, sample, 0] = (
-        angular + internal_twist[environment, sample, 0]
-    )
+    twists[environment, sample, 0] = angular + internal_twist[environment, sample, 0]
     twists[environment, sample, 1] = (
         base_velocity[environment, 1]
         - angular * radius_y
@@ -420,12 +485,8 @@ def _compose_planar_poses_kernel(
     x = relative_pose[environment, sample, 1]
     y = relative_pose[environment, sample, 2]
     output[environment, sample, 0] = theta + relative_pose[environment, sample, 0]
-    output[environment, sample, 1] = (
-        base_pose[environment, 1] + cosine * x - sine * y
-    )
-    output[environment, sample, 2] = (
-        base_pose[environment, 2] + sine * x + cosine * y
-    )
+    output[environment, sample, 1] = base_pose[environment, 1] + cosine * x - sine * y
+    output[environment, sample, 2] = base_pose[environment, 2] + sine * x + cosine * y
 
 
 @wp.kernel(enable_backward=False)
@@ -488,28 +549,51 @@ def launch_spatial_floating_jacobian_composition(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array4d[wp.float64],
     internal: wp.array4d[wp.float64],
+    block_dim: int,
     jacobians: wp.array4d[wp.float64],
 ):
-    """Build batched spatial base columns and rotate internal columns."""
-    wp.launch(
-        _compose_spatial_jacobians_kernel,
-        dim=(relative_pose.shape[0], relative_pose.shape[1]),
-        inputs=[base_pose, relative_pose, internal],
-        outputs=[jacobians],
-    )
+    """Build batched spatial base columns and rotate internal columns.
+
+    Args:
+        base_pose: Batched scalar-last quaternion poses with shape ``(E, 7)``.
+        relative_pose: Base-relative transforms with shape ``(E, N, 4, 4)``.
+        internal: Base-frame internal Jacobians with shape ``(E, N, 6, D)``.
+        block_dim: Model-configured CUDA threads per cooperative block.
+        jacobians: World-frame augmented output with shape
+            ``(E, N, 6, D + 6)``.
+
+    Returns:
+        None. ``jacobians`` is updated in place.
+    """
+    if base_pose.device.is_cuda:
+        wp.launch_tiled(
+            _compose_spatial_jacobians_tiled_kernel,
+            dim=relative_pose.shape[0] * relative_pose.shape[1],
+            inputs=[base_pose, relative_pose, internal],
+            outputs=[jacobians],
+            block_dim=block_dim,
+        )
+    else:
+        wp.launch(
+            _compose_spatial_jacobians_kernel,
+            dim=(relative_pose.shape[0], relative_pose.shape[1]),
+            inputs=[base_pose, relative_pose, internal],
+            outputs=[jacobians],
+        )
 
 
 def launch_spatial_floating_kinematics_composition(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array4d[wp.float64],
     internal: wp.array4d[wp.float64],
+    block_dim: int,
     poses: wp.array4d[wp.float64],
     jacobians: wp.array4d[wp.float64],
 ):
     """Compose spatial poses and augmented Jacobians in one callable."""
     launch_spatial_floating_pose_composition(base_pose, relative_pose, poses)
     launch_spatial_floating_jacobian_composition(
-        base_pose, relative_pose, internal, jacobians
+        base_pose, relative_pose, internal, block_dim, jacobians
     )
 
 

--- a/src/soromox/execution/warp/common/rotations.py
+++ b/src/soromox/execution/warp/common/rotations.py
@@ -1,0 +1,114 @@
+# ruff: noqa: I001, UP018
+"""Shared quaternion rotation operators for continuum Warp kernels."""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.func
+def _normalized_quaternion(poses: wp.array2d[wp.float64], environment: int) -> wp.vec4d:
+    """Load one normalized scalar-last quaternion with an identity fallback."""
+    x = poses[environment, 0]
+    y = poses[environment, 1]
+    z = poses[environment, 2]
+    w = poses[environment, 3]
+    norm_sq = x * x + y * y + z * z + w * w
+    if norm_sq <= wp.float64(0.0):
+        return wp.vec4d(
+            wp.float64(0.0),
+            wp.float64(0.0),
+            wp.float64(0.0),
+            wp.float64(1.0),
+        )
+    inverse_norm = wp.float64(1.0) / wp.sqrt(norm_sq)
+    return wp.vec4d(
+        x * inverse_norm,
+        y * inverse_norm,
+        z * inverse_norm,
+        w * inverse_norm,
+    )
+
+
+@wp.func
+def _quaternion_rotation_matrix(
+    poses: wp.array2d[wp.float64], environment: int
+) -> wp.mat33d:
+    """Return one normalized scalar-last quaternion rotation matrix.
+
+    Args:
+        poses: Batched scalar-last quaternion poses with shape ``(E, 7)``.
+        environment: Environment row in ``poses``.
+
+    Returns:
+        The normalized three-dimensional rotation. A zero quaternion follows
+        the trace-safe JAX path and maps to identity.
+    """
+    quaternion = _normalized_quaternion(poses, environment)
+    x = quaternion[0]
+    y = quaternion[1]
+    z = quaternion[2]
+    w = quaternion[3]
+    rotation = wp.mat33d()
+    rotation[0, 0] = wp.float64(1.0) - wp.float64(2.0) * (y * y + z * z)
+    rotation[0, 1] = wp.float64(2.0) * (x * y - w * z)
+    rotation[0, 2] = wp.float64(2.0) * (x * z + w * y)
+    rotation[1, 0] = wp.float64(2.0) * (x * y + w * z)
+    rotation[1, 1] = wp.float64(1.0) - wp.float64(2.0) * (x * x + z * z)
+    rotation[1, 2] = wp.float64(2.0) * (y * z - w * x)
+    rotation[2, 0] = wp.float64(2.0) * (x * z - w * y)
+    rotation[2, 1] = wp.float64(2.0) * (y * z + w * x)
+    rotation[2, 2] = wp.float64(1.0) - wp.float64(2.0) * (x * x + y * y)
+    return rotation
+
+
+@wp.func
+def _quaternion_rotation_transpose_entry(
+    poses: wp.array2d[wp.float64], environment: int, row: int, column: int
+) -> wp.float64:
+    """Return one normalized quaternion rotation-transpose entry.
+
+    Args:
+        poses: Batched scalar-last quaternion poses with shape ``(E, 7)``.
+        environment: Environment row in ``poses``.
+        row: Requested matrix row.
+        column: Requested matrix column.
+
+    Returns:
+        Entry ``(row, column)`` of the normalized rotation transpose. A zero
+        quaternion follows the trace-safe JAX path and maps to identity.
+    """
+    quaternion = _normalized_quaternion(poses, environment)
+    x = quaternion[0]
+    y = quaternion[1]
+    z = quaternion[2]
+    w = quaternion[3]
+
+    value = wp.float64(0.0)
+    if row == 0 and column == 0:
+        value = wp.float64(1.0) - wp.float64(2.0) * (y * y + z * z)
+    elif row == 0 and column == 1:
+        value = wp.float64(2.0) * (x * y + w * z)
+    elif row == 0 and column == 2:
+        value = wp.float64(2.0) * (x * z - w * y)
+    elif row == 1 and column == 0:
+        value = wp.float64(2.0) * (x * y - w * z)
+    elif row == 1 and column == 1:
+        value = wp.float64(1.0) - wp.float64(2.0) * (x * x + z * z)
+    elif row == 1 and column == 2:
+        value = wp.float64(2.0) * (y * z + w * x)
+    elif row == 2 and column == 0:
+        value = wp.float64(2.0) * (x * z + w * y)
+    elif row == 2 and column == 1:
+        value = wp.float64(2.0) * (y * z - w * x)
+    elif row == 2 and column == 2:
+        value = wp.float64(1.0) - wp.float64(2.0) * (x * x + y * y)
+    return value
+
+
+__all__ = [
+    "_quaternion_rotation_matrix",
+    "_quaternion_rotation_transpose_entry",
+]

--- a/src/soromox/execution/warp/common/se2.py
+++ b/src/soromox/execution/warp/common/se2.py
@@ -1,0 +1,252 @@
+# ruff: noqa: I001, UP018
+"""Shared Warp operators for planar rigid motions."""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.func
+def _forward_coefficients(z: wp.float64, cutoff: wp.float64) -> wp.vec3d:
+    """Evaluate stable scalar coefficients for planar exponential operators.
+
+    Args:
+        z: Integrated planar rotation.
+        cutoff: Magnitude below which a polynomial expansion is used.
+
+    Returns:
+        Stable ``(sinc, cosc, tanc)`` coefficients.
+    """
+    x = z * z
+    if wp.abs(z) <= cutoff:
+        return wp.vec3d(
+            wp.float64(1.0)
+            + x
+            * (
+                -wp.float64(1.0 / 6.0)
+                + x
+                * (
+                    wp.float64(1.0 / 120.0)
+                    + x * (-wp.float64(1.0 / 5040.0) + x * wp.float64(1.0 / 362880.0))
+                )
+            ),
+            wp.float64(0.5)
+            + x
+            * (
+                -wp.float64(1.0 / 24.0)
+                + x
+                * (
+                    wp.float64(1.0 / 720.0)
+                    + x * (-wp.float64(1.0 / 40320.0) + x * wp.float64(1.0 / 3628800.0))
+                )
+            ),
+            wp.float64(1.0 / 6.0)
+            + x
+            * (
+                -wp.float64(1.0 / 120.0)
+                + x
+                * (
+                    wp.float64(1.0 / 5040.0)
+                    + x
+                    * (-wp.float64(1.0 / 362880.0) + x * wp.float64(1.0 / 39916800.0))
+                )
+            ),
+        )
+    sine = wp.sin(z)
+    cosine = wp.cos(z)
+    return wp.vec3d(
+        sine / z,
+        (wp.float64(1.0) - cosine) / x,
+        (z - sine) / (x * z),
+    )
+
+
+@wp.func
+def _forward_derivatives(z: wp.float64, cutoff: wp.float64) -> wp.vec3d:
+    """Differentiate planar exponential coefficients with respect to ``z**2``.
+
+    Args:
+        z: Integrated planar rotation.
+        cutoff: Magnitude below which a polynomial expansion is used.
+
+    Returns:
+        Derivatives of ``(sinc, cosc, tanc)`` with respect to ``z**2``.
+    """
+    x = z * z
+    if wp.abs(z) <= cutoff:
+        return wp.vec3d(
+            -wp.float64(1.0 / 6.0)
+            + x
+            * (
+                wp.float64(1.0 / 60.0)
+                + x * (-wp.float64(1.0 / 1680.0) + x * wp.float64(1.0 / 90720.0))
+            ),
+            -wp.float64(1.0 / 24.0)
+            + x
+            * (
+                wp.float64(1.0 / 360.0)
+                + x * (-wp.float64(1.0 / 13440.0) + x * wp.float64(1.0 / 907200.0))
+            ),
+            -wp.float64(1.0 / 120.0)
+            + x
+            * (
+                wp.float64(1.0 / 2520.0)
+                + x * (-wp.float64(1.0 / 120960.0) + x * wp.float64(1.0 / 9979200.0))
+            ),
+        )
+    sine = wp.sin(z)
+    cosine = wp.cos(z)
+    return wp.vec3d(
+        (z * cosine - sine) / (wp.float64(2.0) * x * z),
+        (z * sine + wp.float64(2.0) * cosine - wp.float64(2.0))
+        / (wp.float64(2.0) * x * x),
+        (wp.float64(3.0) * sine - wp.float64(2.0) * z - z * cosine)
+        / (wp.float64(2.0) * x * x * z),
+    )
+
+
+@wp.func
+def _constant_strain_operators(
+    xi: wp.vec3d,
+    xid: wp.vec3d,
+    s: wp.float64,
+    global_eps: wp.float64,
+    tangent_eps: wp.float64,
+) -> tuple[wp.mat33d, wp.mat33d, wp.vec3d, wp.vec3d]:
+    """Evaluate constant-strain SE(2) recurrence operators.
+
+    Args:
+        xi: Constant planar strain of the current segment.
+        xid: Constant planar strain rate of the current segment.
+        s: Segment-local integration coordinate.
+        global_eps: Small-angle tolerance for the exponential adjoint.
+        tangent_eps: Small-angle tolerance for tangent derivatives.
+
+    Returns:
+        Inverse adjoint, transported left tangent, local velocity, and the
+        transported tangent time-derivative action on strain rate.
+    """
+    z = s * xi[0]
+    adjoint_cutoff = wp.max(wp.abs(s * global_eps), wp.float64(0.04964607461902946))
+    adjoint_coefficients = _forward_coefficients(z, adjoint_cutoff)
+    sinc_a = adjoint_coefficients[0]
+    cosc_a = adjoint_coefficients[1]
+    cosine = wp.cos(z)
+    sine = wp.sin(z)
+    q0 = s * (sinc_a * xi[2] + z * cosc_a * xi[1])
+    q1 = s * (-sinc_a * xi[1] + z * cosc_a * xi[2])
+
+    adjoint_inverse = wp.mat33d()
+    adjoint_inverse[0, 0] = wp.float64(1.0)
+    adjoint_inverse[1, 0] = -(cosine * q0 + sine * q1)
+    adjoint_inverse[1, 1] = cosine
+    adjoint_inverse[1, 2] = sine
+    adjoint_inverse[2, 0] = sine * q0 - cosine * q1
+    adjoint_inverse[2, 1] = -sine
+    adjoint_inverse[2, 2] = cosine
+
+    tangent_cutoff = wp.max(wp.abs(s * tangent_eps), wp.float64(0.07618835359095202))
+    coefficients = _forward_coefficients(z, tangent_cutoff)
+    derivatives = _forward_derivatives(z, tangent_cutoff)
+    sinc = coefficients[0]
+    cosc = coefficients[1]
+    tanc = coefficients[2]
+    accumulated_x = s * xi[1]
+    accumulated_y = s * xi[2]
+    lower0 = cosc * accumulated_y + z * tanc * accumulated_x
+    lower1 = -cosc * accumulated_x + z * tanc * accumulated_y
+    tangent = wp.mat33d()
+    tangent[0, 0] = s
+    tangent[1, 0] = s * lower0
+    tangent[1, 1] = s * sinc
+    tangent[1, 2] = -s * z * cosc
+    tangent[2, 0] = s * lower1
+    tangent[2, 1] = s * z * cosc
+    tangent[2, 2] = s * sinc
+
+    accumulated_dot_x = s * xid[1]
+    accumulated_dot_y = s * xid[2]
+    z_dot = s * xid[0]
+    x = z * z
+    sinc_dot = wp.float64(2.0) * z * derivatives[0] * z_dot
+    cosc_dot = wp.float64(2.0) * z * derivatives[1] * z_dot
+    z_cosc_dot = z_dot * (cosc + wp.float64(2.0) * x * derivatives[1])
+    z_tanc = z * tanc
+    z_tanc_dot = z_dot * (tanc + wp.float64(2.0) * x * derivatives[2])
+    lower_dot0 = (
+        cosc_dot * accumulated_y
+        + cosc * accumulated_dot_y
+        + z_tanc_dot * accumulated_x
+        + z_tanc * accumulated_dot_x
+    )
+    lower_dot1 = (
+        -cosc_dot * accumulated_x
+        - cosc * accumulated_dot_x
+        + z_tanc_dot * accumulated_y
+        + z_tanc * accumulated_dot_y
+    )
+    tangent_dot = wp.mat33d()
+    tangent_dot[1, 0] = s * lower_dot0
+    tangent_dot[1, 1] = s * sinc_dot
+    tangent_dot[1, 2] = -s * z_cosc_dot
+    tangent_dot[2, 0] = s * lower_dot1
+    tangent_dot[2, 1] = s * z_cosc_dot
+    tangent_dot[2, 2] = s * sinc_dot
+
+    transported_tangent = adjoint_inverse * tangent
+    local_velocity = transported_tangent * xid
+    transported_tangent_dot_velocity = adjoint_inverse * (tangent_dot * xid)
+    return (
+        adjoint_inverse,
+        transported_tangent,
+        local_velocity,
+        transported_tangent_dot_velocity,
+    )
+
+
+@wp.func
+def planar_pose_step(
+    theta: wp.float64,
+    x: wp.float64,
+    y: wp.float64,
+    xi: wp.vec3d,
+    arc_length: wp.float64,
+    eps: wp.float64,
+) -> wp.vec3d:
+    """Integrate one constant-strain SE(2) pose step.
+
+    Args:
+        theta: Absolute orientation at the start of the step.
+        x: Absolute horizontal position at the start of the step.
+        y: Absolute vertical position at the start of the step.
+        xi: Constant planar strain in angular-first coordinates.
+        arc_length: Local integration distance.
+        eps: Requested small-angle threshold.
+
+    Returns:
+        Absolute planar pose ``[theta, x, y]`` after the step.
+    """
+    z = arc_length * xi[0]
+    cutoff = wp.max(wp.abs(arc_length * eps), wp.float64(0.04964607461902946))
+    coefficients = _forward_coefficients(z, cutoff)
+    vx = arc_length * xi[1]
+    vy = arc_length * xi[2]
+    local_x = coefficients[0] * vx - z * coefficients[1] * vy
+    local_y = z * coefficients[1] * vx + coefficients[0] * vy
+    cosine = wp.cos(theta)
+    sine = wp.sin(theta)
+    return wp.vec3d(
+        theta + z,
+        x + cosine * local_x - sine * local_y,
+        y + sine * local_x + cosine * local_y,
+    )
+
+
+__all__ = [
+    "_constant_strain_operators",
+    "_forward_coefficients",
+    "_forward_derivatives",
+    "planar_pose_step",
+]

--- a/src/soromox/execution/warp/common/se3.py
+++ b/src/soromox/execution/warp/common/se3.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import warp as wp
 
+from soromox.execution.warp.common.so3 import _rotation_entry
+
 
 Vec6d = wp.types.vector(length=6, dtype=wp.float64)
 SPATIAL_DIM = 6
@@ -267,46 +269,6 @@ def _forward_coefficients(angle_sq: wp.float64) -> wp.vec3d:
         cosc = (wp.float64(1.0) - wp.cos(theta)) / angle_sq
         tanc = (theta - wp.sin(theta)) / (angle_sq * theta)
     return wp.vec3d(sinc, cosc, tanc)
-
-
-@wp.func
-def _rotation_entry(
-    omega: wp.vec3d,
-    angle_sq: wp.float64,
-    forward: wp.vec3d,
-    row: int,
-    column: int,
-) -> wp.float64:
-    """Evaluate one entry of the SO(3) exponential rotation matrix.
-
-    Args:
-        omega: Rotational exponential coordinate.
-        angle_sq: Squared norm of ``omega``.
-        forward: Stable exponential-map coefficients.
-        row: Matrix row index.
-        column: Matrix column index.
-
-    Returns:
-        The selected rotation-matrix entry.
-    """
-    delta = wp.float64(0.0)
-    if row == column:
-        delta = wp.float64(1.0)
-    skew = wp.float64(0.0)
-    if row == 0 and column == 1:
-        skew = -omega[2]
-    elif row == 0 and column == 2:
-        skew = omega[1]
-    elif row == 1 and column == 0:
-        skew = omega[2]
-    elif row == 1 and column == 2:
-        skew = -omega[0]
-    elif row == 2 and column == 0:
-        skew = -omega[1]
-    elif row == 2 and column == 1:
-        skew = omega[0]
-    square = omega[row] * omega[column] - angle_sq * delta
-    return delta + forward[0] * skew + forward[1] * square
 
 
 @wp.func

--- a/src/soromox/execution/warp/common/se3.py
+++ b/src/soromox/execution/warp/common/se3.py
@@ -289,6 +289,34 @@ def _translation(omega: wp.vec3d, linear: wp.vec3d, forward: wp.vec3d) -> wp.vec
 
 
 @wp.func
+def _exponential_transform(xi: Vec6d) -> wp.mat44d:
+    """Evaluate the homogeneous SE(3) exponential of a spatial coordinate.
+
+    Args:
+        xi: Angular-linear exponential coordinate.
+
+    Returns:
+        Homogeneous transform ``exp(xi)``.
+    """
+    omega = wp.vec3d(xi[0], xi[1], xi[2])
+    linear = wp.vec3d(xi[3], xi[4], xi[5])
+    angle_sq = wp.dot(omega, omega)
+    forward = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, forward)
+    result = wp.mat44d()
+    row = int(0)
+    while row < 3:
+        column = int(0)
+        while column < 3:
+            result[row, column] = _rotation_entry(omega, angle_sq, forward, row, column)
+            column += 1
+        result[row, 3] = translation[row]
+        row += 1
+    result[3, 3] = wp.float64(1.0)
+    return result
+
+
+@wp.func
 def _adjoint_inverse_entry(
     omega: wp.vec3d,
     translation: wp.vec3d,

--- a/src/soromox/execution/warp/common/so2.py
+++ b/src/soromox/execution/warp/common/so2.py
@@ -9,6 +9,52 @@ wp.set_module_options({"enable_backward": False})
 
 
 @wp.func
+def _rotation_components(theta: wp.float64) -> wp.vec2d:
+    """Return ``(cos(theta), sin(theta))`` for shared planar actions."""
+    return wp.vec2d(wp.cos(theta), wp.sin(theta))
+
+
+@wp.func
+def _rotation_matrix(theta: wp.float64) -> wp.mat22d:
+    """Return the planar rotation for ``theta``.
+
+    Args:
+        theta: Right-handed planar rotation angle.
+
+    Returns:
+        Two-dimensional active rotation matrix.
+    """
+    components = _rotation_components(theta)
+    cosine = components[0]
+    sine = components[1]
+    return wp.mat22d(cosine, -sine, sine, cosine)
+
+
+@wp.func
+def _rotate_vector(theta: wp.float64, value: wp.vec2d) -> wp.vec2d:
+    """Rotate one planar vector by ``theta``."""
+    components = _rotation_components(theta)
+    cosine = components[0]
+    sine = components[1]
+    return wp.vec2d(
+        cosine * value[0] - sine * value[1],
+        sine * value[0] + cosine * value[1],
+    )
+
+
+@wp.func
+def _rotate_vector_transpose(theta: wp.float64, value: wp.vec2d) -> wp.vec2d:
+    """Apply the transpose of a planar rotation to one vector."""
+    components = _rotation_components(theta)
+    cosine = components[0]
+    sine = components[1]
+    return wp.vec2d(
+        cosine * value[0] + sine * value[1],
+        -sine * value[0] + cosine * value[1],
+    )
+
+
+@wp.func
 def _rotation_transpose_entry(theta: wp.float64, row: int, column: int) -> wp.float64:
     """Return one entry of the transpose of a planar rotation.
 
@@ -20,8 +66,9 @@ def _rotation_transpose_entry(theta: wp.float64, row: int, column: int) -> wp.fl
     Returns:
         Entry ``(row, column)`` of ``R(theta).T``.
     """
-    cosine = wp.cos(theta)
-    sine = wp.sin(theta)
+    components = _rotation_components(theta)
+    cosine = components[0]
+    sine = components[1]
     value = wp.float64(0.0)
     if row == 0 and column == 0 or row == 1 and column == 1:
         value = cosine
@@ -32,4 +79,10 @@ def _rotation_transpose_entry(theta: wp.float64, row: int, column: int) -> wp.fl
     return value
 
 
-__all__ = ["_rotation_transpose_entry"]
+__all__ = [
+    "_rotate_vector",
+    "_rotate_vector_transpose",
+    "_rotation_components",
+    "_rotation_matrix",
+    "_rotation_transpose_entry",
+]

--- a/src/soromox/execution/warp/common/so2.py
+++ b/src/soromox/execution/warp/common/so2.py
@@ -1,0 +1,35 @@
+# ruff: noqa: I001, UP018
+"""Shared Warp operators for planar rotations."""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.func
+def _rotation_transpose_entry(theta: wp.float64, row: int, column: int) -> wp.float64:
+    """Return one entry of the transpose of a planar rotation.
+
+    Args:
+        theta: Rotation angle.
+        row: Requested matrix row.
+        column: Requested matrix column.
+
+    Returns:
+        Entry ``(row, column)`` of ``R(theta).T``.
+    """
+    cosine = wp.cos(theta)
+    sine = wp.sin(theta)
+    value = wp.float64(0.0)
+    if row == 0 and column == 0 or row == 1 and column == 1:
+        value = cosine
+    elif row == 0 and column == 1:
+        value = sine
+    elif row == 1 and column == 0:
+        value = -sine
+    return value
+
+
+__all__ = ["_rotation_transpose_entry"]

--- a/src/soromox/execution/warp/common/so3.py
+++ b/src/soromox/execution/warp/common/so3.py
@@ -1,0 +1,51 @@
+# ruff: noqa: I001, UP018
+"""Shared Warp operators for spatial rotations."""
+
+from __future__ import annotations
+
+import warp as wp
+
+wp.set_module_options({"enable_backward": False})
+
+
+@wp.func
+def _rotation_entry(
+    omega: wp.vec3d,
+    angle_sq: wp.float64,
+    forward: wp.vec3d,
+    row: int,
+    column: int,
+) -> wp.float64:
+    """Evaluate one entry of an SO(3) exponential rotation matrix.
+
+    Args:
+        omega: Rotational exponential coordinate.
+        angle_sq: Squared norm of ``omega``.
+        forward: Stable exponential-map coefficients.
+        row: Matrix row index.
+        column: Matrix column index.
+
+    Returns:
+        The selected rotation-matrix entry.
+    """
+    delta = wp.float64(0.0)
+    if row == column:
+        delta = wp.float64(1.0)
+    skew = wp.float64(0.0)
+    if row == 0 and column == 1:
+        skew = -omega[2]
+    elif row == 0 and column == 2:
+        skew = omega[1]
+    elif row == 1 and column == 0:
+        skew = omega[2]
+    elif row == 1 and column == 2:
+        skew = -omega[0]
+    elif row == 2 and column == 0:
+        skew = -omega[1]
+    elif row == 2 and column == 1:
+        skew = omega[0]
+    square = omega[row] * omega[column] - angle_sq * delta
+    return delta + forward[0] * skew + forward[1] * square
+
+
+__all__ = ["_rotation_entry"]

--- a/src/soromox/execution/warp/gvs/directional_kinematics.py
+++ b/src/soromox/execution/warp/gvs/directional_kinematics.py
@@ -10,6 +10,7 @@ from soromox.execution.warp.common.se3 import (
     _ad_action,
     _adjoint_inverse_action,
     _adjoint_inverse_transpose_action,
+    _exponential_transform,
     _forward_coefficients,
     _left_action,
     _left_coefficients,
@@ -28,7 +29,6 @@ from soromox.execution.warp.gvs.kinematics import (
     _basis_column_value,
     _load_node_pose,
     _relative_pose_from_inverse_adjoint,
-    _relative_pose_from_magnus,
     _store_node_pose,
     gvs_node_poses_kernel,
 )
@@ -263,7 +263,7 @@ def gvs_pose_twist_samples_kernel(
     magnus_dot = alpha * (xid1 + xid2) + coefficient * (
         _ad_action(xid1, xi2) + _ad_action(xi1, xid2)
     )
-    pose = base_pose * _relative_pose_from_magnus(magnus)
+    pose = base_pose * _exponential_transform(magnus)
     omega = wp.vec3d(magnus[0], magnus[1], magnus[2])
     linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
     angle_sq = wp.dot(omega, omega)
@@ -422,7 +422,7 @@ def gvs_sample_vjp_kernel(
     alpha = ds * wp.float64(0.5)
     coefficient = wp.sqrt(wp.float64(3.0)) * ds * ds / wp.float64(12.0)
     magnus = alpha * (xi1 + xi2) + coefficient * _ad_action(xi1, xi2)
-    pose = base_pose * _relative_pose_from_magnus(magnus)
+    pose = base_pose * _exponential_transform(magnus)
     omega = wp.vec3d(magnus[0], magnus[1], magnus[2])
     linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
     angle_sq = wp.dot(omega, omega)
@@ -563,8 +563,7 @@ def gvs_node_vjp_kernel(
             row = int(0)
             while row < SPATIAL_DIM:
                 effort += (
-                    joint_tangent[joint_base + row, global_index]
-                    * source_wrench[row]
+                    joint_tangent[joint_base + row, global_index] * source_wrench[row]
                 )
                 row += 1
             generalized_force[environment, global_index] += effort

--- a/src/soromox/execution/warp/gvs/floating_chain.py
+++ b/src/soromox/execution/warp/gvs/floating_chain.py
@@ -11,10 +11,8 @@ from __future__ import annotations
 
 import warp as wp
 
-from soromox.execution.warp.common.floating_base import (
-    _quaternion_rotation_transpose_entry,
-    _spatial_root_jacobian_entry,
-)
+from soromox.execution.warp.common.floating_base import _spatial_root_jacobian_entry
+from soromox.execution.warp.common.rotations import _quaternion_rotation_matrix
 from soromox.execution.warp.common.se3 import Vec6d, _ad_action
 from soromox.execution.warp.common.spatial import _coadjoint_wrench
 from soromox.execution.warp.common.storage import (
@@ -135,24 +133,20 @@ def floating_persistent_chain_kernel(
         entry += lane_stride
     row = lane
     while row < SPATIAL_DIM:
+        rotation = _quaternion_rotation_matrix(base_pose, environment)
         root_velocity = wp.float64(0.0)
         column = int(0)
-        while column < base_dofs:
+        while column < 3:
             root_velocity += (
-                _spatial_root_jacobian_entry(base_pose, environment, row, column)
-                * velocity[environment, column]
+                rotation[column, row % 3]
+                * velocity[environment, (0 if row < 3 else 3) + column]
             )
             column += 1
         root_gravity = wp.float64(0.0)
         if row >= 3:
             column = int(0)
             while column < 3:
-                root_gravity += (
-                    _quaternion_rotation_transpose_entry(
-                        base_pose, environment, row - 3, column
-                    )
-                    * gravity_world[column + 3]
-                )
+                root_gravity += rotation[column, row - 3] * gravity_world[column + 3]
                 column += 1
         jacobian_dot_qd_first[state_base_row + row, 0] = wp.float64(0.0)
         jacobian_dot_qd_second[state_base_row + row, 0] = wp.float64(0.0)

--- a/src/soromox/execution/warp/gvs/kinematics.py
+++ b/src/soromox/execution/warp/gvs/kinematics.py
@@ -12,9 +12,9 @@ from soromox.execution.warp.common.se3 import (
     _forward_coefficients,
     _left_action,
     _left_coefficients,
-    _rotation_entry,
     _translation,
 )
+from soromox.execution.warp.common.so3 import _rotation_entry
 
 wp.set_module_options({"enable_backward": False})
 

--- a/src/soromox/execution/warp/gvs/kinematics.py
+++ b/src/soromox/execution/warp/gvs/kinematics.py
@@ -9,12 +9,12 @@ from soromox.execution.warp.common.se3 import (
     Vec6d,
     _ad_action,
     _adjoint_inverse_action,
+    _exponential_transform,
     _forward_coefficients,
     _left_action,
     _left_coefficients,
     _translation,
 )
-from soromox.execution.warp.common.so3 import _rotation_entry
 
 wp.set_module_options({"enable_backward": False})
 
@@ -65,35 +65,6 @@ def _relative_pose_from_inverse_adjoint(
     result[0, 3] = p_hat[2, 1]
     result[1, 3] = p_hat[0, 2]
     result[2, 3] = p_hat[1, 0]
-    result[3, 3] = wp.float64(1.0)
-    return result
-
-
-@wp.func
-def _relative_pose_from_magnus(magnus: Vec6d) -> wp.mat44d:
-    """Evaluate an SE(3) exponential from one Magnus vector.
-
-    Args:
-        magnus: Integrated six-dimensional strain.
-
-    Returns:
-        Relative homogeneous transform ``exp(magnus)``.
-    """
-
-    omega = wp.vec3d(magnus[0], magnus[1], magnus[2])
-    linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
-    angle_sq = wp.dot(omega, omega)
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
-    result = wp.mat44d()
-    row = int(0)
-    while row < 3:
-        column = int(0)
-        while column < 3:
-            result[row, column] = _rotation_entry(omega, angle_sq, forward, row, column)
-            column += 1
-        result[row, 3] = translation[row]
-        row += 1
     result[3, 3] = wp.float64(1.0)
     return result
 
@@ -708,7 +679,7 @@ def gvs_pose_samples_kernel(
         row += 1
     coefficient = wp.sqrt(wp.float64(3.0)) * ds * ds / wp.float64(12.0)
     magnus = ds * wp.float64(0.5) * (xi1 + xi2) + coefficient * _ad_action(xi1, xi2)
-    pose = base_pose * _relative_pose_from_magnus(magnus)
+    pose = base_pose * _exponential_transform(magnus)
     row = int(0)
     while row < 4:
         column = int(0)
@@ -970,7 +941,7 @@ def gvs_jacobian_samples_kernel(
         row += 1
     coefficient = wp.sqrt(wp.float64(3.0)) * ds * ds / wp.float64(12.0)
     magnus = ds * wp.float64(0.5) * (xi1 + xi2) + coefficient * _ad_action(xi1, xi2)
-    pose = base_pose * _relative_pose_from_magnus(magnus)
+    pose = base_pose * _exponential_transform(magnus)
     write_gvs_sample_jacobian(
         environment,
         sample,
@@ -1128,7 +1099,7 @@ def gvs_samples_kernel(
     magnus = ds * wp.float64(0.5) * (xi1 + xi2) + commutator_coefficient * _ad_action(
         xi1, xi2
     )
-    relative = _relative_pose_from_magnus(magnus)
+    relative = _exponential_transform(magnus)
     pose = base_pose * relative
     row = int(0)
     while row < 4:

--- a/src/soromox/execution/warp/gvs/kinematics_executor.py
+++ b/src/soromox/execution/warp/gvs/kinematics_executor.py
@@ -106,12 +106,14 @@ def execute_kinematics(
                 base_pose,
                 relative_pose,
                 internal_jacobian,
+                operands.relative.block_dim,
                 output_dims={"jacobians": jacobian_shape},
             )[-1]
         outputs = spatial_floating_kinematics_composition(
             base_pose,
             relative_pose,
             internal_jacobian,
+            operands.relative.block_dim,
             output_dims={"poses": pose_shape, "jacobians": jacobian_shape},
         )
         return outputs[-2], outputs[-1]

--- a/src/soromox/execution/warp/pcs/kinematics_executor.py
+++ b/src/soromox/execution/warp/pcs/kinematics_executor.py
@@ -86,6 +86,7 @@ def execute_kinematics(
             3 if operands.is_planar else 6,
             operands.num_velocities,
         )
+        composition_block = () if operands.is_planar else (operands.relative.block_dim,)
         if operation == "jacobian":
             callable_ = (
                 planar_floating_jacobian_composition
@@ -96,6 +97,7 @@ def execute_kinematics(
                 base_pose,
                 relative_pose,
                 internal_jacobian,
+                *composition_block,
                 output_dims={"jacobians": jacobian_shape},
             )[-1]
         pose_shape = (
@@ -112,6 +114,7 @@ def execute_kinematics(
             base_pose,
             relative_pose,
             internal_jacobian,
+            *composition_block,
             output_dims={"poses": pose_shape, "jacobians": jacobian_shape},
         )
         return outputs[-2], outputs[-1]

--- a/src/soromox/execution/warp/pcs/planar_directional_kinematics.py
+++ b/src/soromox/execution/warp/pcs/planar_directional_kinematics.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 
 import warp as wp
 
-from soromox.execution.warp.pcs.planar_kernels import _planar_operators
+from soromox.execution.warp.common.se2 import (
+    _constant_strain_operators,
+    planar_pose_step,
+)
+from soromox.execution.warp.common.so2 import (
+    _rotate_vector,
+    _rotate_vector_transpose,
+)
 from soromox.execution.warp.pcs.planar_kinematics import (
     planar_pose_segment_states_kernel,
-    planar_pose_step,
 )
 
 wp.set_module_options({"enable_backward": False})
@@ -83,7 +89,7 @@ def planar_segment_pose_twist_kernel(
             epsilons[0],
         )
         adjoint_inverse, transported_tangent, local_velocity, tangent_dot_velocity = (
-            _planar_operators(
+            _constant_strain_operators(
                 xi,
                 xid,
                 length,
@@ -173,7 +179,7 @@ def planar_pose_twist_samples_kernel(
         epsilons[0],
     )
     adjoint_inverse, transported_tangent, local_velocity, tangent_dot_velocity = (
-        _planar_operators(
+        _constant_strain_operators(
             xi,
             xid,
             local_s,
@@ -190,12 +196,11 @@ def planar_pose_twist_samples_kernel(
         )
         + local_velocity
     )
-    cosine = wp.cos(pose[0])
-    sine = wp.sin(pose[0])
+    inertial_linear = _rotate_vector(pose[0], wp.vec2d(body_twist[1], body_twist[2]))
     inertial_twist = wp.vec3d(
         body_twist[0],
-        cosine * body_twist[1] - sine * body_twist[2],
-        sine * body_twist[1] + cosine * body_twist[2],
+        inertial_linear[0],
+        inertial_linear[1],
     )
     row = int(0)
     while row < PLANAR_DIM:
@@ -261,7 +266,7 @@ def planar_sample_vjp_kernel(
         epsilons[0],
     )
     adjoint_inverse, transported_tangent, local_velocity, tangent_dot_velocity = (
-        _planar_operators(
+        _constant_strain_operators(
             xi,
             wp.vec3d(),
             local_s,
@@ -269,14 +274,17 @@ def planar_sample_vjp_kernel(
             epsilons[1],
         )
     )
-    cosine = wp.cos(pose[0])
-    sine = wp.sin(pose[0])
+    body_force = _rotate_vector_transpose(
+        pose[0],
+        wp.vec2d(
+            inertial_wrenches[environment, sample, 1],
+            inertial_wrenches[environment, sample, 2],
+        ),
+    )
     body_wrench = wp.vec3d(
         inertial_wrenches[environment, sample, 0],
-        cosine * inertial_wrenches[environment, sample, 1]
-        + sine * inertial_wrenches[environment, sample, 2],
-        -sine * inertial_wrenches[environment, sample, 1]
-        + cosine * inertial_wrenches[environment, sample, 2],
+        body_force[0],
+        body_force[1],
     )
     row = int(0)
     while row < PLANAR_DIM:
@@ -334,7 +342,7 @@ def planar_segment_vjp_kernel(
             segment_strain[environment, segment, 2],
         )
         adjoint_inverse, transported_tangent, local_velocity, tangent_dot_velocity = (
-            _planar_operators(
+            _constant_strain_operators(
                 xi,
                 wp.vec3d(),
                 segment_lengths[segment],

--- a/src/soromox/execution/warp/pcs/planar_floating_kernels.py
+++ b/src/soromox/execution/warp/pcs/planar_floating_kernels.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 
 import warp as wp
 
-from soromox.execution.warp.common.floating_base import (
-    _planar_rotation_transpose_entry,
-)
+from soromox.execution.warp.common.so2 import _rotation_transpose_entry
 from soromox.execution.warp.common.storage import (
     _matrix_value,
     _vector_value,
@@ -107,7 +105,7 @@ def planar_floating_persistent_chain_kernel(
         if row == 0 and column == 0:
             value = wp.float64(1.0)
         elif row >= 1 and column >= 1 and column < base_dofs:
-            value = _planar_rotation_transpose_entry(theta, row - 1, column - 1)
+            value = _rotation_transpose_entry(theta, row - 1, column - 1)
         jacobian_first[state_base_row + row, column] = value
         jacobian_second[state_base_row + row, column] = wp.float64(0.0)
         entry += lane_stride
@@ -120,7 +118,7 @@ def planar_floating_persistent_chain_kernel(
             if row == 0 and column == 0:
                 root_jacobian = wp.float64(1.0)
             elif row >= 1 and column >= 1:
-                root_jacobian = _planar_rotation_transpose_entry(
+                root_jacobian = _rotation_transpose_entry(
                     theta, row - 1, column - 1
                 )
             root_velocity += root_jacobian * velocity[environment, column]
@@ -130,7 +128,7 @@ def planar_floating_persistent_chain_kernel(
             column = int(0)
             while column < 2:
                 root_gravity += (
-                    _planar_rotation_transpose_entry(theta, row - 1, column)
+                    _rotation_transpose_entry(theta, row - 1, column)
                     * gravity_world[column + 1]
                 )
                 column += 1

--- a/src/soromox/execution/warp/pcs/planar_kernels.py
+++ b/src/soromox/execution/warp/pcs/planar_kernels.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import warp as wp
 
+from soromox.execution.warp.common.se2 import _constant_strain_operators
 from soromox.execution.warp.common.storage import (
     _matrix_value,
     _vector_value,
@@ -15,204 +16,6 @@ from soromox.execution.warp.common.storage import (
 wp.set_module_options({"enable_backward": False})
 
 SPATIAL_DIM = 3
-
-
-@wp.func
-def _forward_coefficients(z: wp.float64, cutoff: wp.float64) -> wp.vec3d:
-    """Evaluate stable scalar coefficients for planar exponential operators.
-
-    Args:
-        z: Integrated planar rotation.
-        cutoff: Magnitude below which a polynomial expansion is used.
-
-    Returns:
-        Stable ``(sinc, cosc, tanc)`` coefficients.
-    """
-    x = z * z
-    if wp.abs(z) <= cutoff:
-        return wp.vec3d(
-            wp.float64(1.0)
-            + x
-            * (
-                -wp.float64(1.0 / 6.0)
-                + x
-                * (
-                    wp.float64(1.0 / 120.0)
-                    + x * (-wp.float64(1.0 / 5040.0) + x * wp.float64(1.0 / 362880.0))
-                )
-            ),
-            wp.float64(0.5)
-            + x
-            * (
-                -wp.float64(1.0 / 24.0)
-                + x
-                * (
-                    wp.float64(1.0 / 720.0)
-                    + x * (-wp.float64(1.0 / 40320.0) + x * wp.float64(1.0 / 3628800.0))
-                )
-            ),
-            wp.float64(1.0 / 6.0)
-            + x
-            * (
-                -wp.float64(1.0 / 120.0)
-                + x
-                * (
-                    wp.float64(1.0 / 5040.0)
-                    + x
-                    * (-wp.float64(1.0 / 362880.0) + x * wp.float64(1.0 / 39916800.0))
-                )
-            ),
-        )
-    sine = wp.sin(z)
-    cosine = wp.cos(z)
-    return wp.vec3d(
-        sine / z,
-        (wp.float64(1.0) - cosine) / x,
-        (z - sine) / (x * z),
-    )
-
-
-@wp.func
-def _forward_derivatives(z: wp.float64, cutoff: wp.float64) -> wp.vec3d:
-    """Evaluate derivatives of planar exponential coefficients.
-
-    Args:
-        z: Integrated planar rotation.
-        cutoff: Magnitude below which a polynomial expansion is used.
-
-    Returns:
-        Derivatives of ``(sinc, cosc, tanc)`` with respect to ``z**2``.
-    """
-    x = z * z
-    if wp.abs(z) <= cutoff:
-        return wp.vec3d(
-            -wp.float64(1.0 / 6.0)
-            + x
-            * (
-                wp.float64(1.0 / 60.0)
-                + x * (-wp.float64(1.0 / 1680.0) + x * wp.float64(1.0 / 90720.0))
-            ),
-            -wp.float64(1.0 / 24.0)
-            + x
-            * (
-                wp.float64(1.0 / 360.0)
-                + x * (-wp.float64(1.0 / 13440.0) + x * wp.float64(1.0 / 907200.0))
-            ),
-            -wp.float64(1.0 / 120.0)
-            + x
-            * (
-                wp.float64(1.0 / 2520.0)
-                + x * (-wp.float64(1.0 / 120960.0) + x * wp.float64(1.0 / 9979200.0))
-            ),
-        )
-    sine = wp.sin(z)
-    cosine = wp.cos(z)
-    return wp.vec3d(
-        (z * cosine - sine) / (wp.float64(2.0) * x * z),
-        (z * sine + wp.float64(2.0) * cosine - wp.float64(2.0))
-        / (wp.float64(2.0) * x * x),
-        (wp.float64(3.0) * sine - wp.float64(2.0) * z - z * cosine)
-        / (wp.float64(2.0) * x * x * z),
-    )
-
-
-@wp.func
-def _planar_operators(
-    xi: wp.vec3d,
-    xid: wp.vec3d,
-    s: wp.float64,
-    global_eps: wp.float64,
-    tangent_eps: wp.float64,
-) -> tuple[wp.mat33d, wp.mat33d, wp.vec3d, wp.vec3d]:
-    """Evaluate planar adjoint, tangent, and velocity recurrence operators.
-
-    Args:
-        xi: Constant planar strain of the current segment.
-        xid: Constant planar strain rate of the current segment.
-        s: Segment-local integration coordinate.
-        global_eps: Small-angle tolerance for the exponential adjoint.
-        tangent_eps: Small-angle tolerance for tangent derivatives.
-
-    Returns:
-        Inverse adjoint, left tangent, local velocity, and the tangent time-
-        derivative action on strain rate.
-    """
-    z = s * xi[0]
-    adjoint_cutoff = wp.max(wp.abs(s * global_eps), wp.float64(0.04964607461902946))
-    adjoint_coefficients = _forward_coefficients(z, adjoint_cutoff)
-    sinc_a = adjoint_coefficients[0]
-    cosc_a = adjoint_coefficients[1]
-    sine = wp.sin(z)
-    cosine = wp.cos(z)
-    q0 = s * (sinc_a * xi[2] + z * cosc_a * xi[1])
-    q1 = s * (-sinc_a * xi[1] + z * cosc_a * xi[2])
-
-    adjoint_inverse = wp.mat33d()
-    adjoint_inverse[0, 0] = wp.float64(1.0)
-    adjoint_inverse[1, 0] = -(cosine * q0 + sine * q1)
-    adjoint_inverse[1, 1] = cosine
-    adjoint_inverse[1, 2] = sine
-    adjoint_inverse[2, 0] = sine * q0 - cosine * q1
-    adjoint_inverse[2, 1] = -sine
-    adjoint_inverse[2, 2] = cosine
-
-    tangent_cutoff = wp.max(wp.abs(s * tangent_eps), wp.float64(0.07618835359095202))
-    coefficients = _forward_coefficients(z, tangent_cutoff)
-    derivatives = _forward_derivatives(z, tangent_cutoff)
-    sinc = coefficients[0]
-    cosc = coefficients[1]
-    tanc = coefficients[2]
-    accumulated_x = s * xi[1]
-    accumulated_y = s * xi[2]
-    lower0 = cosc * accumulated_y + z * tanc * accumulated_x
-    lower1 = -cosc * accumulated_x + z * tanc * accumulated_y
-    tangent = wp.mat33d()
-    tangent[0, 0] = s
-    tangent[1, 0] = s * lower0
-    tangent[1, 1] = s * sinc
-    tangent[1, 2] = -s * z * cosc
-    tangent[2, 0] = s * lower1
-    tangent[2, 1] = s * z * cosc
-    tangent[2, 2] = s * sinc
-
-    accumulated_dot_x = s * xid[1]
-    accumulated_dot_y = s * xid[2]
-    z_dot = s * xid[0]
-    x = z * z
-    sinc_dot = wp.float64(2.0) * z * derivatives[0] * z_dot
-    cosc_dot = wp.float64(2.0) * z * derivatives[1] * z_dot
-    z_cosc_dot = z_dot * (cosc + wp.float64(2.0) * x * derivatives[1])
-    z_tanc = z * tanc
-    z_tanc_dot = z_dot * (tanc + wp.float64(2.0) * x * derivatives[2])
-    lower_dot0 = (
-        cosc_dot * accumulated_y
-        + cosc * accumulated_dot_y
-        + z_tanc_dot * accumulated_x
-        + z_tanc * accumulated_dot_x
-    )
-    lower_dot1 = (
-        -cosc_dot * accumulated_x
-        - cosc * accumulated_dot_x
-        + z_tanc_dot * accumulated_y
-        + z_tanc * accumulated_dot_y
-    )
-    tangent_dot = wp.mat33d()
-    tangent_dot[1, 0] = s * lower_dot0
-    tangent_dot[1, 1] = s * sinc_dot
-    tangent_dot[1, 2] = -s * z_cosc_dot
-    tangent_dot[2, 0] = s * lower_dot1
-    tangent_dot[2, 1] = s * z_cosc_dot
-    tangent_dot[2, 2] = s * sinc_dot
-
-    transported_tangent = adjoint_inverse * tangent
-    local_velocity = transported_tangent * xid
-    transported_tangent_dot_velocity = adjoint_inverse * (tangent_dot * xid)
-    return (
-        adjoint_inverse,
-        transported_tangent,
-        local_velocity,
-        transported_tangent_dot_velocity,
-    )
 
 
 @wp.kernel(enable_backward=False)
@@ -273,7 +76,7 @@ def planar_local_operators_kernel(
         transported_tangent_value,
         local_velocity_value,
         transported_tangent_dot_velocity_value,
-    ) = _planar_operators(
+    ) = _constant_strain_operators(
         xi,
         xid,
         operator_points[segment, point],

--- a/src/soromox/execution/warp/pcs/planar_kinematics.py
+++ b/src/soromox/execution/warp/pcs/planar_kinematics.py
@@ -5,51 +5,13 @@ from __future__ import annotations
 
 import warp as wp
 
-from soromox.execution.warp.pcs.planar_kernels import (
-    _forward_coefficients,
-    _planar_operators,
+from soromox.execution.warp.common.se2 import (
+    _constant_strain_operators,
+    planar_pose_step,
 )
+from soromox.execution.warp.common.so2 import _rotation_matrix
 
 wp.set_module_options({"enable_backward": False})
-
-
-@wp.func
-def planar_pose_step(
-    theta: wp.float64,
-    x: wp.float64,
-    y: wp.float64,
-    xi: wp.vec3d,
-    arc_length: wp.float64,
-    eps: wp.float64,
-) -> wp.vec3d:
-    """Integrate one constant-strain SE(2) pose step.
-
-    Args:
-        theta: Absolute orientation at the start of the step.
-        x: Absolute horizontal position at the start of the step.
-        y: Absolute vertical position at the start of the step.
-        xi: Constant planar strain in angular-first coordinates.
-        arc_length: Local integration distance.
-        eps: Requested small-angle threshold.
-
-    Returns:
-        Absolute planar pose ``[theta, x, y]`` after the step.
-    """
-
-    z = arc_length * xi[0]
-    cutoff = wp.max(wp.abs(arc_length * eps), wp.float64(0.04964607461902946))
-    coefficients = _forward_coefficients(z, cutoff)
-    vx = arc_length * xi[1]
-    vy = arc_length * xi[2]
-    local_x = coefficients[0] * vx - z * coefficients[1] * vy
-    local_y = z * coefficients[1] * vx + coefficients[0] * vy
-    cosine = wp.cos(theta)
-    sine = wp.sin(theta)
-    return wp.vec3d(
-        theta + z,
-        x + cosine * local_x - sine * local_y,
-        y + sine * local_x + cosine * local_y,
-    )
 
 
 @wp.kernel(enable_backward=False)
@@ -187,7 +149,7 @@ def planar_segment_states_kernel(
         while row < 3:
             segment_pose[environment, segment + 1, row] = pose[row]
             row += 1
-        adjoint_inverse, transported_tangent, _, _ = _planar_operators(
+        adjoint_inverse, transported_tangent, _, _ = _constant_strain_operators(
             xi, wp.vec3d(), length, epsilons[0], epsilons[1]
         )
         row = int(0)
@@ -248,11 +210,10 @@ def write_planar_sample_jacobian(
         segment_strain[environment, segment, 1],
         segment_strain[environment, segment, 2],
     )
-    adjoint_inverse, transported_tangent, _, _ = _planar_operators(
+    adjoint_inverse, transported_tangent, _, _ = _constant_strain_operators(
         xi, wp.vec3d(), local_s, epsilons[0], epsilons[1]
     )
-    cosine = wp.cos(pose[0])
-    sine = wp.sin(pose[0])
+    rotation = _rotation_matrix(pose[0])
     row = int(0)
     while row < 3:
         column = int(0)
@@ -276,9 +237,9 @@ def write_planar_sample_jacobian(
                 body_row += 1
             output = body[0]
             if row == 1:
-                output = cosine * body[1] - sine * body[2]
+                output = rotation[0, 0] * body[1] + rotation[0, 1] * body[2]
             elif row == 2:
-                output = sine * body[1] + cosine * body[2]
+                output = rotation[1, 0] * body[1] + rotation[1, 1] * body[2]
             jacobians[environment, sample, row, column] = output
             column += 1
         row += 1

--- a/src/soromox/execution/warp/pcs/spatial_floating_kernels.py
+++ b/src/soromox/execution/warp/pcs/spatial_floating_kernels.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 
 import warp as wp
 
-from soromox.execution.warp.common.floating_base import (
-    _quaternion_rotation_transpose_entry,
-    _spatial_root_jacobian_entry,
-)
+from soromox.execution.warp.common.floating_base import _spatial_root_jacobian_entry
+from soromox.execution.warp.common.rotations import _quaternion_rotation_matrix
 from soromox.execution.warp.common.se3 import Vec6d, _ad_action
 from soromox.execution.warp.common.spatial import _coadjoint_wrench
 from soromox.execution.warp.common.storage import (
@@ -111,24 +109,20 @@ def spatial_floating_persistent_chain_kernel(
         entry += lane_stride
     row = lane
     while row < SPATIAL_DIM:
+        rotation = _quaternion_rotation_matrix(base_pose, environment)
         root_velocity = wp.float64(0.0)
         column = int(0)
-        while column < base_dofs:
+        while column < 3:
             root_velocity += (
-                _spatial_root_jacobian_entry(base_pose, environment, row, column)
-                * velocity[environment, column]
+                rotation[column, row % 3]
+                * velocity[environment, (0 if row < 3 else 3) + column]
             )
             column += 1
         root_gravity = wp.float64(0.0)
         if row >= 3:
             column = int(0)
             while column < 3:
-                root_gravity += (
-                    _quaternion_rotation_transpose_entry(
-                        base_pose, environment, row - 3, column
-                    )
-                    * gravity_world[column + 3]
-                )
+                root_gravity += rotation[column, row - 3] * gravity_world[column + 3]
                 column += 1
         derivative_first[state_base_row + row, 0] = wp.float64(0.0)
         derivative_second[state_base_row + row, 0] = wp.float64(0.0)

--- a/src/soromox/execution/warp/pcs/spatial_kinematics.py
+++ b/src/soromox/execution/warp/pcs/spatial_kinematics.py
@@ -12,9 +12,9 @@ from soromox.execution.warp.common.se3 import (
     _forward_coefficients,
     _left_action,
     _left_coefficients,
-    _rotation_entry,
     _translation,
 )
+from soromox.execution.warp.common.so3 import _rotation_entry
 
 wp.set_module_options({"enable_backward": False})
 

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -1619,65 +1619,66 @@ class SoftRobot(DynamicalSystem):
             World-frame Jacobians with matching leading dimensions and
             ``num_velocities`` columns.
         """
-        spatial_dimension = 3 if self.is_planar else 6
-        transform_dimension = 3 if self.is_planar else 4
         leading_shape = relative_transforms.shape[:-2]
-        transforms_flat = relative_transforms.reshape(
-            -1, transform_dimension, transform_dimension
-        )
-        jacobians_internal_flat = jacobians_internal.reshape(
-            -1, spatial_dimension, self.num_internal_dofs
-        )
-
-        adjoint_inverse = se2.adjoint_inverse if self.is_planar else se3.adjoint_inverse
-        relative_adjoint_inverses = vmap(adjoint_inverse)(transforms_flat)
-        root_jacobian = self._floating_base_body_jacobian(q)
-        jacobians_base_body = jnp.einsum(
-            "nij,jk->nik", relative_adjoint_inverses, root_jacobian
-        )
-
         base_transform = self.base_transform_from_configuration(q)
-        base_rotation = (
-            base_transform[:2, :2] if self.is_planar else base_transform[:3, :3]
-        )
-        world_transforms = jnp.einsum("ij,njk->nik", base_transform, transforms_flat)
+        linear_dimension = 2 if self.is_planar else 3
+        base_rotation = base_transform[:linear_dimension, :linear_dimension]
+        relative_positions = relative_transforms[
+            ..., :linear_dimension, linear_dimension
+        ]
+        world_offsets = jnp.einsum("ij,...j->...i", base_rotation, relative_positions)
+
         if self.is_planar:
-            base_rotation_action = jnp.zeros((3, 3), dtype=q.dtype)
-            base_rotation_action = base_rotation_action.at[0, 0].set(1.0)
-            base_rotation_action = base_rotation_action.at[1:, 1:].set(base_rotation)
-            world_rotation_actions = jnp.zeros(
-                (world_transforms.shape[0], 3, 3), dtype=q.dtype
+            jacobians_base = jnp.zeros(
+                (*leading_shape, 3, 3), dtype=jacobians_internal.dtype
             )
-            world_rotation_actions = world_rotation_actions.at[:, 0, 0].set(1.0)
-            world_rotation_actions = world_rotation_actions.at[:, 1:, 1:].set(
-                world_transforms[:, :2, :2]
+            jacobians_base = jacobians_base.at[..., 0, 0].set(1.0)
+            jacobians_base = jacobians_base.at[..., 1, 0].set(-world_offsets[..., 1])
+            jacobians_base = jacobians_base.at[..., 2, 0].set(world_offsets[..., 0])
+            jacobians_base = jacobians_base.at[..., 1, 1].set(1.0)
+            jacobians_base = jacobians_base.at[..., 2, 2].set(1.0)
+            jacobians_internal_world = jnp.concatenate(
+                [
+                    jacobians_internal[..., :1, :],
+                    jnp.einsum(
+                        "ij,...jk->...ik",
+                        base_rotation,
+                        jacobians_internal[..., 1:, :],
+                    ),
+                ],
+                axis=-2,
             )
         else:
-            base_rotation_action = jnp.zeros((6, 6), dtype=q.dtype)
-            base_rotation_action = base_rotation_action.at[:3, :3].set(base_rotation)
-            base_rotation_action = base_rotation_action.at[3:, 3:].set(base_rotation)
-            world_rotation_actions = jnp.zeros(
-                (world_transforms.shape[0], 6, 6), dtype=q.dtype
+            jacobians_base = jnp.broadcast_to(
+                jnp.eye(6, dtype=jacobians_internal.dtype), (*leading_shape, 6, 6)
             )
-            world_rotation_actions = world_rotation_actions.at[:, :3, :3].set(
-                world_transforms[:, :3, :3]
+            rx, ry, rz = (
+                world_offsets[..., 0],
+                world_offsets[..., 1],
+                world_offsets[..., 2],
             )
-            world_rotation_actions = world_rotation_actions.at[:, 3:, 3:].set(
-                world_transforms[:, :3, :3]
+            jacobians_base = jacobians_base.at[..., 3, 1].set(rz)
+            jacobians_base = jacobians_base.at[..., 3, 2].set(-ry)
+            jacobians_base = jacobians_base.at[..., 4, 0].set(-rz)
+            jacobians_base = jacobians_base.at[..., 4, 2].set(rx)
+            jacobians_base = jacobians_base.at[..., 5, 0].set(ry)
+            jacobians_base = jacobians_base.at[..., 5, 1].set(-rx)
+            jacobians_internal_world = jnp.concatenate(
+                [
+                    jnp.einsum(
+                        "ij,...jk->...ik",
+                        base_rotation,
+                        jacobians_internal[..., :3, :],
+                    ),
+                    jnp.einsum(
+                        "ij,...jk->...ik",
+                        base_rotation,
+                        jacobians_internal[..., 3:, :],
+                    ),
+                ],
+                axis=-2,
             )
-
-        jacobians_base_world = jnp.einsum(
-            "nij,njk->nik", world_rotation_actions, jacobians_base_body
-        )
-        jacobians_internal_world = jnp.einsum(
-            "ij,njk->nik", base_rotation_action, jacobians_internal_flat
-        )
-        jacobians_world = jnp.concatenate(
-            [jacobians_base_world, jacobians_internal_world], axis=-1
-        )
-        return jacobians_world.reshape(
-            *leading_shape, spatial_dimension, self.num_velocities
-        )
+        return jnp.concatenate([jacobians_base, jacobians_internal_world], axis=-1)
 
     def _floating_world_positions(self, q: Array, relative_positions: Array) -> Array:
         """

--- a/tests/execution/warp/test_gvs_directional.py
+++ b/tests/execution/warp/test_gvs_directional.py
@@ -261,14 +261,19 @@ def test_directional_gvs_products_match_dense_jacobians(
     assert_allclose(generalized_force.numpy(), 0.0, rtol=0.0, atol=0.0)
 
 
+@pytest.mark.parametrize("device_alias", ("cpu", "cuda:0"))
 def test_spatial_floating_directional_composition_matches_dense(
+    device_alias: str,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
     """Match common floating JVP/VJP composition to augmented Jacobians."""
 
     wp = pytest.importorskip("warp")
-    monkeypatch.setenv("WARP_CACHE_PATH", str(tmp_path / "floating-directional-cache"))
+    if device_alias == "cuda:0" and not wp.is_cuda_available():
+        pytest.skip("Floating directional CUDA composition requires CUDA.")
+    cache_name = f"floating-directional-cache-{device_alias.replace(':', '-')}"
+    monkeypatch.setenv("WARP_CACHE_PATH", str(tmp_path / cache_name))
     from soromox.execution.warp.common.floating_kinematics import (
         launch_spatial_floating_jacobian_composition,
         launch_spatial_floating_kinematics_jvp_composition,
@@ -276,7 +281,7 @@ def test_spatial_floating_directional_composition_matches_dense(
         launch_spatial_floating_vjp_composition,
     )
 
-    device = wp.get_device("cpu")
+    device = wp.get_device(device_alias)
     wp.set_device(device)
     batch_size, sample_count, internal_dofs = 2, 5, 7
     base_pose_host = np.asarray(
@@ -320,7 +325,7 @@ def test_spatial_floating_directional_composition_matches_dense(
         device=device,
     )
     launch_spatial_floating_jacobian_composition(
-        base_pose, relative_pose, internal_jacobian, full_jacobian
+        base_pose, relative_pose, internal_jacobian, 32, full_jacobian
     )
 
     full_velocity = _warp_array(wp, full_velocity_host, device=device)


### PR DESCRIPTION
## Summary

- parallelize spatial floating-Jacobian composition with one cooperative CUDA
  block per environment/sample and shared root-rotation and offset data
- construct floating-world Jacobians directly in JAX instead of materializing
  inverse adjoints and dense spatial rotation actions
- centralize Warp quaternion, SO(2), SO(3), SE(2), and SE(3) helpers and reuse
  shared rotation actions and exponential operators across pose,
  dense-Jacobian, JVP, VJP, PCS, and GVS execution
- reuse each normalized root rotation across velocity and gravity products in
  floating GVS and PCS dynamics
- fold the resulting kinematics and dynamics measurements into the existing
  unreleased changelog entries

The changes preserve the current scalar-last spatial base pose convention
`[qx, qy, qz, qw, x, y, z]`, the identity fallback for a zero quaternion, and
the existing public kinematics and directional-product APIs.

## Implementation

The spatial CUDA Jacobian path now launches a tiled kernel with one block per
environment/sample. The first lanes populate the normalized root rotation and
world offset in shared memory; all lanes then distribute the
`6 * (num_internal_dofs + 6)` output entries. The block dimension comes from
the validated backend parameters. Warp CPU execution retains a simple
one-thread-per-sample kernel, avoiding CUDA synchronization structure on the
CPU path.

Pose composition and the matrix-free floating JVP/VJP kernels compute one full
quaternion rotation matrix per sample and reuse it. The JVP/VJP paths were
added after the original dense composition implementation, so this PR extends
the same matrix-reuse principle to them without adding a tiled schedule whose
barriers would dominate their six-value output.

The JAX path directly constructs the floating base columns from the rotated
sample offset and rotates only the internal angular and linear Jacobian
blocks. This removes flattened transforms, inverse adjoints, and intermediate
`6 x 6` rotation-action arrays while retaining arbitrary leading sample
dimensions.

Shared Warp math is split by representation: `rotations.py` owns normalized
scalar-last quaternion matrices, `so2.py` owns planar matrices and vector
actions, `so3.py` owns exponential-coordinate rotation entries, `se2.py` owns
stable planar exponential and constant-strain operators, and `se3.py` owns the
spatial exponential transform. Floating, directional, GVS, and PCS kernels use
those helpers instead of carrying model-local copies. Existing public PCS
imports, including `planar_pose_step`, remain unchanged.

## Performance

Benchmarks compare this commit with `origin/main` at `0c2276a`. Warm runtimes
are synchronized medians after compilation and warm-up. JAX CPU measurements
ran on one pinned core of an Intel Core Ultra 9 285K and report the average of
two independent benchmark processes. CUDA measurements ran on an NVIDIA
GeForce RTX 5090. Both use FP64 with JAX 0.11.0 and Warp 1.16.0.

### JAX CPU floating-world Jacobian composition

The direct adapter case uses a four-segment spatial PCS model with 24 internal
DOFs. The public case includes the fixed-base PCS traversal plus floating pose
and inertial-Jacobian composition.

| Workload | `origin/main` (us) | This PR (us) | Speedup | Reduction |
|---|---:|---:|---:|---:|
| Direct adapter, 1 sample | 6.347 | 6.004 | **1.06x** | 5.5% |
| Direct adapter, 64 samples | 27.165 | 17.647 | **1.54x** | 35.0% |
| Direct adapter, 1024 samples | 380.119 | 222.971 | **1.70x** | 41.3% |
| Public PCS4 pose + Jacobian, 64 samples | 137.765 | 119.064 | **1.16x** | 13.6% |

The direct adapter's StableHLO text is approximately **41% smaller** across
the measured sample counts, reflecting the removal of the inverse-adjoint and
dense rotation-action intermediates.

### Warp CUDA floating composition

Dense-Jacobian cases use 64 samples per environment. `E` denotes environments
and `D` internal DOFs.

| Shape `(E, N, D)` | `origin/main` (us) | This PR (us) | Speedup | Reduction |
|---|---:|---:|---:|---:|
| `(1, 64, 24)` | 171.3 | 8.10 | **21.1x** | 95.3% |
| `(64, 64, 24)` | 327.1 | 16.52 | **19.8x** | 94.9% |
| `(256, 64, 24)` | 328.2 | 55.08 | **5.96x** | 83.2% |
| `(64, 64, 96)` | 1290.1 | 23.57 | **54.7x** | 98.2% |

Full-matrix reuse also reduces pose composition by **2.18x-3.47x** across
`E = 1, 64, 256`.

Directional composition produces only six values per sample and therefore
does not expose the large output-parallelism gain of the dense tiled kernel.
It still benefits from calculating the normalized root rotation once:

| Operation | `E=1` | `E=64` | `E=256` |
|---|---:|---:|---:|
| Floating JVP speedup | **1.86x** | **3.25x** | **3.06x** |
| Floating VJP speedup | **1.13x** | **1.80x** | **1.67x** |

Candidate JVP/VJP runtimes are approximately 9-12 microseconds, where launch
and VJP atomic-accumulation costs form a substantial fraction of the total.
Moving the remaining generic Lie-group operations into shared modules keeps
these directional runtimes within 3.3% of the already-optimized implementation
across the same shapes; unlike the dense Jacobian, their six-value output does
not benefit from cooperative output tiling. A helper-only A/B comparison with
the preceding PR revision kept the complete four-segment PlanarPCS
pose-plus-Jacobian path within the 2.5% regression gate: +0.2% at batch 1 and
+2.2% at batch 256. One-segment PlanarPCS dynamics improved 1.9% at batch 256.

### Warp CUDA floating dynamics

The dynamics comparison uses one-segment systems, a one-second warm-up, and
nine trials with repeated calls per trial. Root setup is a small fraction of
the full fused dynamics kernel, so the end-to-end effect is intentionally more
modest than isolated composition.

| System / batch | `origin/main` (us) | This PR (us) | Speedup | Reduction |
|---|---:|---:|---:|---:|
| PCS, batch 1 | 77.998 | 73.135 | **1.07x** | 6.2% |
| PCS, batch 256 | 90.594 | 86.652 | **1.05x** | 4.4% |
| GVS, batch 1 | 117.160 | 112.667 | **1.04x** | 3.8% |
| GVS, batch 256 | 128.229 | 124.128 | **1.03x** | 3.2% |

## Validation

- final focused Warp architecture, PlanarPCS, GVS, and directional CPU
  regression suite: `25 passed, 7 skipped`
- final focused PlanarPCS, GVS, and directional CUDA regression suite:
  `15 passed`
- floating continuum Warp kinematics agrees with JAX on CPU and CUDA
- floating PCS and GVS dynamics regression tests pass on CUDA
- direct spatial floating dense-Jacobian, JVP, and VJP equivalence passes on
  both CPU and CUDA
- Ruff lint and `git diff --check` pass for all modified files
