### PR TITLE
Improve Warp naming and docstring conventions

### DIFF
--- a/src/soromox/execution/warp/common/floating_base.py
+++ b/src/soromox/execution/warp/common/floating_base.py
@@ -38,38 +38,47 @@ def _spatial_root_jacobian_entry(
 
 @wp.kernel(enable_backward=False)
 def _prepend_zeros_kernel(
-    internal: wp.array2d[wp.float64],
+    values_internal: wp.array2d[wp.float64],
     prefix: int,
-    output: wp.array2d[wp.float64],
+    values: wp.array2d[wp.float64],
 ):
-    """Copy an internal generalized vector behind an exact zero prefix."""
+    """Copy an internal generalized vector behind an exact zero prefix.
+
+    Args:
+        values_internal: Batched internal generalized vectors.
+        prefix: Number of leading entries to set to zero.
+        values: Caller-owned augmented generalized vectors.
+
+    Returns:
+        None. One entry in ``values`` is written per thread.
+    """
     environment, column = wp.tid()
     value = wp.float64(0.0)
     if column >= prefix:
-        value = internal[environment, column - prefix]
-    output[environment, column] = value
+        value = values_internal[environment, column - prefix]
+    values[environment, column] = value
 
 
 def launch_prepend_zeros(
-    internal: wp.array2d[wp.float64],
+    values_internal: wp.array2d[wp.float64],
     prefix: int,
-    output: wp.array2d[wp.float64],
+    values: wp.array2d[wp.float64],
 ):
     """Launch a specialized zero-prefix copy into caller-owned storage.
 
     Args:
-        internal: Batched internal generalized vectors.
+        values_internal: Batched internal generalized vectors.
         prefix: Number of leading floating-base entries.
-        output: Batched total generalized-vector output.
+        values: Batched total generalized-vector output.
 
     Returns:
-        None. ``output`` is updated in place.
+        None. ``values`` is updated in place.
     """
     wp.launch(
         _prepend_zeros_kernel,
-        dim=output.shape,
-        inputs=[internal, prefix],
-        outputs=[output],
+        dim=values.shape,
+        inputs=[values_internal, prefix],
+        outputs=[values],
     )
 
 

--- a/src/soromox/execution/warp/common/floating_kinematics.py
+++ b/src/soromox/execution/warp/common/floating_kinematics.py
@@ -21,10 +21,20 @@ wp.set_module_options({"enable_backward": False})
 def _compose_spatial_poses_kernel(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array4d[wp.float64],
-    output: wp.array4d[wp.float64],
+    poses: wp.array4d[wp.float64],
 ):
+    """Compose batched spatial base poses and base-relative transforms.
+
+    Args:
+        base_pose: Scalar-last base poses with shape ``(E, 7)``.
+        relative_pose: Base-relative transforms with shape ``(E, N, 4, 4)``.
+        poses: Inertial-frame transform output with shape ``(E, N, 4, 4)``.
+
+    Returns:
+        None. One transform in ``poses`` is written per thread.
+    """
     environment, sample = wp.tid()
-    rotation = _quaternion_rotation_matrix(base_pose, environment)
+    base_rotation = _quaternion_rotation_matrix(base_pose, environment)
     row = int(0)
     while row < 3:
         column = int(0)
@@ -33,45 +43,64 @@ def _compose_spatial_poses_kernel(
             inner = int(0)
             while inner < 3:
                 value += (
-                    rotation[row, inner]
+                    base_rotation[row, inner]
                     * relative_pose[environment, sample, inner, column]
                 )
                 inner += 1
-            output[environment, sample, row, column] = value
+            poses[environment, sample, row, column] = value
             column += 1
         position = base_pose[environment, 4 + row]
         inner = int(0)
         while inner < 3:
             position += (
-                rotation[row, inner] * relative_pose[environment, sample, inner, 3]
+                base_rotation[row, inner] * relative_pose[environment, sample, inner, 3]
             )
             inner += 1
-        output[environment, sample, row, 3] = position
+        poses[environment, sample, row, 3] = position
         row += 1
     column = int(0)
     while column < 3:
-        output[environment, sample, 3, column] = wp.float64(0.0)
+        poses[environment, sample, 3, column] = wp.float64(0.0)
         column += 1
-    output[environment, sample, 3, 3] = wp.float64(1.0)
+    poses[environment, sample, 3, 3] = wp.float64(1.0)
 
 
 @wp.kernel(enable_backward=False)
 def _compose_spatial_jacobians_kernel(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array4d[wp.float64],
-    internal: wp.array4d[wp.float64],
-    output: wp.array4d[wp.float64],
+    jacobians_internal: wp.array4d[wp.float64],
+    jacobians: wp.array4d[wp.float64],
 ):
+    """Compose spatial floating-base Jacobians on one thread per sample.
+
+    Args:
+        base_pose: Scalar-last base poses with shape ``(E, 7)``.
+        relative_pose: Base-relative transforms with shape ``(E, N, 4, 4)``.
+        jacobians_internal: Base-frame internal Jacobians with shape
+            ``(E, N, 6, D)``.
+        jacobians: Inertial-frame augmented output with shape
+            ``(E, N, 6, D + 6)``.
+
+    Returns:
+        None. One augmented Jacobian in ``jacobians`` is written per thread.
+    """
     environment, sample = wp.tid()
-    rotation = _quaternion_rotation_matrix(base_pose, environment)
-    rx = wp.float64(0.0)
-    ry = wp.float64(0.0)
-    rz = wp.float64(0.0)
+    base_rotation = _quaternion_rotation_matrix(base_pose, environment)
+    offset_x = wp.float64(0.0)
+    offset_y = wp.float64(0.0)
+    offset_z = wp.float64(0.0)
     inner = int(0)
     while inner < 3:
-        rx += rotation[0, inner] * relative_pose[environment, sample, inner, 3]
-        ry += rotation[1, inner] * relative_pose[environment, sample, inner, 3]
-        rz += rotation[2, inner] * relative_pose[environment, sample, inner, 3]
+        offset_x += (
+            base_rotation[0, inner] * relative_pose[environment, sample, inner, 3]
+        )
+        offset_y += (
+            base_rotation[1, inner] * relative_pose[environment, sample, inner, 3]
+        )
+        offset_z += (
+            base_rotation[2, inner] * relative_pose[environment, sample, inner, 3]
+        )
         inner += 1
 
     row = int(0)
@@ -82,27 +111,27 @@ def _compose_spatial_jacobians_kernel(
             if (row < 3 and column < 3 or row >= 3 and column >= 3) and row == column:
                 value = wp.float64(1.0)
             elif row == 3 and column == 1:
-                value = rz
+                value = offset_z
             elif row == 3 and column == 2:
-                value = -ry
+                value = -offset_y
             elif row == 4 and column == 0:
-                value = -rz
+                value = -offset_z
             elif row == 4 and column == 2:
-                value = rx
+                value = offset_x
             elif row == 5 and column == 0:
-                value = ry
+                value = offset_y
             elif row == 5 and column == 1:
-                value = -rx
-            output[environment, sample, row, column] = value
+                value = -offset_x
+            jacobians[environment, sample, row, column] = value
             column += 1
         internal_column = int(0)
-        while internal_column < internal.shape[3]:
+        while internal_column < jacobians_internal.shape[3]:
             value = wp.float64(0.0)
             inner = int(0)
             while inner < 3:
                 value += (
-                    rotation[row % 3, inner]
-                    * internal[
+                    base_rotation[row % 3, inner]
+                    * jacobians_internal[
                         environment,
                         sample,
                         (0 if row < 3 else 3) + inner,
@@ -110,7 +139,7 @@ def _compose_spatial_jacobians_kernel(
                     ]
                 )
                 inner += 1
-            output[environment, sample, row, 6 + internal_column] = value
+            jacobians[environment, sample, row, 6 + internal_column] = value
             internal_column += 1
         row += 1
 
@@ -119,28 +148,29 @@ def _compose_spatial_jacobians_kernel(
 def _compose_spatial_jacobians_tiled_kernel(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array4d[wp.float64],
-    internal: wp.array4d[wp.float64],
-    output: wp.array4d[wp.float64],
+    jacobians_internal: wp.array4d[wp.float64],
+    jacobians: wp.array4d[wp.float64],
 ):
     """Compose one floating spatial Jacobian cooperatively per sample.
 
     Args:
         base_pose: Batched scalar-last quaternion poses with shape ``(E, 7)``.
         relative_pose: Base-relative transforms with shape ``(E, N, 4, 4)``.
-        internal: Base-frame internal Jacobians with shape ``(E, N, 6, D)``.
-        output: World-frame augmented Jacobians with shape
+        jacobians_internal: Base-frame internal Jacobians with shape
+            ``(E, N, 6, D)``.
+        jacobians: Inertial-frame augmented Jacobians with shape
             ``(E, N, 6, D + 6)``.
 
     Returns:
-        None. ``output`` is updated in place by one cooperative block for each
-        environment-sample pair.
+        None. ``jacobians`` is updated in place by one cooperative block for
+        each environment-sample pair.
     """
     work_item, lane = wp.tid()
     sample_count = relative_pose.shape[1]
     environment = work_item // sample_count
     sample = work_item - environment * sample_count
-    rotation = wp.tile_zeros(shape=(9,), dtype=wp.float64, storage="shared")
-    position = wp.tile_zeros(shape=(3,), dtype=wp.float64, storage="shared")
+    base_rotation = wp.tile_zeros(shape=(9,), dtype=wp.float64, storage="shared")
+    world_offset = wp.tile_zeros(shape=(3,), dtype=wp.float64, storage="shared")
 
     rotation_entry = wp.float64(0.0)
     if lane < 9:
@@ -149,21 +179,21 @@ def _compose_spatial_jacobians_tiled_kernel(
         rotation_entry = _quaternion_rotation_transpose_entry(
             base_pose, environment, rotation_column, rotation_row
         )
-    wp.tile_scatter_masked(rotation, lane, rotation_entry, lane < 9)
+    wp.tile_scatter_masked(base_rotation, lane, rotation_entry, lane < 9)
 
-    position_entry = wp.float64(0.0)
+    world_offset_entry = wp.float64(0.0)
     if lane < 3:
         inner = int(0)
         while inner < 3:
-            position_entry += (
-                rotation[3 * lane + inner]
+            world_offset_entry += (
+                base_rotation[3 * lane + inner]
                 * relative_pose[environment, sample, inner, 3]
             )
             inner += 1
-    wp.tile_scatter_masked(position, lane, position_entry, lane < 3)
+    wp.tile_scatter_masked(world_offset, lane, world_offset_entry, lane < 3)
 
     entry = lane
-    column_count = output.shape[3]
+    column_count = jacobians.shape[3]
     while entry < 6 * column_count:
         row = entry // column_count
         column = entry - row * column_count
@@ -172,24 +202,24 @@ def _compose_spatial_jacobians_tiled_kernel(
             if row == column and (row < 3 and column < 3 or row >= 3 and column >= 3):
                 value = wp.float64(1.0)
             elif row == 3 and column == 1:
-                value = position[2]
+                value = world_offset[2]
             elif row == 3 and column == 2:
-                value = -position[1]
+                value = -world_offset[1]
             elif row == 4 and column == 0:
-                value = -position[2]
+                value = -world_offset[2]
             elif row == 4 and column == 2:
-                value = position[0]
+                value = world_offset[0]
             elif row == 5 and column == 0:
-                value = position[1]
+                value = world_offset[1]
             elif row == 5 and column == 1:
-                value = -position[0]
+                value = -world_offset[0]
         else:
             internal_column = column - 6
             inner = int(0)
             while inner < 3:
                 value += (
-                    rotation[3 * (row % 3) + inner]
-                    * internal[
+                    base_rotation[3 * (row % 3) + inner]
+                    * jacobians_internal[
                         environment,
                         sample,
                         (0 if row < 3 else 3) + inner,
@@ -197,16 +227,16 @@ def _compose_spatial_jacobians_tiled_kernel(
                     ]
                 )
                 inner += 1
-        output[environment, sample, row, column] = value
+        jacobians[environment, sample, row, column] = value
         entry += wp.block_dim()
 
 
 @wp.kernel(enable_backward=False)
 def _compose_spatial_poses_and_twists_kernel(
     base_pose: wp.array2d[wp.float64],
-    base_velocity: wp.array2d[wp.float64],
+    qd: wp.array2d[wp.float64],
     relative_pose: wp.array4d[wp.float64],
-    internal_twist: wp.array3d[wp.float64],
+    twists_internal: wp.array3d[wp.float64],
     poses: wp.array4d[wp.float64],
     twists: wp.array3d[wp.float64],
 ):
@@ -214,10 +244,10 @@ def _compose_spatial_poses_and_twists_kernel(
 
     Args:
         base_pose: Runtime scalar-last base poses ``(E, 7)``.
-        base_velocity: Runtime generalized velocities whose first six entries
-            are the angular-linear base direction.
+        qd: Batched generalized-velocity directions. The first six entries are
+            the angular-linear world-frame base direction.
         relative_pose: Fixed-base relative sample poses ``(E, N, 4, 4)``.
-        internal_twist: Relative inertial JVPs ``(E, N, 6)``.
+        twists_internal: Base-frame internal-Jacobian products ``(E, N, 6)``.
         poses: Absolute pose output ``(E, N, 4, 4)``.
         twists: Absolute inertial JVP output ``(E, N, 6)``.
 
@@ -226,26 +256,32 @@ def _compose_spatial_poses_and_twists_kernel(
     """
 
     environment, sample = wp.tid()
-    rotation = _quaternion_rotation_matrix(base_pose, environment)
-    rx = wp.float64(0.0)
-    ry = wp.float64(0.0)
-    rz = wp.float64(0.0)
+    base_rotation = _quaternion_rotation_matrix(base_pose, environment)
+    offset_x = wp.float64(0.0)
+    offset_y = wp.float64(0.0)
+    offset_z = wp.float64(0.0)
     inner = int(0)
     while inner < 3:
-        rx += rotation[0, inner] * relative_pose[environment, sample, inner, 3]
-        ry += rotation[1, inner] * relative_pose[environment, sample, inner, 3]
-        rz += rotation[2, inner] * relative_pose[environment, sample, inner, 3]
+        offset_x += (
+            base_rotation[0, inner] * relative_pose[environment, sample, inner, 3]
+        )
+        offset_y += (
+            base_rotation[1, inner] * relative_pose[environment, sample, inner, 3]
+        )
+        offset_z += (
+            base_rotation[2, inner] * relative_pose[environment, sample, inner, 3]
+        )
         inner += 1
-    radius = wp.vec3d(rx, ry, rz)
-    base_angular = wp.vec3d(
-        base_velocity[environment, 0],
-        base_velocity[environment, 1],
-        base_velocity[environment, 2],
+    world_offset = wp.vec3d(offset_x, offset_y, offset_z)
+    base_angular_velocity = wp.vec3d(
+        qd[environment, 0],
+        qd[environment, 1],
+        qd[environment, 2],
     )
-    base_linear = wp.vec3d(
-        base_velocity[environment, 3],
-        base_velocity[environment, 4],
-        base_velocity[environment, 5],
+    base_linear_velocity = wp.vec3d(
+        qd[environment, 3],
+        qd[environment, 4],
+        qd[environment, 5],
     )
 
     row = int(0)
@@ -256,14 +292,14 @@ def _compose_spatial_poses_and_twists_kernel(
             inner = int(0)
             while inner < 3:
                 value += (
-                    rotation[row, inner]
+                    base_rotation[row, inner]
                     * relative_pose[environment, sample, inner, column]
                 )
                 inner += 1
             poses[environment, sample, row, column] = value
             column += 1
         poses[environment, sample, row, 3] = (
-            base_pose[environment, 4 + row] + radius[row]
+            base_pose[environment, 4 + row] + world_offset[row]
         )
         row += 1
     column = int(0)
@@ -272,19 +308,25 @@ def _compose_spatial_poses_and_twists_kernel(
         column += 1
     poses[environment, sample, 3, 3] = wp.float64(1.0)
 
-    point_velocity = base_linear + wp.cross(base_angular, radius)
+    base_point_velocity = base_linear_velocity + wp.cross(
+        base_angular_velocity, world_offset
+    )
     row = int(0)
     while row < 3:
-        angular = base_angular[row]
-        linear = point_velocity[row]
+        angular_velocity = base_angular_velocity[row]
+        linear_velocity = base_point_velocity[row]
         inner = int(0)
         while inner < 3:
-            rotation_entry = rotation[row, inner]
-            angular += rotation_entry * internal_twist[environment, sample, inner]
-            linear += rotation_entry * internal_twist[environment, sample, 3 + inner]
+            rotation_entry = base_rotation[row, inner]
+            angular_velocity += (
+                rotation_entry * twists_internal[environment, sample, inner]
+            )
+            linear_velocity += (
+                rotation_entry * twists_internal[environment, sample, 3 + inner]
+            )
             inner += 1
-        twists[environment, sample, row] = angular
-        twists[environment, sample, 3 + row] = linear
+        twists[environment, sample, row] = angular_velocity
+        twists[environment, sample, 3 + row] = linear_velocity
         row += 1
 
 
@@ -302,7 +344,8 @@ def _compose_spatial_wrench_vjp_kernel(
         base_pose: Runtime scalar-last base poses ``(E, 7)``.
         relative_pose: Fixed-base relative sample poses ``(E, N, 4, 4)``.
         inertial_wrenches: Absolute inertial sample cotangents ``(E, N, 6)``.
-        relative_wrenches: Rotated cotangent output for the internal VJP.
+        relative_wrenches: Rotated cotangent output for the internal VJP with
+            shape ``(E, N, 6)``.
         base_generalized_force: Base effort accumulator ``(E, 6)``.
 
     Returns:
@@ -311,14 +354,14 @@ def _compose_spatial_wrench_vjp_kernel(
     """
 
     environment, sample = wp.tid()
-    rotation = _quaternion_rotation_matrix(base_pose, environment)
-    radius = wp.vec3d()
+    base_rotation = _quaternion_rotation_matrix(base_pose, environment)
+    world_offset = wp.vec3d()
     row = int(0)
     while row < 3:
         inner = int(0)
         while inner < 3:
-            radius[row] += (
-                rotation[row, inner] * relative_pose[environment, sample, inner, 3]
+            world_offset[row] += (
+                base_rotation[row, inner] * relative_pose[environment, sample, inner, 3]
             )
             inner += 1
         row += 1
@@ -332,14 +375,14 @@ def _compose_spatial_wrench_vjp_kernel(
         inertial_wrenches[environment, sample, 4],
         inertial_wrenches[environment, sample, 5],
     )
-    base_moment = moment + wp.cross(radius, force)
+    base_moment = moment + wp.cross(world_offset, force)
     row = int(0)
     while row < 3:
         relative_moment = wp.float64(0.0)
         relative_force = wp.float64(0.0)
         inner = int(0)
         while inner < 3:
-            rotation_entry = rotation[inner, row]
+            rotation_entry = base_rotation[inner, row]
             relative_moment += rotation_entry * moment[inner]
             relative_force += rotation_entry * force[inner]
             inner += 1
@@ -382,9 +425,9 @@ def _assemble_floating_vjp_kernel(
 @wp.kernel(enable_backward=False)
 def _compose_planar_poses_and_twists_kernel(
     base_pose: wp.array2d[wp.float64],
-    base_velocity: wp.array2d[wp.float64],
+    qd: wp.array2d[wp.float64],
     relative_pose: wp.array3d[wp.float64],
-    internal_twist: wp.array3d[wp.float64],
+    twists_internal: wp.array3d[wp.float64],
     poses: wp.array3d[wp.float64],
     twists: wp.array3d[wp.float64],
 ):
@@ -392,10 +435,10 @@ def _compose_planar_poses_and_twists_kernel(
 
     Args:
         base_pose: Runtime planar base poses ``(E, 3)``.
-        base_velocity: Runtime generalized velocities whose first three entries
-            are the angular-linear base direction.
+        qd: Batched generalized-velocity directions. The first three entries
+            are the angular-linear world-frame base direction.
         relative_pose: Fixed-base relative sample poses ``(E, N, 3)``.
-        internal_twist: Relative inertial JVPs ``(E, N, 3)``.
+        twists_internal: Base-frame internal-Jacobian products ``(E, N, 3)``.
         poses: Absolute pose output ``(E, N, 3)``.
         twists: Absolute inertial JVP output ``(E, N, 3)``.
 
@@ -405,25 +448,31 @@ def _compose_planar_poses_and_twists_kernel(
 
     environment, sample = wp.tid()
     theta = base_pose[environment, 0]
-    rotation = _rotation_matrix(theta)
-    radius = rotation * wp.vec2d(
+    base_rotation = _rotation_matrix(theta)
+    world_offset = base_rotation * wp.vec2d(
         relative_pose[environment, sample, 1],
         relative_pose[environment, sample, 2],
     )
-    internal_linear = rotation * wp.vec2d(
-        internal_twist[environment, sample, 1],
-        internal_twist[environment, sample, 2],
+    internal_linear_velocity = base_rotation * wp.vec2d(
+        twists_internal[environment, sample, 1],
+        twists_internal[environment, sample, 2],
     )
-    angular = base_velocity[environment, 0]
+    base_angular_velocity = qd[environment, 0]
     poses[environment, sample, 0] = theta + relative_pose[environment, sample, 0]
-    poses[environment, sample, 1] = base_pose[environment, 1] + radius[0]
-    poses[environment, sample, 2] = base_pose[environment, 2] + radius[1]
-    twists[environment, sample, 0] = angular + internal_twist[environment, sample, 0]
+    poses[environment, sample, 1] = base_pose[environment, 1] + world_offset[0]
+    poses[environment, sample, 2] = base_pose[environment, 2] + world_offset[1]
+    twists[environment, sample, 0] = (
+        base_angular_velocity + twists_internal[environment, sample, 0]
+    )
     twists[environment, sample, 1] = (
-        base_velocity[environment, 1] - angular * radius[1] + internal_linear[0]
+        qd[environment, 1]
+        - base_angular_velocity * world_offset[1]
+        + internal_linear_velocity[0]
     )
     twists[environment, sample, 2] = (
-        base_velocity[environment, 2] + angular * radius[0] + internal_linear[1]
+        qd[environment, 2]
+        + base_angular_velocity * world_offset[0]
+        + internal_linear_velocity[1]
     )
 
 
@@ -441,7 +490,8 @@ def _compose_planar_wrench_vjp_kernel(
         base_pose: Runtime planar base poses ``(E, 3)``.
         relative_pose: Fixed-base relative sample poses ``(E, N, 3)``.
         inertial_wrenches: Absolute inertial sample cotangents ``(E, N, 3)``.
-        relative_wrenches: Rotated cotangent output for the internal VJP.
+        relative_wrenches: Rotated cotangent output for the internal VJP with
+            shape ``(E, N, 3)``.
         base_generalized_force: Base effort accumulator ``(E, 3)``.
 
     Returns:
@@ -451,8 +501,8 @@ def _compose_planar_wrench_vjp_kernel(
 
     environment, sample = wp.tid()
     theta = base_pose[environment, 0]
-    rotation = _rotation_matrix(theta)
-    radius = rotation * wp.vec2d(
+    base_rotation = _rotation_matrix(theta)
+    world_offset = base_rotation * wp.vec2d(
         relative_pose[environment, sample, 1],
         relative_pose[environment, sample, 2],
     )
@@ -460,8 +510,8 @@ def _compose_planar_wrench_vjp_kernel(
     force_x = inertial_wrenches[environment, sample, 1]
     force_y = inertial_wrenches[environment, sample, 2]
     relative_force = wp.vec2d(
-        rotation[0, 0] * force_x + rotation[1, 0] * force_y,
-        rotation[0, 1] * force_x + rotation[1, 1] * force_y,
+        base_rotation[0, 0] * force_x + base_rotation[1, 0] * force_y,
+        base_rotation[0, 1] * force_x + base_rotation[1, 1] * force_y,
     )
     relative_wrenches[environment, sample, 0] = moment
     relative_wrenches[environment, sample, 1] = relative_force[0]
@@ -470,7 +520,7 @@ def _compose_planar_wrench_vjp_kernel(
         base_generalized_force,
         environment,
         0,
-        moment + radius[0] * force_y - radius[1] * force_x,
+        moment + world_offset[0] * force_y - world_offset[1] * force_x,
     )
     wp.atomic_add(base_generalized_force, environment, 1, force_x)
     wp.atomic_add(base_generalized_force, environment, 2, force_y)
@@ -480,58 +530,81 @@ def _compose_planar_wrench_vjp_kernel(
 def _compose_planar_poses_kernel(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array3d[wp.float64],
-    output: wp.array3d[wp.float64],
+    poses: wp.array3d[wp.float64],
 ):
+    """Compose batched planar base poses and base-relative poses.
+
+    Args:
+        base_pose: Planar base poses with shape ``(E, 3)``.
+        relative_pose: Base-relative poses with shape ``(E, N, 3)``.
+        poses: Inertial-frame pose output with shape ``(E, N, 3)``.
+
+    Returns:
+        None. One pose in ``poses`` is written per thread.
+    """
     environment, sample = wp.tid()
     theta = base_pose[environment, 0]
-    radius = _rotate_vector(
+    world_offset = _rotate_vector(
         theta,
         wp.vec2d(
             relative_pose[environment, sample, 1],
             relative_pose[environment, sample, 2],
         ),
     )
-    output[environment, sample, 0] = theta + relative_pose[environment, sample, 0]
-    output[environment, sample, 1] = base_pose[environment, 1] + radius[0]
-    output[environment, sample, 2] = base_pose[environment, 2] + radius[1]
+    poses[environment, sample, 0] = theta + relative_pose[environment, sample, 0]
+    poses[environment, sample, 1] = base_pose[environment, 1] + world_offset[0]
+    poses[environment, sample, 2] = base_pose[environment, 2] + world_offset[1]
 
 
 @wp.kernel(enable_backward=False)
 def _compose_planar_jacobians_kernel(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array3d[wp.float64],
-    internal: wp.array4d[wp.float64],
-    output: wp.array4d[wp.float64],
+    jacobians_internal: wp.array4d[wp.float64],
+    jacobians: wp.array4d[wp.float64],
 ):
+    """Compose planar floating-base Jacobians on one thread per sample.
+
+    Args:
+        base_pose: Planar base poses with shape ``(E, 3)``.
+        relative_pose: Base-relative poses with shape ``(E, N, 3)``.
+        jacobians_internal: Base-frame internal Jacobians with shape
+            ``(E, N, 3, D)``.
+        jacobians: Inertial-frame augmented output with shape
+            ``(E, N, 3, D + 3)``.
+
+    Returns:
+        None. One augmented Jacobian in ``jacobians`` is written per thread.
+    """
     environment, sample = wp.tid()
     theta = base_pose[environment, 0]
-    rotation = _rotation_matrix(theta)
-    radius = rotation * wp.vec2d(
+    base_rotation = _rotation_matrix(theta)
+    world_offset = base_rotation * wp.vec2d(
         relative_pose[environment, sample, 1],
         relative_pose[environment, sample, 2],
     )
 
-    output[environment, sample, 0, 0] = wp.float64(1.0)
-    output[environment, sample, 0, 1] = wp.float64(0.0)
-    output[environment, sample, 0, 2] = wp.float64(0.0)
-    output[environment, sample, 1, 0] = -radius[1]
-    output[environment, sample, 1, 1] = wp.float64(1.0)
-    output[environment, sample, 1, 2] = wp.float64(0.0)
-    output[environment, sample, 2, 0] = radius[0]
-    output[environment, sample, 2, 1] = wp.float64(0.0)
-    output[environment, sample, 2, 2] = wp.float64(1.0)
+    jacobians[environment, sample, 0, 0] = wp.float64(1.0)
+    jacobians[environment, sample, 0, 1] = wp.float64(0.0)
+    jacobians[environment, sample, 0, 2] = wp.float64(0.0)
+    jacobians[environment, sample, 1, 0] = -world_offset[1]
+    jacobians[environment, sample, 1, 1] = wp.float64(1.0)
+    jacobians[environment, sample, 1, 2] = wp.float64(0.0)
+    jacobians[environment, sample, 2, 0] = world_offset[0]
+    jacobians[environment, sample, 2, 1] = wp.float64(0.0)
+    jacobians[environment, sample, 2, 2] = wp.float64(1.0)
 
     column = int(0)
-    while column < internal.shape[3]:
-        output[environment, sample, 0, 3 + column] = internal[
+    while column < jacobians_internal.shape[3]:
+        jacobians[environment, sample, 0, 3 + column] = jacobians_internal[
             environment, sample, 0, column
         ]
-        internal_linear = rotation * wp.vec2d(
-            internal[environment, sample, 1, column],
-            internal[environment, sample, 2, column],
+        jacobian_linear_world = base_rotation * wp.vec2d(
+            jacobians_internal[environment, sample, 1, column],
+            jacobians_internal[environment, sample, 2, column],
         )
-        output[environment, sample, 1, 3 + column] = internal_linear[0]
-        output[environment, sample, 2, 3 + column] = internal_linear[1]
+        jacobians[environment, sample, 1, 3 + column] = jacobian_linear_world[0]
+        jacobians[environment, sample, 2, 3 + column] = jacobian_linear_world[1]
         column += 1
 
 
@@ -540,7 +613,17 @@ def launch_spatial_floating_pose_composition(
     relative_pose: wp.array4d[wp.float64],
     poses: wp.array4d[wp.float64],
 ):
-    """Compose batched spatial runtime-base and relative poses."""
+    """Compose batched spatial runtime-base and relative poses.
+
+    Args:
+        base_pose: Scalar-last base poses with shape ``(E, 7)``.
+        relative_pose: Base-relative transforms with shape ``(E, N, 4, 4)``.
+        poses: Caller-owned inertial-frame transforms with shape
+            ``(E, N, 4, 4)``.
+
+    Returns:
+        None. The pose kernel is enqueued on the active Warp stream.
+    """
     wp.launch(
         _compose_spatial_poses_kernel,
         dim=(relative_pose.shape[0], relative_pose.shape[1]),
@@ -552,7 +635,7 @@ def launch_spatial_floating_pose_composition(
 def launch_spatial_floating_jacobian_composition(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array4d[wp.float64],
-    internal: wp.array4d[wp.float64],
+    jacobians_internal: wp.array4d[wp.float64],
     block_dim: int,
     jacobians: wp.array4d[wp.float64],
 ):
@@ -561,9 +644,10 @@ def launch_spatial_floating_jacobian_composition(
     Args:
         base_pose: Batched scalar-last quaternion poses with shape ``(E, 7)``.
         relative_pose: Base-relative transforms with shape ``(E, N, 4, 4)``.
-        internal: Base-frame internal Jacobians with shape ``(E, N, 6, D)``.
+        jacobians_internal: Base-frame internal Jacobians with shape
+            ``(E, N, 6, D)``.
         block_dim: Model-configured CUDA threads per cooperative block.
-        jacobians: World-frame augmented output with shape
+        jacobians: Inertial-frame augmented output with shape
             ``(E, N, 6, D + 6)``.
 
     Returns:
@@ -573,7 +657,7 @@ def launch_spatial_floating_jacobian_composition(
         wp.launch_tiled(
             _compose_spatial_jacobians_tiled_kernel,
             dim=relative_pose.shape[0] * relative_pose.shape[1],
-            inputs=[base_pose, relative_pose, internal],
+            inputs=[base_pose, relative_pose, jacobians_internal],
             outputs=[jacobians],
             block_dim=block_dim,
         )
@@ -581,7 +665,7 @@ def launch_spatial_floating_jacobian_composition(
         wp.launch(
             _compose_spatial_jacobians_kernel,
             dim=(relative_pose.shape[0], relative_pose.shape[1]),
-            inputs=[base_pose, relative_pose, internal],
+            inputs=[base_pose, relative_pose, jacobians_internal],
             outputs=[jacobians],
         )
 
@@ -589,23 +673,39 @@ def launch_spatial_floating_jacobian_composition(
 def launch_spatial_floating_kinematics_composition(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array4d[wp.float64],
-    internal: wp.array4d[wp.float64],
+    jacobians_internal: wp.array4d[wp.float64],
     block_dim: int,
     poses: wp.array4d[wp.float64],
     jacobians: wp.array4d[wp.float64],
 ):
-    """Compose spatial poses and augmented Jacobians in one callable."""
+    """Compose spatial poses and augmented Jacobians in one callable.
+
+    Args:
+        base_pose: Scalar-last base poses with shape ``(E, 7)``.
+        relative_pose: Base-relative transforms with shape ``(E, N, 4, 4)``.
+        jacobians_internal: Base-frame internal Jacobians with shape
+            ``(E, N, 6, D)``.
+        block_dim: Model-configured CUDA threads per cooperative block.
+        poses: Caller-owned inertial-frame transforms with shape
+            ``(E, N, 4, 4)``.
+        jacobians: Caller-owned inertial-frame augmented Jacobians with shape
+            ``(E, N, 6, D + 6)``.
+
+    Returns:
+        None. The pose and Jacobian kernels are enqueued on the active Warp
+        stream.
+    """
     launch_spatial_floating_pose_composition(base_pose, relative_pose, poses)
     launch_spatial_floating_jacobian_composition(
-        base_pose, relative_pose, internal, block_dim, jacobians
+        base_pose, relative_pose, jacobians_internal, block_dim, jacobians
     )
 
 
 def launch_spatial_floating_kinematics_jvp_composition(
     base_pose: wp.array2d[wp.float64],
-    base_velocity: wp.array2d[wp.float64],
+    qd: wp.array2d[wp.float64],
     relative_pose: wp.array4d[wp.float64],
-    internal_twist: wp.array3d[wp.float64],
+    twists_internal: wp.array3d[wp.float64],
     poses: wp.array4d[wp.float64],
     twists: wp.array3d[wp.float64],
 ):
@@ -613,11 +713,12 @@ def launch_spatial_floating_kinematics_jvp_composition(
 
     Args:
         base_pose: Runtime scalar-last base poses ``(E, 7)``.
-        base_velocity: Runtime base velocities beginning in angular-linear order.
+        qd: Batched generalized-velocity directions. The first six entries are
+            the angular-linear world-frame base direction.
         relative_pose: Fixed-base relative sample poses ``(E, N, 4, 4)``.
-        internal_twist: Relative inertial JVPs ``(E, N, 6)``.
-        poses: Caller-owned absolute pose output.
-        twists: Caller-owned absolute inertial JVP output.
+        twists_internal: Base-frame internal-Jacobian products ``(E, N, 6)``.
+        poses: Caller-owned inertial-frame transforms ``(E, N, 4, 4)``.
+        twists: Caller-owned inertial-frame JVP output ``(E, N, 6)``.
 
     Returns:
         None. The composition kernel is enqueued on the active Warp stream.
@@ -626,7 +727,7 @@ def launch_spatial_floating_kinematics_jvp_composition(
     wp.launch(
         _compose_spatial_poses_and_twists_kernel,
         dim=(relative_pose.shape[0], relative_pose.shape[1]),
-        inputs=[base_pose, base_velocity, relative_pose, internal_twist],
+        inputs=[base_pose, qd, relative_pose, twists_internal],
         outputs=[poses, twists],
     )
 
@@ -644,7 +745,8 @@ def launch_spatial_floating_vjp_composition(
         base_pose: Runtime scalar-last base poses ``(E, 7)``.
         relative_pose: Fixed-base relative sample poses ``(E, N, 4, 4)``.
         inertial_wrenches: Absolute inertial sample cotangents ``(E, N, 6)``.
-        relative_wrenches: Caller-owned rotated cotangents for the internal VJP.
+        relative_wrenches: Caller-owned rotated cotangents for the internal VJP
+            with shape ``(E, N, 6)``.
         base_generalized_force: Caller-owned base effort output ``(E, 6)``.
 
     Returns:
@@ -686,9 +788,9 @@ def launch_spatial_floating_vjp_assembly(
 
 def launch_planar_floating_kinematics_jvp_composition(
     base_pose: wp.array2d[wp.float64],
-    base_velocity: wp.array2d[wp.float64],
+    qd: wp.array2d[wp.float64],
     relative_pose: wp.array3d[wp.float64],
-    internal_twist: wp.array3d[wp.float64],
+    twists_internal: wp.array3d[wp.float64],
     poses: wp.array3d[wp.float64],
     twists: wp.array3d[wp.float64],
 ):
@@ -696,12 +798,12 @@ def launch_planar_floating_kinematics_jvp_composition(
 
     Args:
         base_pose: Runtime planar base poses ``(E, 3)``.
-        base_velocity: Runtime generalized velocities beginning in
-            angular-linear order.
+        qd: Batched generalized-velocity directions. The first three entries
+            are the angular-linear world-frame base direction.
         relative_pose: Fixed-base relative sample poses ``(E, N, 3)``.
-        internal_twist: Relative inertial JVPs ``(E, N, 3)``.
-        poses: Caller-owned absolute pose output.
-        twists: Caller-owned absolute inertial JVP output.
+        twists_internal: Base-frame internal-Jacobian products ``(E, N, 3)``.
+        poses: Caller-owned inertial-frame poses ``(E, N, 3)``.
+        twists: Caller-owned inertial-frame JVP output ``(E, N, 3)``.
 
     Returns:
         None. The composition kernel is enqueued on the current Warp stream.
@@ -710,7 +812,7 @@ def launch_planar_floating_kinematics_jvp_composition(
     wp.launch(
         _compose_planar_poses_and_twists_kernel,
         dim=(relative_pose.shape[0], relative_pose.shape[1]),
-        inputs=[base_pose, base_velocity, relative_pose, internal_twist],
+        inputs=[base_pose, qd, relative_pose, twists_internal],
         outputs=[poses, twists],
     )
 
@@ -728,7 +830,8 @@ def launch_planar_floating_vjp_composition(
         base_pose: Runtime planar base poses ``(E, 3)``.
         relative_pose: Fixed-base relative sample poses ``(E, N, 3)``.
         inertial_wrenches: Absolute inertial sample cotangents ``(E, N, 3)``.
-        relative_wrenches: Caller-owned rotated cotangents for the internal VJP.
+        relative_wrenches: Caller-owned rotated cotangents for the internal VJP
+            with shape ``(E, N, 3)``.
         base_generalized_force: Caller-owned base effort output ``(E, 3)``.
 
     Returns:
@@ -773,7 +876,16 @@ def launch_planar_floating_pose_composition(
     relative_pose: wp.array3d[wp.float64],
     poses: wp.array3d[wp.float64],
 ):
-    """Compose batched planar runtime-base and relative poses."""
+    """Compose batched planar runtime-base and relative poses.
+
+    Args:
+        base_pose: Planar base poses with shape ``(E, 3)``.
+        relative_pose: Base-relative poses with shape ``(E, N, 3)``.
+        poses: Caller-owned inertial-frame poses with shape ``(E, N, 3)``.
+
+    Returns:
+        None. The pose kernel is enqueued on the active Warp stream.
+    """
     wp.launch(
         _compose_planar_poses_kernel,
         dim=(relative_pose.shape[0], relative_pose.shape[1]),
@@ -785,14 +897,26 @@ def launch_planar_floating_pose_composition(
 def launch_planar_floating_jacobian_composition(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array3d[wp.float64],
-    internal: wp.array4d[wp.float64],
+    jacobians_internal: wp.array4d[wp.float64],
     jacobians: wp.array4d[wp.float64],
 ):
-    """Build batched planar base columns and rotate internal columns."""
+    """Build batched planar base columns and rotate internal columns.
+
+    Args:
+        base_pose: Planar base poses with shape ``(E, 3)``.
+        relative_pose: Base-relative poses with shape ``(E, N, 3)``.
+        jacobians_internal: Base-frame internal Jacobians with shape
+            ``(E, N, 3, D)``.
+        jacobians: Caller-owned inertial-frame augmented Jacobians with shape
+            ``(E, N, 3, D + 3)``.
+
+    Returns:
+        None. The Jacobian kernel is enqueued on the active Warp stream.
+    """
     wp.launch(
         _compose_planar_jacobians_kernel,
         dim=(relative_pose.shape[0], relative_pose.shape[1]),
-        inputs=[base_pose, relative_pose, internal],
+        inputs=[base_pose, relative_pose, jacobians_internal],
         outputs=[jacobians],
     )
 
@@ -800,14 +924,28 @@ def launch_planar_floating_jacobian_composition(
 def launch_planar_floating_kinematics_composition(
     base_pose: wp.array2d[wp.float64],
     relative_pose: wp.array3d[wp.float64],
-    internal: wp.array4d[wp.float64],
+    jacobians_internal: wp.array4d[wp.float64],
     poses: wp.array3d[wp.float64],
     jacobians: wp.array4d[wp.float64],
 ):
-    """Compose planar poses and augmented Jacobians in one callable."""
+    """Compose planar poses and augmented Jacobians in one callable.
+
+    Args:
+        base_pose: Planar base poses with shape ``(E, 3)``.
+        relative_pose: Base-relative poses with shape ``(E, N, 3)``.
+        jacobians_internal: Base-frame internal Jacobians with shape
+            ``(E, N, 3, D)``.
+        poses: Caller-owned inertial-frame poses with shape ``(E, N, 3)``.
+        jacobians: Caller-owned inertial-frame augmented Jacobians with shape
+            ``(E, N, 3, D + 3)``.
+
+    Returns:
+        None. The pose and Jacobian kernels are enqueued on the active Warp
+        stream.
+    """
     launch_planar_floating_pose_composition(base_pose, relative_pose, poses)
     launch_planar_floating_jacobian_composition(
-        base_pose, relative_pose, internal, jacobians
+        base_pose, relative_pose, jacobians_internal, jacobians
     )
 
 

--- a/src/soromox/execution/warp/common/joints.py
+++ b/src/soromox/execution/warp/common/joints.py
@@ -178,11 +178,13 @@ def joint_terms_kernel(
     angle_sq_dot = wp.float64(2.0) * (xi[0] * xid[0] + xi[1] * xid[1] + xi[2] * xid[2])
     omega = wp.vec3d(xi[0], xi[1], xi[2])
     linear = wp.vec3d(xi[3], xi[4], xi[5])
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
 
     velocity = _left_action(xi, xid, coefficients)
-    eta = _adjoint_inverse_action(omega, translation, angle_sq, forward, velocity)
+    eta = _adjoint_inverse_action(
+        omega, translation, angle_sq, exponential_coefficients, velocity
+    )
     derivative_velocity = _left_total_derivative_action(
         xi,
         xid,
@@ -202,7 +204,7 @@ def joint_terms_kernel(
                 omega,
                 translation,
                 angle_sq,
-                forward,
+                exponential_coefficients,
                 row,
                 column,
             )

--- a/src/soromox/execution/warp/common/rotations.py
+++ b/src/soromox/execution/warp/common/rotations.py
@@ -9,12 +9,24 @@ wp.set_module_options({"enable_backward": False})
 
 
 @wp.func
-def _normalized_quaternion(poses: wp.array2d[wp.float64], environment: int) -> wp.vec4d:
-    """Load one normalized scalar-last quaternion with an identity fallback."""
-    x = poses[environment, 0]
-    y = poses[environment, 1]
-    z = poses[environment, 2]
-    w = poses[environment, 3]
+def _load_normalized_quaternion(
+    base_pose: wp.array2d[wp.float64], environment: int
+) -> wp.vec4d:
+    """Load one normalized scalar-last quaternion from a batched base pose.
+
+    Args:
+        base_pose: Batched spatial poses with shape ``(E, 7)`` in
+            ``[qx, qy, qz, qw, x, y, z]`` order.
+        environment: Environment row in ``base_pose``.
+
+    Returns:
+        Unit Hamilton quaternion in scalar-last order. An exactly zero
+        quaternion maps to ``[0, 0, 0, 1]`` to match the trace-safe JAX path.
+    """
+    x = base_pose[environment, 0]
+    y = base_pose[environment, 1]
+    z = base_pose[environment, 2]
+    w = base_pose[environment, 3]
     norm_sq = x * x + y * y + z * z + w * w
     if norm_sq <= wp.float64(0.0):
         return wp.vec4d(
@@ -34,19 +46,20 @@ def _normalized_quaternion(poses: wp.array2d[wp.float64], environment: int) -> w
 
 @wp.func
 def _quaternion_rotation_matrix(
-    poses: wp.array2d[wp.float64], environment: int
+    base_pose: wp.array2d[wp.float64], environment: int
 ) -> wp.mat33d:
     """Return one normalized scalar-last quaternion rotation matrix.
 
     Args:
-        poses: Batched scalar-last quaternion poses with shape ``(E, 7)``.
-        environment: Environment row in ``poses``.
+        base_pose: Batched spatial poses with shape ``(E, 7)`` in
+            ``[qx, qy, qz, qw, x, y, z]`` order.
+        environment: Environment row in ``base_pose``.
 
     Returns:
         The normalized three-dimensional rotation. A zero quaternion follows
         the trace-safe JAX path and maps to identity.
     """
-    quaternion = _normalized_quaternion(poses, environment)
+    quaternion = _load_normalized_quaternion(base_pose, environment)
     x = quaternion[0]
     y = quaternion[1]
     z = quaternion[2]
@@ -66,13 +79,14 @@ def _quaternion_rotation_matrix(
 
 @wp.func
 def _quaternion_rotation_transpose_entry(
-    poses: wp.array2d[wp.float64], environment: int, row: int, column: int
+    base_pose: wp.array2d[wp.float64], environment: int, row: int, column: int
 ) -> wp.float64:
     """Return one normalized quaternion rotation-transpose entry.
 
     Args:
-        poses: Batched scalar-last quaternion poses with shape ``(E, 7)``.
-        environment: Environment row in ``poses``.
+        base_pose: Batched spatial poses with shape ``(E, 7)`` in
+            ``[qx, qy, qz, qw, x, y, z]`` order.
+        environment: Environment row in ``base_pose``.
         row: Requested matrix row.
         column: Requested matrix column.
 
@@ -80,7 +94,7 @@ def _quaternion_rotation_transpose_entry(
         Entry ``(row, column)`` of the normalized rotation transpose. A zero
         quaternion follows the trace-safe JAX path and maps to identity.
     """
-    quaternion = _normalized_quaternion(poses, environment)
+    quaternion = _load_normalized_quaternion(base_pose, environment)
     x = quaternion[0]
     y = quaternion[1]
     z = quaternion[2]

--- a/src/soromox/execution/warp/common/se2.py
+++ b/src/soromox/execution/warp/common/se2.py
@@ -64,7 +64,7 @@ def _forward_coefficients(z: wp.float64, cutoff: wp.float64) -> wp.vec3d:
 
 
 @wp.func
-def _forward_derivatives(z: wp.float64, cutoff: wp.float64) -> wp.vec3d:
+def _forward_coefficient_x_derivatives(z: wp.float64, cutoff: wp.float64) -> wp.vec3d:
     """Differentiate planar exponential coefficients with respect to ``z**2``.
 
     Args:
@@ -112,7 +112,7 @@ def _constant_strain_operators(
     xi: wp.vec3d,
     xid: wp.vec3d,
     s: wp.float64,
-    global_eps: wp.float64,
+    adjoint_eps: wp.float64,
     tangent_eps: wp.float64,
 ) -> tuple[wp.mat33d, wp.mat33d, wp.vec3d, wp.vec3d]:
     """Evaluate constant-strain SE(2) recurrence operators.
@@ -121,7 +121,7 @@ def _constant_strain_operators(
         xi: Constant planar strain of the current segment.
         xid: Constant planar strain rate of the current segment.
         s: Segment-local integration coordinate.
-        global_eps: Small-angle tolerance for the exponential adjoint.
+        adjoint_eps: Small-angle tolerance for the exponential adjoint.
         tangent_eps: Small-angle tolerance for tangent derivatives.
 
     Returns:
@@ -129,40 +129,48 @@ def _constant_strain_operators(
         transported tangent time-derivative action on strain rate.
     """
     z = s * xi[0]
-    adjoint_cutoff = wp.max(wp.abs(s * global_eps), wp.float64(0.04964607461902946))
+    adjoint_cutoff = wp.max(wp.abs(s * adjoint_eps), wp.float64(0.04964607461902946))
     adjoint_coefficients = _forward_coefficients(z, adjoint_cutoff)
-    sinc_a = adjoint_coefficients[0]
-    cosc_a = adjoint_coefficients[1]
+    adjoint_sinc = adjoint_coefficients[0]
+    adjoint_cosc = adjoint_coefficients[1]
     cosine = wp.cos(z)
     sine = wp.sin(z)
-    q0 = s * (sinc_a * xi[2] + z * cosc_a * xi[1])
-    q1 = s * (-sinc_a * xi[1] + z * cosc_a * xi[2])
+    adjoint_translation = wp.vec2d(
+        s * (adjoint_sinc * xi[2] + z * adjoint_cosc * xi[1]),
+        s * (-adjoint_sinc * xi[1] + z * adjoint_cosc * xi[2]),
+    )
 
     adjoint_inverse = wp.mat33d()
     adjoint_inverse[0, 0] = wp.float64(1.0)
-    adjoint_inverse[1, 0] = -(cosine * q0 + sine * q1)
+    adjoint_inverse[1, 0] = -(
+        cosine * adjoint_translation[0] + sine * adjoint_translation[1]
+    )
     adjoint_inverse[1, 1] = cosine
     adjoint_inverse[1, 2] = sine
-    adjoint_inverse[2, 0] = sine * q0 - cosine * q1
+    adjoint_inverse[2, 0] = (
+        sine * adjoint_translation[0] - cosine * adjoint_translation[1]
+    )
     adjoint_inverse[2, 1] = -sine
     adjoint_inverse[2, 2] = cosine
 
     tangent_cutoff = wp.max(wp.abs(s * tangent_eps), wp.float64(0.07618835359095202))
     coefficients = _forward_coefficients(z, tangent_cutoff)
-    derivatives = _forward_derivatives(z, tangent_cutoff)
+    coefficient_x_derivatives = _forward_coefficient_x_derivatives(z, tangent_cutoff)
     sinc = coefficients[0]
     cosc = coefficients[1]
     tanc = coefficients[2]
     accumulated_x = s * xi[1]
     accumulated_y = s * xi[2]
-    lower0 = cosc * accumulated_y + z * tanc * accumulated_x
-    lower1 = -cosc * accumulated_x + z * tanc * accumulated_y
+    lower_left = wp.vec2d(
+        cosc * accumulated_y + z * tanc * accumulated_x,
+        -cosc * accumulated_x + z * tanc * accumulated_y,
+    )
     tangent = wp.mat33d()
     tangent[0, 0] = s
-    tangent[1, 0] = s * lower0
+    tangent[1, 0] = s * lower_left[0]
     tangent[1, 1] = s * sinc
     tangent[1, 2] = -s * z * cosc
-    tangent[2, 0] = s * lower1
+    tangent[2, 0] = s * lower_left[1]
     tangent[2, 1] = s * z * cosc
     tangent[2, 2] = s * sinc
 
@@ -170,28 +178,29 @@ def _constant_strain_operators(
     accumulated_dot_y = s * xid[2]
     z_dot = s * xid[0]
     x = z * z
-    sinc_dot = wp.float64(2.0) * z * derivatives[0] * z_dot
-    cosc_dot = wp.float64(2.0) * z * derivatives[1] * z_dot
-    z_cosc_dot = z_dot * (cosc + wp.float64(2.0) * x * derivatives[1])
+    sinc_x = coefficient_x_derivatives[0]
+    cosc_x = coefficient_x_derivatives[1]
+    tanc_x = coefficient_x_derivatives[2]
+    sinc_dot = wp.float64(2.0) * z * sinc_x * z_dot
+    cosc_dot = wp.float64(2.0) * z * cosc_x * z_dot
+    z_cosc_dot = z_dot * (cosc + wp.float64(2.0) * x * cosc_x)
     z_tanc = z * tanc
-    z_tanc_dot = z_dot * (tanc + wp.float64(2.0) * x * derivatives[2])
-    lower_dot0 = (
+    z_tanc_dot = z_dot * (tanc + wp.float64(2.0) * x * tanc_x)
+    lower_left_dot = wp.vec2d(
         cosc_dot * accumulated_y
         + cosc * accumulated_dot_y
         + z_tanc_dot * accumulated_x
-        + z_tanc * accumulated_dot_x
-    )
-    lower_dot1 = (
+        + z_tanc * accumulated_dot_x,
         -cosc_dot * accumulated_x
         - cosc * accumulated_dot_x
         + z_tanc_dot * accumulated_y
-        + z_tanc * accumulated_dot_y
+        + z_tanc * accumulated_dot_y,
     )
     tangent_dot = wp.mat33d()
-    tangent_dot[1, 0] = s * lower_dot0
+    tangent_dot[1, 0] = s * lower_left_dot[0]
     tangent_dot[1, 1] = s * sinc_dot
     tangent_dot[1, 2] = -s * z_cosc_dot
-    tangent_dot[2, 0] = s * lower_dot1
+    tangent_dot[2, 0] = s * lower_left_dot[1]
     tangent_dot[2, 1] = s * z_cosc_dot
     tangent_dot[2, 2] = s * sinc_dot
 
@@ -247,6 +256,6 @@ def planar_pose_step(
 __all__ = [
     "_constant_strain_operators",
     "_forward_coefficients",
-    "_forward_derivatives",
+    "_forward_coefficient_x_derivatives",
     "planar_pose_step",
 ]

--- a/src/soromox/execution/warp/common/se3.py
+++ b/src/soromox/execution/warp/common/se3.py
@@ -272,25 +272,36 @@ def _forward_coefficients(angle_sq: wp.float64) -> wp.vec3d:
 
 
 @wp.func
-def _translation(omega: wp.vec3d, linear: wp.vec3d, forward: wp.vec3d) -> wp.vec3d:
+def _translation(
+    omega: wp.vec3d,
+    linear: wp.vec3d,
+    exponential_coefficients: wp.vec3d,
+) -> wp.vec3d:
     """Evaluate the translational component of an SE(3) exponential.
 
     Args:
         omega: Rotational exponential coordinate.
         linear: Translational exponential coordinate.
-        forward: Stable exponential-map coefficients.
+        exponential_coefficients: Stable ``(sinc, cosc, tanc)`` coefficients.
 
     Returns:
         Translation of the resulting homogeneous transformation.
     """
-    first = wp.cross(omega, linear)
-    second = wp.cross(omega, first)
-    return linear + forward[1] * first + forward[2] * second
+    omega_cross_linear = wp.cross(omega, linear)
+    omega_cross_squared_linear = wp.cross(omega, omega_cross_linear)
+    return (
+        linear
+        + exponential_coefficients[1] * omega_cross_linear
+        + exponential_coefficients[2] * omega_cross_squared_linear
+    )
 
 
 @wp.func
 def _exponential_transform(xi: Vec6d) -> wp.mat44d:
     """Evaluate the homogeneous SE(3) exponential of a spatial coordinate.
+
+    The final three entries are twist coordinates integrated through the
+    ``SE(3)`` left Jacobian, not direct pose-translation coordinates.
 
     Args:
         xi: Angular-linear exponential coordinate.
@@ -301,19 +312,25 @@ def _exponential_transform(xi: Vec6d) -> wp.mat44d:
     omega = wp.vec3d(xi[0], xi[1], xi[2])
     linear = wp.vec3d(xi[3], xi[4], xi[5])
     angle_sq = wp.dot(omega, omega)
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
-    result = wp.mat44d()
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
+    transform = wp.mat44d()
     row = int(0)
     while row < 3:
         column = int(0)
         while column < 3:
-            result[row, column] = _rotation_entry(omega, angle_sq, forward, row, column)
+            transform[row, column] = _rotation_entry(
+                omega,
+                angle_sq,
+                exponential_coefficients,
+                row,
+                column,
+            )
             column += 1
-        result[row, 3] = translation[row]
+        transform[row, 3] = translation[row]
         row += 1
-    result[3, 3] = wp.float64(1.0)
-    return result
+    transform[3, 3] = wp.float64(1.0)
+    return transform
 
 
 @wp.func
@@ -321,7 +338,7 @@ def _adjoint_inverse_entry(
     omega: wp.vec3d,
     translation: wp.vec3d,
     angle_sq: wp.float64,
-    forward: wp.vec3d,
+    exponential_coefficients: wp.vec3d,
     row: int,
     column: int,
 ) -> wp.float64:
@@ -331,7 +348,7 @@ def _adjoint_inverse_entry(
         omega: Rotational exponential coordinate.
         translation: Translation of the SE(3) transformation.
         angle_sq: Squared norm of ``omega``.
-        forward: Stable exponential-map coefficients.
+        exponential_coefficients: Stable ``(sinc, cosc, tanc)`` coefficients.
         row: Adjoint row index.
         column: Adjoint column index.
 
@@ -340,9 +357,15 @@ def _adjoint_inverse_entry(
     """
     value = wp.float64(0.0)
     if row < 3 and column < 3:
-        value = _rotation_entry(omega, angle_sq, forward, column, row)
+        value = _rotation_entry(omega, angle_sq, exponential_coefficients, column, row)
     elif row >= 3 and column >= 3:
-        value = _rotation_entry(omega, angle_sq, forward, column - 3, row - 3)
+        value = _rotation_entry(
+            omega,
+            angle_sq,
+            exponential_coefficients,
+            column - 3,
+            row - 3,
+        )
     elif row >= 3 and column < 3:
         local_row = row - 3
         for k in range(3):
@@ -359,7 +382,16 @@ def _adjoint_inverse_entry(
                 skew = -translation[1]
             elif k == 2 and column == 1:
                 skew = translation[0]
-            value -= _rotation_entry(omega, angle_sq, forward, k, local_row) * skew
+            value -= (
+                _rotation_entry(
+                    omega,
+                    angle_sq,
+                    exponential_coefficients,
+                    k,
+                    local_row,
+                )
+                * skew
+            )
     return value
 
 
@@ -368,7 +400,7 @@ def _adjoint_inverse_action(
     omega: wp.vec3d,
     translation: wp.vec3d,
     angle_sq: wp.float64,
-    forward: wp.vec3d,
+    exponential_coefficients: wp.vec3d,
     value: Vec6d,
 ) -> Vec6d:
     """Apply an inverse SE(3) adjoint without materializing the matrix.
@@ -377,7 +409,7 @@ def _adjoint_inverse_action(
         omega: Rotational exponential coordinate.
         translation: Translation of the SE(3) transformation.
         angle_sq: Squared norm of ``omega``.
-        forward: Stable exponential-map coefficients.
+        exponential_coefficients: Stable ``(sinc, cosc, tanc)`` coefficients.
         value: Spatial vector to transform.
 
     Returns:
@@ -392,7 +424,7 @@ def _adjoint_inverse_action(
                     omega,
                     translation,
                     angle_sq,
-                    forward,
+                    exponential_coefficients,
                     row,
                     column,
                 )
@@ -407,7 +439,7 @@ def _adjoint_inverse_transpose_action(
     omega: wp.vec3d,
     translation: wp.vec3d,
     angle_sq: wp.float64,
-    forward: wp.vec3d,
+    exponential_coefficients: wp.vec3d,
     value: Vec6d,
 ) -> Vec6d:
     """Apply a transposed inverse SE(3) adjoint without a matrix.
@@ -419,7 +451,7 @@ def _adjoint_inverse_transpose_action(
         omega: Rotational exponential coordinate.
         translation: Translation of the SE(3) transformation.
         angle_sq: Squared norm of ``omega``.
-        forward: Stable exponential-map coefficients.
+        exponential_coefficients: Stable ``(sinc, cosc, tanc)`` coefficients.
         value: Spatial cotangent to transform.
 
     Returns:
@@ -435,7 +467,7 @@ def _adjoint_inverse_transpose_action(
                     omega,
                     translation,
                     angle_sq,
-                    forward,
+                    exponential_coefficients,
                     row,
                     column,
                 )

--- a/src/soromox/execution/warp/common/so2.py
+++ b/src/soromox/execution/warp/common/so2.py
@@ -10,7 +10,14 @@ wp.set_module_options({"enable_backward": False})
 
 @wp.func
 def _rotation_components(theta: wp.float64) -> wp.vec2d:
-    """Return ``(cos(theta), sin(theta))`` for shared planar actions."""
+    """Return the cosine and sine shared by planar rotation actions.
+
+    Args:
+        theta: Right-handed planar rotation angle.
+
+    Returns:
+        Vector ``[cos(theta), sin(theta)]``.
+    """
     return wp.vec2d(wp.cos(theta), wp.sin(theta))
 
 
@@ -32,7 +39,15 @@ def _rotation_matrix(theta: wp.float64) -> wp.mat22d:
 
 @wp.func
 def _rotate_vector(theta: wp.float64, value: wp.vec2d) -> wp.vec2d:
-    """Rotate one planar vector by ``theta``."""
+    """Apply a planar active rotation to one vector.
+
+    Args:
+        theta: Right-handed planar rotation angle.
+        value: Two-dimensional vector to rotate.
+
+    Returns:
+        Rotated vector ``R(theta) @ value``.
+    """
     components = _rotation_components(theta)
     cosine = components[0]
     sine = components[1]
@@ -44,7 +59,15 @@ def _rotate_vector(theta: wp.float64, value: wp.vec2d) -> wp.vec2d:
 
 @wp.func
 def _rotate_vector_transpose(theta: wp.float64, value: wp.vec2d) -> wp.vec2d:
-    """Apply the transpose of a planar rotation to one vector."""
+    """Apply the transpose of a planar rotation to one vector.
+
+    Args:
+        theta: Right-handed planar rotation angle.
+        value: Two-dimensional vector to rotate.
+
+    Returns:
+        Rotated vector ``R(theta).T @ value``.
+    """
     components = _rotation_components(theta)
     cosine = components[0]
     sine = components[1]

--- a/src/soromox/execution/warp/common/so3.py
+++ b/src/soromox/execution/warp/common/so3.py
@@ -12,7 +12,7 @@ wp.set_module_options({"enable_backward": False})
 def _rotation_entry(
     omega: wp.vec3d,
     angle_sq: wp.float64,
-    forward: wp.vec3d,
+    exponential_coefficients: wp.vec3d,
     row: int,
     column: int,
 ) -> wp.float64:
@@ -21,31 +21,35 @@ def _rotation_entry(
     Args:
         omega: Rotational exponential coordinate.
         angle_sq: Squared norm of ``omega``.
-        forward: Stable exponential-map coefficients.
+        exponential_coefficients: Stable ``(sinc, cosc, tanc)`` coefficients.
         row: Matrix row index.
         column: Matrix column index.
 
     Returns:
         The selected rotation-matrix entry.
     """
-    delta = wp.float64(0.0)
+    identity_entry = wp.float64(0.0)
     if row == column:
-        delta = wp.float64(1.0)
-    skew = wp.float64(0.0)
+        identity_entry = wp.float64(1.0)
+    skew_entry = wp.float64(0.0)
     if row == 0 and column == 1:
-        skew = -omega[2]
+        skew_entry = -omega[2]
     elif row == 0 and column == 2:
-        skew = omega[1]
+        skew_entry = omega[1]
     elif row == 1 and column == 0:
-        skew = omega[2]
+        skew_entry = omega[2]
     elif row == 1 and column == 2:
-        skew = -omega[0]
+        skew_entry = -omega[0]
     elif row == 2 and column == 0:
-        skew = -omega[1]
+        skew_entry = -omega[1]
     elif row == 2 and column == 1:
-        skew = omega[0]
-    square = omega[row] * omega[column] - angle_sq * delta
-    return delta + forward[0] * skew + forward[1] * square
+        skew_entry = omega[0]
+    skew_square_entry = omega[row] * omega[column] - angle_sq * identity_entry
+    return (
+        identity_entry
+        + exponential_coefficients[0] * skew_entry
+        + exponential_coefficients[1] * skew_square_entry
+    )
 
 
 __all__ = ["_rotation_entry"]

--- a/src/soromox/execution/warp/gvs/cell.py
+++ b/src/soromox/execution/warp/gvs/cell.py
@@ -231,8 +231,8 @@ def cell_terms_kernel(
     coefficients = _left_coefficients(angle_sq)
     omega = wp.vec3d(magnus[0], magnus[1], magnus[2])
     linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
 
     row = int(0)
     while row < SPATIAL_DIM:
@@ -242,7 +242,7 @@ def cell_terms_kernel(
                 omega,
                 translation,
                 angle_sq,
-                forward,
+                exponential_coefficients,
                 row,
                 column,
             )
@@ -270,7 +270,9 @@ def cell_terms_kernel(
         local_column += 1
 
     link = _left_action(magnus, magnus_dot, coefficients)
-    step = _adjoint_inverse_action(omega, translation, angle_sq, forward, link)
+    step = _adjoint_inverse_action(
+        omega, translation, angle_sq, exponential_coefficients, link
+    )
     magnus_basis_dot_qd = Vec6d()
     if order_zero[0] == 0:
         magnus_basis_dot_qd = (

--- a/src/soromox/execution/warp/gvs/directional_kinematics.py
+++ b/src/soromox/execution/warp/gvs/directional_kinematics.py
@@ -268,14 +268,14 @@ def gvs_pose_twist_samples_kernel(
     linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
     angle_sq = wp.dot(omega, omega)
     coefficients = _left_coefficients(angle_sq)
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
     partial_twist = _left_action(magnus, magnus_dot, coefficients)
     body_twist = _adjoint_inverse_action(
         omega,
         translation,
         angle_sq,
-        forward,
+        exponential_coefficients,
         _load_spatial_vector(node_twist, node_item) + partial_twist,
     )
     inertial_twist = _rotate_spatial_to_inertial(pose, body_twist)
@@ -427,14 +427,14 @@ def gvs_sample_vjp_kernel(
     linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
     angle_sq = wp.dot(omega, omega)
     coefficients = _left_coefficients(angle_sq)
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
     body_wrench = _rotate_spatial_from_inertial(
         pose,
         _load_spatial_vector3d(inertial_wrenches, environment, sample),
     )
     source_wrench = _adjoint_inverse_transpose_action(
-        omega, translation, angle_sq, forward, body_wrench
+        omega, translation, angle_sq, exponential_coefficients, body_wrench
     )
     row = int(0)
     while row < SPATIAL_DIM:

--- a/src/soromox/execution/warp/gvs/kinematics.py
+++ b/src/soromox/execution/warp/gvs/kinematics.py
@@ -746,8 +746,8 @@ def write_gvs_sample_jacobian(
     linear = wp.vec3d(magnus[3], magnus[4], magnus[5])
     angle_sq = wp.dot(omega, omega)
     coefficients = _left_coefficients(angle_sq)
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
     commutator_coefficient = wp.sqrt(wp.float64(3.0)) * ds * ds / wp.float64(12.0)
     x1 = x_base + magnus_points[0] * width
     x2 = x_base + magnus_points[1] * width
@@ -795,7 +795,13 @@ def write_gvs_sample_jacobian(
         while k < SPATIAL_DIM:
             source[k] = node_jacobian[node_item * SPATIAL_DIM + k, column] + tangent[k]
             k += 1
-        body = _adjoint_inverse_action(omega, translation, angle_sq, forward, source)
+        body = _adjoint_inverse_action(
+            omega,
+            translation,
+            angle_sq,
+            exponential_coefficients,
+            source,
+        )
         row = int(0)
         while row < SPATIAL_DIM:
             local_row = row if row < 3 else row - 3

--- a/src/soromox/execution/warp/gvs/kinematics_executor.py
+++ b/src/soromox/execution/warp/gvs/kinematics_executor.py
@@ -94,7 +94,7 @@ def execute_kinematics(
                 relative,
                 output_dims={"poses": pose_shape},
             )[-1]
-        relative_pose, internal_jacobian = relative
+        relative_pose, jacobians_internal = relative
         jacobian_shape = (
             q.shape[0],
             s.shape[1],
@@ -105,14 +105,14 @@ def execute_kinematics(
             return spatial_floating_jacobian_composition(
                 base_pose,
                 relative_pose,
-                internal_jacobian,
+                jacobians_internal,
                 operands.relative.block_dim,
                 output_dims={"jacobians": jacobian_shape},
             )[-1]
         outputs = spatial_floating_kinematics_composition(
             base_pose,
             relative_pose,
-            internal_jacobian,
+            jacobians_internal,
             operands.relative.block_dim,
             output_dims={"poses": pose_shape, "jacobians": jacobian_shape},
         )

--- a/src/soromox/execution/warp/pcs/kinematics_executor.py
+++ b/src/soromox/execution/warp/pcs/kinematics_executor.py
@@ -79,14 +79,14 @@ def execute_kinematics(
                 relative_pose,
                 output_dims={"poses": pose_shape},
             )[-1]
-        relative_pose, internal_jacobian = relative
+        relative_pose, jacobians_internal = relative
         jacobian_shape = (
             q.shape[0],
             s.shape[1],
             3 if operands.is_planar else 6,
             operands.num_velocities,
         )
-        composition_block = () if operands.is_planar else (operands.relative.block_dim,)
+        composition_args = () if operands.is_planar else (operands.relative.block_dim,)
         if operation == "jacobian":
             callable_ = (
                 planar_floating_jacobian_composition
@@ -96,8 +96,8 @@ def execute_kinematics(
             return callable_(
                 base_pose,
                 relative_pose,
-                internal_jacobian,
-                *composition_block,
+                jacobians_internal,
+                *composition_args,
                 output_dims={"jacobians": jacobian_shape},
             )[-1]
         pose_shape = (
@@ -113,8 +113,8 @@ def execute_kinematics(
         outputs = callable_(
             base_pose,
             relative_pose,
-            internal_jacobian,
-            *composition_block,
+            jacobians_internal,
+            *composition_args,
             output_dims={"poses": pose_shape, "jacobians": jacobian_shape},
         )
         return outputs[-2], outputs[-1]

--- a/src/soromox/execution/warp/pcs/spatial_directional_kinematics.py
+++ b/src/soromox/execution/warp/pcs/spatial_directional_kinematics.py
@@ -94,8 +94,8 @@ def spatial_segment_pose_twist_kernel(
         omega = wp.vec3d(accumulated[0], accumulated[1], accumulated[2])
         linear = wp.vec3d(accumulated[3], accumulated[4], accumulated[5])
         angle_sq = wp.dot(omega, omega)
-        forward = _forward_coefficients(angle_sq)
-        translation = _translation(omega, linear, forward)
+        exponential_coefficients = _forward_coefficients(angle_sq)
+        translation = _translation(omega, linear, exponential_coefficients)
         partial_twist = _left_action(
             accumulated,
             accumulated_dot,
@@ -105,7 +105,7 @@ def spatial_segment_pose_twist_kernel(
             omega,
             translation,
             angle_sq,
-            forward,
+            exponential_coefficients,
             _load_spatial_vector3d(segment_twist, environment, segment) + partial_twist,
         )
         row = int(0)
@@ -187,8 +187,8 @@ def spatial_pose_twist_samples_kernel(
     omega = wp.vec3d(accumulated[0], accumulated[1], accumulated[2])
     linear = wp.vec3d(accumulated[3], accumulated[4], accumulated[5])
     angle_sq = wp.dot(omega, omega)
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
     partial_twist = _left_action(
         accumulated,
         accumulated_dot,
@@ -198,7 +198,7 @@ def spatial_pose_twist_samples_kernel(
         omega,
         translation,
         angle_sq,
-        forward,
+        exponential_coefficients,
         _load_spatial_vector3d(segment_twist, environment, segment) + partial_twist,
     )
     pose = wp.mat44d()
@@ -276,8 +276,8 @@ def spatial_sample_vjp_kernel(
     linear = wp.vec3d(accumulated[3], accumulated[4], accumulated[5])
     angle_sq = wp.dot(omega, omega)
     coefficients = _left_coefficients(angle_sq)
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
     pose = wp.mat44d()
     row = int(0)
     while row < 4:
@@ -301,7 +301,7 @@ def spatial_sample_vjp_kernel(
         omega,
         translation,
         angle_sq,
-        forward,
+        exponential_coefficients,
         body_wrench,
     )
     row = int(0)
@@ -359,13 +359,13 @@ def spatial_segment_vjp_kernel(
         linear = wp.vec3d(accumulated[3], accumulated[4], accumulated[5])
         angle_sq = wp.dot(omega, omega)
         coefficients = _left_coefficients(angle_sq)
-        forward = _forward_coefficients(angle_sq)
-        translation = _translation(omega, linear, forward)
+        exponential_coefficients = _forward_coefficients(angle_sq)
+        translation = _translation(omega, linear, exponential_coefficients)
         source_wrench = _adjoint_inverse_transpose_action(
             omega,
             translation,
             angle_sq,
-            forward,
+            exponential_coefficients,
             _load_spatial_vector3d(segment_wrench, environment, segment + 1),
         )
         row = int(0)
@@ -428,8 +428,8 @@ def spatial_cooperative_segment_vjp_kernel(
         linear = wp.vec3d(accumulated[3], accumulated[4], accumulated[5])
         angle_sq = wp.dot(omega, omega)
         coefficients = _left_coefficients(angle_sq)
-        forward = _forward_coefficients(angle_sq)
-        translation = _translation(omega, linear, forward)
+        exponential_coefficients = _forward_coefficients(angle_sq)
+        translation = _translation(omega, linear, exponential_coefficients)
 
         source_value = wp.float64(0.0)
         if lane < SPATIAL_DIM:
@@ -440,7 +440,7 @@ def spatial_cooperative_segment_vjp_kernel(
                         omega,
                         translation,
                         angle_sq,
-                        forward,
+                        exponential_coefficients,
                         row,
                         lane,
                     )

--- a/src/soromox/execution/warp/pcs/spatial_kernels.py
+++ b/src/soromox/execution/warp/pcs/spatial_kernels.py
@@ -95,10 +95,10 @@ def spatial_local_operators_kernel(
         + accumulated[2] * accumulated[2]
     )
     coefficients = _left_coefficients(angle_sq)
-    forward = _forward_coefficients(angle_sq)
+    exponential_coefficients = _forward_coefficients(angle_sq)
     omega = wp.vec3d(accumulated[0], accumulated[1], accumulated[2])
     linear = wp.vec3d(accumulated[3], accumulated[4], accumulated[5])
-    translation = _translation(omega, linear, forward)
+    translation = _translation(omega, linear, exponential_coefficients)
     output_base_row = item * SPATIAL_DIM
 
     row = int(0)
@@ -109,7 +109,7 @@ def spatial_local_operators_kernel(
                 omega,
                 translation,
                 angle_sq,
-                forward,
+                exponential_coefficients,
                 row,
                 column,
             )
@@ -125,7 +125,7 @@ def spatial_local_operators_kernel(
             omega,
             translation,
             angle_sq,
-            forward,
+            exponential_coefficients,
             tangent_column,
         )
         row = int(0)
@@ -139,7 +139,7 @@ def spatial_local_operators_kernel(
         omega,
         translation,
         angle_sq,
-        forward,
+        exponential_coefficients,
         tangent_velocity,
     )
     coefficient_derivatives = _left_coefficient_x_derivatives(angle_sq)
@@ -160,7 +160,7 @@ def spatial_local_operators_kernel(
         omega,
         translation,
         angle_sq,
-        forward,
+        exponential_coefficients,
         tangent_dot_velocity,
     )
     row = int(0)

--- a/src/soromox/execution/warp/pcs/spatial_kinematics.py
+++ b/src/soromox/execution/warp/pcs/spatial_kinematics.py
@@ -48,14 +48,14 @@ def spatial_pose_step_entry(
     omega = wp.vec3d(accumulated[0], accumulated[1], accumulated[2])
     linear = wp.vec3d(accumulated[3], accumulated[4], accumulated[5])
     angle_sq = wp.dot(omega, omega)
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
     value = wp.float64(0.0)
     if row < 3 and column < 3:
         k = int(0)
         while k < 3:
             value += base[environment, base_index, row, k] * _rotation_entry(
-                omega, angle_sq, forward, k, column
+                omega, angle_sq, exponential_coefficients, k, column
             )
             k += 1
     elif row < 3 and column == 3:
@@ -92,16 +92,23 @@ def spatial_operator_entry(
     omega = wp.vec3d(accumulated[0], accumulated[1], accumulated[2])
     linear = wp.vec3d(accumulated[3], accumulated[4], accumulated[5])
     angle_sq = wp.dot(omega, omega)
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
     if not transported:
         return _adjoint_inverse_entry(
-            omega, translation, angle_sq, forward, row, column
+            omega,
+            translation,
+            angle_sq,
+            exponential_coefficients,
+            row,
+            column,
         )
     basis = Vec6d()
     basis[column] = wp.float64(1.0)
     tangent = _left_action(accumulated, basis, _left_coefficients(angle_sq))
-    tangent = _adjoint_inverse_action(omega, translation, angle_sq, forward, tangent)
+    tangent = _adjoint_inverse_action(
+        omega, translation, angle_sq, exponential_coefficients, tangent
+    )
     return tangent[row]
 
 
@@ -111,7 +118,7 @@ def propagate_spatial_jacobian_column(
     omega: wp.vec3d,
     translation: wp.vec3d,
     angle_sq: wp.float64,
-    forward: wp.vec3d,
+    exponential_coefficients: wp.vec3d,
     coefficients: wp.vec4d,
     distance: wp.float64,
     environment: int,
@@ -128,7 +135,7 @@ def propagate_spatial_jacobian_column(
         omega: Angular part of ``accumulated``.
         translation: SE(3) exponential translation for the step.
         angle_sq: Squared norm of ``omega``.
-        forward: Stable SE(3) exponential coefficients.
+        exponential_coefficients: Stable ``(sinc, cosc, tanc)`` coefficients.
         coefficients: Stable left-tangent coefficients.
         distance: Physical integration distance within the segment.
         environment: Environment index.
@@ -155,7 +162,7 @@ def propagate_spatial_jacobian_column(
         omega,
         translation,
         angle_sq,
-        forward,
+        exponential_coefficients,
         source,
     )
 
@@ -285,8 +292,8 @@ def spatial_segment_states_kernel(
         omega = wp.vec3d(accumulated[0], accumulated[1], accumulated[2])
         linear = wp.vec3d(accumulated[3], accumulated[4], accumulated[5])
         angle_sq = wp.dot(omega, omega)
-        forward = _forward_coefficients(angle_sq)
-        translation = _translation(omega, linear, forward)
+        exponential_coefficients = _forward_coefficients(angle_sq)
+        translation = _translation(omega, linear, exponential_coefficients)
         coefficients = _left_coefficients(angle_sq)
         row = int(0)
         while row < 4:
@@ -306,7 +313,7 @@ def spatial_segment_states_kernel(
                 omega,
                 translation,
                 angle_sq,
-                forward,
+                exponential_coefficients,
                 coefficients,
                 segment_lengths[segment],
                 environment,
@@ -570,8 +577,8 @@ def write_spatial_sample_jacobian(
     omega = wp.vec3d(accumulated[0], accumulated[1], accumulated[2])
     linear = wp.vec3d(accumulated[3], accumulated[4], accumulated[5])
     angle_sq = wp.dot(omega, omega)
-    forward = _forward_coefficients(angle_sq)
-    translation = _translation(omega, linear, forward)
+    exponential_coefficients = _forward_coefficients(angle_sq)
+    translation = _translation(omega, linear, exponential_coefficients)
     coefficients = _left_coefficients(angle_sq)
     column = int(0)
     while column < segment_jacobian.shape[3]:
@@ -580,7 +587,7 @@ def write_spatial_sample_jacobian(
             omega,
             translation,
             angle_sq,
-            forward,
+            exponential_coefficients,
             coefficients,
             local_s,
             environment,

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -919,8 +919,8 @@ class SoftRobot(DynamicalSystem):
             q_internal, s
         )
         relative_transforms = vmap(self._homogeneous_pose)(relative_poses)
-        jacobians_internal = (
-            relative_robot._jacobian_inertialframe_abscissa_batched(q_internal, s)
+        jacobians_internal = relative_robot._jacobian_inertialframe_abscissa_batched(
+            q_internal, s
         )
         return self._floating_jacobians_from_relative_inertial(
             q, relative_transforms, jacobians_internal
@@ -1652,17 +1652,17 @@ class SoftRobot(DynamicalSystem):
             jacobians_base = jnp.broadcast_to(
                 jnp.eye(6, dtype=jacobians_internal.dtype), (*leading_shape, 6, 6)
             )
-            rx, ry, rz = (
+            offset_x, offset_y, offset_z = (
                 world_offsets[..., 0],
                 world_offsets[..., 1],
                 world_offsets[..., 2],
             )
-            jacobians_base = jacobians_base.at[..., 3, 1].set(rz)
-            jacobians_base = jacobians_base.at[..., 3, 2].set(-ry)
-            jacobians_base = jacobians_base.at[..., 4, 0].set(-rz)
-            jacobians_base = jacobians_base.at[..., 4, 2].set(rx)
-            jacobians_base = jacobians_base.at[..., 5, 0].set(ry)
-            jacobians_base = jacobians_base.at[..., 5, 1].set(-rx)
+            jacobians_base = jacobians_base.at[..., 3, 1].set(offset_z)
+            jacobians_base = jacobians_base.at[..., 3, 2].set(-offset_y)
+            jacobians_base = jacobians_base.at[..., 4, 0].set(-offset_z)
+            jacobians_base = jacobians_base.at[..., 4, 2].set(offset_x)
+            jacobians_base = jacobians_base.at[..., 5, 0].set(offset_y)
+            jacobians_base = jacobians_base.at[..., 5, 1].set(-offset_x)
             jacobians_internal_world = jnp.concatenate(
                 [
                     jnp.einsum(


### PR DESCRIPTION
## Summary

- align Warp kernel and helper naming with the established SoRoMoX JAX vocabulary and Newton/Warp conventions
- replace ambiguous private names such as `forward`, `internal`, `output`, and `position` with domain-specific names
- add complete Google-style docstrings with shapes, coordinate frames, mutations, and return behavior
- preserve existing public SoRoMoX API families for consistency

This branch is based on the head of #193.

## Validation

- Ruff formatting and linting
- Python compilation and `git diff --check`
- Warp/JAX CPU parity and directional suites: 33 passed, 12 CUDA-related skipped
