### PR TITLE
Fix Section Vd base pose after scalar-last migration

### DIFF
--- a/paper_results/secVd_control_gain_optimization/code/secvd_case.py
+++ b/paper_results/secVd_control_gain_optimization/code/secvd_case.py
@@ -69,7 +69,8 @@ def build_sec_vd_robot() -> tuple[PCS, ThreadlikeRouting, float]:
     )
     robot = PCS.from_links(
         links,
-        base_pose=jnp.array([0.5, 0.5, -0.5, 0.5, 0.0, 0.0, 0.0]),
+        # Scalar-last quaternion pose: [qx, qy, qz, qw, x, y, z].
+        base_pose=jnp.array([0.5, -0.5, 0.5, 0.5, 0.0, 0.0, 0.0]),
         gravity=jnp.array([0.0, 0.0, 9.81]),
         actuators=ThreadlikeActuator.tendons(routing),
     )


### PR DESCRIPTION
## Summary

- reorder the Section Vd fixed-base quaternion to scalar-last coordinates
- preserve the physical mounting orientation used to generate the committed optimization trajectories
- document the pose layout next to the custom quaternion literal

## Root cause

PR #186 migrated SoRoMoX spatial poses from `[qw, qx, qy, qz, x, y, z]` to `[qx, qy, qz, qw, x, y, z]`, but `build_sec_vd_robot()` retained its scalar-first literal. The same four values were therefore interpreted as a different rotation, causing both committed-pose consistency checks to fail in every current main-branch test job.

Failed main run: https://github.com/tud-phi/soromox/actions/runs/33411748037

Introducing PR: https://github.com/tud-phi/soromox/pull/186

## Validation

- `PYTHONPATH=src .../.venv/bin/python -m pytest tests/paper_results/secVd/test_plot_and_renderer.py -q` — 10 passed
- Ruff check — passed
- Ruff format check — passed
- `git diff --check` — passed
