### PR TITLE
Optimize PCS analytical state Jacobians and JVPs

### DIFF
--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -4,7 +4,7 @@ __all__ = ["PCS"]
 from typing import Any, Self
 
 import equinox as eqx
-from jax import Array, jvp, lax, tree_util, vmap
+from jax import Array, lax, tree_util, vmap
 from jax import numpy as jnp
 
 from soromox.actuation.core import Actuator, PassiveElement
@@ -32,7 +32,7 @@ from soromox.utils.integration import (
     scale_interior_gaussian_quadrature,
 )
 from soromox.utils.joint_motion_subspace import (
-    joint_dSdq_qd,
+    joint_dSTF_dq,
     joint_motion_subspace_with_derivatives,
 )
 from soromox.utils.lie_algebra import se3, so3
@@ -3327,6 +3327,13 @@ class PCS(SoftRobot):
         self, t: Array, y: Array, actuation_args: tuple | None = None
     ) -> Array:
         """Evaluate the PCS forward-dynamics primal without a custom JVP."""
+        yd, _ = self._forward_dynamics_with_inertia(t, y, actuation_args)
+        return yd
+
+    def _forward_dynamics_with_inertia(
+        self, t: Array, y: Array, actuation_args: tuple | None = None
+    ) -> tuple[Array, Array]:
+        """Evaluate forward dynamics and return its assembled inertia matrix."""
         del t
 
         # Split the state vector into configuration and velocity
@@ -3357,7 +3364,7 @@ class PCS(SoftRobot):
 
         yd = jnp.concatenate([qd, qdd])
 
-        return yd
+        return yd, B
 
     @eqx.filter_custom_jvp
     @staticmethod
@@ -3389,7 +3396,7 @@ class PCS(SoftRobot):
         robot, t, y, actuation_args = primals
         robot_tangent, _, y_tangent, actuation_args_tangent = tangents
 
-        yd = robot._forward_dynamics(t, y, actuation_args)
+        yd, mass_matrix = robot._forward_dynamics_with_inertia(t, y, actuation_args)
         q, qd = jnp.split(y, 2)
         _, qdd = jnp.split(yd, 2)
 
@@ -3404,6 +3411,8 @@ class PCS(SoftRobot):
             tau_ext = jnp.zeros_like(q)
             u_tangent = jnp.zeros_like(u)
             tau_ext_tangent = jnp.zeros_like(tau_ext)
+            u_has_tangent = False
+            tau_ext_has_tangent = False
         else:
             u = actuation_args[0]
             tau_ext = actuation_args[1] if len(actuation_args) == 2 else None
@@ -3422,29 +3431,26 @@ class PCS(SoftRobot):
                 u = jnp.zeros((robot.num_actuators,), dtype=q.dtype)
             if tau_ext is None:
                 tau_ext = jnp.zeros_like(q)
+            u_has_tangent = u_tangent is not None
+            tau_ext_has_tangent = tau_ext_tangent is not None
             if u_tangent is None:
                 u_tangent = jnp.zeros_like(u)
             if tau_ext_tangent is None:
                 tau_ext_tangent = jnp.zeros_like(tau_ext)
 
-        def applied_force(
-            q_value: Array,
-            qd_value: Array,
-            u_value: Array,
-            tau_ext_value: Array,
-        ) -> Array:
-            return (
-                robot.actuation_force(q_value, u_value, qd=qd_value)
-                + tau_ext_value
-                - robot.elastic_force(q_value)
-                - robot.damping_matrix(q_value) @ qd_value
+        d_damping_dq, d_damping_dqd = robot.damping_force_derivatives(q, qd)
+        applied_force_tangent = (
+            robot.actuation_force_derivative_q(q, u)
+            - robot.elastic_force_derivative_q(q)
+            - d_damping_dq
+        ) @ q_tangent - d_damping_dqd @ qd_tangent
+        if u_has_tangent:
+            applied_force_tangent = (
+                applied_force_tangent
+                + robot.actuation_force_derivative_u(q) @ u_tangent
             )
-
-        _, applied_force_tangent = jvp(
-            applied_force,
-            (q, qd, u, tau_ext),
-            (q_tangent, qd_tangent, u_tangent, tau_ext_tangent),
-        )
+        if tau_ext_has_tangent:
+            applied_force_tangent = applied_force_tangent + tau_ext_tangent
 
         robot_has_tangent = any(
             tangent is not None
@@ -3483,12 +3489,18 @@ class PCS(SoftRobot):
             (
                 dID_dq,
                 dID_dqd,
-                mass_matrix,
                 _,
                 _,
                 _,
                 _,
-            ) = robot.inverse_dynamics_backward_pass(q, qd, qdd)
+                _,
+            ) = robot.inverse_dynamics_backward_pass(
+                q,
+                qd,
+                qdd,
+                materialize_wrench_history=False,
+                compute_acceleration_jacobian=False,
+            )
             inverse_dynamics_tangent = dID_dq @ q_tangent + dID_dqd @ qd_tangent
 
         qdd_tangent = robot._solve_inertia(
@@ -3769,6 +3781,9 @@ class PCS(SoftRobot):
         q: Array,
         qd: Array,
         qdd: Array,
+        *,
+        materialize_wrench_history: bool = True,
+        compute_acceleration_jacobian: bool = True,
     ) -> tuple[Array, Array, Array, Array, Array, Array, Array]:
         """
         Recurse the composite wrench and its Jacobians from tip to base.
@@ -3786,6 +3801,13 @@ class PCS(SoftRobot):
                 ``(self.num_dofs,)``.
             qdd (Array): Active generalized accelerations. Shape is
                 ``(self.num_dofs,)``.
+            materialize_wrench_history: Whether to return the per-interval
+                resultant-wrench derivative histories. State-Jacobian callers
+                can disable this because they only consume the three aggregate
+                inverse-dynamics Jacobians. Defaults to true.
+            compute_acceleration_jacobian: Whether to propagate
+                ``dID/dqdd``. Callers that already assembled the inertia matrix
+                can disable this duplicate recursion. Defaults to true.
 
         Returns:
             tuple[Array, Array, Array, Array, Array, Array, Array]: Tuple
@@ -3817,22 +3839,30 @@ class PCS(SoftRobot):
         zeros_6 = jnp.zeros((6,), dtype=q.dtype)
         zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
         zeros_nn = jnp.zeros((self.num_dofs, self.num_dofs), dtype=q.dtype)
-        q_basis = jnp.eye(self.num_dofs, dtype=q.dtype)
+        acceleration_zeros_6n = (
+            zeros_6n
+            if compute_acceleration_jacobian
+            else jnp.empty((0, 0), dtype=q.dtype)
+        )
+        acceleration_zeros_nn = (
+            zeros_nn
+            if compute_acceleration_jacobian
+            else jnp.empty((0, 0), dtype=q.dtype)
+        )
         B_xi_segments = self.B_xi.reshape(
             self.num_segments,
             6,
             self.num_dofs,
         )
         xi_ref_segments = self.xi_ref.reshape(self.num_segments, 6)
-
         carry_init = (
             zeros_6,
             zeros_6n,
             zeros_6n,
-            zeros_6n,
+            acceleration_zeros_6n,
             zeros_nn,
             zeros_nn,
-            zeros_nn,
+            acceleration_zeros_nn,
         )
 
         def propagate_interval_backward(
@@ -3853,7 +3883,9 @@ class PCS(SoftRobot):
             ) = carry
 
             segment_idx = segment_indices[step_idx]
-            M = mass_weights[step_idx] * self.M_segments[segment_idx]
+            mass_diagonal = mass_weights[step_idx] * jnp.diagonal(
+                self.M_segments[segment_idx]
+            )
             g_i = g[step_idx]
             eta_i = eta[step_idx]
             etad_i = etad[step_idx]
@@ -3864,49 +3896,83 @@ class PCS(SoftRobot):
             Adginv_i = Adginv[step_idx]
             S_i = S[step_idx]
 
-            M_eta = M @ eta_i
+            def mass_action(value: Array) -> Array:
+                shape = (mass_diagonal.shape[0],) + (1,) * (value.ndim - 1)
+                return mass_diagonal.reshape(shape) * value
+
+            M_eta = mass_action(eta_i)
             gravity_i = se3.adjoint_inverse(g_i) @ self.g
-            F_i = M @ etad_i + se3.coadjoint(eta_i) @ M_eta - M @ gravity_i
-            N = se3.coadjoint(eta_i) @ M + se3.coadjoint_bar(M_eta)
+            F_i = (
+                mass_action(etad_i)
+                + se3.coadjoint_action(eta_i, M_eta)
+                - mass_action(gravity_i)
+            )
+
+            def convective_force_jacobian(twist_jacobian: Array) -> Array:
+                mass_twist_jacobian = mass_action(twist_jacobian)
+                return vmap(
+                    se3.coadjoint_action,
+                    in_axes=(None, 1),
+                    out_axes=1,
+                )(eta_i, mass_twist_jacobian) + vmap(
+                    se3.coadjoint_action,
+                    in_axes=(1, None),
+                    out_axes=1,
+                )(twist_jacobian, M_eta)
+
+            configuration_convective_jacobian = convective_force_jacobian(R_i)
+            velocity_convective_jacobian = convective_force_jacobian(J_i)
+            gravity_twist_jacobian = vmap(
+                se3.small_adjoint_action,
+                in_axes=(None, 1),
+                out_axes=1,
+            )(gravity_i, J_i)
 
             F_res_tip = F_res_child + F_i
             dF_res_dq_tip = (
                 dF_res_dq_child
-                + M @ A_i
-                + N @ R_i
-                - M @ se3.small_adjoint(gravity_i) @ J_i
+                + mass_action(A_i)
+                + configuration_convective_jacobian
+                - mass_action(gravity_twist_jacobian)
             )
-            dF_res_dqd_tip = dF_res_dqd_child + M @ Y_i + N @ J_i
-            dF_res_dqdd_tip = dF_res_dqdd_child + M @ J_i
+            dF_res_dqd_tip = (
+                dF_res_dqd_child + mass_action(Y_i) + velocity_convective_jacobian
+            )
+            if compute_acceleration_jacobian:
+                dF_res_dqdd_tip = dF_res_dqdd_child + mass_action(J_i)
 
             coAdg = Adginv_i.T
             F_res = coAdg @ F_res_tip
             dF_res_dq = coAdg @ dF_res_dq_tip
             dF_res_dqd = coAdg @ dF_res_dqd_tip
-            dF_res_dqdd = coAdg @ dF_res_dqdd_tip
+            if compute_acceleration_jacobian:
+                dF_res_dqdd = coAdg @ dF_res_dqdd_tip
+            else:
+                dF_res_dqdd = dF_res_dqdd_child
 
-            dF_res_dq = dF_res_dq + se3.coadjoint_bar(F_res) @ S_i
+            dF_res_dq = dF_res_dq + vmap(
+                se3.coadjoint_action,
+                in_axes=(1, None),
+                out_axes=1,
+            )(S_i, F_res)
 
             B_xi_i = B_xi_segments[segment_idx]
             xi_ref_i = xi_ref_segments[segment_idx]
             H_i = H_steps[step_idx]
 
-            def projected_wrench_row(q_unit: Array) -> Array:
-                dS_dq_direction = joint_dSdq_qd(
-                    H_i,
-                    B_xi_i,
-                    xi_ref_i,
-                    q,
-                    q_unit,
-                    self.global_eps,
-                )
-                return F_res @ dS_dq_direction
-
-            dSTF_res_dq = vmap(projected_wrench_row)(q_basis)
+            dSTF_res_dq = joint_dSTF_dq(
+                H_i,
+                B_xi_i,
+                xi_ref_i,
+                q,
+                F_res,
+                self.global_eps,
+            )
 
             dID_dq = dID_dq + S_i.T @ dF_res_dq + dSTF_res_dq
             dID_dqd = dID_dqd + S_i.T @ dF_res_dqd
-            dID_dqdd = dID_dqdd + S_i.T @ dF_res_dqdd
+            if compute_acceleration_jacobian:
+                dID_dqdd = dID_dqdd + S_i.T @ dF_res_dqdd
 
             carry_next = (
                 F_res,
@@ -3918,10 +3984,14 @@ class PCS(SoftRobot):
                 dID_dqdd,
             )
             output = (
-                F_res,
-                dF_res_dq,
-                dF_res_dqd,
-                dF_res_dqdd,
+                (
+                    F_res,
+                    dF_res_dq,
+                    dF_res_dqd,
+                    dF_res_dqdd,
+                )
+                if materialize_wrench_history
+                else None
             )
             return carry_next, output
 
@@ -3949,17 +4019,24 @@ class PCS(SoftRobot):
             reverse_indices,
         )
 
-        (
-            F_res,
-            dF_res_dq,
-            dF_res_dqd,
-            dF_res_dqdd,
-        ) = (jnp.flip(value, axis=0) for value in reverse_outputs)
-        step_shape = (self.num_segments, self.num_integration_points - 1)
-        F_res = F_res.reshape(*step_shape, 6)
-        dF_res_dq = dF_res_dq.reshape(*step_shape, 6, self.num_dofs)
-        dF_res_dqd = dF_res_dqd.reshape(*step_shape, 6, self.num_dofs)
-        dF_res_dqdd = dF_res_dqdd.reshape(*step_shape, 6, self.num_dofs)
+        if materialize_wrench_history:
+            (
+                F_res,
+                dF_res_dq,
+                dF_res_dqd,
+                dF_res_dqdd,
+            ) = (jnp.flip(value, axis=0) for value in reverse_outputs)
+            step_shape = (self.num_segments, self.num_integration_points - 1)
+            F_res = F_res.reshape(*step_shape, 6)
+            dF_res_dq = dF_res_dq.reshape(*step_shape, 6, self.num_dofs)
+            dF_res_dqd = dF_res_dqd.reshape(*step_shape, 6, self.num_dofs)
+            dF_res_dqdd = dF_res_dqdd.reshape(*step_shape, 6, self.num_dofs)
+        else:
+            F_res = jnp.empty((0, 6), dtype=q.dtype)
+            empty_derivative = jnp.empty((0, 6, self.num_dofs), dtype=q.dtype)
+            dF_res_dq = empty_derivative
+            dF_res_dqd = empty_derivative
+            dF_res_dqdd = empty_derivative
 
         return (
             dID_dq,
@@ -3997,6 +4074,7 @@ class PCS(SoftRobot):
             q,
             qd,
             qdd,
+            materialize_wrench_history=False,
         )
         return dID_dq, dID_dqd
 
@@ -4125,7 +4203,12 @@ class PCS(SoftRobot):
             _,
             _,
             _,
-        ) = self.inverse_dynamics_backward_pass(q, qd, qdd)
+        ) = self.inverse_dynamics_backward_pass(
+            q,
+            qd,
+            qdd,
+            materialize_wrench_history=False,
+        )
 
         d_elastic_dq = self.elastic_force_derivative_q(q)
         d_damping_dq, d_damping_dqd = self.damping_force_derivatives(q, qd)

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -4,7 +4,7 @@ __all__ = ["PCS"]
 from typing import Any, Self
 
 import equinox as eqx
-from jax import Array, lax, tree_util, vmap
+from jax import Array, jvp, lax, tree_util, vmap
 from jax import numpy as jnp
 
 from soromox.actuation.core import Actuator, PassiveElement
@@ -33,6 +33,7 @@ from soromox.utils.integration import (
 )
 from soromox.utils.joint_motion_subspace import (
     joint_dSTF_dq,
+    joint_dSTF_dq_direction,
     joint_motion_subspace_with_derivatives,
 )
 from soromox.utils.lie_algebra import se3, so3
@@ -3360,6 +3361,7 @@ class PCS(SoftRobot):
         tau_u = self.actuation_force(q, u, qd=qd)
 
         rhs = tau_u + tau_ext - Cqd - G - tau_el - self.damping_matrix(q) @ qd
+
         qdd = self._solve_inertia(B, rhs)
 
         yd = jnp.concatenate([qd, qdd])
@@ -3438,12 +3440,45 @@ class PCS(SoftRobot):
             if tau_ext_tangent is None:
                 tau_ext_tangent = jnp.zeros_like(tau_ext)
 
-        d_damping_dq, d_damping_dqd = robot.damping_force_derivatives(q, qd)
-        applied_force_tangent = (
-            robot.actuation_force_derivative_q(q, u)
-            - robot.elastic_force_derivative_q(q)
-            - d_damping_dq
-        ) @ q_tangent - d_damping_dqd @ qd_tangent
+        if y_tangent is None:
+            applied_force_tangent = jnp.zeros_like(q)
+        else:
+            applied_force_tangent = (
+                -robot.K_active @ q_tangent - robot.D_active @ qd_tangent
+            )
+
+            if robot.actuators:
+
+                def state_dependent_actuation_force(
+                    q_value: Array,
+                    qd_value: Array,
+                ) -> Array:
+                    return robot.actuation_force(q_value, u, qd=qd_value)
+
+                _, actuation_state_tangent = jvp(
+                    state_dependent_actuation_force,
+                    (q, qd),
+                    (q_tangent, qd_tangent),
+                )
+                applied_force_tangent = applied_force_tangent + actuation_state_tangent
+
+            if robot.passive_elements:
+
+                def passive_force(
+                    q_value: Array,
+                    qd_value: Array,
+                ) -> Array:
+                    return (
+                        -robot.passive_elastic_force(q_value)
+                        - robot.passive_damping_matrix(q_value) @ qd_value
+                    )
+
+                _, passive_force_tangent = jvp(
+                    passive_force,
+                    (q, qd),
+                    (q_tangent, qd_tangent),
+                )
+                applied_force_tangent = applied_force_tangent + passive_force_tangent
         if u_has_tangent:
             applied_force_tangent = (
                 applied_force_tangent
@@ -3485,8 +3520,13 @@ class PCS(SoftRobot):
         if y_tangent is None:
             inverse_dynamics_tangent = jnp.zeros_like(q)
         else:
-            dID_dq, dID_dqd = robot.inverse_dynamics_backward_pass(q, qd, qdd)
-            inverse_dynamics_tangent = dID_dq @ q_tangent + dID_dqd @ qd_tangent
+            inverse_dynamics_tangent = robot.inverse_dynamics_state_pushforward(
+                q,
+                qd,
+                qdd,
+                q_tangent[:, None],
+                qd_tangent[:, None],
+            )[:, 0]
 
         qdd_tangent = robot._solve_inertia(
             mass_matrix,
@@ -3559,6 +3599,176 @@ class PCS(SoftRobot):
 
         return g_local, S, Sd, deta_dq, detad_dq
 
+    def _inverse_dynamics_interval_kinematics(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+    ) -> tuple[
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+    ]:
+        """Evaluate interval-local quantities shared by both derivative passes."""
+        Xs_nodes, Ws_nodes = vmap(
+            scale_gaussian_quadrature,
+            in_axes=(None, None, 0, 0),
+        )(
+            self.integration_points,
+            self.integration_weights,
+            self.L_cum[:-1],
+            self.L_cum[1:],
+        )
+        s_local_nodes = Xs_nodes - self.L_cum[:-1, None]
+        H_steps = jnp.diff(s_local_nodes, axis=1)
+        n_steps = self.num_integration_points - 1
+        segment_indices = jnp.repeat(
+            jnp.arange(self.num_segments, dtype=jnp.int32),
+            n_steps,
+        )
+        H_flat = H_steps.reshape(-1)
+        mass_weights = Ws_nodes[:, 1:].reshape(-1)
+        g_local, S, Sd, deta_dq, detad_dq = vmap(
+            self._local_id_jacobian_kinematics,
+            in_axes=(0, 0, None, None, None),
+        )(
+            segment_indices,
+            H_flat,
+            q,
+            qd,
+            qdd,
+        )
+        Adginv = vmap(se3.adjoint_inverse)(g_local)
+        return (
+            segment_indices,
+            H_flat,
+            mass_weights,
+            g_local,
+            S,
+            Sd,
+            deta_dq,
+            detad_dq,
+            Adginv,
+        )
+
+    def _segment_local_dof_layout(self) -> tuple[Array, Array]:
+        """Return padded segment-local active-DOF indices and their mask."""
+        dof_starts = (0, *self._segment_dof_ends[:-1])
+        dof_counts = tuple(
+            end - start
+            for start, end in zip(
+                dof_starts,
+                self._segment_dof_ends,
+                strict=True,
+            )
+        )
+        max_local_dofs = max(dof_counts, default=0)
+        indices = jnp.asarray(
+            [
+                [
+                    start + offset if offset < count else 0
+                    for offset in range(max_local_dofs)
+                ]
+                for start, count in zip(dof_starts, dof_counts, strict=True)
+            ],
+            dtype=jnp.int32,
+        )
+        mask = jnp.asarray(
+            [
+                [offset < count for offset in range(max_local_dofs)]
+                for count in dof_counts
+            ],
+        )
+        return indices, mask
+
+    @eqx.filter_jit
+    def _local_id_state_pushforward_kinematics(
+        self,
+        H: Array,
+        B_xi_local: Array,
+        xi_ref_local: Array,
+        q_local: Array,
+        qd_local: Array,
+        qdd_local: Array,
+        q_directions_local: Array,
+        qd_directions_local: Array,
+    ) -> tuple[Array, Array, Array, Array, Array, Array, Array]:
+        """Evaluate one interval using only its segment-local active DOFs."""
+        num_directions = q_directions_local.shape[1]
+        derivative_directions = jnp.concatenate(
+            [q_directions_local, qd_directions_local],
+            axis=1,
+        )
+        contract_derivatives = B_xi_local.shape[1] > derivative_directions.shape[1]
+        if contract_derivatives:
+            (
+                g_local,
+                S_local,
+                Sd_local,
+                deta_dq_local,
+                dS_dq_qdd_local,
+                dSd_dq_qd_local,
+            ) = joint_motion_subspace_with_derivatives(
+                H,
+                B_xi_local,
+                xi_ref_local,
+                q_local,
+                qd_local,
+                qdd_local,
+                self.global_eps,
+                derivative_directions,
+            )
+            deta_q_directions = deta_dq_local[:, :num_directions]
+            deta_qd_directions = deta_dq_local[:, num_directions:]
+            detad_q_directions = (
+                dS_dq_qdd_local[:, :num_directions]
+                + dSd_dq_qd_local[:, :num_directions]
+            )
+        else:
+            (
+                g_local,
+                S_local,
+                Sd_local,
+                deta_dq_local,
+                dS_dq_qdd_local,
+                dSd_dq_qd_local,
+            ) = joint_motion_subspace_with_derivatives(
+                H,
+                B_xi_local,
+                xi_ref_local,
+                q_local,
+                qd_local,
+                qdd_local,
+                self.global_eps,
+            )
+            deta_q_directions = deta_dq_local @ q_directions_local
+            deta_qd_directions = deta_dq_local @ qd_directions_local
+            detad_q_directions = (
+                dS_dq_qdd_local + dSd_dq_qd_local
+            ) @ q_directions_local
+        eta_local = S_local @ qd_local
+        etad_local = S_local @ qdd_local + Sd_local @ qd_local
+        pose_directions_local = S_local @ q_directions_local
+        eta_directions_local = deta_q_directions + S_local @ qd_directions_local
+        etad_directions_local = (
+            detad_q_directions + Sd_local @ qd_directions_local + deta_qd_directions
+        )
+        return (
+            g_local,
+            S_local,
+            eta_local,
+            etad_local,
+            pose_directions_local,
+            eta_directions_local,
+            etad_directions_local,
+        )
+
     @eqx.filter_jit
     def _inverse_dynamics_jacobian_forward_pass(
         self,
@@ -3612,42 +3822,21 @@ class PCS(SoftRobot):
             ``(num_intervals, 6, self.num_dofs)``; and ``Adginv`` has shape
             ``(num_intervals, 6, 6)``.
         """
-        Xs_nodes, Ws_nodes = vmap(
-            scale_gaussian_quadrature, in_axes=(None, None, 0, 0)
-        )(
-            self.integration_points,
-            self.integration_weights,
-            self.L_cum[:-1],
-            self.L_cum[1:],
-        )
-        s_local_nodes = Xs_nodes - self.L_cum[:-1, None]
-        H_steps = jnp.diff(s_local_nodes, axis=1)
-
-        n_steps = self.num_integration_points - 1
-        segment_indices = jnp.repeat(
-            jnp.arange(self.num_segments, dtype=jnp.int32),
-            n_steps,
-        )
-        H_flat = H_steps.reshape(-1)
-        mass_weights = Ws_nodes[:, 1:].reshape(-1)
-
         (
+            segment_indices,
+            H_flat,
+            mass_weights,
             g_local,
             S,
             Sd,
             deta_dq,
             detad_dq,
-        ) = vmap(
-            self._local_id_jacobian_kinematics,
-            in_axes=(0, 0, None, None, None),
-        )(
-            segment_indices,
-            H_flat,
+            Adginv,
+        ) = self._inverse_dynamics_interval_kinematics(
             q,
             qd,
             qdd,
         )
-        Adginv = vmap(se3.adjoint_inverse)(g_local)
 
         zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
         zeros_6 = jnp.zeros((6,), dtype=q.dtype)
@@ -3756,6 +3945,216 @@ class PCS(SoftRobot):
             R,
             A,
             Y,
+            Adginv,
+            S,
+        )
+
+    @eqx.filter_jit
+    def _inverse_dynamics_state_pushforward_forward_pass(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+        q_directions: Array,
+        qd_directions: Array,
+    ) -> tuple[
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+        Array,
+    ]:
+        """Propagate primal kinematics and contracted state directions."""
+        Xs_nodes, Ws_nodes = vmap(
+            scale_gaussian_quadrature,
+            in_axes=(None, None, 0, 0),
+        )(
+            self.integration_points,
+            self.integration_weights,
+            self.L_cum[:-1],
+            self.L_cum[1:],
+        )
+        H_steps = jnp.diff(Xs_nodes - self.L_cum[:-1, None], axis=1)
+        n_steps = self.num_integration_points - 1
+        segment_indices = jnp.repeat(
+            jnp.arange(self.num_segments, dtype=jnp.int32),
+            n_steps,
+        )
+        H_flat = H_steps.reshape(-1)
+        mass_weights = Ws_nodes[:, 1:].reshape(-1)
+
+        dof_indices, dof_mask = self._segment_local_dof_layout()
+        dof_mask_values = dof_mask.astype(q.dtype)
+        B_xi_segments = self.B_xi.reshape(
+            self.num_segments,
+            6,
+            self.num_dofs,
+        )
+        B_xi_local_segments = vmap(
+            lambda basis, indices, mask: basis[:, indices] * mask[None, :]
+        )(B_xi_segments, dof_indices, dof_mask_values)
+        xi_ref_segments = self.xi_ref.reshape(self.num_segments, 6)
+        q_local_segments = q[dof_indices] * dof_mask_values
+        qd_local_segments = qd[dof_indices] * dof_mask_values
+        qdd_local_segments = qdd[dof_indices] * dof_mask_values
+        q_directions_local_segments = (
+            q_directions[dof_indices] * dof_mask_values[:, :, None]
+        )
+        qd_directions_local_segments = (
+            qd_directions[dof_indices] * dof_mask_values[:, :, None]
+        )
+
+        (
+            g_local,
+            S,
+            eta_local,
+            etad_local,
+            pose_directions_local,
+            eta_directions_local,
+            etad_directions_local,
+        ) = vmap(self._local_id_state_pushforward_kinematics)(
+            H_flat,
+            B_xi_local_segments[segment_indices],
+            xi_ref_segments[segment_indices],
+            q_local_segments[segment_indices],
+            qd_local_segments[segment_indices],
+            qdd_local_segments[segment_indices],
+            q_directions_local_segments[segment_indices],
+            qd_directions_local_segments[segment_indices],
+        )
+        Adginv = vmap(se3.adjoint_inverse)(g_local)
+        num_directions = q_directions.shape[1]
+        zeros_6 = jnp.zeros((6,), dtype=q.dtype)
+        zeros_6k = jnp.zeros((6, num_directions), dtype=q.dtype)
+        carry_init = (
+            self.g0,
+            zeros_6,
+            zeros_6,
+            zeros_6k,
+            zeros_6k,
+            zeros_6k,
+        )
+
+        def propagate_interval(
+            carry: tuple[Array, Array, Array, Array, Array, Array],
+            local: tuple[Array, Array, Array, Array, Array, Array, Array],
+        ) -> tuple[
+            tuple[Array, Array, Array, Array, Array, Array],
+            tuple[Array, Array, Array, Array, Array, Array],
+        ]:
+            (
+                g_base,
+                eta_base,
+                etad_base,
+                pose_directions_base,
+                eta_directions_base,
+                etad_directions_base,
+            ) = carry
+            (
+                g_local_i,
+                Adginv_i,
+                eta_local_i,
+                etad_local_i,
+                pose_directions_local_i,
+                eta_directions_local_i,
+                etad_directions_local_i,
+            ) = local
+
+            eta_plus = eta_base + eta_local_i
+            etad_plus = (
+                etad_base
+                + etad_local_i
+                + se3.small_adjoint_action(eta_base, eta_local_i)
+            )
+            eta_directions_plus = eta_directions_base + eta_directions_local_i
+            etad_directions_plus = (
+                etad_directions_base
+                + etad_directions_local_i
+                + vmap(
+                    se3.small_adjoint_action,
+                    in_axes=(1, None),
+                    out_axes=1,
+                )(eta_directions_base, eta_local_i)
+                + vmap(
+                    se3.small_adjoint_action,
+                    in_axes=(None, 1),
+                    out_axes=1,
+                )(eta_base, eta_directions_local_i)
+            )
+
+            g_tip = g_base @ g_local_i
+            pose_directions_tip = Adginv_i @ (
+                pose_directions_base + pose_directions_local_i
+            )
+            eta_tip = Adginv_i @ eta_plus
+            eta_directions_tip = Adginv_i @ (
+                eta_directions_plus
+                + vmap(
+                    se3.small_adjoint_action,
+                    in_axes=(None, 1),
+                    out_axes=1,
+                )(eta_plus, pose_directions_local_i)
+            )
+            etad_tip = Adginv_i @ etad_plus
+            etad_directions_tip = Adginv_i @ (
+                etad_directions_plus
+                + vmap(
+                    se3.small_adjoint_action,
+                    in_axes=(None, 1),
+                    out_axes=1,
+                )(etad_plus, pose_directions_local_i)
+            )
+
+            carry_next = (
+                g_tip,
+                eta_tip,
+                etad_tip,
+                pose_directions_tip,
+                eta_directions_tip,
+                etad_directions_tip,
+            )
+            return carry_next, carry_next
+
+        (
+            _,
+            (
+                g,
+                eta,
+                etad,
+                pose_directions,
+                eta_directions,
+                etad_directions,
+            ),
+        ) = lax.scan(
+            propagate_interval,
+            carry_init,
+            (
+                g_local,
+                Adginv,
+                eta_local,
+                etad_local,
+                pose_directions_local,
+                eta_directions_local,
+                etad_directions_local,
+            ),
+        )
+
+        return (
+            segment_indices,
+            H_flat,
+            mass_weights,
+            g,
+            eta,
+            etad,
+            pose_directions,
+            eta_directions,
+            etad_directions,
             Adginv,
             S,
         )
@@ -3955,6 +4354,171 @@ class PCS(SoftRobot):
         )
 
         return dID_dq, dID_dqd
+
+    @eqx.filter_jit
+    def inverse_dynamics_state_pushforward(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+        q_directions: Array,
+        qd_directions: Array,
+    ) -> Array:
+        """Apply the state derivative of inverse dynamics to directions.
+
+        Unlike :meth:`inverse_dynamics_backward_pass`, this recurrence
+        contracts the requested directions before the tip-to-base scan. It
+        therefore carries arrays with shape ``(6, num_directions)`` and
+        ``(num_dofs, num_directions)`` instead of materializing the square
+        inverse-dynamics Jacobians.
+
+        Args:
+            q: Generalized coordinates with shape ``(self.num_dofs,)``.
+            qd: Generalized velocities with shape ``(self.num_dofs,)``.
+            qdd: Generalized accelerations with shape ``(self.num_dofs,)``.
+            q_directions: Configuration directions with shape
+                ``(self.num_dofs, num_directions)``.
+            qd_directions: Velocity directions with shape
+                ``(self.num_dofs, num_directions)``.
+
+        Returns:
+            The directional inverse-dynamics derivatives with shape
+            ``(self.num_dofs, num_directions)``.
+        """
+        (
+            segment_indices,
+            H_steps,
+            mass_weights,
+            g,
+            eta,
+            etad,
+            pose_directions,
+            eta_directions,
+            etad_directions,
+            Adginv,
+            S,
+        ) = self._inverse_dynamics_state_pushforward_forward_pass(
+            q,
+            qd,
+            qdd,
+            q_directions,
+            qd_directions,
+        )
+        num_directions = q_directions.shape[1]
+        zeros_6 = jnp.zeros((6,), dtype=q.dtype)
+        zeros_6k = jnp.zeros((6, num_directions), dtype=q.dtype)
+        zeros_nk = jnp.zeros(
+            (self.num_dofs, num_directions),
+            dtype=q.dtype,
+        )
+        dof_indices, dof_mask = self._segment_local_dof_layout()
+        dof_mask_values = dof_mask.astype(q.dtype)
+        B_xi_segments = self.B_xi.reshape(
+            self.num_segments,
+            6,
+            self.num_dofs,
+        )
+        B_xi_local_segments = vmap(
+            lambda basis, indices, mask: basis[:, indices] * mask[None, :]
+        )(B_xi_segments, dof_indices, dof_mask_values)
+        xi_ref_segments = self.xi_ref.reshape(self.num_segments, 6)
+        q_local_segments = q[dof_indices] * dof_mask_values
+        q_directions_local_segments = (
+            q_directions[dof_indices] * dof_mask_values[:, :, None]
+        )
+
+        def propagate_interval_backward(
+            carry: tuple[Array, Array, Array],
+            step_idx: Array,
+        ) -> tuple[tuple[Array, Array, Array], None]:
+            F_res_child, dF_res_child, dID = carry
+
+            segment_idx = segment_indices[step_idx]
+            mass_diagonal = mass_weights[step_idx] * jnp.diagonal(
+                self.M_segments[segment_idx]
+            )
+            g_i = g[step_idx]
+            eta_i = eta[step_idx]
+            etad_i = etad[step_idx]
+            pose_directions_i = pose_directions[step_idx]
+            eta_directions_i = eta_directions[step_idx]
+            etad_directions_i = etad_directions[step_idx]
+            Adginv_i = Adginv[step_idx]
+            S_i = S[step_idx]
+            dof_indices_i = dof_indices[segment_idx]
+            dof_mask_i = dof_mask_values[segment_idx]
+            q_directions_local_i = q_directions_local_segments[segment_idx]
+
+            def mass_action(value: Array) -> Array:
+                shape = (mass_diagonal.shape[0],) + (1,) * (value.ndim - 1)
+                return mass_diagonal.reshape(shape) * value
+
+            M_eta = mass_action(eta_i)
+            gravity_i = se3.adjoint_inverse(g_i) @ self.g
+            F_i = (
+                mass_action(etad_i)
+                + se3.coadjoint_action(eta_i, M_eta)
+                - mass_action(gravity_i)
+            )
+            convective_directions = vmap(
+                se3.coadjoint_action,
+                in_axes=(None, 1),
+                out_axes=1,
+            )(eta_i, mass_action(eta_directions_i)) + vmap(
+                se3.coadjoint_action,
+                in_axes=(1, None),
+                out_axes=1,
+            )(eta_directions_i, M_eta)
+            gravity_directions = vmap(
+                se3.small_adjoint_action,
+                in_axes=(None, 1),
+                out_axes=1,
+            )(gravity_i, pose_directions_i)
+
+            F_res_tip = F_res_child + F_i
+            dF_res_tip = (
+                dF_res_child
+                + mass_action(etad_directions_i)
+                + convective_directions
+                - mass_action(gravity_directions)
+            )
+
+            coAdg = Adginv_i.T
+            F_res = coAdg @ F_res_tip
+            dF_res = coAdg @ dF_res_tip
+            interval_pose_directions = S_i @ q_directions_local_i
+            dF_res = dF_res + vmap(
+                se3.coadjoint_action,
+                in_axes=(1, None),
+                out_axes=1,
+            )(interval_pose_directions, F_res)
+
+            dSTF_res = joint_dSTF_dq_direction(
+                H_steps[step_idx],
+                B_xi_local_segments[segment_idx],
+                xi_ref_segments[segment_idx],
+                q_local_segments[segment_idx],
+                F_res,
+                q_directions_local_i,
+                self.global_eps,
+            )
+            dID_local = (S_i.T @ dF_res + dSTF_res) * dof_mask_i[:, None]
+            dID = dID.at[dof_indices_i].add(dID_local)
+            return (F_res, dF_res, dID), None
+
+        num_intervals = segment_indices.shape[0]
+        reverse_indices = jnp.arange(
+            num_intervals - 1,
+            -1,
+            -1,
+            dtype=jnp.int32,
+        )
+        (_, _, dID), _ = lax.scan(
+            propagate_interval_backward,
+            (zeros_6, zeros_6k, zeros_nk),
+            reverse_indices,
+        )
+        return dID
 
     @eqx.filter_jit
     def inverse_dynamics_derivatives(

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -3483,24 +3483,9 @@ class PCS(SoftRobot):
             robot_parameter_rhs_tangent = jnp.zeros_like(q)
 
         if y_tangent is None:
-            mass_matrix = robot.inertia_matrix(q)
             inverse_dynamics_tangent = jnp.zeros_like(q)
         else:
-            (
-                dID_dq,
-                dID_dqd,
-                _,
-                _,
-                _,
-                _,
-                _,
-            ) = robot.inverse_dynamics_backward_pass(
-                q,
-                qd,
-                qdd,
-                materialize_wrench_history=False,
-                compute_acceleration_jacobian=False,
-            )
+            dID_dq, dID_dqd = robot.inverse_dynamics_backward_pass(q, qd, qdd)
             inverse_dynamics_tangent = dID_dq @ q_tangent + dID_dqd @ qd_tangent
 
         qdd_tangent = robot._solve_inertia(
@@ -3781,10 +3766,7 @@ class PCS(SoftRobot):
         q: Array,
         qd: Array,
         qdd: Array,
-        *,
-        materialize_wrench_history: bool = True,
-        compute_acceleration_jacobian: bool = True,
-    ) -> tuple[Array, Array, Array, Array, Array, Array, Array]:
+    ) -> tuple[Array, Array]:
         """
         Recurse the composite wrench and its Jacobians from tip to base.
 
@@ -3801,24 +3783,13 @@ class PCS(SoftRobot):
                 ``(self.num_dofs,)``.
             qdd (Array): Active generalized accelerations. Shape is
                 ``(self.num_dofs,)``.
-            materialize_wrench_history: Whether to return the per-interval
-                resultant-wrench derivative histories. State-Jacobian callers
-                can disable this because they only consume the three aggregate
-                inverse-dynamics Jacobians. Defaults to true.
-            compute_acceleration_jacobian: Whether to propagate
-                ``dID/dqdd``. Callers that already assembled the inertia matrix
-                can disable this duplicate recursion. Defaults to true.
 
         Returns:
-            tuple[Array, Array, Array, Array, Array, Array, Array]: Tuple
-            ``(dID_dq, dID_dqd, dID_dqdd, F_res, dF_res_dq,
-            dF_res_dqd, dF_res_dqdd)``. The first three inverse-dynamics
-            derivatives have shape ``(self.num_dofs, self.num_dofs)``;
-            ``dID_dqdd`` is also the generalized inertia matrix. ``F_res``
-            has shape ``(self.num_segments,
-            self.num_integration_points - 1, 6)``. Its three derivatives
-            have shape ``(self.num_segments,
-            self.num_integration_points - 1, 6, self.num_dofs)``.
+            tuple[Array, Array]: The inverse-dynamics derivatives
+            ``(dID_dq, dID_dqd)``. Each derivative has shape
+            ``(self.num_dofs, self.num_dofs)``. The acceleration derivative
+            ``dID/dqdd`` is the generalized inertia matrix and should be
+            obtained from the forward-dynamics primal or ``inertia_matrix``.
         """
         (
             segment_indices,
@@ -3839,16 +3810,6 @@ class PCS(SoftRobot):
         zeros_6 = jnp.zeros((6,), dtype=q.dtype)
         zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
         zeros_nn = jnp.zeros((self.num_dofs, self.num_dofs), dtype=q.dtype)
-        acceleration_zeros_6n = (
-            zeros_6n
-            if compute_acceleration_jacobian
-            else jnp.empty((0, 0), dtype=q.dtype)
-        )
-        acceleration_zeros_nn = (
-            zeros_nn
-            if compute_acceleration_jacobian
-            else jnp.empty((0, 0), dtype=q.dtype)
-        )
         B_xi_segments = self.B_xi.reshape(
             self.num_segments,
             6,
@@ -3859,27 +3820,23 @@ class PCS(SoftRobot):
             zeros_6,
             zeros_6n,
             zeros_6n,
-            acceleration_zeros_6n,
             zeros_nn,
             zeros_nn,
-            acceleration_zeros_nn,
         )
 
         def propagate_interval_backward(
-            carry: tuple[Array, Array, Array, Array, Array, Array, Array],
+            carry: tuple[Array, Array, Array, Array, Array],
             step_idx: Array,
         ) -> tuple[
-            tuple[Array, Array, Array, Array, Array, Array, Array],
-            tuple[Array, Array, Array, Array],
+            tuple[Array, Array, Array, Array, Array],
+            None,
         ]:
             (
                 F_res_child,
                 dF_res_dq_child,
                 dF_res_dqd_child,
-                dF_res_dqdd_child,
                 dID_dq,
                 dID_dqd,
-                dID_dqdd,
             ) = carry
 
             segment_idx = segment_indices[step_idx]
@@ -3938,17 +3895,11 @@ class PCS(SoftRobot):
             dF_res_dqd_tip = (
                 dF_res_dqd_child + mass_action(Y_i) + velocity_convective_jacobian
             )
-            if compute_acceleration_jacobian:
-                dF_res_dqdd_tip = dF_res_dqdd_child + mass_action(J_i)
 
             coAdg = Adginv_i.T
             F_res = coAdg @ F_res_tip
             dF_res_dq = coAdg @ dF_res_dq_tip
             dF_res_dqd = coAdg @ dF_res_dqd_tip
-            if compute_acceleration_jacobian:
-                dF_res_dqdd = coAdg @ dF_res_dqdd_tip
-            else:
-                dF_res_dqdd = dF_res_dqdd_child
 
             dF_res_dq = dF_res_dq + vmap(
                 se3.coadjoint_action,
@@ -3971,29 +3922,15 @@ class PCS(SoftRobot):
 
             dID_dq = dID_dq + S_i.T @ dF_res_dq + dSTF_res_dq
             dID_dqd = dID_dqd + S_i.T @ dF_res_dqd
-            if compute_acceleration_jacobian:
-                dID_dqdd = dID_dqdd + S_i.T @ dF_res_dqdd
 
             carry_next = (
                 F_res,
                 dF_res_dq,
                 dF_res_dqd,
-                dF_res_dqdd,
                 dID_dq,
                 dID_dqd,
-                dID_dqdd,
             )
-            output = (
-                (
-                    F_res,
-                    dF_res_dq,
-                    dF_res_dqd,
-                    dF_res_dqdd,
-                )
-                if materialize_wrench_history
-                else None
-            )
-            return carry_next, output
+            return carry_next, None
 
         num_intervals = segment_indices.shape[0]
         reverse_indices = jnp.arange(
@@ -4007,46 +3944,17 @@ class PCS(SoftRobot):
                 _,
                 _,
                 _,
-                _,
                 dID_dq,
                 dID_dqd,
-                dID_dqdd,
             ),
-            reverse_outputs,
+            _,
         ) = lax.scan(
             propagate_interval_backward,
             carry_init,
             reverse_indices,
         )
 
-        if materialize_wrench_history:
-            (
-                F_res,
-                dF_res_dq,
-                dF_res_dqd,
-                dF_res_dqdd,
-            ) = (jnp.flip(value, axis=0) for value in reverse_outputs)
-            step_shape = (self.num_segments, self.num_integration_points - 1)
-            F_res = F_res.reshape(*step_shape, 6)
-            dF_res_dq = dF_res_dq.reshape(*step_shape, 6, self.num_dofs)
-            dF_res_dqd = dF_res_dqd.reshape(*step_shape, 6, self.num_dofs)
-            dF_res_dqdd = dF_res_dqdd.reshape(*step_shape, 6, self.num_dofs)
-        else:
-            F_res = jnp.empty((0, 6), dtype=q.dtype)
-            empty_derivative = jnp.empty((0, 6, self.num_dofs), dtype=q.dtype)
-            dF_res_dq = empty_derivative
-            dF_res_dqd = empty_derivative
-            dF_res_dqdd = empty_derivative
-
-        return (
-            dID_dq,
-            dID_dqd,
-            dID_dqdd,
-            F_res,
-            dF_res_dq,
-            dF_res_dqd,
-            dF_res_dqdd,
-        )
+        return dID_dq, dID_dqd
 
     @eqx.filter_jit
     def inverse_dynamics_derivatives(
@@ -4070,11 +3978,10 @@ class PCS(SoftRobot):
             tuple[Array, Array]: The derivatives ``(dID_dq, dID_dqd)``. Both
             arrays have shape ``(self.num_dofs, self.num_dofs)``.
         """
-        dID_dq, dID_dqd, _, _, _, _, _ = self.inverse_dynamics_backward_pass(
+        dID_dq, dID_dqd = self.inverse_dynamics_backward_pass(
             q,
             qd,
             qdd,
-            materialize_wrench_history=False,
         )
         return dID_dq, dID_dqd
 
@@ -4195,20 +4102,25 @@ class PCS(SoftRobot):
         if u is None:
             u = jnp.zeros((self.num_actuators,), dtype=q.dtype)
 
-        (
-            dID_dq,
-            dID_dqd,
-            mass_matrix,
-            _,
-            _,
-            _,
-            _,
-        ) = self.inverse_dynamics_backward_pass(
+        mass_matrix = self.inertia_matrix(q)
+        return self._forward_dynamics_derivatives_with_inertia(
             q,
             qd,
             qdd,
-            materialize_wrench_history=False,
+            u,
+            mass_matrix,
         )
+
+    def _forward_dynamics_derivatives_with_inertia(
+        self,
+        q: Array,
+        qd: Array,
+        qdd: Array,
+        u: Array,
+        mass_matrix: Array,
+    ) -> tuple[Array, Array]:
+        """Return state derivatives while reusing an assembled inertia matrix."""
+        dID_dq, dID_dqd = self.inverse_dynamics_backward_pass(q, qd, qdd)
 
         d_elastic_dq = self.elastic_force_derivative_q(q)
         d_damping_dq, d_damping_dqd = self.damping_force_derivatives(q, qd)
@@ -4243,6 +4155,14 @@ class PCS(SoftRobot):
             ``(self.num_dofs, self.num_dofs)``, respectively.
         """
         mass_matrix = self.inertia_matrix(q)
+        return self._forward_dynamics_input_derivatives_with_inertia(q, mass_matrix)
+
+    def _forward_dynamics_input_derivatives_with_inertia(
+        self,
+        q: Array,
+        mass_matrix: Array,
+    ) -> tuple[Array, Array]:
+        """Return input derivatives while reusing an assembled inertia matrix."""
         dqdd_du = self._solve_inertia(
             mass_matrix,
             self.actuation_force_derivative_u(q),
@@ -4295,9 +4215,19 @@ class PCS(SoftRobot):
         if tau_ext is None:
             tau_ext = jnp.zeros((q.shape[0],), dtype=q.dtype)
 
-        yd = self.forward_dynamics(t, y, (u, tau_ext))
+        yd, mass_matrix = self._forward_dynamics_with_inertia(
+            t,
+            y,
+            (u, tau_ext),
+        )
         _, qdd = jnp.split(yd, 2)
-        dqdd_dq, dqdd_dqd = self.forward_dynamics_derivatives(q, qd, qdd, u)
+        dqdd_dq, dqdd_dqd = self._forward_dynamics_derivatives_with_inertia(
+            q,
+            qd,
+            qdd,
+            u,
+            mass_matrix,
+        )
 
         eye = jnp.eye(q.shape[0], dtype=q.dtype)
         zeros = jnp.zeros_like(eye)
@@ -4334,18 +4264,40 @@ class PCS(SoftRobot):
         q, qd = jnp.split(y, 2)
 
         if actuation_args is None:
-            u = None
-        elif len(actuation_args) == 1 or len(actuation_args) == 2:
+            u, tau_ext = None, None
+        elif len(actuation_args) == 1:
             u = actuation_args[0]
+            tau_ext = None
+        elif len(actuation_args) == 2:
+            u, tau_ext = actuation_args
         else:
             raise ValueError("actuation_args must be a tuple of length 1 or 2.")
 
         if u is None:
             u = jnp.zeros((self.num_actuators,), dtype=q.dtype)
+        if tau_ext is None:
+            tau_ext = jnp.zeros((q.shape[0],), dtype=q.dtype)
 
-        dyd_dy = self.forward_dynamics_state_jacobian(t, y, actuation_args)
-        dqdd_du, dqdd_dtau_ext = self.forward_dynamics_input_derivatives(q)
+        yd, mass_matrix = self._forward_dynamics_with_inertia(
+            t,
+            y,
+            (u, tau_ext),
+        )
+        _, qdd = jnp.split(yd, 2)
+        dqdd_dq, dqdd_dqd = self._forward_dynamics_derivatives_with_inertia(
+            q,
+            qd,
+            qdd,
+            u,
+            mass_matrix,
+        )
+        dqdd_du, dqdd_dtau_ext = self._forward_dynamics_input_derivatives_with_inertia(
+            q, mass_matrix
+        )
 
+        eye = jnp.eye(q.shape[0], dtype=q.dtype)
+        zeros = jnp.zeros_like(eye)
+        dyd_dy = jnp.block([[zeros, eye], [dqdd_dq, dqdd_dqd]])
         zeros_du = jnp.zeros((q.shape[0], u.shape[0]), dtype=q.dtype)
         zeros_tau = jnp.zeros((q.shape[0], q.shape[0]), dtype=q.dtype)
         dyd_du = jnp.concatenate([zeros_du, dqdd_du], axis=0)

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -4,7 +4,7 @@ __all__ = ["PCS"]
 from typing import Any, Self
 
 import equinox as eqx
-from jax import Array, jvp, lax, vmap
+from jax import Array, jvp, lax, tree_util, vmap
 from jax import numpy as jnp
 
 from soromox.actuation.core import Actuator, PassiveElement
@@ -3381,10 +3381,13 @@ class PCS(SoftRobot):
         The inertial, Coriolis, and gravity directions use the analytical
         inverse-dynamics Jacobian passes. Actuator and passive-element force
         directions remain under JAX autodiff so configuration-dependent
-        components retain their exact derivatives.
+        components retain their exact derivatives. Model-parameter directions
+        differentiate the force residual at fixed ``(q, qd, qdd)`` and use
+        ``dID/dqdd = M`` for the implicit acceleration solve; this avoids
+        differentiating through the forward-dynamics linear solve.
         """
         robot, t, y, actuation_args = primals
-        _, _, y_tangent, actuation_args_tangent = tangents
+        robot_tangent, _, y_tangent, actuation_args_tangent = tangents
 
         yd = robot._forward_dynamics(t, y, actuation_args)
         q, qd = jnp.split(y, 2)
@@ -3443,6 +3446,36 @@ class PCS(SoftRobot):
             (q_tangent, qd_tangent, u_tangent, tau_ext_tangent),
         )
 
+        robot_has_tangent = any(
+            tangent is not None
+            for tangent in tree_util.tree_leaves(
+                robot_tangent,
+                is_leaf=lambda value: value is None,
+            )
+        )
+        if robot_has_tangent:
+
+            def dynamics_residual(robot_value: "PCS") -> Array:
+                mass_matrix_value, coriolis_qd, gravity_force = (
+                    robot_value.dynamics_terms(q, qd)
+                )
+                inverse_dynamics = mass_matrix_value @ qdd + coriolis_qd + gravity_force
+                applied_force = (
+                    robot_value.actuation_force(q, u, qd=qd)
+                    + tau_ext
+                    - robot_value.elastic_force(q)
+                    - robot_value.damping_matrix(q) @ qd
+                )
+                return applied_force - inverse_dynamics
+
+            _, robot_parameter_rhs_tangent = eqx.filter_jvp(
+                dynamics_residual,
+                (robot,),
+                (robot_tangent,),
+            )
+        else:
+            robot_parameter_rhs_tangent = jnp.zeros_like(q)
+
         if y_tangent is None:
             mass_matrix = robot.inertia_matrix(q)
             inverse_dynamics_tangent = jnp.zeros_like(q)
@@ -3460,7 +3493,9 @@ class PCS(SoftRobot):
 
         qdd_tangent = robot._solve_inertia(
             mass_matrix,
-            applied_force_tangent - inverse_dynamics_tangent,
+            applied_force_tangent
+            + robot_parameter_rhs_tangent
+            - inverse_dynamics_tangent,
         )
         yd_tangent = jnp.concatenate([qd_tangent, qdd_tangent])
         return yd, yd_tangent

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -41,6 +41,8 @@ from soromox.utils.lie_algebra import se3, so3
 from soromox.utils.lie_algebra.constant_strain import se3 as constant_strain_se3
 from soromox.utils.numerics import safe_divide, safe_norm, safe_normalize
 
+_FUSED_STATE_PUSHFORWARD_MAX_DOFS = 64
+
 
 class PCS(SoftRobot):
     """
@@ -2844,9 +2846,7 @@ class PCS(SoftRobot):
                 return weights[point_index] * basis_tangent
 
             return jnp.sum(
-                vmap(point_matrix_tangent)(
-                    jnp.arange(self.num_integration_points)
-                ),
+                vmap(point_matrix_tangent)(jnp.arange(self.num_integration_points)),
                 axis=0,
             )
 
@@ -2894,9 +2894,7 @@ class PCS(SoftRobot):
                     )
                     * actuator.transmission.params.coordinate_scale[None, :]
                 )
-                force_tangent = (
-                    force_tangent + moment_matrix_tangent @ u[start:stop]
-                )
+                force_tangent = force_tangent + moment_matrix_tangent @ u[start:stop]
             else:
                 raise NotImplementedError(
                     "Analytical PCS state JVPs require an analytical actuator "
@@ -2943,12 +2941,10 @@ class PCS(SoftRobot):
                 )
 
             moment_matrix = self._threadlike_moment_matrix(q, element.routing)
-            moment_matrix_tangent = (
-                self._threadlike_moment_matrix_state_pushforward(
-                    q,
-                    q_tangent,
-                    element.routing,
-                )
+            moment_matrix_tangent = self._threadlike_moment_matrix_state_pushforward(
+                q,
+                q_tangent,
+                element.routing,
             )
             path_extension = (
                 self._threadlike_path_lengths(q, element.routing)
@@ -2967,11 +2963,9 @@ class PCS(SoftRobot):
             path_velocity_tangent = (
                 moment_matrix_tangent.T @ qd + moment_matrix.T @ qd_tangent
             )
-            damping_force_tangent = (
-                moment_matrix_tangent @ (element.params.damping * path_velocity)
-                + moment_matrix
-                @ (element.params.damping * path_velocity_tangent)
-            )
+            damping_force_tangent = moment_matrix_tangent @ (
+                element.params.damping * path_velocity
+            ) + moment_matrix @ (element.params.damping * path_velocity_tangent)
             force_tangent = (
                 force_tangent - elastic_force_tangent - damping_force_tangent
             )
@@ -3378,6 +3372,48 @@ class PCS(SoftRobot):
 
         return Ws_inner, g_ps, J_ps, Jd_or_Jd_qd_ps
 
+    def _dynamics_strain_inputs(
+        self,
+        q: Array,
+        qd: Array,
+    ) -> tuple[Array, Array, Array]:
+        """
+        Return segment strains, strain rates, and active strain bases.
+
+        Args:
+            q: Active generalized coordinates, shape ``(self.num_dofs,)``.
+            qd: Active generalized velocities, shape ``(self.num_dofs,)``.
+
+        Returns:
+            Tuple ``(xi, xid, B_xi_segments)``. The strain arrays have shape
+            ``(self.num_segments, 6)`` and the basis has shape
+            ``(self.num_segments, 6, self.num_dofs)``.
+        """
+        return (
+            self.strain(q).reshape(self.num_segments, 6),
+            (self.B_xi @ qd).reshape(self.num_segments, 6),
+            self.B_xi.reshape(self.num_segments, 6, self.num_dofs),
+        )
+
+    def _dynamics_quadrature(self) -> tuple[Array, Array]:
+        """
+        Return dynamics quadrature weights and segment-local abscissae.
+
+        Returns:
+            Tuple ``(weights, s_local)``. Both arrays have shape
+            ``(self.num_segments, self.num_gauss_points)``.
+        """
+        abscissae, weights = vmap(
+            scale_interior_gaussian_quadrature,
+            in_axes=(None, None, 0, 0),
+        )(
+            self.integration_points,
+            self.integration_weights,
+            self.L_cum[:-1],
+            self.L_cum[1:],
+        )
+        return weights, abscissae - self.L_cum[:-1, None]
+
     @eqx.filter_jit
     def _dynamics_integration_kinematics(
         self, q: Array, qd: Array
@@ -3403,22 +3439,11 @@ class PCS(SoftRobot):
             ``jacobians`` has shape
             ``(self.num_segments, self.num_gauss_points, 6, self.num_dofs)``.
         """
-        xi = self.strain(q).reshape(self.num_segments, 6)
-        xid = (self.B_xi @ qd).reshape(self.num_segments, 6)
-        B_xi_segments = self.B_xi.reshape(self.num_segments, 6, self.num_dofs)
+        xi, xid, B_xi_segments = self._dynamics_strain_inputs(q, qd)
         prepared_adjoint_powers = vmap(constant_strain_se3._prepare_adjoint_powers)(
             xi, xid
         )
-
-        Xs_inner, Ws_inner = vmap(
-            scale_interior_gaussian_quadrature, in_axes=(None, None, 0, 0)
-        )(
-            self.integration_points,
-            self.integration_weights,
-            self.L_cum[:-1],
-            self.L_cum[1:],
-        )
-        s_local = Xs_inner - self.L_cum[:-1, None]
+        weights, s_local = self._dynamics_quadrature()
 
         J_tips, Jd_qd_tips, Ad_inv_tips = self._active_J_Jd_local_tips_from_strain(
             xi,
@@ -3485,7 +3510,421 @@ class PCS(SoftRobot):
             Jd_qd_bases,
             s_local,
         )
-        return Ws_inner, gravity_ps, J_ps, Jd_qd_ps
+        return weights, gravity_ps, J_ps, Jd_qd_ps
+
+    def _assemble_dynamics_terms_from_kinematics(
+        self,
+        qd: Array,
+        weights: Array,
+        gravity: Array,
+        jacobians: Array,
+        convective: Array,
+        *,
+        qd_direction: Array | None = None,
+        gravity_directions: Array | None = None,
+        jacobian_directions: Array | None = None,
+        convective_directions: Array | None = None,
+    ) -> tuple[Array, Array, Array] | tuple[Array, Array, Array, Array, Array, Array]:
+        """
+        Assemble dynamics terms and optional contracted state derivatives.
+
+        Args:
+            qd: Active generalized velocities, shape ``(self.num_dofs,)``.
+            weights: Segment quadrature weights, shape
+                ``(self.num_segments, self.num_gauss_points)``.
+            gravity: Body-frame gravity at each quadrature point.
+            jacobians: Active body Jacobians at each quadrature point.
+            convective: Contractions ``Jdot @ qd`` at each quadrature point.
+            qd_direction: Optional contracted velocity direction.
+            gravity_directions: Optional directional gravity derivatives.
+            jacobian_directions: Optional directional Jacobian derivatives.
+            convective_directions: Optional directional derivatives of
+                ``Jdot @ qd``.
+
+        Returns:
+            Tuple ``(B, Cqd, G)`` when no directional arrays are supplied.
+            Supplying them appends ``(dB, dCqd, dG)``. Matrices have shape
+            ``(self.num_dofs, self.num_dofs)`` and vectors have shape
+            ``(self.num_dofs,)``.
+        """
+        directional_arguments = (
+            qd_direction,
+            gravity_directions,
+            jacobian_directions,
+            convective_directions,
+        )
+        has_direction = all(value is not None for value in directional_arguments)
+        if (
+            any(value is not None for value in directional_arguments)
+            and not has_direction
+        ):
+            raise ValueError("Directional kinematics must be supplied together.")
+        if has_direction:
+            assert qd_direction is not None
+            assert gravity_directions is not None
+            assert jacobian_directions is not None
+            assert convective_directions is not None
+
+        inertia = jnp.zeros((self.num_dofs, self.num_dofs), dtype=jacobians.dtype)
+        coriolis_qd = jnp.zeros((self.num_dofs,), dtype=jacobians.dtype)
+        gravity_force = jnp.zeros((self.num_dofs,), dtype=jacobians.dtype)
+        if has_direction:
+            inertia_direction = jnp.zeros_like(inertia)
+            coriolis_qd_direction = jnp.zeros_like(coriolis_qd)
+            gravity_force_direction = jnp.zeros_like(gravity_force)
+
+        # This trace-time loop intentionally keeps each contraction at its causal
+        # prefix width; scan/fori_loop require a fixed-width body and do extra work.
+        for segment_index, dof_end in enumerate(self._segment_dof_ends):
+            mass_diagonal = jnp.diagonal(self.M_segments[segment_index])
+            jacobian = jacobians[segment_index, :, :, :dof_end]
+            weight = weights[segment_index]
+
+            def mass_action(
+                value: Array,
+                diagonal: Array = mass_diagonal,
+            ) -> Array:
+                shape = (1, diagonal.shape[0]) + (1,) * (value.ndim - 2)
+                return diagonal.reshape(shape) * value
+
+            flattened_rows = self.num_gauss_points * 6
+            jacobian_flat = jacobian.reshape(flattened_rows, dof_end)
+            weighted_mass_jacobian = (
+                weight[:, None, None] * mass_action(jacobian)
+            ).reshape(flattened_rows, dof_end)
+            inertia_segment = jacobian_flat.T @ weighted_mass_jacobian
+
+            eta = jacobian @ qd[:dof_end]
+            momentum = mass_action(eta)
+            wrench = mass_action(convective[segment_index]) + vmap(
+                se3.coadjoint_action,
+            )(eta, momentum)
+            weighted_wrench = (weight[:, None] * wrench).reshape(-1)
+            coriolis_segment = jacobian_flat.T @ weighted_wrench
+
+            weighted_mass_gravity = (
+                weight[:, None] * mass_action(gravity[segment_index])
+            ).reshape(-1)
+            gravity_segment = -jacobian_flat.T @ weighted_mass_gravity
+
+            inertia = inertia.at[:dof_end, :dof_end].add(inertia_segment)
+            coriolis_qd = coriolis_qd.at[:dof_end].add(coriolis_segment)
+            gravity_force = gravity_force.at[:dof_end].add(gravity_segment)
+
+            if has_direction:
+                jacobian_direction = jacobian_directions[
+                    segment_index,
+                    :,
+                    :,
+                    :dof_end,
+                ]
+                jacobian_direction_flat = jacobian_direction.reshape(
+                    flattened_rows,
+                    dof_end,
+                )
+                weighted_mass_jacobian_direction = (
+                    weight[:, None, None] * mass_action(jacobian_direction)
+                ).reshape(flattened_rows, dof_end)
+                inertia_direction_segment = (
+                    jacobian_direction_flat.T @ weighted_mass_jacobian
+                    + jacobian_flat.T @ weighted_mass_jacobian_direction
+                )
+
+                eta_direction = (
+                    jacobian_direction @ qd[:dof_end]
+                    + jacobian @ qd_direction[:dof_end]
+                )
+                momentum_direction = mass_action(eta_direction)
+                wrench_direction = (
+                    mass_action(convective_directions[segment_index])
+                    + vmap(se3.coadjoint_action)(eta_direction, momentum)
+                    + vmap(se3.coadjoint_action)(eta, momentum_direction)
+                )
+                weighted_wrench_direction = (
+                    weight[:, None] * wrench_direction
+                ).reshape(-1)
+                coriolis_direction_segment = (
+                    jacobian_direction_flat.T @ weighted_wrench
+                    + jacobian_flat.T @ weighted_wrench_direction
+                )
+
+                weighted_mass_gravity_direction = (
+                    weight[:, None] * mass_action(gravity_directions[segment_index])
+                ).reshape(-1)
+                gravity_direction_segment = -(
+                    jacobian_direction_flat.T @ weighted_mass_gravity
+                    + jacobian_flat.T @ weighted_mass_gravity_direction
+                )
+
+                inertia_direction = inertia_direction.at[
+                    :dof_end,
+                    :dof_end,
+                ].add(inertia_direction_segment)
+                coriolis_qd_direction = coriolis_qd_direction.at[:dof_end].add(
+                    coriolis_direction_segment
+                )
+                gravity_force_direction = gravity_force_direction.at[:dof_end].add(
+                    gravity_direction_segment
+                )
+
+        if not has_direction:
+            return inertia, coriolis_qd, gravity_force
+        return (
+            inertia,
+            coriolis_qd,
+            gravity_force,
+            inertia_direction,
+            coriolis_qd_direction,
+            gravity_force_direction,
+        )
+
+    @eqx.filter_jit
+    def _dynamics_terms_with_state_pushforward(
+        self,
+        q: Array,
+        qd: Array,
+        q_direction: Array,
+        qd_direction: Array,
+    ) -> tuple[Array, Array, Array, Array, Array, Array]:
+        """
+        Assemble dynamics terms and one analytical state pushforward.
+
+        Segment power preparation is shared by every quadrature point and the
+        segment tip. The recurrence propagates the body Jacobian, convective
+        acceleration, and gravity together with one contracted state
+        direction; no autodiff or full state Jacobian is used.
+
+        Args:
+            q: Active generalized coordinates, shape ``(self.num_dofs,)``.
+            qd: Active generalized velocities, shape ``(self.num_dofs,)``.
+            q_direction: Contracted configuration direction with the same
+                shape as ``q``.
+            qd_direction: Contracted velocity direction with the same shape
+                as ``qd``.
+
+        Returns:
+            Tuple ``(B, Cqd, G, dB, dCqd, dG)``. The first three arrays are
+            the primal dynamics terms. The final three are their directional
+            state derivatives; ``B`` and ``dB`` have shape
+            ``(self.num_dofs, self.num_dofs)`` and all vectors have shape
+            ``(self.num_dofs,)``.
+        """
+        xi, xid, B_xi_segments = self._dynamics_strain_inputs(q, qd)
+        configuration_directions = (self.B_xi @ q_direction).reshape(
+            self.num_segments,
+            6,
+        )
+        rate_directions = (self.B_xi @ qd_direction).reshape(
+            self.num_segments,
+            6,
+        )
+        prepared = vmap(constant_strain_se3._prepare_state_directional_powers)(
+            xi,
+            xid,
+            configuration_directions,
+            rate_directions,
+        )
+
+        weights, s_local = self._dynamics_quadrature()
+
+        zeros_6 = jnp.zeros((6,), dtype=q.dtype)
+        zeros_6n = jnp.zeros((6, self.num_dofs), dtype=q.dtype)
+        gravity_initial = se3.adjoint_inverse(self.g0) @ self.g
+        carry_initial = (
+            zeros_6n,
+            zeros_6n,
+            zeros_6,
+            zeros_6,
+            gravity_initial,
+            zeros_6,
+        )
+
+        def propagate_kinematics(
+            carry: tuple[Array, Array, Array, Array, Array, Array],
+            prepared_i: constant_strain_se3._PreparedStateDirectionalPowers,
+            basis_i: Array,
+            xid_i: Array,
+            configuration_direction_i: Array,
+            rate_direction_i: Array,
+            s_i: Array,
+        ) -> tuple[Array, Array, Array, Array, Array, Array]:
+            (
+                jacobian_base,
+                jacobian_direction_base,
+                convective_base,
+                convective_direction_base,
+                gravity_base,
+                gravity_direction_base,
+            ) = carry
+            (
+                inverse_adjoint,
+                transported_tangent,
+                transported_tangent_velocity_direction,
+                transported_tangent_configuration_direction,
+                transported_tangent_mixed_direction,
+                transported_tangent_rate_direction,
+            ) = constant_strain_se3._kinematic_operators_from_state_directional_powers(
+                prepared_i,
+                s_i,
+                self.global_eps,
+                self.tangent_eps,
+            )
+
+            pose_direction_local = transported_tangent @ configuration_direction_i
+            inverse_adjoint_direction = -vmap(
+                se3.small_adjoint_action,
+                in_axes=(None, 1),
+                out_axes=1,
+            )(pose_direction_local, inverse_adjoint)
+            eta_local = transported_tangent @ xid_i
+            eta_direction_local = (
+                transported_tangent_configuration_direction @ xid_i
+                + transported_tangent @ rate_direction_i
+            )
+            base_velocity = jacobian_base @ qd
+            base_velocity_direction = (
+                jacobian_direction_base @ qd + jacobian_base @ qd_direction
+            )
+            transported_base_velocity = inverse_adjoint @ base_velocity
+            transported_base_velocity_direction = (
+                inverse_adjoint_direction @ base_velocity
+                + inverse_adjoint @ base_velocity_direction
+            )
+
+            transported_tangent_velocity_direction_direction = (
+                transported_tangent_mixed_direction + transported_tangent_rate_direction
+            )
+            local_convective = transported_tangent_velocity_direction @ xid_i
+            local_convective_direction = (
+                transported_tangent_velocity_direction_direction @ xid_i
+                + transported_tangent_velocity_direction @ rate_direction_i
+            )
+
+            jacobian = inverse_adjoint @ jacobian_base + transported_tangent @ basis_i
+            jacobian_direction = (
+                inverse_adjoint_direction @ jacobian_base
+                + inverse_adjoint @ jacobian_direction_base
+                + transported_tangent_configuration_direction @ basis_i
+            )
+            convective = (
+                inverse_adjoint @ convective_base
+                - se3.small_adjoint_action(
+                    eta_local,
+                    transported_base_velocity,
+                )
+                + local_convective
+            )
+            convective_direction = (
+                inverse_adjoint_direction @ convective_base
+                + inverse_adjoint @ convective_direction_base
+                - se3.small_adjoint_action(
+                    eta_direction_local,
+                    transported_base_velocity,
+                )
+                - se3.small_adjoint_action(
+                    eta_local,
+                    transported_base_velocity_direction,
+                )
+                + local_convective_direction
+            )
+            gravity = inverse_adjoint @ gravity_base
+            gravity_direction = (
+                inverse_adjoint_direction @ gravity_base
+                + inverse_adjoint @ gravity_direction_base
+            )
+            return (
+                jacobian,
+                jacobian_direction,
+                convective,
+                convective_direction,
+                gravity,
+                gravity_direction,
+            )
+
+        def propagate_tip(
+            carry: tuple[Array, Array, Array, Array, Array, Array],
+            inputs: tuple[
+                constant_strain_se3._PreparedStateDirectionalPowers,
+                Array,
+                Array,
+                Array,
+                Array,
+                Array,
+            ],
+        ) -> tuple[
+            tuple[Array, Array, Array, Array, Array, Array],
+            tuple[Array, Array, Array, Array, Array, Array],
+        ]:
+            next_carry = propagate_kinematics(carry, *inputs)
+            return next_carry, next_carry
+
+        _, tip_values = lax.scan(
+            propagate_tip,
+            carry_initial,
+            (
+                prepared,
+                B_xi_segments,
+                xid,
+                configuration_directions,
+                rate_directions,
+                self.L,
+            ),
+        )
+        base_values = tree_util.tree_map(
+            lambda initial, tips: jnp.concatenate([initial[None], tips[:-1]]),
+            carry_initial,
+            tip_values,
+        )
+
+        def segment_kinematics(
+            carry_i: tuple[Array, Array, Array, Array, Array, Array],
+            prepared_i: constant_strain_se3._PreparedStateDirectionalPowers,
+            basis_i: Array,
+            xid_i: Array,
+            configuration_direction_i: Array,
+            rate_direction_i: Array,
+            s_local_i: Array,
+        ) -> tuple[Array, Array, Array, Array, Array, Array]:
+            return vmap(
+                lambda s_i: propagate_kinematics(
+                    carry_i,
+                    prepared_i,
+                    basis_i,
+                    xid_i,
+                    configuration_direction_i,
+                    rate_direction_i,
+                    s_i,
+                )
+            )(s_local_i)
+
+        (
+            jacobians,
+            jacobian_directions,
+            convective,
+            convective_directions,
+            gravity,
+            gravity_directions,
+        ) = vmap(segment_kinematics)(
+            base_values,
+            prepared,
+            B_xi_segments,
+            xid,
+            configuration_directions,
+            rate_directions,
+            s_local,
+        )
+
+        return self._assemble_dynamics_terms_from_kinematics(
+            qd,
+            weights,
+            gravity,
+            jacobians,
+            convective,
+            qd_direction=qd_direction,
+            gravity_directions=gravity_directions,
+            jacobian_directions=jacobian_directions,
+            convective_directions=convective_directions,
+        )
 
     @eqx.filter_jit
     def dynamics_terms(self, q: Array, qd: Array) -> tuple[Array, Array, Array]:
@@ -3509,42 +3948,13 @@ class PCS(SoftRobot):
         weights, gravity, jacobians, jacobian_dot_qd = (
             self._dynamics_integration_kinematics(q, qd)
         )
-        inertia = jnp.zeros((self.num_dofs, self.num_dofs), dtype=jacobians.dtype)
-        coriolis_qd = jnp.zeros((self.num_dofs,), dtype=jacobians.dtype)
-        gravity_force = jnp.zeros((self.num_dofs,), dtype=jacobians.dtype)
-
-        # This trace-time loop intentionally keeps each contraction at its causal
-        # prefix width; scan/fori_loop require a fixed-width body and do extra work.
-        for segment_index, dof_end in enumerate(self._segment_dof_ends):
-            mass_diagonal = jnp.diagonal(self.M_segments[segment_index])
-            jacobian = jacobians[segment_index, :, :, :dof_end]
-            weight = weights[segment_index]
-
-            def mass_action(value: Array, diagonal: Array = mass_diagonal) -> Array:
-                shape = (1, diagonal.shape[0]) + (1,) * (value.ndim - 2)
-                return diagonal.reshape(shape) * value
-
-            flattened_rows = self.num_gauss_points * 6
-            jacobian_flat = jacobian.reshape(flattened_rows, dof_end)
-            weighted_mass_jacobian = (
-                weight[:, None, None] * mass_action(jacobian)
-            ).reshape(flattened_rows, dof_end)
-            inertia_segment = jacobian_flat.T @ weighted_mass_jacobian
-
-            eta = jacobian @ qd[:dof_end]
-            momentum = mass_action(eta)
-            coadjoint_momentum = vmap(se3.coadjoint_action)(eta, momentum)
-            wrench = mass_action(jacobian_dot_qd[segment_index]) + coadjoint_momentum
-            coriolis_segment = jacobian_flat.T @ (weight[:, None] * wrench).reshape(-1)
-            gravity_segment = -jacobian_flat.T @ (
-                weight[:, None] * mass_action(gravity[segment_index])
-            ).reshape(-1)
-
-            inertia = inertia.at[:dof_end, :dof_end].add(inertia_segment)
-            coriolis_qd = coriolis_qd.at[:dof_end].add(coriolis_segment)
-            gravity_force = gravity_force.at[:dof_end].add(gravity_segment)
-
-        return inertia, coriolis_qd, gravity_force
+        return self._assemble_dynamics_terms_from_kinematics(
+            qd,
+            weights,
+            gravity,
+            jacobians,
+            jacobian_dot_qd,
+        )
 
     @eqx.filter_jit
     def forward_dynamics(
@@ -3630,12 +4040,12 @@ class PCS(SoftRobot):
         """
         Evaluate the analytical PCS forward-dynamics state JVP.
 
-        State directions use the segment-local analytical inverse-dynamics
-        recurrence and apply ``dID/dqdd = M`` through an implicit acceleration
-        solve instead of differentiating the Cholesky solve. PCS actuator and
-        passive-element state directions use explicit directional kernels as
-        well. Model-parameter directions are handled separately below because
-        they are outside the state-only analytical contract.
+        State directions use a fused analytical dynamics assembly and apply
+        ``dID/dqdd = M`` through an implicit acceleration solve instead of
+        differentiating the Cholesky solve. PCS actuator and passive-element
+        state directions use explicit directional kernels as well.
+        Model-parameter directions are handled separately below because they
+        are outside the state-only analytical contract.
         """
         robot, t, y, actuation_args = primals
         robot_tangent, _, y_tangent, actuation_args_tangent = tangents
@@ -3647,9 +4057,7 @@ class PCS(SoftRobot):
                 is_leaf=lambda value: value is None,
             )
         )
-        yd, mass_matrix = robot._forward_dynamics_with_inertia(t, y, actuation_args)
         q, qd = jnp.split(y, 2)
-        _, qdd = jnp.split(yd, 2)
 
         if y_tangent is None:
             q_tangent = jnp.zeros_like(q)
@@ -3688,6 +4096,59 @@ class PCS(SoftRobot):
                 u_tangent = jnp.zeros_like(u)
             if tau_ext_tangent is None:
                 tau_ext_tangent = jnp.zeros_like(tau_ext)
+
+        if y_tangent is None:
+            yd, mass_matrix = robot._forward_dynamics_with_inertia(
+                t,
+                y,
+                actuation_args,
+            )
+            _, qdd = jnp.split(yd, 2)
+            inverse_dynamics_tangent = jnp.zeros_like(q)
+        elif robot.num_dofs > _FUSED_STATE_PUSHFORWARD_MAX_DOFS:
+            # For large dense systems, carrying one contracted wrench direction
+            # is cheaper than materializing the directional inertia matrix.
+            yd, mass_matrix = robot._forward_dynamics_with_inertia(
+                t,
+                y,
+                actuation_args,
+            )
+            _, qdd = jnp.split(yd, 2)
+            inverse_dynamics_tangent = robot.inverse_dynamics_state_pushforward(
+                q,
+                qd,
+                qdd,
+                q_tangent[:, None],
+                qd_tangent[:, None],
+            )[:, 0]
+        else:
+            (
+                mass_matrix,
+                coriolis_qd,
+                gravity_force,
+                mass_matrix_tangent,
+                coriolis_qd_tangent,
+                gravity_force_tangent,
+            ) = robot._dynamics_terms_with_state_pushforward(
+                q,
+                qd,
+                q_tangent,
+                qd_tangent,
+            )
+            applied_force = (
+                robot.actuation_force(q, u, qd=qd)
+                + tau_ext
+                - robot.elastic_force(q)
+                - robot.damping_matrix(q) @ qd
+            )
+            qdd = robot._solve_inertia(
+                mass_matrix,
+                applied_force - coriolis_qd - gravity_force,
+            )
+            yd = jnp.concatenate([qd, qdd])
+            inverse_dynamics_tangent = (
+                mass_matrix_tangent @ qdd + coriolis_qd_tangent + gravity_force_tangent
+            )
 
         if y_tangent is None:
             applied_force_tangent = jnp.zeros_like(q)
@@ -3735,17 +4196,6 @@ class PCS(SoftRobot):
             )
         else:
             robot_parameter_rhs_tangent = jnp.zeros_like(q)
-
-        if y_tangent is None:
-            inverse_dynamics_tangent = jnp.zeros_like(q)
-        else:
-            inverse_dynamics_tangent = robot.inverse_dynamics_state_pushforward(
-                q,
-                qd,
-                qdd,
-                q_tangent[:, None],
-                qd_tangent[:, None],
-            )[:, 0]
 
         qdd_tangent = robot._solve_inertia(
             mass_matrix,
@@ -3918,89 +4368,111 @@ class PCS(SoftRobot):
         q_directions_local: Array,
         qd_directions_local: Array,
     ) -> tuple[Array, Array, Array, Array, Array, Array, Array, Array]:
-        """Evaluate one interval using only its segment-local active DOFs."""
-        num_directions = q_directions_local.shape[1]
-        derivative_directions = jnp.concatenate(
-            [q_directions_local, qd_directions_local],
-            axis=1,
-        )
-        contract_derivatives = B_xi_local.shape[1] > derivative_directions.shape[1]
-        if contract_derivatives:
-            (
-                g_local,
-                S_local,
-                Sd_local,
-                deta_dq_local,
-                dS_dq_qdd_local,
-                dSd_dq_qd_local,
-            ) = joint_motion_subspace_with_derivatives(
-                H,
-                B_xi_local,
-                xi_ref_local,
-                q_local,
-                qd_local,
-                qdd_local,
-                self.global_eps,
-                derivative_directions,
-            )
-            deta_q_directions = deta_dq_local[:, :num_directions]
-            deta_qd_directions = deta_dq_local[:, num_directions:]
-            detad_q_directions = (
-                dS_dq_qdd_local[:, :num_directions]
-                + dSd_dq_qd_local[:, :num_directions]
-            )
-        else:
-            (
-                g_local,
-                S_local,
-                Sd_local,
-                deta_dq_local,
-                dS_dq_qdd_local,
-                dSd_dq_qd_local,
-            ) = joint_motion_subspace_with_derivatives(
-                H,
-                B_xi_local,
-                xi_ref_local,
-                q_local,
-                qd_local,
-                qdd_local,
-                self.global_eps,
-            )
-            deta_q_directions = deta_dq_local @ q_directions_local
-            deta_qd_directions = deta_dq_local @ qd_directions_local
-            detad_q_directions = (
-                dS_dq_qdd_local + dSd_dq_qd_local
-            ) @ q_directions_local
+        """Evaluate one interval using only segment-local active DOFs.
 
+        Args:
+            H: Local quadrature-interval length.
+            B_xi_local: Padded active strain basis for the interval's segment.
+            xi_ref_local: Reference strain for the interval's segment.
+            q_local: Segment-local generalized coordinates.
+            qd_local: Segment-local generalized velocities.
+            qdd_local: Segment-local generalized accelerations.
+            q_directions_local: Contracted local configuration directions.
+            qd_directions_local: Contracted local velocity directions.
+
+        Returns:
+            Tuple containing the inverse adjoint, motion subspace, its
+            contracted configuration derivatives, local velocity and
+            acceleration twists, and their contracted state derivatives.
+        """
         xi = B_xi_local @ q_local + xi_ref_local
+        xid = B_xi_local @ qd_local
+        xidd = B_xi_local @ qdd_local
         strain_directions = B_xi_local @ q_directions_local
+        strain_rate_directions = B_xi_local @ qd_directions_local
+        accumulated_xi = H * xi
+        accumulated_xid = H * xid
 
-        def motion_subspace_direction(strain_direction: Array) -> Array:
-            prepared = constant_strain_se3._prepare_adjoint_powers(
-                xi,
-                strain_direction,
-            )
-            _, _, tangent_direction = constant_strain_se3._operators_from_prepared(
-                prepared,
-                H,
+        def directional_operators(
+            strain_direction: Array,
+            strain_rate_direction: Array,
+        ) -> tuple[Array, Array, Array, Array, Array, Array]:
+            (
+                inverse_adjoint,
+                tangent,
+                tangent_velocity_direction,
+                tangent_configuration_direction,
+                tangent_mixed_direction,
+                tangent_rate_direction,
+            ) = se3._kinematic_operators_with_state_directional_derivatives(
+                accumulated_xi,
+                accumulated_xid,
+                H * strain_direction,
+                H * strain_rate_direction,
                 self.global_eps,
                 self.tangent_eps,
             )
-            return tangent_direction @ B_xi_local
+            return (
+                inverse_adjoint,
+                tangent,
+                tangent_velocity_direction,
+                tangent_configuration_direction,
+                tangent_mixed_direction,
+                tangent_rate_direction,
+            )
 
-        S_directions_local = vmap(
-            motion_subspace_direction,
-            in_axes=1,
-            out_axes=2,
-        )(strain_directions)
+        (
+            inverse_adjoints,
+            tangents,
+            tangent_velocity_directions,
+            tangent_configuration_directions,
+            tangent_mixed_directions,
+            tangent_rate_directions,
+        ) = vmap(
+            directional_operators,
+            in_axes=(1, 1),
+        )(strain_directions, strain_rate_directions)
+        tangent = H * tangents[0]
+        tangent_velocity_direction = H * tangent_velocity_directions[0]
+        tangent_configuration_directions = H * tangent_configuration_directions
+        tangent_mixed_directions = H * tangent_mixed_directions
+        tangent_rate_directions = H * tangent_rate_directions
 
-        Adginv_local = se3.adjoint_inverse(g_local)
-        eta_local = S_local @ qd_local
-        etad_local = S_local @ qdd_local + Sd_local @ qd_local
-        pose_directions_local = S_local @ q_directions_local
-        eta_directions_local = deta_q_directions + S_local @ qd_directions_local
+        Adginv_local = inverse_adjoints[0]
+        S_local = tangent @ B_xi_local
+        S_directions_local = jnp.einsum(
+            "kij,jm->imk",
+            tangent_configuration_directions,
+            B_xi_local,
+        )
+        eta_local = tangent @ xid
+        etad_local = tangent @ xidd + tangent_velocity_direction @ xid
+        pose_directions_local = tangent @ strain_directions
+        eta_directions_local = (
+            jnp.einsum(
+                "kij,j->ik",
+                tangent_configuration_directions,
+                xid,
+            )
+            + tangent @ strain_rate_directions
+        )
         etad_directions_local = (
-            detad_q_directions + Sd_local @ qd_directions_local + deta_qd_directions
+            jnp.einsum(
+                "kij,j->ik",
+                tangent_configuration_directions,
+                xidd,
+            )
+            + jnp.einsum(
+                "kij,j->ik",
+                tangent_mixed_directions,
+                xid,
+            )
+            + jnp.einsum(
+                "kij,j->ik",
+                tangent_rate_directions,
+                xid,
+            )
+            + tangent_velocity_direction @ strain_rate_directions
         )
         return (
             Adginv_local,

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -2746,7 +2746,30 @@ class PCS(SoftRobot):
         start_segment_index: Array,
         end_segment_index: Array,
     ) -> Array:
-        """Return the analytical state pushforward of one routing basis."""
+        """
+        Compute the directional derivative of one routed-path basis density.
+
+        Args:
+            segment_index (Array): Index of the PCS segment containing the
+                integration point. Shape is ``()``.
+            strain (Array): Spatial strain of the segment. Shape is ``(6,)``.
+            strain_tangent (Array): Directional derivative of ``strain``.
+                Shape is ``(6,)``.
+            s (Array): Backbone coordinate of the integration point. Shape is
+                ``()``.
+            routing (ThreadlikeRouting): Runtime routing functions for the
+                threadlike paths.
+            path_params (BaseThreadlikeRoutingParams): Parameters of one
+                routed path.
+            start_segment_index (Array): First segment traversed by the path.
+                Shape is ``()``.
+            end_segment_index (Array): Last segment traversed by the path.
+                Shape is ``()``.
+
+        Returns:
+            basis_tangent (Array): Directional derivative of the spatial
+            routed-path length-gradient density. Shape is ``(6,)``.
+        """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
         )
@@ -2773,7 +2796,21 @@ class PCS(SoftRobot):
         q_tangent: Array,
         routing: ThreadlikeRouting,
     ) -> Array:
-        """Differentiate raw routed-length moment arms in one state direction."""
+        """
+        Compute the routed-length moment-matrix directional derivative.
+
+        Args:
+            q (Array): Generalized coordinates. Shape is ``(self.num_dofs,)``.
+            q_tangent (Array): Directional derivative of ``q``. Shape is
+                ``(self.num_dofs,)``.
+            routing (ThreadlikeRouting): Runtime routing functions for the
+                threadlike paths.
+
+        Returns:
+            moment_matrix_tangent (Array): Directional derivative of the raw
+            routed-length moment matrix. Shape is
+            ``(self.num_dofs, routing.num_paths)``.
+        """
         params = routing.params
         count = params.num_paths
         if count == 0:
@@ -2824,7 +2861,24 @@ class PCS(SoftRobot):
         u: Array,
         q_tangent: Array,
     ) -> Array:
-        """Return the analytical PCS actuation-force state pushforward."""
+        """
+        Compute the actuation-force directional derivative with respect to state.
+
+        Args:
+            q (Array): Generalized coordinates. Shape is ``(self.num_dofs,)``.
+            u (Array): Ordered actuator controls. Shape is
+                ``(self.num_actuators,)``.
+            q_tangent (Array): Directional derivative of ``q``. Shape is
+                ``(self.num_dofs,)``.
+
+        Returns:
+            force_tangent (Array): Directional derivative of the generalized
+            actuation force. Shape is ``(self.num_dofs,)``.
+
+        Raises:
+            NotImplementedError: If an installed actuator has no analytical
+                PCS state-pushforward implementation.
+        """
         force_tangent = jnp.zeros((self.num_dofs,), dtype=q.dtype)
         start = 0
         for actuator in self.actuators:
@@ -2858,7 +2912,28 @@ class PCS(SoftRobot):
         q_tangent: Array,
         qd_tangent: Array,
     ) -> Array:
-        """Return the analytical passive applied-force state pushforward."""
+        """
+        Compute the passive applied-force state directional derivative.
+
+        The differentiated applied force is the negative sum of the passive
+        elastic force and the passive damping force.
+
+        Args:
+            q (Array): Generalized coordinates. Shape is ``(self.num_dofs,)``.
+            qd (Array): Generalized velocities. Shape is ``(self.num_dofs,)``.
+            q_tangent (Array): Directional derivative of ``q``. Shape is
+                ``(self.num_dofs,)``.
+            qd_tangent (Array): Directional derivative of ``qd``. Shape is
+                ``(self.num_dofs,)``.
+
+        Returns:
+            force_tangent (Array): Directional derivative of the generalized
+            passive applied force. Shape is ``(self.num_dofs,)``.
+
+        Raises:
+            NotImplementedError: If an installed passive element has no
+                analytical PCS state-pushforward implementation.
+        """
         force_tangent = jnp.zeros((self.num_dofs,), dtype=q.dtype)
         for element in self.passive_elements:
             if not isinstance(element, ThreadlikeImpedance):

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -4,12 +4,14 @@ __all__ = ["PCS"]
 from typing import Any, Self
 
 import equinox as eqx
-from jax import Array, jvp, lax, tree_util, vmap
+from jax import Array, lax, tree_util, vmap
 from jax import numpy as jnp
 
-from soromox.actuation.core import Actuator, PassiveElement
+from soromox.actuation.core import Actuator, IdentityActuator, PassiveElement
 from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
+    ThreadlikeActuator,
+    ThreadlikeImpedance,
     ThreadlikeRouting,
 )
 from soromox.autodiff import custom_jvp_enabled
@@ -33,7 +35,6 @@ from soromox.utils.integration import (
 )
 from soromox.utils.joint_motion_subspace import (
     joint_dSTF_dq,
-    joint_dSTF_dq_direction,
     joint_motion_subspace_with_derivatives,
 )
 from soromox.utils.lie_algebra import se3, so3
@@ -2734,6 +2735,173 @@ class PCS(SoftRobot):
         )
         return self.B_xi.T @ full_matrix
 
+    def _threadlike_local_basis_state_pushforward(
+        self,
+        segment_index: Array,
+        strain: Array,
+        strain_tangent: Array,
+        s: Array,
+        routing: ThreadlikeRouting,
+        path_params: BaseThreadlikeRoutingParams,
+        start_segment_index: Array,
+        end_segment_index: Array,
+    ) -> Array:
+        """Return the analytical state pushforward of one routing basis."""
+        active = (start_segment_index <= segment_index) & (
+            segment_index <= end_segment_index
+        )
+        offset = jnp.append(routing.offset(path_params, s), 1.0)
+        offset_derivative = jnp.append(routing.derivative(path_params, s), 1.0)
+        tangent_unnormalized = (offset_derivative + se3.hat(strain) @ offset)[:-1]
+        tangent_unnormalized_tangent = (se3.hat(strain_tangent) @ offset)[:-1]
+        tangent_norm = safe_norm(tangent_unnormalized)
+        tangent = safe_normalize(tangent_unnormalized, eps=self.global_eps)
+        tangent_tangent = safe_divide(
+            tangent_unnormalized_tangent
+            - tangent * (tangent @ tangent_unnormalized_tangent),
+            tangent_norm,
+            self.global_eps,
+        )
+        basis_tangent = jnp.hstack(
+            [so3.skew(offset[:-1]) @ tangent_tangent, tangent_tangent]
+        )
+        return active * basis_tangent
+
+    def _threadlike_moment_matrix_state_pushforward(
+        self,
+        q: Array,
+        q_tangent: Array,
+        routing: ThreadlikeRouting,
+    ) -> Array:
+        """Differentiate raw routed-length moment arms in one state direction."""
+        params = routing.params
+        count = params.num_paths
+        if count == 0:
+            return jnp.zeros((self.num_dofs, 0), dtype=q.dtype)
+        strains = self.strain(q).reshape((self.num_segments, 6))
+        strain_tangents = (self.B_xi @ q_tangent).reshape((self.num_segments, 6))
+
+        def segment_matrix_tangent(segment_index: Array) -> Array:
+            points, weights = scale_gaussian_quadrature(
+                self.integration_points,
+                self.integration_weights,
+                self.L_cum[segment_index],
+                self.L_cum[segment_index + 1],
+            )
+
+            def point_matrix_tangent(point_index: Array) -> Array:
+                basis_tangent = vmap(
+                    self._threadlike_local_basis_state_pushforward,
+                    in_axes=(None, None, None, None, None, 0, 0, 0),
+                    out_axes=1,
+                )(
+                    segment_index,
+                    strains[segment_index],
+                    strain_tangents[segment_index],
+                    points[point_index],
+                    routing,
+                    params,
+                    params.start_segment_index_array,
+                    params.end_segment_index_array,
+                )
+                return weights[point_index] * basis_tangent
+
+            return jnp.sum(
+                vmap(point_matrix_tangent)(
+                    jnp.arange(self.num_integration_points)
+                ),
+                axis=0,
+            )
+
+        full_matrix_tangent = vmap(segment_matrix_tangent)(
+            jnp.arange(self.num_segments)
+        ).reshape(self.num_strains, count)
+        return self.B_xi.T @ full_matrix_tangent
+
+    def _actuation_force_state_pushforward(
+        self,
+        q: Array,
+        u: Array,
+        q_tangent: Array,
+    ) -> Array:
+        """Return the analytical PCS actuation-force state pushforward."""
+        force_tangent = jnp.zeros((self.num_dofs,), dtype=q.dtype)
+        start = 0
+        for actuator in self.actuators:
+            stop = start + actuator.num_channels
+            if isinstance(actuator, IdentityActuator):
+                pass
+            elif isinstance(actuator, ThreadlikeActuator):
+                moment_matrix_tangent = (
+                    self._threadlike_moment_matrix_state_pushforward(
+                        q,
+                        q_tangent,
+                        actuator.transmission.routing,
+                    )
+                    * actuator.transmission.params.coordinate_scale[None, :]
+                )
+                force_tangent = (
+                    force_tangent + moment_matrix_tangent @ u[start:stop]
+                )
+            else:
+                raise NotImplementedError(
+                    "Analytical PCS state JVPs require an analytical actuator "
+                    f"pushforward; unsupported component: {type(actuator).__name__}."
+                )
+            start = stop
+        return force_tangent
+
+    def _passive_force_state_pushforward(
+        self,
+        q: Array,
+        qd: Array,
+        q_tangent: Array,
+        qd_tangent: Array,
+    ) -> Array:
+        """Return the analytical passive applied-force state pushforward."""
+        force_tangent = jnp.zeros((self.num_dofs,), dtype=q.dtype)
+        for element in self.passive_elements:
+            if not isinstance(element, ThreadlikeImpedance):
+                raise NotImplementedError(
+                    "Analytical PCS state JVPs require an analytical passive-force "
+                    f"pushforward; unsupported component: {type(element).__name__}."
+                )
+
+            moment_matrix = self._threadlike_moment_matrix(q, element.routing)
+            moment_matrix_tangent = (
+                self._threadlike_moment_matrix_state_pushforward(
+                    q,
+                    q_tangent,
+                    element.routing,
+                )
+            )
+            path_extension = (
+                self._threadlike_path_lengths(q, element.routing)
+                - element.params.rest_length
+            )
+            spring_effort = element.params.stiffness * path_extension
+            spring_effort_tangent = element.params.stiffness * (
+                moment_matrix.T @ q_tangent
+            )
+            elastic_force_tangent = (
+                moment_matrix_tangent @ spring_effort
+                + moment_matrix @ spring_effort_tangent
+            )
+
+            path_velocity = moment_matrix.T @ qd
+            path_velocity_tangent = (
+                moment_matrix_tangent.T @ qd + moment_matrix.T @ qd_tangent
+            )
+            damping_force_tangent = (
+                moment_matrix_tangent @ (element.params.damping * path_velocity)
+                + moment_matrix
+                @ (element.params.damping * path_velocity_tangent)
+            )
+            force_tangent = (
+                force_tangent - elastic_force_tangent - damping_force_tangent
+            )
+        return force_tangent
+
     def _threadlike_path_lengths(self, q: Array, routing: ThreadlikeRouting) -> Array:
         """Integrate raw threadlike path lengths without signed work scaling."""
         params = routing.params
@@ -3385,19 +3553,25 @@ class PCS(SoftRobot):
         tangents: tuple[Any, Array | None, Array | None, tuple | None],
     ) -> tuple[Array, Array]:
         """
-        Evaluate a hybrid analytical/autodiff forward-dynamics JVP.
+        Evaluate the analytical PCS forward-dynamics state JVP.
 
-        The inertial, Coriolis, and gravity directions use the analytical
-        inverse-dynamics Jacobian passes. Actuator and passive-element force
-        directions remain under JAX autodiff so configuration-dependent
-        components retain their exact derivatives. Model-parameter directions
-        differentiate the force residual at fixed ``(q, qd, qdd)`` and use
-        ``dID/dqdd = M`` for the implicit acceleration solve; this avoids
-        differentiating through the forward-dynamics linear solve.
+        State directions use the segment-local analytical inverse-dynamics
+        recurrence and apply ``dID/dqdd = M`` through an implicit acceleration
+        solve instead of differentiating the Cholesky solve. PCS actuator and
+        passive-element state directions use explicit directional kernels as
+        well. Model-parameter directions are handled separately below because
+        they are outside the state-only analytical contract.
         """
         robot, t, y, actuation_args = primals
         robot_tangent, _, y_tangent, actuation_args_tangent = tangents
 
+        robot_has_tangent = any(
+            tangent is not None
+            for tangent in tree_util.tree_leaves(
+                robot_tangent,
+                is_leaf=lambda value: value is None,
+            )
+        )
         yd, mass_matrix = robot._forward_dynamics_with_inertia(t, y, actuation_args)
         q, qd = jnp.split(y, 2)
         _, qdd = jnp.split(yd, 2)
@@ -3446,39 +3620,16 @@ class PCS(SoftRobot):
             applied_force_tangent = (
                 -robot.K_active @ q_tangent - robot.D_active @ qd_tangent
             )
-
-            if robot.actuators:
-
-                def state_dependent_actuation_force(
-                    q_value: Array,
-                    qd_value: Array,
-                ) -> Array:
-                    return robot.actuation_force(q_value, u, qd=qd_value)
-
-                _, actuation_state_tangent = jvp(
-                    state_dependent_actuation_force,
-                    (q, qd),
-                    (q_tangent, qd_tangent),
+            applied_force_tangent = (
+                applied_force_tangent
+                + robot._actuation_force_state_pushforward(q, u, q_tangent)
+                + robot._passive_force_state_pushforward(
+                    q,
+                    qd,
+                    q_tangent,
+                    qd_tangent,
                 )
-                applied_force_tangent = applied_force_tangent + actuation_state_tangent
-
-            if robot.passive_elements:
-
-                def passive_force(
-                    q_value: Array,
-                    qd_value: Array,
-                ) -> Array:
-                    return (
-                        -robot.passive_elastic_force(q_value)
-                        - robot.passive_damping_matrix(q_value) @ qd_value
-                    )
-
-                _, passive_force_tangent = jvp(
-                    passive_force,
-                    (q, qd),
-                    (q_tangent, qd_tangent),
-                )
-                applied_force_tangent = applied_force_tangent + passive_force_tangent
+            )
         if u_has_tangent:
             applied_force_tangent = (
                 applied_force_tangent
@@ -3487,13 +3638,6 @@ class PCS(SoftRobot):
         if tau_ext_has_tangent:
             applied_force_tangent = applied_force_tangent + tau_ext_tangent
 
-        robot_has_tangent = any(
-            tangent is not None
-            for tangent in tree_util.tree_leaves(
-                robot_tangent,
-                is_leaf=lambda value: value is None,
-            )
-        )
         if robot_has_tangent:
 
             def dynamics_residual(robot_value: "PCS") -> Array:
@@ -3698,7 +3842,7 @@ class PCS(SoftRobot):
         qdd_local: Array,
         q_directions_local: Array,
         qd_directions_local: Array,
-    ) -> tuple[Array, Array, Array, Array, Array, Array, Array]:
+    ) -> tuple[Array, Array, Array, Array, Array, Array, Array, Array]:
         """Evaluate one interval using only its segment-local active DOFs."""
         num_directions = q_directions_local.shape[1]
         derivative_directions = jnp.concatenate(
@@ -3752,6 +3896,30 @@ class PCS(SoftRobot):
             detad_q_directions = (
                 dS_dq_qdd_local + dSd_dq_qd_local
             ) @ q_directions_local
+
+        xi = B_xi_local @ q_local + xi_ref_local
+        strain_directions = B_xi_local @ q_directions_local
+
+        def motion_subspace_direction(strain_direction: Array) -> Array:
+            prepared = constant_strain_se3._prepare_adjoint_powers(
+                xi,
+                strain_direction,
+            )
+            _, _, tangent_direction = constant_strain_se3._operators_from_prepared(
+                prepared,
+                H,
+                self.global_eps,
+                self.tangent_eps,
+            )
+            return tangent_direction @ B_xi_local
+
+        S_directions_local = vmap(
+            motion_subspace_direction,
+            in_axes=1,
+            out_axes=2,
+        )(strain_directions)
+
+        Adginv_local = se3.adjoint_inverse(g_local)
         eta_local = S_local @ qd_local
         etad_local = S_local @ qdd_local + Sd_local @ qd_local
         pose_directions_local = S_local @ q_directions_local
@@ -3760,8 +3928,9 @@ class PCS(SoftRobot):
             detad_q_directions + Sd_local @ qd_directions_local + deta_qd_directions
         )
         return (
-            g_local,
+            Adginv_local,
             S_local,
+            S_directions_local,
             eta_local,
             etad_local,
             pose_directions_local,
@@ -3969,6 +4138,7 @@ class PCS(SoftRobot):
         Array,
         Array,
         Array,
+        Array,
     ]:
         """Propagate primal kinematics and contracted state directions."""
         Xs_nodes, Ws_nodes = vmap(
@@ -4011,8 +4181,9 @@ class PCS(SoftRobot):
         )
 
         (
-            g_local,
+            Adginv,
             S,
+            S_directions,
             eta_local,
             etad_local,
             pose_directions_local,
@@ -4028,12 +4199,12 @@ class PCS(SoftRobot):
             q_directions_local_segments[segment_indices],
             qd_directions_local_segments[segment_indices],
         )
-        Adginv = vmap(se3.adjoint_inverse)(g_local)
         num_directions = q_directions.shape[1]
         zeros_6 = jnp.zeros((6,), dtype=q.dtype)
         zeros_6k = jnp.zeros((6, num_directions), dtype=q.dtype)
+        gravity_base_initial = se3.adjoint_inverse(self.g0) @ self.g
         carry_init = (
-            self.g0,
+            gravity_base_initial,
             zeros_6,
             zeros_6,
             zeros_6k,
@@ -4043,13 +4214,13 @@ class PCS(SoftRobot):
 
         def propagate_interval(
             carry: tuple[Array, Array, Array, Array, Array, Array],
-            local: tuple[Array, Array, Array, Array, Array, Array, Array],
+            local: tuple[Array, Array, Array, Array, Array, Array],
         ) -> tuple[
             tuple[Array, Array, Array, Array, Array, Array],
             tuple[Array, Array, Array, Array, Array, Array],
         ]:
             (
-                g_base,
+                gravity_base,
                 eta_base,
                 etad_base,
                 pose_directions_base,
@@ -4057,7 +4228,6 @@ class PCS(SoftRobot):
                 etad_directions_base,
             ) = carry
             (
-                g_local_i,
                 Adginv_i,
                 eta_local_i,
                 etad_local_i,
@@ -4088,7 +4258,7 @@ class PCS(SoftRobot):
                 )(eta_base, eta_directions_local_i)
             )
 
-            g_tip = g_base @ g_local_i
+            gravity_tip = Adginv_i @ gravity_base
             pose_directions_tip = Adginv_i @ (
                 pose_directions_base + pose_directions_local_i
             )
@@ -4112,7 +4282,7 @@ class PCS(SoftRobot):
             )
 
             carry_next = (
-                g_tip,
+                gravity_tip,
                 eta_tip,
                 etad_tip,
                 pose_directions_tip,
@@ -4121,35 +4291,54 @@ class PCS(SoftRobot):
             )
             return carry_next, carry_next
 
-        (
-            _,
+        interval_values = (
+            Adginv,
+            eta_local,
+            etad_local,
+            pose_directions_local,
+            eta_directions_local,
+            etad_directions_local,
+        )
+        num_intervals = segment_indices.shape[0]
+        if num_intervals <= 16:
+            carry = carry_init
+            outputs = []
+            for step_idx in range(num_intervals):
+                local_values = tree_util.tree_map(
+                    lambda value, step=step_idx: value[step],
+                    interval_values,
+                )
+                carry, output = propagate_interval(carry, local_values)
+                outputs.append(output)
             (
-                g,
+                gravity,
                 eta,
                 etad,
                 pose_directions,
                 eta_directions,
                 etad_directions,
-            ),
-        ) = lax.scan(
-            propagate_interval,
-            carry_init,
+            ) = tree_util.tree_map(lambda *values: jnp.stack(values), *outputs)
+        else:
             (
-                g_local,
-                Adginv,
-                eta_local,
-                etad_local,
-                pose_directions_local,
-                eta_directions_local,
-                etad_directions_local,
-            ),
-        )
+                _,
+                (
+                    gravity,
+                    eta,
+                    etad,
+                    pose_directions,
+                    eta_directions,
+                    etad_directions,
+                ),
+            ) = lax.scan(
+                propagate_interval,
+                carry_init,
+                interval_values,
+            )
 
         return (
             segment_indices,
-            H_flat,
             mass_weights,
-            g,
+            gravity,
             eta,
             etad,
             pose_directions,
@@ -4157,6 +4346,8 @@ class PCS(SoftRobot):
             etad_directions,
             Adginv,
             S,
+            S_directions,
+            pose_directions_local,
         )
 
     @eqx.filter_jit
@@ -4387,9 +4578,8 @@ class PCS(SoftRobot):
         """
         (
             segment_indices,
-            H_steps,
             mass_weights,
-            g,
+            gravity,
             eta,
             etad,
             pose_directions,
@@ -4397,6 +4587,8 @@ class PCS(SoftRobot):
             etad_directions,
             Adginv,
             S,
+            S_directions,
+            pose_directions_local,
         ) = self._inverse_dynamics_state_pushforward_forward_pass(
             q,
             qd,
@@ -4413,19 +4605,6 @@ class PCS(SoftRobot):
         )
         dof_indices, dof_mask = self._segment_local_dof_layout()
         dof_mask_values = dof_mask.astype(q.dtype)
-        B_xi_segments = self.B_xi.reshape(
-            self.num_segments,
-            6,
-            self.num_dofs,
-        )
-        B_xi_local_segments = vmap(
-            lambda basis, indices, mask: basis[:, indices] * mask[None, :]
-        )(B_xi_segments, dof_indices, dof_mask_values)
-        xi_ref_segments = self.xi_ref.reshape(self.num_segments, 6)
-        q_local_segments = q[dof_indices] * dof_mask_values
-        q_directions_local_segments = (
-            q_directions[dof_indices] * dof_mask_values[:, :, None]
-        )
 
         def propagate_interval_backward(
             carry: tuple[Array, Array, Array],
@@ -4437,7 +4616,7 @@ class PCS(SoftRobot):
             mass_diagonal = mass_weights[step_idx] * jnp.diagonal(
                 self.M_segments[segment_idx]
             )
-            g_i = g[step_idx]
+            gravity_i = gravity[step_idx]
             eta_i = eta[step_idx]
             etad_i = etad[step_idx]
             pose_directions_i = pose_directions[step_idx]
@@ -4445,16 +4624,16 @@ class PCS(SoftRobot):
             etad_directions_i = etad_directions[step_idx]
             Adginv_i = Adginv[step_idx]
             S_i = S[step_idx]
+            S_directions_i = S_directions[step_idx]
+            pose_directions_local_i = pose_directions_local[step_idx]
             dof_indices_i = dof_indices[segment_idx]
             dof_mask_i = dof_mask_values[segment_idx]
-            q_directions_local_i = q_directions_local_segments[segment_idx]
 
             def mass_action(value: Array) -> Array:
                 shape = (mass_diagonal.shape[0],) + (1,) * (value.ndim - 1)
                 return mass_diagonal.reshape(shape) * value
 
             M_eta = mass_action(eta_i)
-            gravity_i = se3.adjoint_inverse(g_i) @ self.g
             F_i = (
                 mass_action(etad_i)
                 + se3.coadjoint_action(eta_i, M_eta)
@@ -4486,21 +4665,16 @@ class PCS(SoftRobot):
             coAdg = Adginv_i.T
             F_res = coAdg @ F_res_tip
             dF_res = coAdg @ dF_res_tip
-            interval_pose_directions = S_i @ q_directions_local_i
             dF_res = dF_res + vmap(
                 se3.coadjoint_action,
                 in_axes=(1, None),
                 out_axes=1,
-            )(interval_pose_directions, F_res)
+            )(pose_directions_local_i, F_res)
 
-            dSTF_res = joint_dSTF_dq_direction(
-                H_steps[step_idx],
-                B_xi_local_segments[segment_idx],
-                xi_ref_segments[segment_idx],
-                q_local_segments[segment_idx],
+            dSTF_res = jnp.einsum(
+                "imk,i->mk",
+                S_directions_i,
                 F_res,
-                q_directions_local_i,
-                self.global_eps,
             )
             dID_local = (S_i.T @ dF_res + dSTF_res) * dof_mask_i[:, None]
             dID = dID.at[dof_indices_i].add(dID_local)
@@ -4513,11 +4687,20 @@ class PCS(SoftRobot):
             -1,
             dtype=jnp.int32,
         )
-        (_, _, dID), _ = lax.scan(
-            propagate_interval_backward,
-            (zeros_6, zeros_6k, zeros_nk),
-            reverse_indices,
-        )
+        backward_carry = (zeros_6, zeros_6k, zeros_nk)
+        if num_intervals <= 16:
+            for step_idx in range(num_intervals - 1, -1, -1):
+                backward_carry, _ = propagate_interval_backward(
+                    backward_carry,
+                    jnp.asarray(step_idx, dtype=jnp.int32),
+                )
+            _, _, dID = backward_carry
+        else:
+            (_, _, dID), _ = lax.scan(
+                propagate_interval_backward,
+                backward_carry,
+                reverse_indices,
+            )
         return dID
 
     @eqx.filter_jit

--- a/src/soromox/utils/_matrix_polynomials.py
+++ b/src/soromox/utils/_matrix_polynomials.py
@@ -31,6 +31,70 @@ def powers_and_directional_derivatives(
     return result, result_directions
 
 
+def powers_and_state_directional_derivatives(
+    matrix: Array,
+    velocity_direction: Array,
+    configuration_direction: Array,
+    rate_direction: Array,
+    degree: int,
+) -> tuple[list[Array], list[Array], list[Array], list[Array], list[Array]]:
+    """
+    Return matrix powers and the state derivatives used by PCS kinematics.
+
+    Args:
+        matrix: Matrix whose powers are evaluated.
+        velocity_direction: First direction associated with the strain rate.
+        configuration_direction: Second direction associated with the
+            configuration tangent.
+        rate_direction: Independent direction associated with the velocity
+            tangent.
+        degree: Highest matrix-power order to return.
+
+    Returns:
+        Tuple containing powers from order zero through ``degree``, their
+        derivatives along the three supplied directions, and the mixed
+        velocity/configuration derivative.
+    """
+    current = jnp.eye(matrix.shape[0], dtype=matrix.dtype)
+    current_velocity = jnp.zeros_like(matrix)
+    current_configuration = jnp.zeros_like(matrix)
+    current_rate = jnp.zeros_like(matrix)
+    current_mixed = jnp.zeros_like(matrix)
+    powers = [current]
+    velocity_derivatives = [current_velocity]
+    configuration_derivatives = [current_configuration]
+    rate_derivatives = [current_rate]
+    mixed_derivatives = [current_mixed]
+    for _ in range(degree):
+        next_mixed = (
+            current_mixed @ matrix
+            + current_velocity @ configuration_direction
+            + current_configuration @ velocity_direction
+        )
+        next_velocity = current_velocity @ matrix + current @ velocity_direction
+        next_configuration = (
+            current_configuration @ matrix + current @ configuration_direction
+        )
+        next_rate = current_rate @ matrix + current @ rate_direction
+        current = current @ matrix
+        powers.append(current)
+        velocity_derivatives.append(next_velocity)
+        configuration_derivatives.append(next_configuration)
+        rate_derivatives.append(next_rate)
+        mixed_derivatives.append(next_mixed)
+        current_velocity = next_velocity
+        current_configuration = next_configuration
+        current_rate = next_rate
+        current_mixed = next_mixed
+    return (
+        powers,
+        velocity_derivatives,
+        configuration_derivatives,
+        rate_derivatives,
+        mixed_derivatives,
+    )
+
+
 def evaluate(matrix_powers: Sequence[Array], coefficients: Sequence[Array]) -> Array:
     """Evaluate a polynomial with an implicit unit constant coefficient."""
     result = matrix_powers[0]
@@ -58,5 +122,68 @@ def evaluate_directional_derivative(
             result
             + coefficient_direction * matrix_power
             + coefficient * matrix_power_direction
+        )
+    return result
+
+
+def evaluate_mixed_directional_derivative(
+    matrix_powers: Sequence[Array],
+    velocity_power_derivatives: Sequence[Array],
+    configuration_power_derivatives: Sequence[Array],
+    mixed_power_derivatives: Sequence[Array],
+    coefficients: Sequence[Array],
+    velocity_coefficient_derivatives: Sequence[Array],
+    configuration_coefficient_derivatives: Sequence[Array],
+    mixed_coefficient_derivatives: Sequence[Array],
+) -> Array:
+    """
+    Evaluate a matrix polynomial's mixed state derivative.
+
+    Args:
+        matrix_powers: Powers from order zero through the polynomial degree.
+        velocity_power_derivatives: Power derivatives along the velocity
+            direction.
+        configuration_power_derivatives: Power derivatives along the
+            configuration direction.
+        mixed_power_derivatives: Mixed velocity/configuration derivatives of
+            the powers.
+        coefficients: Polynomial coefficients for powers one and above.
+        velocity_coefficient_derivatives: Coefficient derivatives along the
+            velocity direction.
+        configuration_coefficient_derivatives: Coefficient derivatives along
+            the configuration direction.
+        mixed_coefficient_derivatives: Mixed velocity/configuration
+            derivatives of the coefficients.
+
+    Returns:
+        Matrix containing the mixed directional derivative of the polynomial.
+    """
+    result = jnp.zeros_like(matrix_powers[0])
+    for (
+        coefficient,
+        coefficient_velocity,
+        coefficient_configuration,
+        coefficient_mixed,
+        power,
+        power_velocity,
+        power_configuration,
+        power_mixed,
+    ) in zip(
+        coefficients,
+        velocity_coefficient_derivatives,
+        configuration_coefficient_derivatives,
+        mixed_coefficient_derivatives,
+        matrix_powers[1:],
+        velocity_power_derivatives[1:],
+        configuration_power_derivatives[1:],
+        mixed_power_derivatives[1:],
+        strict=True,
+    ):
+        result = (
+            result
+            + coefficient_mixed * power
+            + coefficient_velocity * power_configuration
+            + coefficient_configuration * power_velocity
+            + coefficient * power_mixed
         )
     return result

--- a/src/soromox/utils/joint_motion_subspace.py
+++ b/src/soromox/utils/joint_motion_subspace.py
@@ -1,10 +1,11 @@
 __all__ = [
+    "joint_dSTF_dq",
     "joint_dSdq_qd",
     "joint_motion_subspace_with_derivatives",
 ]
 
 import jax.numpy as jnp
-from jax import Array, lax
+from jax import Array, lax, vmap
 
 from soromox.utils.lie_algebra import se3
 from soromox.utils.numerics import safe_norm
@@ -467,5 +468,123 @@ def joint_dSdq_qd(H, B_xi, xi_ref, q, qd, eps) -> Array:
         theta <= _THETA_SERIES_THRESHOLD,
         _series_branch,
         _general_branch,
+        operand=theta,
+    )
+
+
+def joint_dSTF_dq(H, B_xi, xi_ref, q, wrench, eps) -> Array:
+    """Compute ``d(S.T @ wrench) / dq`` without a rank-three ``dS/dq``.
+
+    The result is equivalent to evaluating :func:`joint_dSdq_qd` along every
+    generalized-coordinate basis direction and contracting each result with
+    ``wrench``. Coadjoint actions perform the wrench contraction before the
+    strain-basis products, avoiding the intermediate array with shape
+    ``(num_dofs, 6, num_dofs)``.
+
+    Args:
+        H: Scalar interval length.
+        B_xi: Strain basis matrix with shape ``(6, num_dofs)``.
+        xi_ref: Reference strain vector with shape ``(6,)``.
+        q: Generalized coordinates with shape ``(num_dofs,)``.
+        wrench: Spatial dual vector with shape ``(6,)``.
+        eps: Small positive tolerance used to avoid singular divisions.
+
+    Returns:
+        Jacobian of ``S(q).T @ wrench`` with respect to ``q``, with shape
+        ``(num_dofs, num_dofs)``.
+    """
+    xi = B_xi @ q + xi_ref
+    Omega = H * xi
+    Z = H * B_xi
+    theta = jnp.maximum(safe_norm(Omega[:3]), eps)
+
+    adjOmega = se3.small_adjoint(Omega)
+    adjOmegap2 = adjOmega @ adjOmega
+    adjOmegap3 = adjOmegap2 @ adjOmega
+    adjOmegap4 = adjOmegap3 @ adjOmega
+    adjOmegap = jnp.stack((adjOmega, adjOmegap2, adjOmegap3, adjOmegap4))
+    identity = jnp.eye(6, dtype=Omega.dtype)
+
+    def adjoint_power_or_eye(power: int) -> Array:
+        return identity if power < 0 else adjOmegap[power]
+
+    def contracted_adjoint_term(adj1: Array, adj2: Array) -> Array:
+        direction_twists = adj2 @ Z
+        transported_wrench = adj1.T @ wrench
+        coadjoint_actions = vmap(
+            se3.coadjoint_action,
+            in_axes=(1, None),
+            out_axes=1,
+        )(direction_twists, transported_wrench)
+        return coadjoint_actions.T @ Z
+
+    def series_branch(_: Array) -> Array:
+        coefficients = jnp.array(
+            [1 / 2, 1 / 6, 1 / 24, 1 / 120],
+            dtype=Omega.dtype,
+        )
+        result = jnp.zeros((q.shape[0], q.shape[0]), dtype=q.dtype)
+        for r in range(4):
+            for u in range(1, r + 2):
+                adj1 = adjoint_power_or_eye(u - 2)
+                adj2 = adjoint_power_or_eye(r - u)
+                result = result + coefficients[r] * contracted_adjoint_term(
+                    adj1,
+                    adj2,
+                )
+        return result
+
+    def general_branch(theta: Array) -> Array:
+        theta2 = theta * theta
+        theta3 = theta2 * theta
+        theta4 = theta3 * theta
+        theta5 = theta4 * theta
+        theta6 = theta5 * theta
+        cosine = jnp.cos(theta)
+        sine = jnp.sin(theta)
+        theta_sine = theta * sine
+        theta_cosine = theta * cosine
+        t3 = -8 + (8 - theta2) * cosine + 5 * theta_sine
+        t4 = -8 * theta + (15 - theta2) * sine - 7 * theta_cosine
+
+        coefficients = jnp.stack(
+            (
+                (4 - 4 * cosine - theta_sine) / (2 * theta2),
+                (4 * theta - 5 * sine + theta_cosine) / (2 * theta3),
+                (2 - 2 * cosine - theta_sine) / (2 * theta4),
+                (2 * theta - 3 * sine + theta_cosine) / (2 * theta5),
+            )
+        )
+        coefficient_derivatives = jnp.stack(
+            (
+                t3 / (2 * theta3),
+                t4 / (2 * theta4),
+                t3 / (2 * theta5),
+                t4 / (2 * theta6),
+            )
+        )
+        rotational_projection = Omega[:3] @ Z[:3, :]
+
+        result = jnp.zeros((q.shape[0], q.shape[0]), dtype=q.dtype)
+        for r in range(4):
+            directional_coefficients = wrench @ adjOmegap[r] @ Z
+            result = result + (
+                coefficient_derivatives[r]
+                / theta
+                * jnp.outer(directional_coefficients, rotational_projection)
+            )
+            for u in range(1, r + 2):
+                adj1 = adjoint_power_or_eye(u - 2)
+                adj2 = adjoint_power_or_eye(r - u)
+                result = result + coefficients[r] * contracted_adjoint_term(
+                    adj1,
+                    adj2,
+                )
+        return result
+
+    return lax.cond(
+        theta <= _THETA_SERIES_THRESHOLD,
+        series_branch,
+        general_branch,
         operand=theta,
     )

--- a/src/soromox/utils/joint_motion_subspace.py
+++ b/src/soromox/utils/joint_motion_subspace.py
@@ -41,9 +41,12 @@ def joint_motion_subspace_with_derivatives(
         - g: Transformation matrix over the interval, shape "(4, 4)".
         - S: Joint motion subspace over the interval, shape "(6, num_dofs)".
         - Sd: Time derivative of S induced by qd, shape "(6, num_dofs)".
-        - dSdq_qd: Directional derivative dS/dq contracted with qd, shape "(6, num_dofs)".
-        - dSdq_qdd: Directional derivative dS/dq contracted with qdd, shape "(6, num_dofs)".
-        - dSddq_qd: Directional derivative dSd/dq contracted with qd, shape "(6, num_dofs)".
+        - dSdq_qd: Jacobian of ``S(q) @ qd`` with respect to ``q``, shape
+          ``(6, num_dofs)``.
+        - dSdq_qdd: Jacobian of ``S(q) @ qdd`` with respect to ``q``, shape
+          ``(6, num_dofs)``.
+        - dSddq_qd: Jacobian of ``Sd(q, qd) @ qd`` with respect to ``q``,
+          shape ``(6, num_dofs)``.
     """
 
     I_theta = jnp.diag(jnp.array([1, 1, 1, 0, 0, 0]))
@@ -353,11 +356,12 @@ def joint_dSdq_qd(H, B_xi, xi_ref, q, qd, eps) -> Array:
         xi_ref: Reference strain vector, shape (6,).
         q: Generalized coordinates, shape (num_dofs,).
         qd: Generalized velocities, shape (num_dofs,).
-        eps: Small positive tolerance for the small-angle branch.
+        eps: Small positive tolerance used to avoid singular divisions. The
+            small-angle formulas switch branches at a fixed ``1e-2`` threshold.
 
     Returns:
-        dSdq_qd: Directional derivative dS/dq contracted with qd,
-            shape (6, num_dofs).
+        dSdq_qd: Jacobian of ``S(q) @ qd`` with respect to ``q``, shape
+            ``(6, num_dofs)``.
     """
 
     # Quantities required by both branches
@@ -460,7 +464,7 @@ def joint_dSdq_qd(H, B_xi, xi_ref, q, qd, eps) -> Array:
         return result
 
     return lax.cond(
-        theta <= eps,
+        theta <= _THETA_SERIES_THRESHOLD,
         _series_branch,
         _general_branch,
         operand=theta,

--- a/src/soromox/utils/joint_motion_subspace.py
+++ b/src/soromox/utils/joint_motion_subspace.py
@@ -1,5 +1,6 @@
 __all__ = [
     "joint_dSTF_dq",
+    "joint_dSTF_dq_direction",
     "joint_dSdq_qd",
     "joint_motion_subspace_with_derivatives",
 ]
@@ -14,7 +15,14 @@ _THETA_SERIES_THRESHOLD = 1.0e-2
 
 
 def joint_motion_subspace_with_derivatives(
-    H, B_xi, xi_ref, q, qd, qdd, eps
+    H,
+    B_xi,
+    xi_ref,
+    q,
+    qd,
+    qdd,
+    eps,
+    q_directions=None,
 ) -> tuple[Array, Array, Array, Array, Array, Array]:
     """
     Compute the joint transform, motion subspace, and derivatives.
@@ -35,6 +43,10 @@ def joint_motion_subspace_with_derivatives(
         qdd: Generalized accelerations with shape "(num_dofs,)".
         eps: Small positive tolerance used to avoid singular divisions. The
             small-angle formulas switch branches at a fixed ``1e-2`` threshold.
+        q_directions: Optional configuration directions with shape
+            ``(num_dofs, num_directions)``. When provided, the three
+            configuration derivatives are applied to these directions inside
+            their analytical series instead of being materialized in full.
 
     Returns:
         A tuple "(g, S, Sd, dSdq_qd, dSdq_qdd, dSddq_qd)".
@@ -42,12 +54,12 @@ def joint_motion_subspace_with_derivatives(
         - g: Transformation matrix over the interval, shape "(4, 4)".
         - S: Joint motion subspace over the interval, shape "(6, num_dofs)".
         - Sd: Time derivative of S induced by qd, shape "(6, num_dofs)".
-        - dSdq_qd: Jacobian of ``S(q) @ qd`` with respect to ``q``, shape
-          ``(6, num_dofs)``.
-        - dSdq_qdd: Jacobian of ``S(q) @ qdd`` with respect to ``q``, shape
-          ``(6, num_dofs)``.
-        - dSddq_qd: Jacobian of ``Sd(q, qd) @ qd`` with respect to ``q``,
-          shape ``(6, num_dofs)``.
+        - dSdq_qd: Jacobian of ``S(q) @ qd`` with respect to ``q``.
+        - dSdq_qdd: Jacobian of ``S(q) @ qdd`` with respect to ``q``.
+        - dSddq_qd: Jacobian of ``Sd(q, qd) @ qd`` with respect to ``q``.
+
+        The derivative shapes are ``(6, num_dofs)`` when ``q_directions`` is
+        omitted and ``(6, num_directions)`` otherwise.
     """
 
     I_theta = jnp.diag(jnp.array([1, 1, 1, 0, 0, 0]))
@@ -187,6 +199,7 @@ def joint_motion_subspace_with_derivatives(
     S = T @ Z
     Sd = Td @ Z
     Zqdd = Z @ qdd
+    Z_derivative = Z if q_directions is None else Z @ q_directions
 
     def _adjoint_power_or_eye(k: int) -> Array:
         return jnp.eye(6) if k < 0 else adjOmegap[k]
@@ -204,10 +217,16 @@ def joint_motion_subspace_with_derivatives(
                 adjOmegap2 = _adjoint_power_or_eye(r - u)
 
                 dSdq_qd_terms.append(
-                    -f[r] * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Omegad) @ Z)
+                    -f[r]
+                    * (
+                        adjOmegap1
+                        @ se3.small_adjoint(adjOmegap2 @ Omegad)
+                        @ Z_derivative
+                    )
                 )
                 dSdq_qdd_terms.append(
-                    -f[r] * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Zqdd) @ Z)
+                    -f[r]
+                    * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Zqdd) @ Z_derivative)
                 )
 
                 for p in range(1, u):
@@ -221,7 +240,7 @@ def joint_motion_subspace_with_derivatives(
                             @ se3.small_adjoint(
                                 adjOmegap4 @ adjOmegapd[0] @ adjOmegap2 @ Omegad
                             )
-                            @ Z
+                            @ Z_derivative
                         )
                     )
 
@@ -236,7 +255,7 @@ def joint_motion_subspace_with_derivatives(
                             @ adjOmegapd[0]
                             @ adjOmegap3
                             @ se3.small_adjoint(adjOmegap4 @ Omegad)
-                            @ Z
+                            @ Z_derivative
                         )
                     )
         return (
@@ -258,7 +277,7 @@ def joint_motion_subspace_with_derivatives(
                 * fd[r]
                 * jnp.outer(
                     adjr @ Omegad,
-                    Omega @ (I_theta @ Z),
+                    Omega @ (I_theta @ Z_derivative),
                 )
             )
 
@@ -267,20 +286,21 @@ def joint_motion_subspace_with_derivatives(
                 * fd[r]
                 * jnp.outer(
                     adjr @ Zqdd,
-                    Omega @ (I_theta @ Z),
+                    Omega @ (I_theta @ Z_derivative),
                 )
             )
 
             term1 = (1 / theta) * jnp.outer(
                 ((fdd[r] * thetad) * adjr + fd[r] * adjrd) @ Omegad,
-                Omega @ (I_theta @ Z),
+                Omega @ (I_theta @ Z_derivative),
             )
 
             term2 = (
                 (1 / theta)
                 * fd[r]
                 * jnp.outer(
-                    adjr @ Omegad, (Omegad - (thetad / theta) * Omega) @ (I_theta @ Z)
+                    adjr @ Omegad,
+                    (Omegad - (thetad / theta) * Omega) @ (I_theta @ Z_derivative),
                 )
             )
 
@@ -290,15 +310,25 @@ def joint_motion_subspace_with_derivatives(
                 adjOmegap2 = _adjoint_power_or_eye(r - u)
 
                 dSdq_qd_terms.append(
-                    -f[r] * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Omegad) @ Z)
+                    -f[r]
+                    * (
+                        adjOmegap1
+                        @ se3.small_adjoint(adjOmegap2 @ Omegad)
+                        @ Z_derivative
+                    )
                 )
                 dSdq_qdd_terms.append(
-                    -f[r] * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Zqdd) @ Z)
+                    -f[r]
+                    * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Zqdd) @ Z_derivative)
                 )
                 dSddq_qd_terms.append(
                     -fd[r]
                     * thetad
-                    * (adjOmegap1 @ se3.small_adjoint(adjOmegap2 @ Omegad) @ Z)
+                    * (
+                        adjOmegap1
+                        @ se3.small_adjoint(adjOmegap2 @ Omegad)
+                        @ Z_derivative
+                    )
                 )
 
                 for p in range(1, u):
@@ -312,7 +342,7 @@ def joint_motion_subspace_with_derivatives(
                             @ se3.small_adjoint(
                                 adjOmegap4 @ adjOmegapd[0] @ adjOmegap2 @ Omegad
                             )
-                            @ Z
+                            @ Z_derivative
                         )
                     )
 
@@ -327,7 +357,7 @@ def joint_motion_subspace_with_derivatives(
                             @ adjOmegapd[0]
                             @ adjOmegap3
                             @ se3.small_adjoint(adjOmegap4 @ Omegad)
-                            @ Z
+                            @ Z_derivative
                         )
                     )
 
@@ -572,6 +602,139 @@ def joint_dSTF_dq(H, B_xi, xi_ref, q, wrench, eps) -> Array:
                 coefficient_derivatives[r]
                 / theta
                 * jnp.outer(directional_coefficients, rotational_projection)
+            )
+            for u in range(1, r + 2):
+                adj1 = adjoint_power_or_eye(u - 2)
+                adj2 = adjoint_power_or_eye(r - u)
+                result = result + coefficients[r] * contracted_adjoint_term(
+                    adj1,
+                    adj2,
+                )
+        return result
+
+    return lax.cond(
+        theta <= _THETA_SERIES_THRESHOLD,
+        series_branch,
+        general_branch,
+        operand=theta,
+    )
+
+
+def joint_dSTF_dq_direction(
+    H,
+    B_xi,
+    xi_ref,
+    q,
+    wrench,
+    q_directions,
+    eps,
+) -> Array:
+    """Apply ``d(S.T @ wrench) / dq`` to one or more directions.
+
+    This is the directional counterpart of :func:`joint_dSTF_dq`. It
+    contracts the configuration directions inside each analytical term and
+    therefore never materializes the square generalized-coordinate Jacobian.
+
+    Args:
+        H: Scalar interval length.
+        B_xi: Strain basis matrix with shape ``(6, num_dofs)``.
+        xi_ref: Reference strain vector with shape ``(6,)``.
+        q: Generalized coordinates with shape ``(num_dofs,)``.
+        wrench: Spatial dual vector with shape ``(6,)``.
+        q_directions: Configuration directions with shape
+            ``(num_dofs, num_directions)``.
+        eps: Small positive tolerance used to avoid singular divisions.
+
+    Returns:
+        Directional derivatives with shape
+        ``(num_dofs, num_directions)``.
+    """
+    xi = B_xi @ q + xi_ref
+    Omega = H * xi
+    Z = H * B_xi
+    theta = jnp.maximum(safe_norm(Omega[:3]), eps)
+
+    adjOmega = se3.small_adjoint(Omega)
+    adjOmegap2 = adjOmega @ adjOmega
+    adjOmegap3 = adjOmegap2 @ adjOmega
+    adjOmegap4 = adjOmegap3 @ adjOmega
+    adjOmegap = jnp.stack((adjOmega, adjOmegap2, adjOmegap3, adjOmegap4))
+    identity = jnp.eye(6, dtype=Omega.dtype)
+    direction_strains = Z @ q_directions
+
+    def adjoint_power_or_eye(power: int) -> Array:
+        return identity if power < 0 else adjOmegap[power]
+
+    def contracted_adjoint_term(adj1: Array, adj2: Array) -> Array:
+        coordinate_twists = adj2 @ Z
+        transported_wrench = adj1.T @ wrench
+        coadjoint_actions = vmap(
+            se3.coadjoint_action,
+            in_axes=(1, None),
+            out_axes=1,
+        )(coordinate_twists, transported_wrench)
+        return coadjoint_actions.T @ direction_strains
+
+    def series_branch(_: Array) -> Array:
+        coefficients = jnp.array(
+            [1 / 2, 1 / 6, 1 / 24, 1 / 120],
+            dtype=Omega.dtype,
+        )
+        result = jnp.zeros(
+            (q.shape[0], q_directions.shape[1]),
+            dtype=q.dtype,
+        )
+        for r in range(4):
+            for u in range(1, r + 2):
+                adj1 = adjoint_power_or_eye(u - 2)
+                adj2 = adjoint_power_or_eye(r - u)
+                result = result + coefficients[r] * contracted_adjoint_term(
+                    adj1,
+                    adj2,
+                )
+        return result
+
+    def general_branch(theta: Array) -> Array:
+        theta2 = theta * theta
+        theta3 = theta2 * theta
+        theta4 = theta3 * theta
+        theta5 = theta4 * theta
+        theta6 = theta5 * theta
+        cosine = jnp.cos(theta)
+        sine = jnp.sin(theta)
+        theta_sine = theta * sine
+        theta_cosine = theta * cosine
+        t3 = -8 + (8 - theta2) * cosine + 5 * theta_sine
+        t4 = -8 * theta + (15 - theta2) * sine - 7 * theta_cosine
+
+        coefficients = jnp.stack(
+            (
+                (4 - 4 * cosine - theta_sine) / (2 * theta2),
+                (4 * theta - 5 * sine + theta_cosine) / (2 * theta3),
+                (2 - 2 * cosine - theta_sine) / (2 * theta4),
+                (2 * theta - 3 * sine + theta_cosine) / (2 * theta5),
+            )
+        )
+        coefficient_derivatives = jnp.stack(
+            (
+                t3 / (2 * theta3),
+                t4 / (2 * theta4),
+                t3 / (2 * theta5),
+                t4 / (2 * theta6),
+            )
+        )
+        rotational_direction = Omega[:3] @ direction_strains[:3, :]
+
+        result = jnp.zeros(
+            (q.shape[0], q_directions.shape[1]),
+            dtype=q.dtype,
+        )
+        for r in range(4):
+            directional_coefficients = wrench @ adjOmegap[r] @ Z
+            result = result + (
+                coefficient_derivatives[r]
+                / theta
+                * jnp.outer(directional_coefficients, rotational_direction)
             )
             for u in range(1, r + 2):
                 adj1 = adjoint_power_or_eye(u - 2)

--- a/src/soromox/utils/lie_algebra/constant_strain/se3.py
+++ b/src/soromox/utils/lie_algebra/constant_strain/se3.py
@@ -67,6 +67,244 @@ class _PreparedAdjointPowers(NamedTuple):
     dot_powers: Array
 
 
+class _PreparedStateDirectionalPowers(NamedTuple):
+    """Unscaled adjoint powers and contracted state derivatives.
+
+    Every matrix field stacks powers from order zero through four. The
+    rotational invariants are stored before arclength scaling so one segment
+    preparation can serve its tip and all quadrature points.
+    """
+
+    angle_sq: Array
+    angle_sq_velocity: Array
+    angle_sq_configuration: Array
+    angle_sq_rate: Array
+    angle_sq_mixed: Array
+    powers: Array
+    velocity_power_derivatives: Array
+    configuration_power_derivatives: Array
+    rate_power_derivatives: Array
+    mixed_power_derivatives: Array
+
+
+def _prepare_state_directional_powers(
+    xi: Array,
+    xid: Array,
+    configuration_direction: Array,
+    rate_direction: Array,
+) -> _PreparedStateDirectionalPowers:
+    """Precompute arclength-independent powers for one PCS state direction.
+
+    Args:
+        xi: Constant spatial strain in angular-first order.
+        xid: Spatial strain rate with the same shape as ``xi``.
+        configuration_direction: Contracted configuration direction in strain
+            coordinates.
+        rate_direction: Contracted velocity direction in strain-rate
+            coordinates.
+
+    Returns:
+        Prepared powers, first directional derivatives, the mixed
+        strain-rate/configuration derivative, and their rotational
+        invariants.
+    """
+    xi = jnp.asarray(xi).reshape(-1)
+    xid = jnp.asarray(xid).reshape(-1)
+    configuration_direction = jnp.asarray(configuration_direction).reshape(-1)
+    rate_direction = jnp.asarray(rate_direction).reshape(-1)
+    (
+        powers,
+        velocity_power_derivatives,
+        configuration_power_derivatives,
+        rate_power_derivatives,
+        mixed_power_derivatives,
+    ) = _matrix_polynomials.powers_and_state_directional_derivatives(
+        lie_se3.small_adjoint(xi),
+        lie_se3.small_adjoint(xid),
+        lie_se3.small_adjoint(configuration_direction),
+        lie_se3.small_adjoint(rate_direction),
+        _REDUCED_POLYNOMIAL_DEGREE,
+    )
+    return _PreparedStateDirectionalPowers(
+        angle_sq=jnp.dot(xi[:3], xi[:3]),
+        angle_sq_velocity=2.0 * jnp.dot(xi[:3], xid[:3]),
+        angle_sq_configuration=2.0 * jnp.dot(xi[:3], configuration_direction[:3]),
+        angle_sq_rate=2.0 * jnp.dot(xi[:3], rate_direction[:3]),
+        angle_sq_mixed=2.0 * jnp.dot(xid[:3], configuration_direction[:3]),
+        powers=jnp.stack(powers),
+        velocity_power_derivatives=jnp.stack(velocity_power_derivatives),
+        configuration_power_derivatives=jnp.stack(configuration_power_derivatives),
+        rate_power_derivatives=jnp.stack(rate_power_derivatives),
+        mixed_power_derivatives=jnp.stack(mixed_power_derivatives),
+    )
+
+
+def _kinematic_operators_from_state_directional_powers(
+    prepared: _PreparedStateDirectionalPowers,
+    s: Array,
+    adjoint_eps: float | Array,
+    tangent_eps: float | Array,
+) -> tuple[Array, Array, Array, Array, Array, Array]:
+    """Evaluate transported operators and one contracted state direction.
+
+    The tangent operators are returned after transport by the inverse
+    adjoint. This directly supplies the body-frame PCS recurrence and avoids
+    multiplying each tangent derivative by the inverse adjoint afterward.
+
+    Args:
+        prepared: Arclength-independent segment powers and state derivatives.
+        s: Local arclength at which to evaluate the operators.
+        adjoint_eps: Rotational-strain threshold for the adjoint exponential.
+        tangent_eps: Rotational-strain threshold for tangent coefficients.
+
+    Returns:
+        Tuple ``(Ad_inv, P, Pv, Ph, Pvh, Pk)``. Here ``P = Ad_inv @ T``;
+        ``Pv`` and ``Ph`` are its strain-rate and configuration directional
+        derivatives; ``Pvh`` is their mixed derivative; and ``Pk`` is the
+        derivative along the contracted velocity direction.
+    """
+    s = jnp.asarray(s, dtype=prepared.powers.dtype)
+    scale = jnp.ones((), dtype=prepared.powers.dtype)
+    powers: list[Array] = []
+    velocity_power_derivatives: list[Array] = []
+    configuration_power_derivatives: list[Array] = []
+    rate_power_derivatives: list[Array] = []
+    mixed_power_derivatives: list[Array] = []
+    for order in range(_REDUCED_POLYNOMIAL_DEGREE + 1):
+        powers.append(scale * prepared.powers[order])
+        velocity_power_derivatives.append(
+            scale * prepared.velocity_power_derivatives[order]
+        )
+        configuration_power_derivatives.append(
+            scale * prepared.configuration_power_derivatives[order]
+        )
+        rate_power_derivatives.append(scale * prepared.rate_power_derivatives[order])
+        mixed_power_derivatives.append(scale * prepared.mixed_power_derivatives[order])
+        scale = scale * s
+
+    s_sq = s**2
+    angle_sq = s_sq * prepared.angle_sq
+    coefficients, derivatives, second_derivatives = (
+        lie_se3._left_jacobian_coefficients_with_x_derivatives(
+            angle_sq,
+            _accumulated_eps(s, tangent_eps, angle_sq.dtype),
+        )
+    )
+    angle_sq_velocity = s_sq * prepared.angle_sq_velocity
+    angle_sq_configuration = s_sq * prepared.angle_sq_configuration
+    velocity_coefficient_derivatives = tuple(
+        derivative * angle_sq_velocity for derivative in derivatives
+    )
+    configuration_coefficient_derivatives = tuple(
+        derivative * angle_sq_configuration for derivative in derivatives
+    )
+    rate_coefficient_derivatives = tuple(
+        derivative * s_sq * prepared.angle_sq_rate for derivative in derivatives
+    )
+    mixed_coefficient_derivatives = tuple(
+        second_derivative * angle_sq_velocity * angle_sq_configuration
+        + derivative * s_sq * prepared.angle_sq_mixed
+        for derivative, second_derivative in zip(
+            derivatives,
+            second_derivatives,
+            strict=True,
+        )
+    )
+
+    signs = tuple(
+        -1.0 if order % 2 else 1.0 for order in range(1, _REDUCED_POLYNOMIAL_DEGREE + 1)
+    )
+    transported_coefficients = tuple(
+        sign * coefficient
+        for sign, coefficient in zip(signs, coefficients, strict=True)
+    )
+    transported_velocity_coefficient_derivatives = tuple(
+        sign * derivative
+        for sign, derivative in zip(
+            signs,
+            velocity_coefficient_derivatives,
+            strict=True,
+        )
+    )
+    transported_configuration_coefficient_derivatives = tuple(
+        sign * derivative
+        for sign, derivative in zip(
+            signs,
+            configuration_coefficient_derivatives,
+            strict=True,
+        )
+    )
+    transported_rate_coefficient_derivatives = tuple(
+        sign * derivative
+        for sign, derivative in zip(
+            signs,
+            rate_coefficient_derivatives,
+            strict=True,
+        )
+    )
+    transported_mixed_coefficient_derivatives = tuple(
+        sign * derivative
+        for sign, derivative in zip(
+            signs,
+            mixed_coefficient_derivatives,
+            strict=True,
+        )
+    )
+
+    transported_tangent = s * _matrix_polynomials.evaluate(
+        powers,
+        transported_coefficients,
+    )
+    transported_tangent_velocity_direction = s * (
+        _matrix_polynomials.evaluate_directional_derivative(
+            powers,
+            velocity_power_derivatives,
+            transported_coefficients,
+            transported_velocity_coefficient_derivatives,
+        )
+    )
+    transported_tangent_configuration_direction = s * (
+        _matrix_polynomials.evaluate_directional_derivative(
+            powers,
+            configuration_power_derivatives,
+            transported_coefficients,
+            transported_configuration_coefficient_derivatives,
+        )
+    )
+    transported_tangent_rate_direction = s * (
+        _matrix_polynomials.evaluate_directional_derivative(
+            powers,
+            rate_power_derivatives,
+            transported_coefficients,
+            transported_rate_coefficient_derivatives,
+        )
+    )
+    transported_tangent_mixed_direction = s * (
+        _matrix_polynomials.evaluate_mixed_directional_derivative(
+            powers,
+            velocity_power_derivatives,
+            configuration_power_derivatives,
+            mixed_power_derivatives,
+            transported_coefficients,
+            transported_velocity_coefficient_derivatives,
+            transported_configuration_coefficient_derivatives,
+            transported_mixed_coefficient_derivatives,
+        )
+    )
+    adjoint = lie_se3._adjoint_from_powers(
+        powers,
+        _adjoint_coefficients(prepared.angle_sq, s, adjoint_eps),
+    )
+    return (
+        lie_se3._adjoint_inverse_from_adjoint(adjoint),
+        transported_tangent,
+        transported_tangent_velocity_direction,
+        transported_tangent_configuration_direction,
+        transported_tangent_mixed_direction,
+        transported_tangent_rate_direction,
+    )
+
+
 def _prepare_adjoint_powers(xi: Array, xid: Array) -> _PreparedAdjointPowers:
     r"""Precompute SE(3) powers that do not depend on arclength.
 

--- a/src/soromox/utils/lie_algebra/se3.py
+++ b/src/soromox/utils/lie_algebra/se3.py
@@ -66,23 +66,23 @@ def _left_jacobian_series_arguments(
     return angle_sq, use_series, jnp.sqrt(angle_sq_safe)
 
 
-def _left_jacobian_coefficients_and_x_derivatives(
+def _left_jacobian_coefficients_with_x_derivatives(
     angle_sq: Array, eps: float | Array
-) -> tuple[tuple[Array, ...], tuple[Array, ...]]:
-    r"""Return reduced left-Jacobian coefficients and their derivatives in ``x``.
+) -> tuple[tuple[Array, ...], tuple[Array, ...], tuple[Array, ...]]:
+    r"""Return left-Jacobian coefficients and two derivatives in ``x``.
 
     For ``A = ad_xi`` and ``x = dot(omega, omega)``, the Jacobian is
     ``I + c1 A + c2 A**2 + c3 A**3 + c4 A**4``. The second tuple contains
-    ``dc_k / dx``.
+    ``dc_k / dx`` and the third tuple contains ``d2c_k / dx2``.
 
     Args:
         angle_sq: Scalar squared rotational magnitude ``x``.
         eps: Requested non-negative dimensionless small-angle threshold.
 
     Returns:
-        Tuple ``(coefficients, x_derivatives)``. Each element is a four-item
-        tuple for ``c1`` through ``c4`` and their derivatives with respect to
-        ``x``.
+        Tuple ``(coefficients, x_derivatives, x_second_derivatives)``. Each
+        element is a four-item tuple for ``c1`` through ``c4`` and their first
+        and second derivatives with respect to ``x``.
     """
     x, use_series, theta_safe = _left_jacobian_series_arguments(angle_sq, eps)
     series = (
@@ -104,6 +104,12 @@ def _left_jacobian_coefficients_and_x_derivatives(
         -1.0 / 360.0 + x * (1.0 / 6720.0 + x * (-1.0 / 302400.0 + x / 23950080.0)),
         -1.0 / 2520.0 + x * (1.0 / 60480.0 + x * (-1.0 / 3326400.0 + x / 311351040.0)),
     )
+    second_derivative_series = (
+        -1.0 / 360.0 + x * (1.0 / 3360.0 - x / 100800.0),
+        -1.0 / 2520.0 + x * (1.0 / 30240.0 - x / 1108800.0),
+        1.0 / 6720.0 + x * (-1.0 / 151200.0 + x / 7983360.0),
+        1.0 / 60480.0 + x * (-1.0 / 1663200.0 + x / 103783680.0),
+    )
     if strict_singularities_enabled():
         theta_safe = jnp.sqrt(x)
         use_series = jnp.zeros_like(x, dtype=jnp.bool_)
@@ -114,6 +120,17 @@ def _left_jacobian_coefficients_and_x_derivatives(
         -8.0 * theta_safe
         + (15.0 - theta_safe**2) * sin_theta
         - 7.0 * theta_safe * cos_theta
+    )
+    common_derivative = (
+        5.0 * sin_theta
+        + sin_theta * (theta_safe**2 - 8.0)
+        + 3.0 * theta_safe * cos_theta
+    )
+    alternate_derivative = (
+        -8.0
+        + 5.0 * theta_safe * sin_theta
+        + (15.0 - theta_safe**2) * cos_theta
+        - 7.0 * cos_theta
     )
     closed = (
         (4.0 - 4.0 * cos_theta - theta_safe * sin_theta) / (2.0 * theta_safe**2),
@@ -129,6 +146,12 @@ def _left_jacobian_coefficients_and_x_derivatives(
         common / (4.0 * theta_safe**6),
         alternate / (4.0 * theta_safe**7),
     )
+    second_derivative_closed = (
+        (theta_safe * common_derivative - 4.0 * common) / (8.0 * theta_safe**6),
+        (theta_safe * alternate_derivative - 5.0 * alternate) / (8.0 * theta_safe**7),
+        (theta_safe * common_derivative - 6.0 * common) / (8.0 * theta_safe**8),
+        (theta_safe * alternate_derivative - 7.0 * alternate) / (8.0 * theta_safe**9),
+    )
     coefficients = tuple(
         jnp.where(use_series, series_value, closed_value)
         for series_value, closed_value in zip(series, closed, strict=True)
@@ -138,6 +161,25 @@ def _left_jacobian_coefficients_and_x_derivatives(
         for series_value, closed_value in zip(
             derivative_series, derivative_closed, strict=True
         )
+    )
+    second_derivatives = tuple(
+        jnp.where(use_series, series_value, closed_value)
+        for series_value, closed_value in zip(
+            second_derivative_series,
+            second_derivative_closed,
+            strict=True,
+        )
+    )
+    return coefficients, derivatives, second_derivatives
+
+
+def _left_jacobian_coefficients_and_x_derivatives(
+    angle_sq: Array, eps: float | Array
+) -> tuple[tuple[Array, ...], tuple[Array, ...]]:
+    """Return reduced left-Jacobian coefficients and first derivatives."""
+    coefficients, derivatives, _ = _left_jacobian_coefficients_with_x_derivatives(
+        angle_sq,
+        eps,
     )
     return coefficients, derivatives
 
@@ -559,6 +601,242 @@ def left_jacobian_and_directional_derivative(
         angle_sq_dot,
     )
     return jacobian, jacobian_direction
+
+
+def _kinematic_operators_with_state_directional_derivatives(
+    xi: Array,
+    velocity_direction: Array,
+    configuration_direction: Array,
+    rate_direction: Array,
+    adjoint_eps: float | Array,
+    tangent_eps: float | Array,
+) -> tuple[Array, Array, Array, Array, Array, Array]:
+    """Evaluate analytical inverse-adjoint and Jacobian state derivatives.
+
+    Args:
+        xi: Accumulated spatial strain in angular-first order.
+        velocity_direction: Accumulated strain-rate direction.
+        configuration_direction: Accumulated configuration direction.
+        rate_direction: Accumulated velocity direction.
+        adjoint_eps: Small-angle threshold for the adjoint exponential.
+        tangent_eps: Small-angle threshold for left-Jacobian coefficients.
+
+    Returns:
+        Tuple containing the inverse adjoint, left Jacobian, its derivatives
+        along ``velocity_direction`` and ``configuration_direction``, their
+        mixed derivative, and its derivative along ``rate_direction``.
+    """
+    xi = jnp.asarray(xi).reshape(-1)
+    velocity_direction = jnp.asarray(velocity_direction).reshape(-1)
+    configuration_direction = jnp.asarray(configuration_direction).reshape(-1)
+    rate_direction = jnp.asarray(rate_direction).reshape(-1)
+    angle_sq = jnp.dot(xi[:3], xi[:3])
+    angle_sq_velocity = 2.0 * jnp.dot(xi[:3], velocity_direction[:3])
+    angle_sq_configuration = 2.0 * jnp.dot(
+        xi[:3],
+        configuration_direction[:3],
+    )
+    angle_sq_rate = 2.0 * jnp.dot(xi[:3], rate_direction[:3])
+    angle_sq_mixed = 2.0 * jnp.dot(
+        velocity_direction[:3],
+        configuration_direction[:3],
+    )
+
+    def structured_adjoint(value: Array) -> tuple[Array, Array]:
+        return so3.skew(value[:3]), so3.skew(value[3:])
+
+    def structured_product(
+        left: tuple[Array, Array],
+        right: tuple[Array, Array],
+    ) -> tuple[Array, Array]:
+        left_diagonal, left_lower = left
+        right_diagonal, right_lower = right
+        return (
+            left_diagonal @ right_diagonal,
+            left_lower @ right_diagonal + left_diagonal @ right_lower,
+        )
+
+    def structured_sum(
+        *values: tuple[Array, Array],
+    ) -> tuple[Array, Array]:
+        return (
+            sum(value[0] for value in values),
+            sum(value[1] for value in values),
+        )
+
+    adjoint = structured_adjoint(xi)
+    adjoint_velocity = structured_adjoint(velocity_direction)
+    adjoint_configuration = structured_adjoint(configuration_direction)
+    adjoint_rate = structured_adjoint(rate_direction)
+    identity = jnp.eye(3, dtype=xi.dtype)
+    zero = jnp.zeros((3, 3), dtype=xi.dtype)
+    current = (identity, zero)
+    current_velocity = (zero, zero)
+    current_configuration = (zero, zero)
+    current_rate = (zero, zero)
+    current_mixed = (zero, zero)
+    powers = [current]
+    velocity_power_derivatives = [current_velocity]
+    configuration_power_derivatives = [current_configuration]
+    rate_power_derivatives = [current_rate]
+    mixed_power_derivatives = [current_mixed]
+    for _ in range(_REDUCED_POLYNOMIAL_DEGREE):
+        next_mixed = structured_sum(
+            structured_product(current_mixed, adjoint),
+            structured_product(current_velocity, adjoint_configuration),
+            structured_product(current_configuration, adjoint_velocity),
+        )
+        next_velocity = structured_sum(
+            structured_product(current_velocity, adjoint),
+            structured_product(current, adjoint_velocity),
+        )
+        next_configuration = structured_sum(
+            structured_product(current_configuration, adjoint),
+            structured_product(current, adjoint_configuration),
+        )
+        next_rate = structured_sum(
+            structured_product(current_rate, adjoint),
+            structured_product(current, adjoint_rate),
+        )
+        current = structured_product(current, adjoint)
+        powers.append(current)
+        velocity_power_derivatives.append(next_velocity)
+        configuration_power_derivatives.append(next_configuration)
+        rate_power_derivatives.append(next_rate)
+        mixed_power_derivatives.append(next_mixed)
+        current_velocity = next_velocity
+        current_configuration = next_configuration
+        current_rate = next_rate
+        current_mixed = next_mixed
+
+    coefficients, derivatives, second_derivatives = (
+        _left_jacobian_coefficients_with_x_derivatives(angle_sq, tangent_eps)
+    )
+    velocity_coefficient_derivatives = tuple(
+        derivative * angle_sq_velocity for derivative in derivatives
+    )
+    configuration_coefficient_derivatives = tuple(
+        derivative * angle_sq_configuration for derivative in derivatives
+    )
+    rate_coefficient_derivatives = tuple(
+        derivative * angle_sq_rate for derivative in derivatives
+    )
+    mixed_coefficient_derivatives = tuple(
+        second_derivative * angle_sq_velocity * angle_sq_configuration
+        + derivative * angle_sq_mixed
+        for derivative, second_derivative in zip(
+            derivatives,
+            second_derivatives,
+            strict=True,
+        )
+    )
+
+    def evaluate(
+        power_values: list[tuple[Array, Array]],
+        coefficient_values: tuple[Array, ...],
+    ) -> tuple[Array, Array]:
+        result = power_values[0]
+        for coefficient, power in zip(
+            coefficient_values,
+            power_values[1:],
+            strict=True,
+        ):
+            result = structured_sum(
+                result,
+                (coefficient * power[0], coefficient * power[1]),
+            )
+        return result
+
+    def evaluate_direction(
+        power_derivatives: list[tuple[Array, Array]],
+        coefficient_derivatives: tuple[Array, ...],
+    ) -> tuple[Array, Array]:
+        result = (zero, zero)
+        for coefficient, coefficient_direction, power, power_direction in zip(
+            coefficients,
+            coefficient_derivatives,
+            powers[1:],
+            power_derivatives[1:],
+            strict=True,
+        ):
+            result = structured_sum(
+                result,
+                (
+                    coefficient_direction * power[0] + coefficient * power_direction[0],
+                    coefficient_direction * power[1] + coefficient * power_direction[1],
+                ),
+            )
+        return result
+
+    def evaluate_mixed() -> tuple[Array, Array]:
+        result = (zero, zero)
+        for (
+            coefficient,
+            coefficient_velocity,
+            coefficient_configuration,
+            coefficient_mixed,
+            power,
+            power_velocity,
+            power_configuration,
+            power_mixed,
+        ) in zip(
+            coefficients,
+            velocity_coefficient_derivatives,
+            configuration_coefficient_derivatives,
+            mixed_coefficient_derivatives,
+            powers[1:],
+            velocity_power_derivatives[1:],
+            configuration_power_derivatives[1:],
+            mixed_power_derivatives[1:],
+            strict=True,
+        ):
+            result = structured_sum(
+                result,
+                (
+                    coefficient_mixed * power[0]
+                    + coefficient_velocity * power_configuration[0]
+                    + coefficient_configuration * power_velocity[0]
+                    + coefficient * power_mixed[0],
+                    coefficient_mixed * power[1]
+                    + coefficient_velocity * power_configuration[1]
+                    + coefficient_configuration * power_velocity[1]
+                    + coefficient * power_mixed[1],
+                ),
+            )
+        return result
+
+    def assemble(value: tuple[Array, Array]) -> Array:
+        diagonal, lower = value
+        return jnp.block([[diagonal, zero], [lower, diagonal]])
+
+    jacobian = evaluate(powers, coefficients)
+    velocity_jacobian_direction = evaluate_direction(
+        velocity_power_derivatives,
+        velocity_coefficient_derivatives,
+    )
+    configuration_jacobian_direction = evaluate_direction(
+        configuration_power_derivatives,
+        configuration_coefficient_derivatives,
+    )
+    rate_jacobian_direction = evaluate_direction(
+        rate_power_derivatives,
+        rate_coefficient_derivatives,
+    )
+    mixed_jacobian_direction = evaluate_mixed()
+    adjoint = assemble(
+        evaluate(
+            powers,
+            _adjoint_exponential_coefficients(angle_sq, adjoint_eps),
+        )
+    )
+    return (
+        _adjoint_inverse_from_adjoint(adjoint),
+        assemble(jacobian),
+        assemble(velocity_jacobian_direction),
+        assemble(configuration_jacobian_direction),
+        assemble(mixed_jacobian_direction),
+        assemble(rate_jacobian_direction),
+    )
 
 
 def _exp_with_left_jacobian_and_directional_derivative(

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -192,6 +192,36 @@ def test_threadlike_actuator_and_passive_parameter_updates_compile_once():
     assert_allclose(actual, _threadlike_component_summary(eager, q))
 
 
+def test_pcs_custom_jvp_includes_threadlike_passive_state_tangent():
+    actuator, passive = _threadlike_components()
+    robot = _spatial_pcs(actuators=actuator, passive_elements=(passive,))
+    q = jnp.array([0.01, -0.02, 0.03, 0.01, 0.02, -0.01])
+    qd = jnp.linspace(-0.03, 0.04, robot.num_dofs)
+    y = jnp.concatenate([q, qd])
+    y_direction = jnp.linspace(0.1, -0.2, y.shape[0])
+    u = jnp.array([0.05, 0.07])
+    tau_ext = jnp.zeros((robot.num_dofs,))
+
+    reference = jax.jvp(
+        lambda y_value: robot._forward_dynamics(0.0, y_value, (u, tau_ext)),
+        (y,),
+        (y_direction,),
+    )
+    candidate = jax.jvp(
+        lambda y_value: PCS._forward_dynamics_custom_jvp(
+            robot,
+            jnp.array(0.0),
+            y_value,
+            (u, tau_ext),
+        ),
+        (y,),
+        (y_direction,),
+    )
+
+    assert_allclose(candidate[0], reference[0], rtol=1e-5, atol=1e-8)
+    assert_allclose(candidate[1], reference[1], rtol=1e-5, atol=1e-8)
+
+
 def test_threadlike_compiled_partial_component_updates_match_eager_behavior():
     actuator, passive = _threadlike_components()
     robot = _spatial_pcs(actuators=actuator, passive_elements=(passive,))

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -681,6 +681,36 @@ def test_passive_impedance_superposition_and_parameter_updates():
     assert_allclose(robot.passive_elements[0].params.stiffness, jnp.array([50.0]))
 
 
+def test_pcs_analytical_state_jvp_covers_threadlike_actuation_and_impedance():
+    actuator, passive = _threadlike_components()
+    robot = _spatial_pcs(actuators=actuator, passive_elements=(passive,))
+    q = jnp.linspace(-0.015, 0.02, robot.num_dofs)
+    qd = jnp.linspace(0.025, -0.01, robot.num_dofs)
+    y = jnp.concatenate((q, qd))
+    y_tangent = jnp.linspace(-0.2, 0.25, y.size)
+    u = jnp.array([0.3, 0.2])
+    tau_ext = jnp.linspace(-0.01, 0.015, robot.num_dofs)
+    t = jnp.array(0.0)
+
+    _, expected = jax.jvp(
+        lambda y_value: robot._forward_dynamics(t, y_value, (u, tau_ext)),
+        (y,),
+        (y_tangent,),
+    )
+    _, actual = jax.jvp(
+        lambda y_value: PCS._forward_dynamics_custom_jvp(
+            robot,
+            t,
+            y_value,
+            (u, tau_ext),
+        ),
+        (y,),
+        (y_tangent,),
+    )
+
+    assert_allclose(actual, expected, rtol=1e-6, atol=1e-8)
+
+
 def test_gvs_forward_dynamics_includes_passive_threadlike_damping():
     routing = _routing(count=1)
     base = _gvs(actuators=())

--- a/tests/lie_algebra/constant_strain/test_se3.py
+++ b/tests/lie_algebra/constant_strain/test_se3.py
@@ -317,6 +317,75 @@ def test_prepared_powers_match_pointwise_operator_evaluation(dtype, rtol, atol):
 
 
 @pytest.mark.parametrize(
+    "xi",
+    [
+        jnp.array([0.2, -0.1, 0.3, 0.7, -0.4, 0.2]),
+        jnp.array([0.0, 0.0, 0.0, 0.7, -0.4, 0.2]),
+    ],
+)
+def test_prepared_state_directional_operators_match_autodiff(xi):
+    xid = jnp.array([0.1, -0.2, 0.05, -0.3, 0.4, 0.2])
+    configuration_direction = jnp.array([-0.2, 0.3, 0.1, 0.5, -0.1, 0.4])
+    rate_direction = jnp.array([0.15, 0.05, -0.2, -0.4, 0.3, 0.1])
+    s = jnp.asarray(0.73)
+    eps = jnp.asarray(1e-8)
+
+    def transported_tangent(value):
+        return constant_strain_se3.adjoint_inverse(value, s, eps) @ (
+            constant_strain_se3.tangent(value, s, eps)
+        )
+
+    prepared = constant_strain_se3._prepare_state_directional_powers(
+        xi,
+        xid,
+        configuration_direction,
+        rate_direction,
+    )
+    actual = constant_strain_se3._kinematic_operators_from_state_directional_powers(
+        prepared,
+        s,
+        eps,
+        eps,
+    )
+    transported = transported_tangent(xi)
+    transported_velocity = jax.jvp(
+        transported_tangent,
+        (xi,),
+        (xid,),
+    )[1]
+    transported_configuration = jax.jvp(
+        transported_tangent,
+        (xi,),
+        (configuration_direction,),
+    )[1]
+    transported_mixed = jax.jvp(
+        lambda value: jax.jvp(
+            transported_tangent,
+            (value,),
+            (xid,),
+        )[1],
+        (xi,),
+        (configuration_direction,),
+    )[1]
+    transported_rate = jax.jvp(
+        transported_tangent,
+        (xi,),
+        (rate_direction,),
+    )[1]
+    expected = (
+        constant_strain_se3.adjoint_inverse(xi, s, eps),
+        transported,
+        transported_velocity,
+        transported_configuration,
+        transported_mixed,
+        transported_rate,
+    )
+
+    for actual_operator, expected_operator in zip(actual, expected, strict=True):
+        assert_allclose(actual_operator, expected_operator, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize(
     ("dtype", "rtol", "atol"),
     [(jnp.float64, 2e-9, 2e-10), (jnp.float32, 1e-3, 1e-4)],
 )

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -1399,6 +1399,22 @@ def test_inverse_dynamics_jacobian_passes_match_autodiff(
     assert_allclose(dID_dqd, expected_dID_dqd, rtol=RTOL, atol=ATOL)
     assert_allclose(mass_matrix, expected_dID_dqdd, rtol=RTOL, atol=ATOL)
 
+    q_directions = jnp.stack((qd, tau_ext), axis=1)
+    qd_directions = jnp.stack((qdd, q), axis=1)
+    directional_dID = model.inverse_dynamics_state_pushforward(
+        q,
+        qd,
+        qdd,
+        q_directions,
+        qd_directions,
+    )
+    assert_allclose(
+        directional_dID,
+        expected_dID_dq @ q_directions + expected_dID_dqd @ qd_directions,
+        rtol=RTOL,
+        atol=ATOL,
+    )
+
     zero_q = jnp.zeros_like(q)
     zero_results = model.inverse_dynamics_backward_pass(zero_q, qd, qdd)
     zero_expected_dID_dq = jacfwd(lambda q_: inverse_dynamics_force(q_, qd, qdd))(

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -7,6 +7,7 @@ from jax import numpy as jnp
 from numpy.testing import assert_allclose
 from system_param_builders import pcs_params, spatial_base_pose
 
+from soromox.autodiff import custom_jvp_mode
 from soromox.systems import PCS, CrossSectionGeometry, PCSStructure
 from soromox.utils.integration import scale_interior_gaussian_quadrature
 from soromox.utils.lie_algebra import se3
@@ -1352,15 +1353,27 @@ def test_forward_dynamics_matches_manual_computation(num_segments: int):
         assert_allclose(yd, yd_expected, rtol=RTOL, atol=ATOL)
 
 
-def test_inverse_dynamics_jacobian_passes_match_autodiff() -> None:
-    selector_per_segment = jnp.array(
-        [False, False, True, True, False, False],
-        dtype=bool,
+@pytest.mark.parametrize(
+    ("num_segments", "num_gauss_points", "selector_per_segment"),
+    [
+        (1, 5, None),
+        (2, 3, (False, False, True, True, False, False)),
+    ],
+)
+def test_inverse_dynamics_jacobian_passes_match_autodiff(
+    num_segments: int,
+    num_gauss_points: int,
+    selector_per_segment: tuple[bool, ...] | None,
+) -> None:
+    strain_selector = (
+        None
+        if selector_per_segment is None
+        else jnp.tile(jnp.asarray(selector_per_segment, dtype=bool), num_segments)
     )
     model, _ = make_pcs(
-        num_segments=2,
-        num_gauss_points=2,
-        strain_selector=jnp.tile(selector_per_segment, 2),
+        num_segments=num_segments,
+        num_gauss_points=num_gauss_points,
+        strain_selector=strain_selector,
     )
 
     key_q, key_qd, key_qdd, key_tau = jax.random.split(
@@ -1414,6 +1427,197 @@ def test_inverse_dynamics_jacobian_passes_match_autodiff() -> None:
         rtol=RTOL,
         atol=ATOL,
     )
+
+    inverse_dynamics_derivatives = model.inverse_dynamics_derivatives(q, qd, qdd)
+    assert_allclose(
+        inverse_dynamics_derivatives[0],
+        expected_dID_dq,
+        rtol=RTOL,
+        atol=ATOL,
+    )
+    assert_allclose(
+        inverse_dynamics_derivatives[1],
+        expected_dID_dqd,
+        rtol=RTOL,
+        atol=ATOL,
+    )
+
+
+def test_forward_dynamics_jacobian_helpers_match_autodiff() -> None:
+    selector_per_segment = jnp.array(
+        [False, False, True, True, False, False],
+        dtype=bool,
+    )
+    model, _ = make_pcs(
+        num_segments=2,
+        num_gauss_points=5,
+        strain_selector=jnp.tile(selector_per_segment, 2),
+    )
+    key_q, key_qd, key_u, key_tau = jax.random.split(jax.random.PRNGKey(8241), 4)
+    q = random_q(model, key_q, scale=0.04)
+    qd = random_q(model, key_qd, scale=0.03)
+    u = jax.random.normal(key_u, (model.num_actuators,)) * 0.02
+    tau_ext = random_q(model, key_tau, scale=0.01)
+    y = jnp.concatenate([q, qd])
+    t = jnp.array(0.0)
+
+    actual_state, actual_input, actual_external = model.forward_dynamics_jacobians(
+        t,
+        y,
+        (u, tau_ext),
+    )
+    expected_state = jacfwd(
+        lambda y_value: model._forward_dynamics(t, y_value, (u, tau_ext))
+    )(y)
+    expected_input = jacfwd(
+        lambda u_value: model._forward_dynamics(t, y, (u_value, tau_ext))
+    )(u)
+    expected_external = jacfwd(
+        lambda tau_value: model._forward_dynamics(t, y, (u, tau_value))
+    )(tau_ext)
+
+    assert_allclose(actual_state, expected_state, rtol=RTOL, atol=ATOL)
+    assert_allclose(actual_input, expected_input, rtol=RTOL, atol=ATOL)
+    assert_allclose(actual_external, expected_external, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize(
+    "actuation_args",
+    [
+        pytest.param(None, id="none"),
+        pytest.param((None,), id="default-input"),
+        pytest.param((None, None), id="default-input-and-external-force"),
+    ],
+)
+def test_forward_dynamics_state_jacobian_accepts_optional_inputs(
+    actuation_args: tuple | None,
+) -> None:
+    selector = jnp.array([False, False, False, True, False, False], dtype=bool)
+    model, _ = make_pcs(
+        num_segments=1,
+        num_gauss_points=3,
+        strain_selector=selector,
+    )
+    y = jnp.array([0.02, -0.03])
+    t = jnp.array(0.0)
+
+    actual_state, actual_input, actual_external = model.forward_dynamics_jacobians(
+        t,
+        y,
+        actuation_args,
+    )
+    expected_state = jacfwd(
+        lambda y_value: model._forward_dynamics(t, y_value, actuation_args)
+    )(y)
+    zero_input = jnp.zeros((model.num_actuators,), dtype=y.dtype)
+    zero_external = jnp.zeros((model.num_dofs,), dtype=y.dtype)
+    expected_input = jacfwd(
+        lambda u_value: model._forward_dynamics(
+            t,
+            y,
+            (u_value, zero_external),
+        )
+    )(zero_input)
+    expected_external = jacfwd(
+        lambda tau_value: model._forward_dynamics(
+            t,
+            y,
+            (zero_input, tau_value),
+        )
+    )(zero_external)
+
+    assert_allclose(actual_state, expected_state, rtol=RTOL, atol=ATOL)
+    assert_allclose(actual_input, expected_input, rtol=RTOL, atol=ATOL)
+    assert_allclose(actual_external, expected_external, rtol=RTOL, atol=ATOL)
+
+
+def test_forward_dynamics_derivatives_default_input_matches_autodiff() -> None:
+    selector = jnp.array([False, False, False, True, False, False], dtype=bool)
+    model, _ = make_pcs(
+        num_segments=1,
+        num_gauss_points=3,
+        strain_selector=selector,
+    )
+    q = jnp.array([0.02])
+    qd = jnp.array([-0.03])
+    y = jnp.concatenate([q, qd])
+    yd = model._forward_dynamics(jnp.array(0.0), y, None)
+    _, qdd = jnp.split(yd, 2)
+
+    actual_dq, actual_dqd = model.forward_dynamics_derivatives(q, qd, qdd)
+    expected = jacfwd(
+        lambda y_value: model._forward_dynamics(jnp.array(0.0), y_value, None)
+    )(y)
+
+    assert_allclose(actual_dq, expected[1:, :1], rtol=RTOL, atol=ATOL)
+    assert_allclose(actual_dqd, expected[1:, 1:], rtol=RTOL, atol=ATOL)
+
+
+def test_forward_dynamics_rejects_invalid_actuation_argument_length() -> None:
+    selector = jnp.array([False, False, False, True, False, False], dtype=bool)
+    model, _ = make_pcs(num_segments=1, strain_selector=selector)
+    y = jnp.array([0.02, -0.03])
+    invalid_args = (jnp.zeros(1), jnp.zeros(1), jnp.zeros(1))
+
+    with pytest.raises(ValueError, match="tuple of length 1 or 2"):
+        model._forward_dynamics(jnp.array(0.0), y, invalid_args)
+    with pytest.raises(ValueError, match="tuple of length 1 or 2"):
+        model.forward_dynamics_state_jacobian(jnp.array(0.0), y, invalid_args)
+    with pytest.raises(ValueError, match="tuple of length 1 or 2"):
+        model.forward_dynamics_jacobians(jnp.array(0.0), y, invalid_args)
+
+
+def test_forward_dynamics_disabled_custom_jvp_uses_autodiff_primal() -> None:
+    selector = jnp.array([False, False, False, True, False, False], dtype=bool)
+    model, _ = make_pcs(num_segments=1, strain_selector=selector)
+    y = jnp.array([0.02, -0.03])
+    expected = model._forward_dynamics(jnp.array(0.0), y, None)
+
+    jax.clear_caches()
+    with custom_jvp_mode(False):
+        actual = model.forward_dynamics(jnp.array(0.0), y, None)
+    jax.clear_caches()
+
+    assert_allclose(actual, expected, rtol=RTOL, atol=ATOL)
+
+
+def test_forward_dynamics_custom_jvp_includes_model_parameter_tangent() -> None:
+    selector = jnp.array([False, False, False, True, False, False], dtype=bool)
+    model, _ = make_pcs(
+        num_segments=1,
+        num_gauss_points=5,
+        strain_selector=selector,
+    )
+    y = jnp.array([0.02, -0.03])
+    u = jnp.array([0.05])
+    tau_ext = jnp.array([0.01])
+    density = model.rho
+    density_direction = 0.01 * density
+
+    def dynamics(density_value: Array, *, use_custom_jvp: bool) -> Array:
+        updated = model.update_link_params(density=density_value)
+        if use_custom_jvp:
+            return PCS._forward_dynamics_custom_jvp(
+                updated,
+                jnp.array(0.0),
+                y,
+                (u, tau_ext),
+            )
+        return updated._forward_dynamics(jnp.array(0.0), y, (u, tau_ext))
+
+    _, reference = jvp(
+        lambda value: dynamics(value, use_custom_jvp=False),
+        (density,),
+        (density_direction,),
+    )
+    _, candidate = jvp(
+        lambda value: dynamics(value, use_custom_jvp=True),
+        (density,),
+        (density_direction,),
+    )
+
+    assert jnp.linalg.norm(reference) > 0.0
+    assert_allclose(candidate, reference, rtol=RTOL, atol=ATOL)
 
 
 @pytest.mark.parametrize("num_segments", [1, 3])

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -1389,16 +1389,15 @@ def test_inverse_dynamics_jacobian_passes_match_autodiff(
         inertia, coriolis_qd, gravity = model.dynamics_terms(q_, qd_)
         return inertia @ qdd_ + coriolis_qd + gravity
 
-    dID_dq, dID_dqd, dID_dqdd, _, _, _, _ = model.inverse_dynamics_backward_pass(
-        q, qd, qdd
-    )
+    dID_dq, dID_dqd = model.inverse_dynamics_backward_pass(q, qd, qdd)
+    mass_matrix = model.inertia_matrix(q)
     expected_dID_dq = jacfwd(lambda q_: inverse_dynamics_force(q_, qd, qdd))(q)
     expected_dID_dqd = jacfwd(lambda qd_: inverse_dynamics_force(q, qd_, qdd))(qd)
     expected_dID_dqdd = jacfwd(lambda qdd_: inverse_dynamics_force(q, qd, qdd_))(qdd)
 
     assert_allclose(dID_dq, expected_dID_dq, rtol=RTOL, atol=ATOL)
     assert_allclose(dID_dqd, expected_dID_dqd, rtol=RTOL, atol=ATOL)
-    assert_allclose(dID_dqdd, expected_dID_dqdd, rtol=RTOL, atol=ATOL)
+    assert_allclose(mass_matrix, expected_dID_dqdd, rtol=RTOL, atol=ATOL)
 
     zero_q = jnp.zeros_like(q)
     zero_results = model.inverse_dynamics_backward_pass(zero_q, qd, qdd)

--- a/tests/tools/test_pcs_custom_jvp_speed_test.py
+++ b/tests/tools/test_pcs_custom_jvp_speed_test.py
@@ -51,8 +51,14 @@ def test_benchmark_defaults_cover_standard_quadrature_and_larger_models() -> Non
 
     assert args.gauss_points == 5
     assert args.segment_counts == [1, 2, 4, 8, 16, 32]
+    assert args.workloads == [
+        "state_jvp",
+        "state_jacobian_matvec",
+        "state_jacobian",
+    ]
     assert args.rollout_steps == 8
     assert args.rollout_dt == 1.0e-4
+    assert args.calls_per_sample == 1
 
 
 def test_benchmark_custom_jvp_matches_direct_jax_autodiff() -> None:
@@ -92,6 +98,32 @@ def test_custom_jvp_input_only_tangent_matches_direct_jax_autodiff() -> None:
     )(u)
 
     assert_allclose(candidate, reference, rtol=1.0e-5, atol=1.0e-8)
+
+
+def test_directional_jvp_matches_full_analytical_jacobian_matvec() -> None:
+    model = benchmark.build_model("threadlike", num_segments=2, gauss_points=5)
+    _, directional_fn, inputs = _build_workload(
+        model,
+        "state_jvp",
+        use_custom_jvp=True,
+    )
+    _, full_jacobian_fn, _ = _build_workload(
+        model,
+        "state_jacobian_matvec",
+        use_custom_jvp=True,
+    )
+    _, autodiff_full_jacobian_fn, _ = _build_workload(
+        model,
+        "state_jacobian_matvec",
+        use_custom_jvp=False,
+    )
+
+    directional = directional_fn(*inputs)
+    full_jacobian = full_jacobian_fn(*inputs)
+    autodiff_full_jacobian = autodiff_full_jacobian_fn(*inputs)
+
+    _assert_trees_allclose(directional, full_jacobian)
+    _assert_trees_allclose(directional, autodiff_full_jacobian)
 
 
 @pytest.mark.parametrize(
@@ -157,7 +189,11 @@ def test_rollout_derivative_workloads_match_direct_jax_autodiff(workload: str) -
 
 @pytest.mark.parametrize(
     ("option", "value"),
-    [("--rollout-steps", "0"), ("--rollout-dt", "0")],
+    [
+        ("--rollout-steps", "0"),
+        ("--rollout-dt", "0"),
+        ("--calls-per-sample", "0"),
+    ],
 )
 def test_invalid_rollout_options_are_rejected(option: str, value: str) -> None:
     with pytest.raises(SystemExit):

--- a/tests/tools/test_pcs_custom_jvp_speed_test.py
+++ b/tests/tools/test_pcs_custom_jvp_speed_test.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+from numpy.testing import assert_allclose
+
+from soromox.autodiff import custom_jvp_mode
+from soromox.systems import PCS
+from tools.benchmarks import pcs_custom_jvp_speed_test as benchmark
+
+jax.config.update("jax_enable_x64", True)
+
+
+def _assert_trees_allclose(reference, candidate) -> None:
+    reference_leaves, reference_tree = jax.tree_util.tree_flatten(reference)
+    candidate_leaves, candidate_tree = jax.tree_util.tree_flatten(candidate)
+
+    assert candidate_tree == reference_tree
+    for reference_leaf, candidate_leaf in zip(
+        reference_leaves,
+        candidate_leaves,
+        strict=True,
+    ):
+        assert_allclose(candidate_leaf, reference_leaf, rtol=1.0e-5, atol=1.0e-8)
+
+
+def _build_workload(model: PCS, workload: str, *, use_custom_jvp: bool):
+    benchmark_inputs = benchmark.build_inputs(model)
+    workload_fn = benchmark.build_workload(
+        model,
+        workload,
+        benchmark_inputs.y_direction,
+        benchmark_inputs.u_direction,
+        benchmark_inputs.system_parameter_direction,
+        rollout_steps=3,
+        rollout_dt=1.0e-4,
+        use_custom_jvp=use_custom_jvp,
+    )
+    args = (
+        benchmark_inputs.y,
+        benchmark_inputs.u,
+        benchmark_inputs.tau_ext,
+        benchmark_inputs.system_parameters,
+    )
+    return benchmark_inputs, workload_fn, args
+
+
+def test_benchmark_defaults_cover_standard_quadrature_and_larger_models() -> None:
+    args = benchmark.parse_args([])
+
+    assert args.gauss_points == 5
+    assert args.segment_counts == [1, 2, 4, 8, 16, 32]
+    assert args.rollout_steps == 8
+    assert args.rollout_dt == 1.0e-4
+
+
+def test_benchmark_custom_jvp_matches_direct_jax_autodiff() -> None:
+    """The timed baseline must bypass the mutable custom-JVP dispatch toggle."""
+    model = benchmark.build_model("threadlike", num_segments=2, gauss_points=5)
+    _, reference_fn, inputs = _build_workload(
+        model, "all_jacobians", use_custom_jvp=False
+    )
+    _, candidate_fn, _ = _build_workload(model, "all_jacobians", use_custom_jvp=True)
+
+    reference = reference_fn(*inputs)
+    with custom_jvp_mode(True):
+        candidate = candidate_fn(*inputs)
+
+    _assert_trees_allclose(reference, candidate)
+
+
+def test_custom_jvp_input_only_tangent_matches_direct_jax_autodiff() -> None:
+    """Cover the custom rule's no-state-tangent inertia-matrix branch."""
+    model = benchmark.build_model("threadlike", num_segments=2, gauss_points=5)
+    benchmark_inputs = benchmark.build_inputs(model)
+    y = benchmark_inputs.y
+    u = benchmark_inputs.u
+    tau_ext = benchmark_inputs.tau_ext
+    t = jnp.array(0.0)
+
+    reference = jax.jacfwd(
+        lambda u_value: model._forward_dynamics(t, y, (u_value, tau_ext))
+    )(u)
+    candidate = jax.jacfwd(
+        lambda u_value: PCS._forward_dynamics_custom_jvp(
+            model,
+            t,
+            y,
+            (u_value, tau_ext),
+        )
+    )(u)
+
+    assert_allclose(candidate, reference, rtol=1.0e-5, atol=1.0e-8)
+
+
+@pytest.mark.parametrize(
+    "actuation_args",
+    [
+        pytest.param(None, id="none"),
+        pytest.param((None,), id="default-input"),
+    ],
+)
+def test_custom_jvp_state_tangent_accepts_optional_inputs(
+    actuation_args: tuple | None,
+) -> None:
+    model = benchmark.build_model("axial", num_segments=1, gauss_points=5)
+    y = benchmark.build_inputs(model).y
+    t = jnp.array(0.0)
+
+    reference = jax.jacfwd(
+        lambda y_value: model._forward_dynamics(t, y_value, actuation_args)
+    )(y)
+    candidate = jax.jacfwd(
+        lambda y_value: PCS._forward_dynamics_custom_jvp(
+            model,
+            t,
+            y_value,
+            actuation_args,
+        )
+    )(y)
+
+    assert_allclose(candidate, reference, rtol=1.0e-5, atol=1.0e-8)
+
+
+@pytest.mark.parametrize(
+    "workload",
+    [
+        "rollout_actuation_jvp",
+        "rollout_actuation_jacobian",
+        "rollout_initial_position_jvp",
+        "rollout_initial_position_jacobian",
+        "rollout_parameters_jvp",
+        "rollout_parameters_jacobian",
+    ],
+)
+def test_rollout_derivative_workloads_match_direct_jax_autodiff(workload: str) -> None:
+    model = benchmark.build_model("axial", num_segments=1, gauss_points=5)
+    _, reference_fn, inputs = _build_workload(
+        model,
+        workload,
+        use_custom_jvp=False,
+    )
+    _, candidate_fn, _ = _build_workload(
+        model,
+        workload,
+        use_custom_jvp=True,
+    )
+
+    reference = reference_fn(*inputs)
+    candidate = candidate_fn(*inputs)
+
+    _assert_trees_allclose(reference, candidate)
+    derivative = reference[1] if workload.endswith("_jvp") else reference
+    assert jnp.linalg.norm(derivative) > 0.0
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [("--rollout-steps", "0"), ("--rollout-dt", "0")],
+)
+def test_invalid_rollout_options_are_rejected(option: str, value: str) -> None:
+    with pytest.raises(SystemExit):
+        benchmark.parse_args([option, value])

--- a/tests/tools/test_pcs_custom_jvp_speed_test.py
+++ b/tests/tools/test_pcs_custom_jvp_speed_test.py
@@ -100,8 +100,16 @@ def test_custom_jvp_input_only_tangent_matches_direct_jax_autodiff() -> None:
     assert_allclose(candidate, reference, rtol=1.0e-5, atol=1.0e-8)
 
 
-def test_directional_jvp_matches_full_analytical_jacobian_matvec() -> None:
-    model = benchmark.build_model("threadlike", num_segments=2, gauss_points=5)
+@pytest.mark.parametrize("num_segments", [2, 16])
+def test_directional_jvp_matches_full_analytical_jacobian_matvec(
+    num_segments: int,
+) -> None:
+    """Cover short and scan-based analytical state-JVP recurrences."""
+    model = benchmark.build_model(
+        "threadlike",
+        num_segments=num_segments,
+        gauss_points=5,
+    )
     _, directional_fn, inputs = _build_workload(
         model,
         "state_jvp",

--- a/tests/tools/test_pcs_custom_jvp_speed_test.py
+++ b/tests/tools/test_pcs_custom_jvp_speed_test.py
@@ -100,6 +100,33 @@ def test_custom_jvp_input_only_tangent_matches_direct_jax_autodiff() -> None:
     assert_allclose(candidate, reference, rtol=1.0e-5, atol=1.0e-8)
 
 
+@pytest.mark.parametrize("setup", ["full", "bending_extension"])
+def test_fused_dynamics_state_pushforward_matches_direct_jax_autodiff(
+    setup: str,
+) -> None:
+    model = benchmark.build_model(setup, num_segments=2, gauss_points=5)
+    benchmark_inputs = benchmark.build_inputs(model)
+    q, qd = jnp.split(benchmark_inputs.y, 2)
+    q_direction, qd_direction = jnp.split(benchmark_inputs.y_direction, 2)
+
+    expected_primal, expected_direction = jax.jvp(
+        model.dynamics_terms,
+        (q, qd),
+        (q_direction, qd_direction),
+    )
+    actual = model._dynamics_terms_with_state_pushforward(
+        q,
+        qd,
+        q_direction,
+        qd_direction,
+    )
+    actual_primal = actual[:3]
+    actual_direction = actual[3:]
+
+    _assert_trees_allclose(expected_primal, actual_primal)
+    _assert_trees_allclose(expected_direction, actual_direction)
+
+
 @pytest.mark.parametrize("num_segments", [2, 16])
 def test_directional_jvp_matches_full_analytical_jacobian_matvec(
     num_segments: int,
@@ -132,6 +159,26 @@ def test_directional_jvp_matches_full_analytical_jacobian_matvec(
 
     _assert_trees_allclose(directional, full_jacobian)
     _assert_trees_allclose(directional, autodiff_full_jacobian)
+
+
+def test_large_dense_directional_jvp_matches_direct_jax_autodiff() -> None:
+    """Cover the contracted inverse-dynamics route above the fused cutoff."""
+    model = benchmark.build_model("full", num_segments=16, gauss_points=5)
+    _, reference_fn, inputs = _build_workload(
+        model,
+        "state_jvp",
+        use_custom_jvp=False,
+    )
+    _, candidate_fn, _ = _build_workload(
+        model,
+        "state_jvp",
+        use_custom_jvp=True,
+    )
+
+    reference = reference_fn(*inputs)
+    candidate = candidate_fn(*inputs)
+
+    _assert_trees_allclose(reference, candidate)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_joint_motion_subspace.py
+++ b/tests/utils/test_joint_motion_subspace.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_allclose
 from soromox.utils.joint_motion_subspace import (
     joint_dSdq_qd,
     joint_dSTF_dq,
+    joint_dSTF_dq_direction,
     joint_motion_subspace_with_derivatives,
 )
 from soromox.utils.lie_algebra import se3
@@ -48,6 +49,7 @@ def test_joint_motion_subspace_derivatives_match_autodiff(rotation: float) -> No
     expected_dS_qdd_dq = jax.jacfwd(lambda value: motion_subspace(value) @ qdd)(q)
     expected_dSd_qd_dq = jax.jacfwd(lambda value: motion_subspace_dot(value) @ qd)(q)
     expected_dSTF_dq = jax.jacfwd(lambda value: motion_subspace(value).T @ wrench)(q)
+    q_directions = jnp.stack((qd, qdd), axis=1)
 
     (
         transform,
@@ -95,6 +97,49 @@ def test_joint_motion_subspace_derivatives_match_autodiff(rotation: float) -> No
             eps,
         ),
         expected_dSTF_dq,
+        rtol=1.0e-8,
+        atol=1.0e-10,
+    )
+    assert_allclose(
+        joint_dSTF_dq_direction(
+            interval_length,
+            strain_basis,
+            reference_strain,
+            q,
+            wrench,
+            q_directions,
+            eps,
+        ),
+        expected_dSTF_dq @ q_directions,
+        rtol=1.0e-8,
+        atol=1.0e-10,
+    )
+
+    directional_results = joint_motion_subspace_with_derivatives(
+        interval_length,
+        strain_basis,
+        reference_strain,
+        q,
+        qd,
+        qdd,
+        eps,
+        q_directions,
+    )
+    assert_allclose(
+        directional_results[3],
+        expected_deta_dq @ q_directions,
+        rtol=1.0e-8,
+        atol=1.0e-10,
+    )
+    assert_allclose(
+        directional_results[4],
+        expected_dS_qdd_dq @ q_directions,
+        rtol=1.0e-8,
+        atol=1.0e-10,
+    )
+    assert_allclose(
+        directional_results[5],
+        expected_dSd_qd_dq @ q_directions,
         rtol=1.0e-8,
         atol=1.0e-10,
     )

--- a/tests/utils/test_joint_motion_subspace.py
+++ b/tests/utils/test_joint_motion_subspace.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose
 
 from soromox.utils.joint_motion_subspace import (
     joint_dSdq_qd,
+    joint_dSTF_dq,
     joint_motion_subspace_with_derivatives,
 )
 from soromox.utils.lie_algebra import se3
@@ -23,6 +24,7 @@ def test_joint_motion_subspace_derivatives_match_autodiff(rotation: float) -> No
     q = jnp.array([rotation, 0.0, 0.0, 0.02, -0.01, 0.03])
     qd = jnp.array([0.2, -0.3, 0.4, -0.1, 0.5, -0.2])
     qdd = jnp.array([-0.4, 0.1, 0.3, 0.2, -0.2, 0.6])
+    wrench = jnp.array([0.3, -0.2, 0.1, -0.4, 0.6, -0.5])
     eps = jnp.finfo(q.dtype).eps
 
     def motion_subspace(q_value: jax.Array) -> jax.Array:
@@ -45,6 +47,7 @@ def test_joint_motion_subspace_derivatives_match_autodiff(rotation: float) -> No
     expected_deta_dq = jax.jacfwd(lambda value: motion_subspace(value) @ qd)(q)
     expected_dS_qdd_dq = jax.jacfwd(lambda value: motion_subspace(value) @ qdd)(q)
     expected_dSd_qd_dq = jax.jacfwd(lambda value: motion_subspace_dot(value) @ qd)(q)
+    expected_dSTF_dq = jax.jacfwd(lambda value: motion_subspace(value).T @ wrench)(q)
 
     (
         transform,
@@ -79,6 +82,19 @@ def test_joint_motion_subspace_derivatives_match_autodiff(rotation: float) -> No
             eps,
         ),
         expected_deta_dq,
+        rtol=1.0e-8,
+        atol=1.0e-10,
+    )
+    assert_allclose(
+        joint_dSTF_dq(
+            interval_length,
+            strain_basis,
+            reference_strain,
+            q,
+            wrench,
+            eps,
+        ),
+        expected_dSTF_dq,
         rtol=1.0e-8,
         atol=1.0e-10,
     )

--- a/tests/utils/test_joint_motion_subspace.py
+++ b/tests/utils/test_joint_motion_subspace.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+from numpy.testing import assert_allclose
+
+from soromox.utils.joint_motion_subspace import (
+    joint_dSdq_qd,
+    joint_motion_subspace_with_derivatives,
+)
+from soromox.utils.lie_algebra import se3
+
+jax.config.update("jax_enable_x64", True)
+
+
+@pytest.mark.parametrize("rotation", [1.0e-5, 1.0e-1])
+def test_joint_motion_subspace_derivatives_match_autodiff(rotation: float) -> None:
+    """Exercise both the stable-series and closed-form derivative branches."""
+    interval_length = jnp.array(1.0, dtype=jnp.float64)
+    strain_basis = jnp.eye(6, dtype=jnp.float64)
+    reference_strain = jnp.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+    q = jnp.array([rotation, 0.0, 0.0, 0.02, -0.01, 0.03])
+    qd = jnp.array([0.2, -0.3, 0.4, -0.1, 0.5, -0.2])
+    qdd = jnp.array([-0.4, 0.1, 0.3, 0.2, -0.2, 0.6])
+    eps = jnp.finfo(q.dtype).eps
+
+    def motion_subspace(q_value: jax.Array) -> jax.Array:
+        integrated_strain = interval_length * (
+            strain_basis @ q_value + reference_strain
+        )
+        return se3.left_jacobian(integrated_strain, eps) @ (
+            interval_length * strain_basis
+        )
+
+    def motion_subspace_dot(q_value: jax.Array) -> jax.Array:
+        return jax.jvp(motion_subspace, (q_value,), (qd,))[1]
+
+    expected_transform = se3.exp(
+        interval_length * (strain_basis @ q + reference_strain),
+        eps=eps,
+    )
+    expected_subspace = motion_subspace(q)
+    expected_subspace_dot = motion_subspace_dot(q)
+    expected_deta_dq = jax.jacfwd(lambda value: motion_subspace(value) @ qd)(q)
+    expected_dS_qdd_dq = jax.jacfwd(lambda value: motion_subspace(value) @ qdd)(q)
+    expected_dSd_qd_dq = jax.jacfwd(lambda value: motion_subspace_dot(value) @ qd)(q)
+
+    (
+        transform,
+        subspace,
+        subspace_dot,
+        deta_dq,
+        dS_qdd_dq,
+        dSd_qd_dq,
+    ) = joint_motion_subspace_with_derivatives(
+        interval_length,
+        strain_basis,
+        reference_strain,
+        q,
+        qd,
+        qdd,
+        eps,
+    )
+
+    assert_allclose(transform, expected_transform, rtol=1.0e-8, atol=1.0e-10)
+    assert_allclose(subspace, expected_subspace, rtol=1.0e-8, atol=1.0e-10)
+    assert_allclose(subspace_dot, expected_subspace_dot, rtol=1.0e-8, atol=1.0e-10)
+    assert_allclose(deta_dq, expected_deta_dq, rtol=1.0e-8, atol=1.0e-10)
+    assert_allclose(dS_qdd_dq, expected_dS_qdd_dq, rtol=1.0e-8, atol=1.0e-10)
+    assert_allclose(dSd_qd_dq, expected_dSd_qd_dq, rtol=1.0e-8, atol=1.0e-10)
+    assert_allclose(
+        joint_dSdq_qd(
+            interval_length,
+            strain_basis,
+            reference_strain,
+            q,
+            qd,
+            eps,
+        ),
+        expected_deta_dq,
+        rtol=1.0e-8,
+        atol=1.0e-10,
+    )

--- a/tools/benchmarks/pcs_custom_jvp_speed_test.py
+++ b/tools/benchmarks/pcs_custom_jvp_speed_test.py
@@ -5,6 +5,13 @@ The benchmark separates the first-call compilation cost from steady-state
 execution time. Every timed call is synchronized with the active JAX device.
 Custom-JVP and pure-autodiff outputs are also compared for correctness.
 
+For ``state_jvp``, the disabled path is JAX's direct JVP and the enabled path
+is the analytical directional recurrence. For ``state_jacobian_matvec``, both
+paths first materialize a full state Jacobian and then multiply it by the same
+direction: JAX ``jacfwd`` when disabled and the analytical PCS Jacobian when
+enabled. Each workload returns the primal and tangent so their timed work and
+correctness checks are directly comparable.
+
 Rollout workloads apply a constant actuation over a short fixed-step trajectory
 and return the final generalized position ``q(T)``. They benchmark either one
 directional JVP or the full Jacobian with respect to the actuation ``u``, the
@@ -15,7 +22,7 @@ Example:
     python tools/benchmarks/pcs_custom_jvp_speed_test.py \
         --segment-counts 1 2 4 8 16 32 \
         --setups full bending_extension axial threadlike \
-        --workloads state_jvp state_jacobian \
+        --workloads state_jvp state_jacobian_matvec state_jacobian \
             rollout_actuation_jvp rollout_actuation_jacobian \
             rollout_initial_position_jvp rollout_initial_position_jacobian \
             rollout_parameters_jvp rollout_parameters_jacobian \
@@ -61,6 +68,7 @@ SETUPS = ("full", "bending_extension", "axial", "threadlike")
 WORKLOADS = (
     "primal",
     "state_jvp",
+    "state_jacobian_matvec",
     "state_jacobian",
     "all_jacobians",
     "rollout_actuation_jvp",
@@ -265,6 +273,22 @@ def build_workload(
             (y,),
             (y_direction,),
         )
+    if workload == "state_jacobian_matvec":
+        if use_custom_jvp:
+            return lambda y, u, tau_ext, parameters: (
+                dynamics(y, u, tau_ext, parameters),
+                model.forward_dynamics_state_jacobian(
+                    t,
+                    y,
+                    (u, tau_ext),
+                )
+                @ y_direction,
+            )
+        return lambda y, u, tau_ext, parameters: (
+            dynamics(y, u, tau_ext, parameters),
+            jax.jacfwd(lambda y_value: dynamics(y_value, u, tau_ext, parameters))(y)
+            @ y_direction,
+        )
     if workload == "state_jacobian":
         return lambda y, u, tau_ext, parameters: jax.jacfwd(
             lambda y_value: dynamics(y_value, u, tau_ext, parameters)
@@ -339,6 +363,7 @@ def measure(
     args: tuple[Array, Array, Array, Array],
     warmup_runs: int,
     repeats: int,
+    calls_per_sample: int,
 ) -> tuple[float, float, Tree]:
     """Return estimated compilation seconds, median execution seconds, output."""
     compiled = jax.jit(fn)
@@ -354,9 +379,10 @@ def measure(
     samples = []
     for _ in range(repeats):
         start = time.perf_counter()
-        output = compiled(*args)
+        for _ in range(calls_per_sample):
+            output = compiled(*args)
         block_until_ready(output)
-        samples.append(time.perf_counter() - start)
+        samples.append((time.perf_counter() - start) / calls_per_sample)
 
     execution = statistics.median(samples)
     compilation = max(0.0, first_call - execution)
@@ -392,7 +418,8 @@ def run(args: argparse.Namespace) -> list[dict[str, Any]]:
     device = jax.devices()[0]
     print(
         f"device={device.platform}:{getattr(device, 'device_kind', 'unknown')} "
-        f"x64={jax.config.x64_enabled} repeats={args.repeats}"
+        f"x64={jax.config.x64_enabled} repeats={args.repeats} "
+        f"calls_per_sample={args.calls_per_sample}"
     )
     print(
         "setup                 links dof workload                            "
@@ -430,6 +457,7 @@ def run(args: argparse.Namespace) -> list[dict[str, Any]]:
                         inputs,
                         args.warmup_runs,
                         args.repeats,
+                        args.calls_per_sample,
                     )
 
                 compile_off, execution_off, output_off = measurements[False]
@@ -451,6 +479,7 @@ def run(args: argparse.Namespace) -> list[dict[str, Any]]:
                     "workload": workload,
                     "rollout_steps": args.rollout_steps,
                     "rollout_dt": args.rollout_dt,
+                    "calls_per_sample": args.calls_per_sample,
                     "custom_jvp_disabled_compile_s": compile_off,
                     "custom_jvp_enabled_compile_s": compile_on,
                     "custom_jvp_disabled_execution_s": execution_off,
@@ -487,13 +516,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "--workloads",
         nargs="+",
         choices=WORKLOADS,
-        default=["state_jvp", "state_jacobian"],
+        default=["state_jvp", "state_jacobian_matvec", "state_jacobian"],
     )
     parser.add_argument("--gauss-points", type=int, default=5)
     parser.add_argument("--rollout-steps", type=int, default=8)
     parser.add_argument("--rollout-dt", type=float, default=1.0e-4)
     parser.add_argument("--warmup-runs", type=int, default=2)
     parser.add_argument("--repeats", type=int, default=10)
+    parser.add_argument("--calls-per-sample", type=int, default=1)
     parser.add_argument("--correctness-rtol", type=float, default=1.0e-5)
     parser.add_argument("--csv", type=Path)
     args = parser.parse_args(argv)
@@ -507,6 +537,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         parser.error("--rollout-dt must be positive")
     if args.warmup_runs < 0 or args.repeats < 1:
         parser.error("warmup runs must be non-negative and repeats must be positive")
+    if args.calls_per_sample < 1:
+        parser.error("--calls-per-sample must be positive")
     if args.correctness_rtol <= 0.0:
         parser.error("--correctness-rtol must be positive")
     return args

--- a/tools/benchmarks/pcs_custom_jvp_speed_test.py
+++ b/tools/benchmarks/pcs_custom_jvp_speed_test.py
@@ -5,11 +5,20 @@ The benchmark separates the first-call compilation cost from steady-state
 execution time. Every timed call is synchronized with the active JAX device.
 Custom-JVP and pure-autodiff outputs are also compared for correctness.
 
+Rollout workloads apply a constant actuation over a short fixed-step trajectory
+and return the final generalized position ``q(T)``. They benchmark either one
+directional JVP or the full Jacobian with respect to the actuation ``u``, the
+initial generalized position ``q(0)``, or the per-segment parameter vector
+``[length, density, Young's modulus]``.
+
 Example:
     python tools/benchmarks/pcs_custom_jvp_speed_test.py \
-        --segment-counts 1 2 4 \
+        --segment-counts 1 2 4 8 16 32 \
         --setups full bending_extension axial threadlike \
         --workloads state_jvp state_jacobian \
+            rollout_actuation_jvp rollout_actuation_jacobian \
+            rollout_initial_position_jvp rollout_initial_position_jacobian \
+            rollout_parameters_jvp rollout_parameters_jacobian \
         --repeats 10
 """
 
@@ -21,7 +30,7 @@ import statistics
 import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -30,14 +39,49 @@ jax.config.update("jax_enable_x64", True)
 
 from soromox.actuation import ThreadlikeActuator, ThreadlikeRouting  # noqa: E402
 from soromox.autodiff import set_custom_jvp_enabled  # noqa: E402
-from soromox.systems import PCS, LinkSpec, PCSStructure  # noqa: E402
+from soromox.systems import (  # noqa: E402
+    PCS,
+    IsotropicMaterialParams,
+    LinkSpec,
+    PCSStructure,
+)
 
 Array = jax.Array
 Tree = Any
-Workload = Callable[[Array, Array, Array], Tree]
+Workload = Callable[[Array, Array, Array, Array], Tree]
+
+LINK_LENGTH = 0.1
+LINK_DENSITY = 1070.0
+YOUNG_MODULUS = 2.0e3
+SHEAR_MODULUS = 1.0e3
+MATERIAL_DAMPING_COEFFICIENT = 1.0e-3
+DEFAULT_SEGMENT_COUNTS = (1, 2, 4, 8, 16, 32)
 
 SETUPS = ("full", "bending_extension", "axial", "threadlike")
-WORKLOADS = ("primal", "state_jvp", "state_jacobian", "all_jacobians")
+WORKLOADS = (
+    "primal",
+    "state_jvp",
+    "state_jacobian",
+    "all_jacobians",
+    "rollout_actuation_jvp",
+    "rollout_actuation_jacobian",
+    "rollout_initial_position_jvp",
+    "rollout_initial_position_jacobian",
+    "rollout_parameters_jvp",
+    "rollout_parameters_jacobian",
+)
+
+
+class BenchmarkInputs(NamedTuple):
+    """Dynamic inputs and directions shared by the benchmark workloads."""
+
+    y: Array
+    y_direction: Array
+    u: Array
+    u_direction: Array
+    tau_ext: Array
+    system_parameters: Array
+    system_parameter_direction: Array
 
 
 def _strain_selector(setup: str, num_segments: int) -> Array | None:
@@ -71,12 +115,12 @@ def build_model(setup: str, num_segments: int, gauss_points: int) -> PCS:
     return PCS.from_links(
         [
             LinkSpec.circular(
-                length=0.1,
+                length=LINK_LENGTH,
                 radius=0.02,
-                density=1070.0,
-                young_modulus=2.0e3,
-                shear_modulus=1.0e3,
-                material_damping_coefficient=1.0e-3,
+                density=LINK_DENSITY,
+                young_modulus=YOUNG_MODULUS,
+                shear_modulus=SHEAR_MODULUS,
+                material_damping_coefficient=MATERIAL_DAMPING_COEFFICIENT,
                 reference_strain=[0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
             )
             for _ in range(num_segments)
@@ -90,41 +134,196 @@ def build_model(setup: str, num_segments: int, gauss_points: int) -> PCS:
     )
 
 
-def build_inputs(model: PCS) -> tuple[Array, Array, Array, Array]:
-    """Return state, state direction, actuator input, and external force."""
+def build_inputs(model: PCS) -> BenchmarkInputs:
+    """Return dynamic benchmark inputs and directional-JVP tangents."""
     q = jnp.linspace(-0.025, 0.035, model.num_dofs)
     qd = jnp.linspace(0.04, -0.03, model.num_dofs)
     y = jnp.concatenate([q, qd])
     y_direction = jnp.linspace(-0.2, 0.25, 2 * model.num_dofs)
     u = jnp.linspace(0.05, 0.1, model.num_actuators)
+    u_direction = jnp.linspace(-0.15, 0.2, model.num_actuators)
     tau_ext = jnp.linspace(-0.01, 0.015, model.num_dofs)
-    return y, y_direction, u, tau_ext
+    system_parameters = jnp.concatenate(
+        [
+            model.L,
+            model.rho,
+            jnp.full((model.num_segments,), YOUNG_MODULUS, dtype=y.dtype),
+        ]
+    )
+    system_parameter_direction = 0.01 * system_parameters
+    return BenchmarkInputs(
+        y=y,
+        y_direction=y_direction,
+        u=u,
+        u_direction=u_direction,
+        tau_ext=tau_ext,
+        system_parameters=system_parameters,
+        system_parameter_direction=system_parameter_direction,
+    )
 
 
-def build_workload(model: PCS, workload: str, y_direction: Array) -> Workload:
-    """Create one public forward-dynamics derivative workload."""
+def model_with_system_parameters(model: PCS, parameters: Array) -> PCS:
+    """Update per-segment length, density, and Young's modulus."""
+    length, density, young_modulus = jnp.split(parameters, 3)
+    updated = model.update_link_params(length=length, density=density)
+    material = IsotropicMaterialParams(
+        young_modulus=young_modulus,
+        shear_modulus=jnp.full_like(young_modulus, SHEAR_MODULUS),
+        material_damping_coefficient=jnp.full_like(
+            young_modulus,
+            MATERIAL_DAMPING_COEFFICIENT,
+        ),
+    )
+    return updated.with_isotropic_material(material)
+
+
+def rollout_final_position(
+    model: PCS,
+    y: Array,
+    u: Array,
+    tau_ext: Array,
+    *,
+    rollout_steps: int,
+    rollout_dt: float,
+    use_custom_jvp: bool,
+) -> Array:
+    """Return ``q(T)`` from a short fixed-step symplectic-Euler rollout."""
+    dt = jnp.asarray(rollout_dt, dtype=y.dtype)
+
+    def step(y_value: Array, step_index: Array) -> tuple[Array, None]:
+        t = dt * step_index
+        if use_custom_jvp:
+            yd = model.forward_dynamics(t, y_value, (u, tau_ext))
+        else:
+            yd = model._forward_dynamics(t, y_value, (u, tau_ext))
+        q, qd = jnp.split(y_value, 2)
+        _, qdd = jnp.split(yd, 2)
+        qd_next = qd + dt * qdd
+        q_next = q + dt * qd_next
+        return jnp.concatenate([q_next, qd_next]), None
+
+    final_y, _ = jax.lax.scan(
+        step,
+        y,
+        jnp.arange(rollout_steps, dtype=jnp.int32),
+    )
+    final_q, _ = jnp.split(final_y, 2)
+    return final_q
+
+
+def build_workload(
+    model: PCS,
+    workload: str,
+    y_direction: Array,
+    u_direction: Array,
+    system_parameter_direction: Array,
+    *,
+    rollout_steps: int,
+    rollout_dt: float,
+    use_custom_jvp: bool,
+) -> Workload:
+    """Create a custom-JVP or direct-JAX-autodiff derivative workload.
+
+    The reference path calls the protected primal directly. Consequently its
+    derivatives always come from JAX autodiff and cannot accidentally capture
+    the global custom-JVP toggle at trace time.
+    """
     t = jnp.array(0.0)
 
-    def dynamics(y: Array, u: Array, tau_ext: Array) -> Array:
-        return model.forward_dynamics(t, y, (u, tau_ext))
+    def dynamics(
+        y: Array,
+        u: Array,
+        tau_ext: Array,
+        system_parameters: Array,
+    ) -> Array:
+        del system_parameters
+        if use_custom_jvp:
+            return model.forward_dynamics(t, y, (u, tau_ext))
+        return model._forward_dynamics(t, y, (u, tau_ext))
+
+    def rollout(
+        rollout_model: PCS,
+        y: Array,
+        u: Array,
+        tau_ext: Array,
+    ) -> Array:
+        return rollout_final_position(
+            rollout_model,
+            y,
+            u,
+            tau_ext,
+            rollout_steps=rollout_steps,
+            rollout_dt=rollout_dt,
+            use_custom_jvp=use_custom_jvp,
+        )
 
     if workload == "primal":
         return dynamics
     if workload == "state_jvp":
-        return lambda y, u, tau_ext: jax.jvp(
-            lambda y_value: dynamics(y_value, u, tau_ext),
+        return lambda y, u, tau_ext, parameters: jax.jvp(
+            lambda y_value: dynamics(y_value, u, tau_ext, parameters),
             (y,),
             (y_direction,),
         )
     if workload == "state_jacobian":
-        return lambda y, u, tau_ext: jax.jacfwd(
-            lambda y_value: dynamics(y_value, u, tau_ext)
+        return lambda y, u, tau_ext, parameters: jax.jacfwd(
+            lambda y_value: dynamics(y_value, u, tau_ext, parameters)
         )(y)
     if workload == "all_jacobians":
-        return lambda y, u, tau_ext: jax.jacfwd(
+        return lambda y, u, tau_ext, parameters: jax.jacfwd(
             dynamics,
             argnums=(0, 1, 2),
-        )(y, u, tau_ext)
+        )(y, u, tau_ext, parameters)
+    if workload == "rollout_actuation_jvp":
+        return lambda y, u, tau_ext, parameters: jax.jvp(
+            lambda u_value: rollout(model, y, u_value, tau_ext),
+            (u,),
+            (u_direction,),
+        )
+    if workload == "rollout_actuation_jacobian":
+        return lambda y, u, tau_ext, parameters: jax.jacfwd(
+            lambda u_value: rollout(model, y, u_value, tau_ext)
+        )(u)
+    if workload == "rollout_initial_position_jvp":
+        return lambda y, u, tau_ext, parameters: jax.jvp(
+            lambda q_value: rollout(
+                model,
+                jnp.concatenate([q_value, y[model.num_dofs :]]),
+                u,
+                tau_ext,
+            ),
+            (y[: model.num_dofs],),
+            (y_direction[: model.num_dofs],),
+        )
+    if workload == "rollout_initial_position_jacobian":
+        return lambda y, u, tau_ext, parameters: jax.jacfwd(
+            lambda q_value: rollout(
+                model,
+                jnp.concatenate([q_value, y[model.num_dofs :]]),
+                u,
+                tau_ext,
+            )
+        )(y[: model.num_dofs])
+    if workload == "rollout_parameters_jvp":
+        return lambda y, u, tau_ext, parameters: jax.jvp(
+            lambda parameter_values: rollout(
+                model_with_system_parameters(model, parameter_values),
+                y,
+                u,
+                tau_ext,
+            ),
+            (parameters,),
+            (system_parameter_direction,),
+        )
+    if workload == "rollout_parameters_jacobian":
+        return lambda y, u, tau_ext, parameters: jax.jacfwd(
+            lambda parameter_values: rollout(
+                model_with_system_parameters(model, parameter_values),
+                y,
+                u,
+                tau_ext,
+            )
+        )(parameters)
     raise ValueError(f"Unknown workload: {workload}")
 
 
@@ -137,7 +336,7 @@ def block_until_ready(tree: Tree) -> None:
 
 def measure(
     fn: Workload,
-    args: tuple[Array, Array, Array],
+    args: tuple[Array, Array, Array, Array],
     warmup_runs: int,
     repeats: int,
 ) -> tuple[float, float, Tree]:
@@ -196,22 +395,36 @@ def run(args: argparse.Namespace) -> list[dict[str, Any]]:
         f"x64={jax.config.x64_enabled} repeats={args.repeats}"
     )
     print(
-        "setup                 links dof workload          "
+        "setup                 links dof workload                            "
         "off_ms    on_ms speedup compile_off compile_on  rel_error"
     )
 
     for setup in args.setups:
         for num_segments in args.segment_counts:
             model = build_model(setup, num_segments, args.gauss_points)
-            y, y_direction, u, tau_ext = build_inputs(model)
-            inputs = (y, u, tau_ext)
+            benchmark_inputs = build_inputs(model)
+            inputs = (
+                benchmark_inputs.y,
+                benchmark_inputs.u,
+                benchmark_inputs.tau_ext,
+                benchmark_inputs.system_parameters,
+            )
 
             for workload in args.workloads:
                 measurements: dict[bool, tuple[float, float, Tree]] = {}
                 for enabled in (False, True):
                     set_custom_jvp_enabled(enabled)
                     jax.clear_caches()
-                    workload_fn = build_workload(model, workload, y_direction)
+                    workload_fn = build_workload(
+                        model,
+                        workload,
+                        benchmark_inputs.y_direction,
+                        benchmark_inputs.u_direction,
+                        benchmark_inputs.system_parameter_direction,
+                        rollout_steps=args.rollout_steps,
+                        rollout_dt=args.rollout_dt,
+                        use_custom_jvp=enabled,
+                    )
                     measurements[enabled] = measure(
                         workload_fn,
                         inputs,
@@ -236,6 +449,8 @@ def run(args: argparse.Namespace) -> list[dict[str, Any]]:
                     "dof": model.num_dofs,
                     "gauss_points": args.gauss_points,
                     "workload": workload,
+                    "rollout_steps": args.rollout_steps,
+                    "rollout_dt": args.rollout_dt,
                     "custom_jvp_disabled_compile_s": compile_off,
                     "custom_jvp_enabled_compile_s": compile_on,
                     "custom_jvp_disabled_execution_s": execution_off,
@@ -248,7 +463,7 @@ def run(args: argparse.Namespace) -> list[dict[str, Any]]:
                 rows.append(row)
                 print(
                     f"{setup:21s} {num_segments:5d} {model.num_dofs:3d} "
-                    f"{workload:17s} {1e3 * execution_off:8.3f} "
+                    f"{workload:35s} {1e3 * execution_off:8.3f} "
                     f"{1e3 * execution_on:8.3f} {speedup:7.2f}x "
                     f"{compile_off:11.3f} {compile_on:10.3f} "
                     f"{max_relative:10.3e}"
@@ -261,7 +476,12 @@ def run(args: argparse.Namespace) -> list[dict[str, Any]]:
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command-line benchmark options."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--segment-counts", type=int, nargs="+", default=[1, 2, 4])
+    parser.add_argument(
+        "--segment-counts",
+        type=int,
+        nargs="+",
+        default=list(DEFAULT_SEGMENT_COUNTS),
+    )
     parser.add_argument("--setups", nargs="+", choices=SETUPS, default=list(SETUPS))
     parser.add_argument(
         "--workloads",
@@ -269,7 +489,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         choices=WORKLOADS,
         default=["state_jvp", "state_jacobian"],
     )
-    parser.add_argument("--gauss-points", type=int, default=3)
+    parser.add_argument("--gauss-points", type=int, default=5)
+    parser.add_argument("--rollout-steps", type=int, default=8)
+    parser.add_argument("--rollout-dt", type=float, default=1.0e-4)
     parser.add_argument("--warmup-runs", type=int, default=2)
     parser.add_argument("--repeats", type=int, default=10)
     parser.add_argument("--correctness-rtol", type=float, default=1.0e-5)
@@ -279,6 +501,10 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         parser.error("--segment-counts values must be positive")
     if args.gauss_points < 1:
         parser.error("--gauss-points must be positive")
+    if args.rollout_steps < 1:
+        parser.error("--rollout-steps must be positive")
+    if args.rollout_dt <= 0.0:
+        parser.error("--rollout-dt must be positive")
     if args.warmup_runs < 0 or args.repeats < 1:
         parser.error("warmup runs must be non-negative and repeats must be positive")
     if args.correctness_rtol <= 0.0:


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #188 and targets its `pcs-analytical-derivatives`
> branch. It contains the derivative coverage, simplification, and performance
> follow-up requested during review; #188 should merge first.

## Summary

- replace full-state-Jacobian materialization inside the PCS custom JVP with a
  genuinely directional analytical state recurrence
- retain and optimize the public full analytical state-Jacobian path for
  callers that need the complete matrix
- remove acceleration-Jacobian and wrench-history outputs from the inverse-
  dynamics backward recurrence; callers reuse the already assembled inertia
  matrix
- analytically differentiate identity/threadlike actuation and threadlike
  passive forces in state directions, without production autodiff in the PCS
  state-tangent path
- add fused primal/directional dynamics assembly for small and medium systems
  and a contracted inverse-dynamics route for large dense systems
- add directional SE(3), constant-strain, joint-motion-subspace, and matrix-
  polynomial kernels shared by the analytical Jacobian and JVP implementations
- expand analytical/autodiff equivalence tests and the benchmark harness to
  cover 1, 2, 4, 8, 16, and 32 segments, five Gauss points, reduced strains,
  threadlike components, full Jacobians, directional JVPs, and rollout
  derivatives

## Implementation

### Full analytical state Jacobian

The inverse-dynamics recurrence now returns only `dID/dq` and `dID/dqd`.
`dID/dqdd` and its per-interval wrench history duplicated the inertia matrix
that forward dynamics had already computed, so those arrays and their backward
propagation have been removed. The remaining recurrence uses causal active-DOF
prefixes, diagonal mass actions, contracted spatial operations, and reused
constant-strain preparation to avoid work on zero/future columns.

Forward dynamics differentiates the implicit equation

`M qdd_direction = applied_force_direction - ID_state_direction`.

The complete state-Jacobian API still evaluates all state basis directions,
but it shares the optimized recurrence and the existing inertia matrix rather
than constructing an acceleration derivative inside the backward pass.

### Directional analytical state JVP

The custom JVP no longer materializes a full state Jacobian and multiplies it
by the supplied tangent. It propagates one configuration/velocity direction
through PCS kinematics, dynamics, and applied forces.

For systems up to 64 active DOFs, a fused recurrence assembles the primal
`(B, Cqd, G)` values and their contracted derivatives together. It shares
segment strain preparation, quadrature setup, local kinematic powers, and the
final dynamics reduction. Above 64 DOFs, carrying a directional inertia matrix
becomes more expensive than the contracted backward recurrence, so the custom
JVP uses `inverse_dynamics_state_pushforward` instead.

Threadlike moment arms, actuation forces, and passive spring/damping forces
have explicit state pushforwards. Unsupported component types fail explicitly
instead of silently falling back to autodiff. Robot-parameter tangents remain a
separate autodiff-assisted path and are not part of the state-only performance
claim in this PR.

### Shared analytical kernels

The SE(3) and constant-strain helpers evaluate first and mixed directional
derivatives of adjoints, tangents, transported tangents, and their matrix-
polynomial expansions. The full-Jacobian and directional recurrences reuse
these primitives. PCS primal and fused kinematic recurrences remain specialized
because the primal-only path uses cheaper prepared powers, while shared PCS
helpers centralize strain inputs, quadrature, and dynamics-term assembly.

`PlanarPCS` has an analogous constant-strain/quadrature setup, but `GVS` does
not: GVS uses spatially varying strain bases, separate joint/link blocks,
per-segment quadrature counts, padding, and precomputed interior weights. This
PR therefore keeps the new setup helpers private to spatial `PCS`; the common
quadrature scaling primitive remains shared package-wide.

## Correctness

Each benchmark reference differentiates `PCS._forward_dynamics` directly, so
it cannot route through the custom JVP being measured. The state-JVP sweep's
largest scale-normalized analytical/autodiff difference is `1.04e-9`; the full
state-Jacobian sweep's maximum is `2.02e-11` in JAX FP64.

Tests cover fused and large-dense directional routes, equality between the
directional recurrence and the analytical full-Jacobian matrix product,
constant-strain mixed derivatives, reduced strain selectors, threadlike
actuation/passive elements, input/external-force tangents, robot-parameter
tangents, and rollout derivatives.

## Performance

Measurements use JAX 0.11.0 in FP64 on the CPU backend, pinned with `taskset`
to performance core 7 (5.7 GHz maximum) of an Intel Core Ultra 9 285K. Every
configuration uses the PCS default of five Gauss points. JAX and analytical
modes are separately compiled after clearing caches, and every timed result is
synchronized.

- state JVP: median of 20 samples, each containing 50 calls after five warmups
- full state Jacobian: median of 10 samples, each containing two calls after
  five warmups
- `Speedup = JAX autodiff / analytical`, so values above one favor the
  analytical implementation

| Setup | Segments | DOFs | JAX JVP (ms) | Analytical JVP (ms) | JVP speedup | JAX Jacobian (ms) | Analytical Jacobian (ms) | Jacobian speedup |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| full | 1 | 6 | 0.033 | 0.028 | **1.16x** | 0.092 | 0.074 | **1.24x** |
| full | 2 | 12 | 0.065 | 0.055 | **1.17x** | 0.376 | 0.289 | **1.30x** |
| full | 4 | 24 | 0.116 | 0.101 | **1.15x** | 1.651 | 1.243 | **1.33x** |
| full | 8 | 48 | 0.269 | 0.236 | **1.14x** | 27.669 | 23.730 | **1.17x** |
| full | 16 | 96 | 0.867 | 0.683 | **1.27x** | 251.506 | 82.963 | **3.03x** |
| full | 32 | 192 | 4.617 | 2.082 | **2.22x** | 2459.776 | 377.822 | **6.51x** |
| bending_extension | 1 | 2 | 0.030 | 0.027 | **1.13x** | 0.052 | 0.042 | **1.24x** |
| bending_extension | 2 | 4 | 0.059 | 0.052 | **1.14x** | 0.143 | 0.117 | **1.23x** |
| bending_extension | 4 | 8 | 0.096 | 0.086 | **1.12x** | 0.454 | 0.363 | **1.25x** |
| bending_extension | 8 | 16 | 0.188 | 0.167 | **1.12x** | 1.901 | 1.482 | **1.28x** |
| bending_extension | 16 | 32 | 0.422 | 0.392 | **1.08x** | 24.494 | 21.115 | **1.16x** |
| bending_extension | 32 | 64 | 1.204 | 1.122 | **1.07x** | 201.682 | 174.580 | **1.16x** |
| axial | 1 | 1 | 0.029 | 0.027 | **1.07x** | 0.040 | 0.036 | **1.11x** |
| axial | 2 | 2 | 0.057 | 0.051 | **1.13x** | 0.113 | 0.090 | **1.25x** |
| axial | 4 | 4 | 0.092 | 0.081 | **1.13x** | 0.259 | 0.211 | **1.22x** |
| axial | 8 | 8 | 0.169 | 0.155 | **1.10x** | 0.867 | 0.697 | **1.24x** |
| axial | 16 | 16 | 0.357 | 0.336 | **1.06x** | 4.022 | 3.138 | **1.28x** |
| axial | 32 | 32 | 0.806 | 0.775 | **1.04x** | 52.074 | 47.194 | **1.10x** |
| threadlike | 1 | 2 | 0.034 | 0.032 | **1.04x** | 0.060 | 0.047 | **1.28x** |
| threadlike | 2 | 4 | 0.065 | 0.056 | **1.17x** | 0.159 | 0.133 | **1.19x** |
| threadlike | 4 | 8 | 0.106 | 0.093 | **1.14x** | 0.478 | 0.402 | **1.19x** |
| threadlike | 8 | 16 | 0.199 | 0.177 | **1.13x** | 1.985 | 1.587 | **1.25x** |
| threadlike | 16 | 32 | 0.443 | 0.398 | **1.11x** | 25.237 | 21.998 | **1.15x** |
| threadlike | 32 | 64 | 1.213 | 1.128 | **1.08x** | 203.279 | 181.086 | **1.12x** |

The analytical JVP is faster in all 24 configurations, by **1.04x-2.22x**.
The analytical full Jacobian is also faster throughout, by **1.10x-6.51x**.
The largest gains occur for the dense 192-DOF model, where the directional
path avoids materializing 384 state columns and the analytical full-Jacobian
recurrence avoids the much larger autodiff graph.

## Validation

- pinned CPU affected regression suite:
  `273 passed in 1008.12s`
- final 24-case state-JVP benchmark with correctness guards: passed
- final 24-case full state-Jacobian benchmark with correctness guards: passed
- Ruff checks: passed
- `git diff --check`: passed

The benchmark commands were:

```bash
taskset -c 7 env JAX_PLATFORMS=cpu PYTHONPATH=src python \
  tools/benchmarks/pcs_custom_jvp_speed_test.py \
  --segment-counts 1 2 4 8 16 32 \
  --setups full bending_extension axial threadlike \
  --workloads state_jvp --gauss-points 5 \
  --warmup-runs 5 --repeats 20 --calls-per-sample 50

taskset -c 7 env JAX_PLATFORMS=cpu PYTHONPATH=src python \
  tools/benchmarks/pcs_custom_jvp_speed_test.py \
  --segment-counts 1 2 4 8 16 32 \
  --setups full bending_extension axial threadlike \
  --workloads state_jacobian --gauss-points 5 \
  --warmup-runs 5 --repeats 10 --calls-per-sample 2
```
