### PR TITLE
Fix model-parameter gradients across custom JVPs

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -137,9 +137,10 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Fixed
 
-- Fixed forward-kinematics custom JVPs to preserve derivatives with respect to
-  dynamic model leaves, including fixed mounting poses updated inside compiled
-  functions, across JAX and accelerated execution paths.
+- Fixed forward-kinematics, Jacobian, and energy custom JVPs to preserve
+  derivatives with respect to dynamic model leaves, including fixed mounting
+  poses and gravity updated inside compiled functions, across JAX and
+  accelerated execution paths.
 - Fixed GVS abscissa-batched partial-cell poses and inertial Jacobians so
   rotational strain-basis values consistently honor
   `scale_rotational_basis_by_length` for every supported basis family.

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -137,6 +137,9 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Fixed
 
+- Fixed forward-kinematics custom JVPs to preserve derivatives with respect to
+  dynamic model leaves, including fixed mounting poses updated inside compiled
+  functions, across JAX and accelerated execution paths.
 - Fixed GVS abscissa-batched partial-cell poses and inertial Jacobians so
   rotational strain-basis values consistently honor
   `scale_rotational_basis_by_length` for every supported basis family.

--- a/docs/user-guide/parameters-and-optimization.md
+++ b/docs/user-guide/parameters-and-optimization.md
@@ -206,6 +206,7 @@ variables without reconstructing the model or recompiling for each value:
 ```python
 import equinox as eqx
 import jax
+import jax.numpy as jnp
 
 target_position = jnp.array([0.1, -0.05, 0.25])
 

--- a/docs/user-guide/parameters-and-optimization.md
+++ b/docs/user-guide/parameters-and-optimization.md
@@ -16,6 +16,7 @@ damping, and isotropic materials, see
 | Construct a robot from physical descriptions | `LinkSpec`, `JointSpec`, `GVSSegment` |
 | Replace runtime numeric values | `update_params`, `update_link_params`, `update_joint_params` |
 | Replace several nested components together | nested `.replace(...)` followed by `with_params(...)` |
+| Change or optimize a fixed mounting pose | `with_fixed_base_pose(...)` |
 | Identify isotropic material properties | caller-owned `IsotropicMaterialParams` and `with_isotropic_material(...)` |
 | Fit anisotropic or coupled mechanics | optimize `params.link.stiffness` and `params.link.damping` directly |
 | Change basis order, segment count, or padding | reconstruct with a new structure |
@@ -153,6 +154,22 @@ Top-level values use `update_params`:
 pcs = pcs.update_params(gravity=jnp.zeros(3))
 ```
 
+A fixed mounting pose is a dynamic model leaf rather than a field in the
+physical parameter PyTree. Update it independently with
+`with_fixed_base_pose(...)`:
+
+```python
+candidate_base_pose = pcs.fixed_base_pose.at[4].add(0.01)
+mounted_pcs = pcs.with_fixed_base_pose(candidate_base_pose)
+```
+
+This keeps one physical parameter PyTree reusable across different mountings
+and between fixed and floating models without making the fixed pose static or
+nondifferentiable.
+
+Floating systems instead carry their base pose in the runtime configuration
+and reject `with_fixed_base_pose(...)`.
+
 Updates may change numeric values but not static layout. Changing the number of
 links, GVS basis orders, active strain selectors, joint types, matrix padding,
 or quadrature padding requires reconstruction.
@@ -182,6 +199,32 @@ candidate_params = pcs.params.replace(
 )
 candidate = energy(candidate_params, q)
 ```
+
+Fixed mounting poses can likewise be supplied as dynamic optimization
+variables without reconstructing the model or recompiling for each value:
+
+```python
+import jax
+
+target_position = jnp.array([0.1, -0.05, 0.25])
+
+@eqx.filter_jit
+def mounted_loss_and_grad(base_pose, configuration):
+    def loss(pose):
+        candidate = pcs.with_fixed_base_pose(pose)
+        tip_pose = candidate.forward_kinematics(configuration, candidate.length)
+        return jnp.sum((tip_pose[:3, 3] - target_position) ** 2)
+
+    return jax.value_and_grad(loss)(base_pose)
+
+loss, base_pose_gradient = mounted_loss_and_grad(pcs.fixed_base_pose, q)
+```
+
+Repeated calls share one compiled executable while the pose retains the same
+shape and dtype. Use a constrained rotation parameterization or normalize the
+quaternion when optimizing a spatial mounting. To identify physical parameters
+and mounting jointly, pass both `params` and `base_pose` as dynamic arguments
+and chain `with_params(params).with_fixed_base_pose(base_pose)`.
 
 The two calls share one compiled executable when every parameter leaf keeps
 the same PyTree position, shape, and dtype. Numeric system, environment,

--- a/docs/user-guide/parameters-and-optimization.md
+++ b/docs/user-guide/parameters-and-optimization.md
@@ -204,6 +204,7 @@ Fixed mounting poses can likewise be supplied as dynamic optimization
 variables without reconstructing the model or recompiling for each value:
 
 ```python
+import equinox as eqx
 import jax
 
 target_position = jnp.array([0.1, -0.05, 0.25])

--- a/src/soromox/execution/transforms.py
+++ b/src/soromox/execution/transforms.py
@@ -311,10 +311,6 @@ def make_kinematics_evaluators(
     ) -> tuple[KinematicsResult, KinematicsResult]:
         model, q, s = primals
         model_tangent, qd, sd = tangents
-        if operation == "pose":
-            return model._forward_kinematics_jvp(
-                q, s, qd, sd, model_tangent=model_tangent
-            )
         if operation == "jacobian":
             return eqx.filter_jvp(
                 lambda model_, q_, s_: model_._absolute_inertial_jacobian(q_, s_),
@@ -324,6 +320,8 @@ def make_kinematics_evaluators(
         pose, pose_tangent = model._forward_kinematics_jvp(
             q, s, qd, sd, model_tangent=model_tangent
         )
+        if operation == "pose":
+            return pose, pose_tangent
         jacobian, jacobian_tangent = eqx.filter_jvp(
             lambda model_, q_, s_: model_._absolute_inertial_jacobian(q_, s_),
             primals,

--- a/src/soromox/execution/transforms.py
+++ b/src/soromox/execution/transforms.py
@@ -187,8 +187,8 @@ def _evaluate_forward_kinematics_jvp(
     """Route pose derivatives through the model's established JAX rule."""
 
     model, q, s = primals
-    _model_tangent, qd, sd = tangents
-    return model._forward_kinematics_jvp(q, s, qd, sd)
+    model_tangent, qd, sd = tangents
+    return model._forward_kinematics_jvp(q, s, qd, sd, model_tangent=model_tangent)
 
 
 @jax.custom_batching.custom_vmap
@@ -310,16 +310,20 @@ def make_kinematics_evaluators(
         tangents: tuple[Any, Array | None, Array | None],
     ) -> tuple[KinematicsResult, KinematicsResult]:
         model, q, s = primals
-        _model_tangent, qd, sd = tangents
+        model_tangent, qd, sd = tangents
         if operation == "pose":
-            return model._forward_kinematics_jvp(q, s, qd, sd)
+            return model._forward_kinematics_jvp(
+                q, s, qd, sd, model_tangent=model_tangent
+            )
         if operation == "jacobian":
             return eqx.filter_jvp(
                 lambda model_, q_, s_: model_._absolute_inertial_jacobian(q_, s_),
                 primals,
                 tangents,
             )
-        pose, pose_tangent = model._forward_kinematics_jvp(q, s, qd, sd)
+        pose, pose_tangent = model._forward_kinematics_jvp(
+            q, s, qd, sd, model_tangent=model_tangent
+        )
         jacobian, jacobian_tangent = eqx.filter_jvp(
             lambda model_, q_, s_: model_._absolute_inertial_jacobian(q_, s_),
             primals,

--- a/src/soromox/execution/types.py
+++ b/src/soromox/execution/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from typing import Any, Literal, Protocol
 
 from jax import Array
 
@@ -239,8 +239,10 @@ class KinematicsModel(Protocol):
         s: Array,
         qd: Array | None,
         sd: Array | None,
+        *,
+        model_tangent: Any = None,
     ) -> tuple[Array, Array]:
-        """Return the established JAX/custom-JVP pose rule."""
+        """Return the total model, configuration, and abscissa pose JVP."""
 
         ...
 

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -4,6 +4,7 @@ __all__ = [
 
 import copy
 from abc import abstractmethod
+from collections.abc import Callable
 from typing import Any, Self
 
 import equinox as eqx
@@ -972,6 +973,24 @@ class SoftRobot(DynamicalSystem):
             f"{type(self).__name__} must implement _forward_kinematics."
         )
 
+    def _add_model_jvp_tangent(
+        self,
+        output_tangent: Array,
+        model_tangent: Any,
+        output_from_model: Callable[[Self], Array],
+    ) -> Array:
+        """Add a model-only derivative to an established output tangent."""
+        if model_tangent is None or not jax.tree.leaves(model_tangent):
+            return output_tangent
+        _, model_output_tangent = eqx.filter_jvp(
+            output_from_model,
+            (self,),
+            (model_tangent,),
+        )
+        if model_output_tangent is None:
+            return output_tangent
+        return output_tangent + model_output_tangent
+
     @eqx.filter_custom_jvp
     @staticmethod
     def _forward_kinematics_custom_jvp(robot: "SoftRobot", q: Array, s: Array) -> Array:
@@ -1032,14 +1051,11 @@ class SoftRobot(DynamicalSystem):
             pose, poses = self.forward_kinematics_and_arc_length_derivative(q, s)
             pose_tangent = poses * sd
 
-        if model_tangent is not None and jax.tree.leaves(model_tangent):
-            _, model_pose_tangent = eqx.filter_jvp(
-                lambda robot: robot._absolute_forward_kinematics(q, s),
-                (self,),
-                (model_tangent,),
-            )
-            if model_pose_tangent is not None:
-                pose_tangent = pose_tangent + model_pose_tangent
+        pose_tangent = self._add_model_jvp_tangent(
+            pose_tangent,
+            model_tangent,
+            lambda robot: robot._absolute_forward_kinematics(q, s),
+        )
 
         return pose, pose_tangent
 
@@ -1212,12 +1228,18 @@ class SoftRobot(DynamicalSystem):
         tangents: tuple[Any, Array | None, Array | None],
     ) -> tuple[Array, Array]:
         robot, q, s = primals
-        _, qd, sd = tangents
+        robot_tangent, qd, sd = tangents
 
-        return robot._jacobian_jvp(q, s, qd, sd)
+        return robot._jacobian_jvp(q, s, qd, sd, model_tangent=robot_tangent)
 
     def _jacobian_jvp(
-        self, q: Array, s: Array, qd: Array | None, sd: Array | None
+        self,
+        q: Array,
+        s: Array,
+        qd: Array | None,
+        sd: Array | None,
+        *,
+        model_tangent: Any = None,
     ) -> tuple[Array, Array]:
         """
         Evaluate the Jacobian custom-JVP tangent with specialized hooks.
@@ -1229,20 +1251,25 @@ class SoftRobot(DynamicalSystem):
         """
         if qd is None and sd is None:
             J = self._jacobian(q, s)
-            return J, jnp.zeros_like(J)
-
-        if qd is None:
+            J_tangent = jnp.zeros_like(J)
+        elif qd is None:
             J, Js = self.jacobian_and_arc_length_derivative(q, s)
-            return J, Js * sd
+            J_tangent = Js * sd
+        elif sd is None:
+            J, J_tangent = self.jacobian_and_time_derivative(q, qd, s)
+        else:
+            J, J_tangent = jvp(
+                lambda q_, s_: self._jacobian(q_, s_),
+                (q, s),
+                (qd, sd),
+            )
 
-        if sd is None:
-            return self.jacobian_and_time_derivative(q, qd, s)
-
-        return jvp(
-            lambda q_, s_: self._jacobian(q_, s_),
-            (q, s),
-            (qd, sd),
+        J_tangent = self._add_model_jvp_tangent(
+            J_tangent,
+            model_tangent,
+            lambda robot: robot._jacobian(q, s),
         )
+        return J, J_tangent
 
     def jacobian_tips(self, q: Array) -> Array:
         """
@@ -2584,10 +2611,15 @@ class SoftRobot(DynamicalSystem):
         tangents: tuple[Any, Array | None, Array | None],
     ) -> tuple[Array, Array]:
         robot, q, qd = primals
-        _, q_tangent, qdd = tangents
+        robot_tangent, q_tangent, qdd = tangents
 
         T = robot._kinetic_energy(q, qd)
         Td = robot._kinetic_energy_jvp_tangent(q, qd, q_tangent, qdd)
+        Td = robot._add_model_jvp_tangent(
+            Td,
+            robot_tangent,
+            lambda candidate: candidate._kinetic_energy(q, qd),
+        )
         return T, Td
 
     def _kinetic_energy_jvp_tangent(
@@ -2691,13 +2723,18 @@ class SoftRobot(DynamicalSystem):
         tangents: tuple[Any, Array | None],
     ) -> tuple[Array, Array]:
         robot, q = primals
-        _, qd = tangents
+        robot_tangent, qd = tangents
 
         U = robot._gravitational_energy(q)
         if qd is None:
             Ud = jnp.zeros_like(U)
         else:
             Ud = robot.gravitational_force(q) @ qd
+        Ud = robot._add_model_jvp_tangent(
+            Ud,
+            robot_tangent,
+            lambda candidate: candidate._gravitational_energy(q),
+        )
         return U, Ud
 
     def elastic_energy(self, q: Array) -> Array:
@@ -2741,13 +2778,18 @@ class SoftRobot(DynamicalSystem):
         tangents: tuple[Any, Array | None],
     ) -> tuple[Array, Array]:
         robot, q = primals
-        _, qd = tangents
+        robot_tangent, qd = tangents
 
         U_el = robot._elastic_energy(q)
         if qd is None:
             Ueld = jnp.zeros_like(U_el)
         else:
             Ueld = robot.elastic_force(q) @ qd
+        Ueld = robot._add_model_jvp_tangent(
+            Ueld,
+            robot_tangent,
+            lambda candidate: candidate._elastic_energy(q),
+        )
         return U_el, Ueld
 
     def potential_energy(self, q: Array) -> Array:
@@ -2791,13 +2833,18 @@ class SoftRobot(DynamicalSystem):
         tangents: tuple[Any, Array | None],
     ) -> tuple[Array, Array]:
         robot, q = primals
-        _, qd = tangents
+        robot_tangent, qd = tangents
 
         U = robot._potential_energy(q)
         if qd is None:
             Ud = jnp.zeros_like(U)
         else:
             Ud = robot._potential_energy_gradient(q) @ qd
+        Ud = robot._add_model_jvp_tangent(
+            Ud,
+            robot_tangent,
+            lambda candidate: candidate._potential_energy(q),
+        )
         return U, Ud
 
     def total_energy(self, q: Array, qd: Array) -> Array:
@@ -2838,10 +2885,15 @@ class SoftRobot(DynamicalSystem):
         tangents: tuple[Any, Array | None, Array | None],
     ) -> tuple[Array, Array]:
         robot, q, qd = primals
-        _, q_tangent, qdd = tangents
+        robot_tangent, q_tangent, qdd = tangents
 
         E = robot._total_energy(q, qd)
         Ed = robot._total_energy_jvp_tangent(q, qd, q_tangent, qdd)
+        Ed = robot._add_model_jvp_tangent(
+            Ed,
+            robot_tangent,
+            lambda candidate: candidate._total_energy(q, qd),
+        )
         return E, Ed
 
     def _total_energy_jvp_tangent(

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -973,7 +973,7 @@ class SoftRobot(DynamicalSystem):
             f"{type(self).__name__} must implement _forward_kinematics."
         )
 
-    def _add_model_jvp_contribution(
+    def _add_model_jvp_tangent(
         self,
         output_tangent: Array,
         model_tangent: Any,
@@ -1059,7 +1059,7 @@ class SoftRobot(DynamicalSystem):
             pose, poses = self.forward_kinematics_and_arc_length_derivative(q, s)
             pose_tangent = poses * sd
 
-        pose_tangent = self._add_model_jvp_contribution(
+        pose_tangent = self._add_model_jvp_tangent(
             pose_tangent,
             model_tangent,
             lambda robot: robot._absolute_forward_kinematics(q, s),
@@ -1272,7 +1272,7 @@ class SoftRobot(DynamicalSystem):
                 (qd, sd),
             )
 
-        J_tangent = self._add_model_jvp_contribution(
+        J_tangent = self._add_model_jvp_tangent(
             J_tangent,
             model_tangent,
             lambda robot: robot._jacobian(q, s),
@@ -2623,7 +2623,7 @@ class SoftRobot(DynamicalSystem):
 
         T = robot._kinetic_energy(q, qd)
         Td = robot._kinetic_energy_jvp_tangent(q, qd, q_tangent, qdd)
-        Td = robot._add_model_jvp_contribution(
+        Td = robot._add_model_jvp_tangent(
             Td,
             robot_tangent,
             lambda candidate: candidate._kinetic_energy(q, qd),
@@ -2738,7 +2738,7 @@ class SoftRobot(DynamicalSystem):
             Ud = jnp.zeros_like(U)
         else:
             Ud = robot.gravitational_force(q) @ qd
-        Ud = robot._add_model_jvp_contribution(
+        Ud = robot._add_model_jvp_tangent(
             Ud,
             robot_tangent,
             lambda candidate: candidate._gravitational_energy(q),
@@ -2793,7 +2793,7 @@ class SoftRobot(DynamicalSystem):
             Ueld = jnp.zeros_like(U_el)
         else:
             Ueld = robot.elastic_force(q) @ qd
-        Ueld = robot._add_model_jvp_contribution(
+        Ueld = robot._add_model_jvp_tangent(
             Ueld,
             robot_tangent,
             lambda candidate: candidate._elastic_energy(q),
@@ -2848,7 +2848,7 @@ class SoftRobot(DynamicalSystem):
             Ud = jnp.zeros_like(U)
         else:
             Ud = robot._potential_energy_gradient(q) @ qd
-        Ud = robot._add_model_jvp_contribution(
+        Ud = robot._add_model_jvp_tangent(
             Ud,
             robot_tangent,
             lambda candidate: candidate._potential_energy(q),
@@ -2897,7 +2897,7 @@ class SoftRobot(DynamicalSystem):
 
         E = robot._total_energy(q, qd)
         Ed = robot._total_energy_jvp_tangent(q, qd, q_tangent, qdd)
-        Ed = robot._add_model_jvp_contribution(
+        Ed = robot._add_model_jvp_tangent(
             Ed,
             robot_tangent,
             lambda candidate: candidate._total_energy(q, qd),

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -984,15 +984,21 @@ class SoftRobot(DynamicalSystem):
         tangents: tuple[Any, Array | None, Array | None],
     ) -> tuple[Array, Array]:
         robot, q, s = primals
-        _, qd, sd = tangents
+        robot_tangent, qd, sd = tangents
 
-        return robot._forward_kinematics_jvp(q, s, qd, sd)
+        return robot._forward_kinematics_jvp(q, s, qd, sd, model_tangent=robot_tangent)
 
     def _forward_kinematics_jvp(
-        self, q: Array, s: Array, qd: Array | None, sd: Array | None
+        self,
+        q: Array,
+        s: Array,
+        qd: Array | None,
+        sd: Array | None,
+        *,
+        model_tangent: Any = None,
     ) -> tuple[Array, Array]:
         """
-        Evaluate the FK custom-JVP tangent with the narrowest needed hooks.
+        Evaluate the complete FK custom JVP with the narrowest needed hooks.
 
         The arc-length-only tangent uses the analytical
         ``forward_kinematics_and_arc_length_derivative`` hook when available,
@@ -1001,27 +1007,41 @@ class SoftRobot(DynamicalSystem):
         intentionally use JAX autodiff through ``_forward_kinematics``. Earlier
         specialized FK velocity paths duplicated substantial kinematics code
         and did not show enough benchmark benefit to justify the maintenance
-        cost.
+        cost. ``model_tangent`` is optional for direct internal calls. Equinox
+        custom-JVP rules supply a model-shaped filtered tangent whose inactive
+        dynamic leaves are ``None``.
         """
         forward_kinematics = self._absolute_forward_kinematics
         if qd is not None:
             if sd is None:
-                return jvp(lambda q_: forward_kinematics(q_, s), (q,), (qd,))
-            return jvp(
-                lambda q_, s_: forward_kinematics(q_, s_),
-                (q, s),
-                (qd, sd),
-            )
-
-        if sd is None:
+                pose, pose_tangent = jvp(
+                    lambda q_: forward_kinematics(q_, s), (q,), (qd,)
+                )
+            else:
+                pose, pose_tangent = jvp(
+                    lambda q_, s_: forward_kinematics(q_, s_),
+                    (q, s),
+                    (qd, sd),
+                )
+        elif sd is None:
             pose = forward_kinematics(q, s)
-            return pose, jnp.zeros_like(pose)
+            pose_tangent = jnp.zeros_like(pose)
+        elif self.floating_base:
+            pose, pose_tangent = jvp(lambda s_: forward_kinematics(q, s_), (s,), (sd,))
+        else:
+            pose, poses = self.forward_kinematics_and_arc_length_derivative(q, s)
+            pose_tangent = poses * sd
 
-        if self.floating_base:
-            return jvp(lambda s_: forward_kinematics(q, s_), (s,), (sd,))
+        if model_tangent is not None and jax.tree.leaves(model_tangent):
+            _, model_pose_tangent = eqx.filter_jvp(
+                lambda robot: robot._absolute_forward_kinematics(q, s),
+                (self,),
+                (model_tangent,),
+            )
+            if model_pose_tangent is not None:
+                pose_tangent = pose_tangent + model_pose_tangent
 
-        pose, poses = self.forward_kinematics_and_arc_length_derivative(q, s)
-        return pose, poses * sd
+        return pose, pose_tangent
 
     def forward_kinematics_tips(self, q: Array) -> Array:
         """

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -973,14 +973,16 @@ class SoftRobot(DynamicalSystem):
             f"{type(self).__name__} must implement _forward_kinematics."
         )
 
-    def _add_model_jvp_tangent(
+    def _add_model_jvp_contribution(
         self,
         output_tangent: Array,
         model_tangent: Any,
         output_from_model: Callable[[Self], Array],
     ) -> Array:
-        """Add a model-only derivative to an established output tangent."""
-        if model_tangent is None or not jax.tree.leaves(model_tangent):
+        """Add the model-only JVP contribution to an output tangent."""
+        if model_tangent is None or not any(
+            eqx.is_inexact_array(leaf) for leaf in jax.tree.leaves(model_tangent)
+        ):
             return output_tangent
         _, model_output_tangent = eqx.filter_jvp(
             output_from_model,
@@ -1028,7 +1030,13 @@ class SoftRobot(DynamicalSystem):
         and did not show enough benchmark benefit to justify the maintenance
         cost. ``model_tangent`` is optional for direct internal calls. Equinox
         custom-JVP rules supply a model-shaped filtered tangent whose inactive
-        dynamic leaves are ``None``.
+        dynamic leaves are ``None``. The differentiated
+        ``_absolute_forward_kinematics`` hook is a protected primal path and
+        does not call the public custom-JVP wrapper recursively. Its
+        configuration derivative returns a tangent in the stored pose
+        representation; the analytical Jacobian instead returns an inertial
+        velocity, and the previous conversion path duplicated pose-specific
+        logic without a measured benefit.
         """
         forward_kinematics = self._absolute_forward_kinematics
         if qd is not None:
@@ -1051,7 +1059,7 @@ class SoftRobot(DynamicalSystem):
             pose, poses = self.forward_kinematics_and_arc_length_derivative(q, s)
             pose_tangent = poses * sd
 
-        pose_tangent = self._add_model_jvp_tangent(
+        pose_tangent = self._add_model_jvp_contribution(
             pose_tangent,
             model_tangent,
             lambda robot: robot._absolute_forward_kinematics(q, s),
@@ -1264,7 +1272,7 @@ class SoftRobot(DynamicalSystem):
                 (qd, sd),
             )
 
-        J_tangent = self._add_model_jvp_tangent(
+        J_tangent = self._add_model_jvp_contribution(
             J_tangent,
             model_tangent,
             lambda robot: robot._jacobian(q, s),
@@ -2615,7 +2623,7 @@ class SoftRobot(DynamicalSystem):
 
         T = robot._kinetic_energy(q, qd)
         Td = robot._kinetic_energy_jvp_tangent(q, qd, q_tangent, qdd)
-        Td = robot._add_model_jvp_tangent(
+        Td = robot._add_model_jvp_contribution(
             Td,
             robot_tangent,
             lambda candidate: candidate._kinetic_energy(q, qd),
@@ -2730,7 +2738,7 @@ class SoftRobot(DynamicalSystem):
             Ud = jnp.zeros_like(U)
         else:
             Ud = robot.gravitational_force(q) @ qd
-        Ud = robot._add_model_jvp_tangent(
+        Ud = robot._add_model_jvp_contribution(
             Ud,
             robot_tangent,
             lambda candidate: candidate._gravitational_energy(q),
@@ -2785,7 +2793,7 @@ class SoftRobot(DynamicalSystem):
             Ueld = jnp.zeros_like(U_el)
         else:
             Ueld = robot.elastic_force(q) @ qd
-        Ueld = robot._add_model_jvp_tangent(
+        Ueld = robot._add_model_jvp_contribution(
             Ueld,
             robot_tangent,
             lambda candidate: candidate._elastic_energy(q),
@@ -2840,7 +2848,7 @@ class SoftRobot(DynamicalSystem):
             Ud = jnp.zeros_like(U)
         else:
             Ud = robot._potential_energy_gradient(q) @ qd
-        Ud = robot._add_model_jvp_tangent(
+        Ud = robot._add_model_jvp_contribution(
             Ud,
             robot_tangent,
             lambda candidate: candidate._potential_energy(q),
@@ -2889,7 +2897,7 @@ class SoftRobot(DynamicalSystem):
 
         E = robot._total_energy(q, qd)
         Ed = robot._total_energy_jvp_tangent(q, qd, q_tangent, qdd)
-        Ed = robot._add_model_jvp_tangent(
+        Ed = robot._add_model_jvp_contribution(
             Ed,
             robot_tangent,
             lambda candidate: candidate._total_energy(q, qd),

--- a/tests/execution/test_backend.py
+++ b/tests/execution/test_backend.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -112,9 +114,12 @@ class _KinematicsProbe(eqx.Module):
         s: Array,
         qd: Array | None,
         sd: Array | None,
+        *,
+        model_tangent: Any = None,
     ) -> tuple[Array, Array]:
         """Differentiate the probe's scalar pose implementation."""
 
+        del model_tangent
         qd = jnp.zeros_like(q) if qd is None else qd
         sd = jnp.zeros_like(s) if sd is None else sd
         return jax.jvp(self._forward_kinematics, (q, s), (qd, sd))

--- a/tests/execution/test_transforms.py
+++ b/tests/execution/test_transforms.py
@@ -132,7 +132,9 @@ class _KinematicsTransformProbe(eqx.Module):
             (q, s),
             (qd, sd),
         )
-        if model_tangent is not None and jax.tree.leaves(model_tangent):
+        if model_tangent is not None and any(
+            eqx.is_inexact_array(leaf) for leaf in jax.tree.leaves(model_tangent)
+        ):
             _, model_pose_tangent = eqx.filter_jvp(
                 lambda candidate: candidate._absolute_forward_kinematics(q, s),
                 (self,),

--- a/tests/execution/test_transforms.py
+++ b/tests/execution/test_transforms.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -13,6 +15,7 @@ from soromox.execution import (
     ExecutionBackend,
     evaluate_forward_dynamics,
     make_dynamics_evaluator,
+    make_kinematics_evaluators,
 )
 
 jax.config.update("jax_enable_x64", True)
@@ -96,6 +99,50 @@ class _TransformProbe(eqx.Module):
         return jnp.linalg.solve(inertia, rhs)
 
 
+class _KinematicsTransformProbe(eqx.Module):
+    """Differentiable model for kinematics custom-JVP tests."""
+
+    offset: Array
+    backend: ExecutionBackend = eqx.field(static=True, default="warp")
+    num_coordinates: int = eqx.field(static=True, default=3)
+    num_velocities: int = eqx.field(static=True, default=3)
+    floating_base: bool = eqx.field(static=True, default=False)
+    is_planar: bool = eqx.field(static=True, default=True)
+
+    def _absolute_forward_kinematics(self, q: Array, s: Array) -> Array:
+        """Return a pose that depends on state and a dynamic model leaf."""
+
+        return self.offset + jnp.array([s + q[0], q[1], q[2]])
+
+    def _forward_kinematics_jvp(
+        self,
+        q: Array,
+        s: Array,
+        qd: Array | None,
+        sd: Array | None,
+        *,
+        model_tangent: Any = None,
+    ) -> tuple[Array, Array]:
+        """Differentiate the probe's model and state inputs."""
+
+        qd = jnp.zeros_like(q) if qd is None else qd
+        sd = jnp.zeros_like(s) if sd is None else sd
+        pose, pose_tangent = jax.jvp(
+            lambda q_, s_: self._absolute_forward_kinematics(q_, s_),
+            (q, s),
+            (qd, sd),
+        )
+        if model_tangent is not None and jax.tree.leaves(model_tangent):
+            _, model_pose_tangent = eqx.filter_jvp(
+                lambda candidate: candidate._absolute_forward_kinematics(q, s),
+                (self,),
+                (model_tangent,),
+            )
+            if model_pose_tangent is not None:
+                pose_tangent = pose_tangent + model_pose_tangent
+        return pose, pose_tangent
+
+
 def _assert_terms_close(actual: DynamicsTerms, expected: DynamicsTerms) -> None:
     """Compare the three dynamics outputs with strict FP64 tolerances."""
 
@@ -139,6 +186,50 @@ def test_dynamics_evaluator_uses_jax_for_forward_and_reverse_derivatives() -> No
         lambda q_: sum(jnp.sum(value) for value in evaluate(model, q_, qd))
     )(q)
     assert_allclose(actual_gradient, expected_gradient, rtol=1e-12, atol=1e-12)
+
+
+def test_kinematics_evaluator_preserves_model_tangent() -> None:
+    """Differentiate model leaves through the accelerated pose adapter."""
+
+    model = _KinematicsTransformProbe(offset=jnp.zeros(3, dtype=jnp.float64))
+    q = jnp.asarray([0.1, -0.2, 0.3], dtype=jnp.float64)
+    s = jnp.asarray(0.4, dtype=jnp.float64)
+
+    def execute_batch(
+        candidate: _KinematicsTransformProbe,
+        q_batch: Array,
+        s_batch: Array,
+        operation: str,
+    ) -> Array:
+        assert operation == "pose"
+        return jax.vmap(
+            lambda q_, s_: jax.vmap(
+                lambda s__: candidate._absolute_forward_kinematics(q_, s__)
+            )(s_)
+        )(q_batch, s_batch)
+
+    evaluate, _ = make_kinematics_evaluators(
+        execute_batch,
+        family_name="test",
+        operation="pose",
+    )
+
+    def pose_sum(offset: Array, *, accelerated: bool) -> Array:
+        candidate = eqx.tree_at(lambda current: current.offset, model, offset)
+        pose = (
+            evaluate(candidate, q, s)
+            if accelerated
+            else candidate._absolute_forward_kinematics(q, s)
+        )
+        return jnp.sum(pose)
+
+    actual = jax.grad(lambda offset: pose_sum(offset, accelerated=True))(model.offset)
+    expected = jax.grad(lambda offset: pose_sum(offset, accelerated=False))(
+        model.offset
+    )
+
+    assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+    assert jnp.any(actual != 0.0)
 
 
 def test_forward_dynamics_boundary_routes_derivatives_to_jax() -> None:

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -211,6 +211,46 @@ def test_gvs_compiled_partial_base_pose_updates_match_eager_forces():
     assert not jnp.allclose(actual[0], actual[1])
 
 
+def test_gvs_compiled_fixed_base_pose_kinematics_gradients_do_not_retrace():
+    robot, _ = build_matched_gvs_pcs()
+    q = jnp.linspace(-0.02, 0.02, robot.num_internal_dofs)
+    target = jnp.array([0.07, -0.03, 0.24], dtype=jnp.float64)
+    sqrt_half = jnp.sqrt(jnp.asarray(0.5, dtype=jnp.float64))
+    base_poses = (
+        robot.fixed_base_pose,
+        jnp.array([0.0, sqrt_half, 0.0, sqrt_half, 0.01, -0.02, 0.03]),
+    )
+    trace_count = {"value": 0}
+
+    def tip_loss(base_pose, *, public: bool):
+        candidate = robot.with_fixed_base_pose(base_pose)
+        if public:
+            tip_pose = candidate.forward_kinematics(q, candidate.length)
+        else:
+            tip_pose = candidate._absolute_forward_kinematics(q, candidate.length)
+        return jnp.sum((tip_pose[:3, 3] - target) ** 2)
+
+    @eqx.filter_jit
+    def compiled_value_and_grad(base_pose):
+        trace_count["value"] += 1
+        return jax.value_and_grad(lambda pose: tip_loss(pose, public=True))(base_pose)
+
+    actual = tuple(compiled_value_and_grad(base_pose) for base_pose in base_poses)
+    expected = tuple(
+        jax.value_and_grad(lambda pose: tip_loss(pose, public=False))(base_pose)
+        for base_pose in base_poses
+    )
+
+    assert trace_count["value"] == 1
+    for (value, gradient), (expected_value, expected_gradient) in zip(
+        actual, expected, strict=True
+    ):
+        assert_allclose(value, expected_value, rtol=1e-10, atol=1e-12)
+        assert_allclose(gradient, expected_gradient, rtol=1e-9, atol=1e-11)
+        assert jnp.all(jnp.isfinite(gradient))
+        assert jnp.any(jnp.abs(gradient) > 1e-12)
+
+
 def test_gvs_closed_over_complete_params_validate_inside_compiled_evaluation():
     robot, _ = build_matched_gvs_pcs()
     q = jnp.linspace(-0.02, 0.02, robot.num_internal_dofs)

--- a/tests/systems/test_pendulum.py
+++ b/tests/systems/test_pendulum.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_allclose
 from system_param_builders import pendulum_params, planar_base_pose
 
 from soromox.actuation import ArticulatedTendonActuator
+from soromox.autodiff import custom_jvp_mode
 from soromox.systems import Pendulum
 from soromox.utils.tolerance import Tolerance
 
@@ -94,6 +95,47 @@ def test_grad_differentiates_through_typed_params():
 
     grad_value = jax.grad(energy_for_first_mass)(params.mass[0])
     assert jnp.isfinite(grad_value)
+
+
+def test_compiled_gravity_energy_gradients_do_not_retrace():
+    robot = make_pendulum(2)
+    params = robot.params
+    q = jnp.array([0.25, -0.15], dtype=jnp.float64)
+    updated_gravity = params.gravity.at[1].set(-9.7)
+    trace_count = {"value": 0}
+
+    @eqx.filter_jit
+    def compiled_value_and_grad(gravity):
+        trace_count["value"] += 1
+
+        def energy(current_gravity):
+            candidate = robot.with_params(params.replace(gravity=current_gravity))
+            return candidate.gravitational_energy(q)
+
+        return jax.value_and_grad(energy)(gravity)
+
+    def reference_value_and_grad(gravity):
+        def energy(current_gravity):
+            candidate = robot.with_params(params.replace(gravity=current_gravity))
+            return candidate._gravitational_energy(q)
+
+        return jax.value_and_grad(energy)(gravity)
+
+    with custom_jvp_mode(True):
+        baseline = compiled_value_and_grad(params.gravity)
+        updated = compiled_value_and_grad(updated_gravity)
+
+    expected_baseline = reference_value_and_grad(params.gravity)
+    expected_updated = reference_value_and_grad(updated_gravity)
+
+    assert trace_count["value"] == 1
+    assert not jnp.allclose(updated[0], baseline[0])
+    for actual, expected in zip(baseline, expected_baseline, strict=True):
+        assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+    for actual, expected in zip(updated, expected_updated, strict=True):
+        assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+    assert jnp.isfinite(baseline[1]).all()
+    assert jnp.any(baseline[1] != 0.0)
 
 
 def test_pendulum_update_rejects_all_fixed_size_shape_changes():

--- a/tests/systems/test_soft_robot_defaults.py
+++ b/tests/systems/test_soft_robot_defaults.py
@@ -241,6 +241,22 @@ def test_public_forward_kinematics_custom_jvp_preserves_model_tangent() -> None:
     assert jnp.any(actual != 0.0)
 
 
+def test_model_jvp_contribution_skips_inactive_tangent_tree() -> None:
+    robot = _ModelTangentDefaultRobot()
+    output_tangent = jnp.array([0.2, -0.4], dtype=jnp.float64)
+
+    def unexpected_model_evaluation(_robot: _ModelTangentDefaultRobot) -> Array:
+        raise AssertionError("inactive model tangents must not evaluate the model JVP")
+
+    actual = robot._add_model_jvp_contribution(
+        output_tangent,
+        {"none": None, "integer_zero": 0},
+        unexpected_model_evaluation,
+    )
+
+    assert_allclose(actual, output_tangent, rtol=0.0, atol=0.0)
+
+
 @pytest.mark.parametrize(
     "operation",
     (

--- a/tests/systems/test_soft_robot_defaults.py
+++ b/tests/systems/test_soft_robot_defaults.py
@@ -241,14 +241,14 @@ def test_public_forward_kinematics_custom_jvp_preserves_model_tangent() -> None:
     assert jnp.any(actual != 0.0)
 
 
-def test_model_jvp_contribution_skips_inactive_tangent_tree() -> None:
+def test_model_jvp_tangent_skips_inactive_tangent_tree() -> None:
     robot = _ModelTangentDefaultRobot()
     output_tangent = jnp.array([0.2, -0.4], dtype=jnp.float64)
 
     def unexpected_model_evaluation(_robot: _ModelTangentDefaultRobot) -> Array:
         raise AssertionError("inactive model tangents must not evaluate the model JVP")
 
-    actual = robot._add_model_jvp_contribution(
+    actual = robot._add_model_jvp_tangent(
         output_tangent,
         {"none": None, "integer_zero": 0},
         unexpected_model_evaluation,

--- a/tests/systems/test_soft_robot_defaults.py
+++ b/tests/systems/test_soft_robot_defaults.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 from jax import Array
 from jax import numpy as jnp
@@ -141,6 +142,12 @@ class _ToggleSentinelDefaultRobot(_PlanarDefaultRobot):
         return jnp.array([4.0, -2.0], dtype=q.dtype)
 
 
+class _ModelTangentDefaultRobot(_PlanarDefaultRobot):
+    def _forward_kinematics(self, q: Array, s: Array) -> Array:
+        pose = super()._forward_kinematics(q, s)
+        return pose.at[1:].add(self.L)
+
+
 def test_custom_jvp_global_toggle_context_manager_restores_state() -> None:
     set_custom_jvp_enabled(True)
     assert custom_jvp_enabled()
@@ -192,6 +199,28 @@ def test_custom_jvp_toggle_controls_public_forward_kinematics_arc_length_jvp() -
 
     _, expected = jax.jvp(lambda s_: robot._forward_kinematics(q, s_), (s,), (sd,))
     assert_allclose(posed, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_public_forward_kinematics_custom_jvp_preserves_model_tangent() -> None:
+    robot = _ModelTangentDefaultRobot()
+    q = jnp.array([0.2, -0.3], dtype=jnp.float64)
+    s = jnp.array(0.8, dtype=jnp.float64)
+
+    def pose_sum(lengths: Array, *, public: bool) -> Array:
+        candidate = eqx.tree_at(lambda model: model.L, robot, lengths)
+        pose = (
+            candidate.forward_kinematics(q, s)
+            if public
+            else candidate._forward_kinematics(q, s)
+        )
+        return jnp.sum(pose)
+
+    with custom_jvp_mode(True):
+        actual = jax.grad(lambda lengths: pose_sum(lengths, public=True))(robot.L)
+    expected = jax.grad(lambda lengths: pose_sum(lengths, public=False))(robot.L)
+
+    assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+    assert jnp.any(actual != 0.0)
 
 
 def test_custom_jvp_toggle_controls_public_gravity_energy_grad() -> None:

--- a/tests/systems/test_soft_robot_defaults.py
+++ b/tests/systems/test_soft_robot_defaults.py
@@ -1,5 +1,6 @@
 import equinox as eqx
 import jax
+import pytest
 from jax import Array
 from jax import numpy as jnp
 from numpy.testing import assert_allclose
@@ -143,9 +144,26 @@ class _ToggleSentinelDefaultRobot(_PlanarDefaultRobot):
 
 
 class _ModelTangentDefaultRobot(_PlanarDefaultRobot):
+    model_scale: Array
+
+    def __init__(self):
+        super().__init__()
+        self.model_scale = jnp.asarray(1.25, dtype=jnp.float64)
+
     def _forward_kinematics(self, q: Array, s: Array) -> Array:
-        pose = super()._forward_kinematics(q, s)
-        return pose.at[1:].add(self.L)
+        return self.model_scale * super()._forward_kinematics(q, s)
+
+    def inertia_matrix(self, q: Array) -> Array:
+        return self.model_scale * super().inertia_matrix(q)
+
+    def stiffness_matrix(self) -> Array:
+        return self.model_scale * super().stiffness_matrix()
+
+    def elastic_force(self, q: Array) -> Array:
+        return self.model_scale * super().elastic_force(q)
+
+    def _gravitational_energy(self, q: Array) -> Array:
+        return self.model_scale * super()._gravitational_energy(q)
 
 
 def test_custom_jvp_global_toggle_context_manager_restores_state() -> None:
@@ -206,8 +224,8 @@ def test_public_forward_kinematics_custom_jvp_preserves_model_tangent() -> None:
     q = jnp.array([0.2, -0.3], dtype=jnp.float64)
     s = jnp.array(0.8, dtype=jnp.float64)
 
-    def pose_sum(lengths: Array, *, public: bool) -> Array:
-        candidate = eqx.tree_at(lambda model: model.L, robot, lengths)
+    def pose_sum(model_scale: Array, *, public: bool) -> Array:
+        candidate = eqx.tree_at(lambda model: model.model_scale, robot, model_scale)
         pose = (
             candidate.forward_kinematics(q, s)
             if public
@@ -216,11 +234,67 @@ def test_public_forward_kinematics_custom_jvp_preserves_model_tangent() -> None:
         return jnp.sum(pose)
 
     with custom_jvp_mode(True):
-        actual = jax.grad(lambda lengths: pose_sum(lengths, public=True))(robot.L)
-    expected = jax.grad(lambda lengths: pose_sum(lengths, public=False))(robot.L)
+        actual = jax.grad(lambda scale: pose_sum(scale, public=True))(robot.model_scale)
+    expected = jax.grad(lambda scale: pose_sum(scale, public=False))(robot.model_scale)
 
     assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
     assert jnp.any(actual != 0.0)
+
+
+@pytest.mark.parametrize(
+    "operation",
+    (
+        "jacobian",
+        "kinetic_energy",
+        "gravitational_energy",
+        "elastic_energy",
+        "potential_energy",
+        "total_energy",
+    ),
+)
+def test_public_custom_jvps_preserve_model_tangents(operation: str) -> None:
+    robot = _ModelTangentDefaultRobot()
+    q = jnp.array([0.2, -0.3], dtype=jnp.float64)
+    qd = jnp.array([0.7, -0.4], dtype=jnp.float64)
+    s = jnp.array(0.8, dtype=jnp.float64)
+
+    public_outputs = {
+        "jacobian": lambda model: model.jacobian(q, s),
+        "kinetic_energy": lambda model: model.kinetic_energy(q, qd),
+        "gravitational_energy": lambda model: model.gravitational_energy(q),
+        "elastic_energy": lambda model: model.elastic_energy(q),
+        "potential_energy": lambda model: model.potential_energy(q),
+        "total_energy": lambda model: model.total_energy(q, qd),
+    }
+    protected_outputs = {
+        "jacobian": lambda model: model._jacobian(q, s),
+        "kinetic_energy": lambda model: model._kinetic_energy(q, qd),
+        "gravitational_energy": lambda model: model._gravitational_energy(q),
+        "elastic_energy": lambda model: model._elastic_energy(q),
+        "potential_energy": lambda model: model._potential_energy(q),
+        "total_energy": lambda model: model._total_energy(q, qd),
+    }
+
+    def output_sum(model_scale: Array, *, public: bool) -> Array:
+        candidate = eqx.tree_at(lambda model: model.model_scale, robot, model_scale)
+        output = (
+            public_outputs[operation](candidate)
+            if public
+            else protected_outputs[operation](candidate)
+        )
+        return jnp.sum(output)
+
+    with custom_jvp_mode(True):
+        actual = eqx.filter_jit(jax.grad(lambda scale: output_sum(scale, public=True)))(
+            robot.model_scale
+        )
+    expected = eqx.filter_jit(jax.grad(lambda scale: output_sum(scale, public=False)))(
+        robot.model_scale
+    )
+
+    assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+    assert jnp.isfinite(actual)
+    assert actual != 0.0
 
 
 def test_custom_jvp_toggle_controls_public_gravity_energy_grad() -> None:


### PR DESCRIPTION
## Summary

- preserve derivatives with respect to dynamic model leaves across the public
  forward-kinematics, Jacobian, and energy custom JVPs while retaining their
  optimized state-derivative paths
- add compiled regressions for fixed-base-pose and gravity optimization,
  including numerical agreement with direct autodiff and repeated values
  without retracing
- document `with_fixed_base_pose(...)`, joint parameter/mounting optimization,
  and the fixed-base versus floating-base ownership of the pose; add an
  Unreleased changelog entry under Fixed

## Regression

#184 moved a fixed mounting pose out of the typed parameter PyTree introduced
around #156. The pose remained a dynamic, differentiable model leaf, so its
value could change inside a compiled function without recompilation. However,
the forward-kinematics custom JVP preserved only configuration and abscissa
tangents and discarded the incoming model tangent, producing a zero gradient
with respect to the mounting pose.

The audit found the same dropped-model-tangent pattern in the shared
fixed-base `jacobian`, `kinetic_energy`, `gravitational_energy`,
`elastic_energy`, `potential_energy`, and `total_energy` custom JVPs. Each rule
now adds the model-only derivative to its established optimized state tangent.
The accelerated kinematics, dynamics, forward-dynamics, and actuation adapters
already differentiated their protected JAX implementations with respect to the
complete model and required no analogous change.

The GVS regression evaluates `jax.value_and_grad` inside `eqx.filter_jit` for
two fixed mounting poses and verifies one trace, finite nonzero gradients, and
agreement with direct autodiff. A Pendulum regression applies the same contract
to gravity. A parameterized base-class regression independently checks the
Jacobian and all five energy boundaries.

## API design

`fixed_base_pose` remains outside the typed dynamic parameter struct because it
is a model leaf for fixed robots but runtime configuration state for floating
robots. Keeping it separate lets one parameter PyTree be reused across
mountings and avoids making that tree depend on a fixed-versus-floating choice.

Gravity remains in the parameter PyTree: it has the same stable world-frame
environment semantics for fixed and floating systems. Moving it to a separate
model leaf would not improve JIT or differentiation and would fragment the
parameter-update interface.

## Validation

- `127 passed` across the complete default-model and Pendulum suites, execution
  and compiled model-tangent checks, and cross-family PCS, PlanarPCS, GVS,
  PlanarHSA, and articulated energy/Jacobian autodiff checks
- an additional `45 passed` across broader selected GVS, Pendulum,
  ArticulatedSoftRobot, and PlanarHSA kinematics checks
- Ruff lint and format checks on every changed Python file
- Python byte-compilation checks on every changed Python file
- Zensical documentation build
- scoped `git diff --check`
