### PR TITLE
Prepare SoRoMoX v0.4.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,11 +23,11 @@ authors:
   - family-names: "Della Santina"
     given-names: "Cosimo"
 repository-code: "https://github.com/tud-phi/soromox"
-repository-artifact: "https://pypi.org/project/soromox/0.3.0/"
+repository-artifact: "https://pypi.org/project/soromox/0.4.0/"
 url: "https://tud-phi.github.io/soromox"
 license: MIT
-version: "0.3.0"
-date-released: "2026-08-25"
+version: "0.4.0"
+date-released: "2026-09-01"
 keywords:
   - "JAX"
   - "Soft Robotics"

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -35,12 +35,12 @@ If reproducibility depends materially on a particular release, we encourage an
 additional software citation for that release:
 
 ```bibtex
-@software{soromox_v0_3_0,
+@software{soromox_v0_4_0,
   title = {{SoRoMoX}: Soft Robot Models in {JAX}},
   author = {Maximilian St{\"o}lzle and Solange Gribonval and Daniel {Feliu-Talegon} and Vito Daniele Perfetta and Michele Martini and Chuhan Zhang and Kiwan Wong and Daniela Rus and Cosimo {Della Santina}},
   year = {2026},
-  version = {0.3.0},
-  url = {https://github.com/tud-phi/soromox/releases/tag/v0.3.0},
+  version = {0.4.0},
+  url = {https://github.com/tud-phi/soromox/releases/tag/v0.4.0},
 }
 ```
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -13,101 +13,116 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Added
 
-- Added optional floating-base configurations and dynamics across all system
-  families, with runtime planar or quaternion base poses, unequal configuration
-  and velocity dimensions, world-frame base velocities and wrenches, JAX
-  support for every model, vectorized JAX floating-frame Jacobian composition,
-  and specialized Warp execution for `GVS`, `PCS`, and `PlanarPCS`; see
-  [Floating-base systems](../user-guide/floating-base-systems.md).
-- Added fused Warp forward-kinematics and inertial-Jacobian execution for
-  `GVS`, `PCS`, and `PlanarPCS`, including spatial, environment, and combined
-  batches through the explicit `*_abscissa_batched` methods and `jax.vmap`.
-  Allocation-free matrix-free launchers additionally evaluate
-  `J(q, s) @ qd` and `sum_s J(q, s).T @ wrench_s` directly, reuse caller-owned
-  boundary-pose state, and compose planar or spatial floating-base products
-  without materializing sample Jacobians. Shared Warp quaternion, `SO(2)`,
-  `SO(3)`, `SE(2)`, and `SE(3)` helpers centralize rotation actions, stable
-  constant-strain operators, and exponential transforms across these paths.
-- Added optional Warp dynamics backends for `GVS`, `PCS`, and `PlanarPCS`,
-  including automatic GPU selection, arbitrary positive PCS quadrature counts,
-  JAX-routed differentiation, typed `GVSBackendParams` and `PCSBackendParams`
-  launch configuration, and reusable Warp-native execution APIs under the
-  top-level `soromox.execution` namespace; see
-  [Execution Devices and Backends](../user-guide/execution-devices-and-backends.md)
-  and [PR #177](https://github.com/tud-phi/soromox/pull/177).
-- Added public allocation-free, CUDA-graph-capturable Warp kernels, operand
-  bundles, output-shape contracts, and fused direct-effort launchers for
-  built-in linear threadlike actuation in `PlanarPCS`, `PCS`, and `GVS`.
-  Eligible `forward_dynamics` calls combine dynamics and threadlike actuation
-  in one Warp invocation for all three systems.
-
 ### Changed
-
-- Made effort laws declare their transmission-state dependencies so
-  `DirectEffort` skips unused actuator-coordinate and velocity evaluation, and
-  generalized-force assembly evaluates each actuator moment matrix only once.
-- Made the system-method and parallel-rollout benchmarks device-selectable and
-  reproducible by recording source, software, precision, accelerator, and CPU
-  affinity metadata. The system-method benchmark adds optional steady-state
-  warmup and reports median synchronized execution samples; the parallel-rollout
-  generator defaults explicitly to GPU, refuses silent CPU fallback when no
-  compatible GPU is available, and supports opt-in CPU measurements.
 
 ### Performance
 
-- Added fused Warp kinematics kernels and measured 324 matched warmed cases per
-  device across two- and eight-segment `PlanarPCS`, `PCS`, and `GVS` models,
-  1/16/256 environments, and 1/8/64 abscissae. On an RTX 5090, Warp improved
-  the geometric mean over JAX by 2.79×; the eight-segment, 256-environment,
-  64-abscissa PCS and GVS Jacobians improved 4.73× (1.596 to 0.337 ms) and
-  12.67× (7.706 to 0.608 ms). On an Intel Core Ultra 9 285K, the overall
-  geometric mean was 1.00× and large PCS cases ranged from 0.57–0.95×,
-  supporting the existing JAX-on-CPU `auto` policy.
-  Measurements used FP64, JAX 0.11.0, Warp 1.16.0, separate first-call timing,
-  two warmups, and the median of nine GPU or seven CPU synchronized repeats.
-  An Nsight Systems trace of the large fused PCS case confirmed two Warp
-  launches per call: approximately 69 microseconds for the cooperative
-  recurrence and 233 microseconds for sample evaluation. Against materializing
-  and contracting dense Jacobians at 60 samples per environment, the new
-  matrix-free path improved CUDA JVP/VJP execution by 1.88–2.77×/1.59–1.89×
-  for four-segment, 48-DOF GVS; 1.77–4.01×/1.82–2.44× for eight-segment,
-  48-DOF PCS; and 3.45–3.80×/3.20–4.03× for eight-segment, 24-DOF PlanarPCS
-  across 1, 16, and 256 environments. Directional-specific workspace was
-  44×, 43×, and 21.5× smaller, respectively. On an Intel Core Ultra 9 285K,
-  GVS JVP/VJP improved 1.51–2.35×/1.19–1.38× and PCS improved
-  4.07–6.97×/3.06–5.03×. Directional measurements used Warp 1.16.0, five
-  warmups, and medians of seven runs with 20 synchronized iterations each;
-  see [PR #191](https://github.com/tud-phi/soromox/pull/191). Optimizing the
-  floating-frame adapter further improved isolated CUDA dense-Jacobian
-  composition by 5.96–54.7×, pose composition by 2.18–3.47×, JVP composition
-  by 1.86–3.25×, and VJP composition by 1.13–1.80× across 1–256 environments
-  and 64 abscissae. Direct JAX CPU composition improved 1.06–1.70× across
-  1–1024 abscissae, and the complete four-segment PCS pose-plus-Jacobian call
-  improved 1.16× at 64 abscissae. These FP64 measurements used the same JAX
-  and Warp versions, one pinned Intel Core Ultra 9 285K core for JAX, and an
-  RTX 5090 for Warp.
-- Accelerated batched FP64 continuum dynamics on an RTX 5090 with Warp. For
-  four-segment models at batch 256, order-1 GVS dynamics terms improved 3.02×
-  (2.224 to 0.735 ms) and forward dynamics 2.40× (2.482 to 1.034 ms), while
-  five-point PlanarPCS and PCS forward dynamics improved 2.21× and 1.66×.
-  Reusing each normalized floating-root rotation across velocity and gravity
-  products additionally reduced one-segment floating PCS and GVS dynamics-term
-  runtimes by 3.2–6.2% across batches 1 and 256.
-  Warp is not a CPU optimization: single-environment order-5/9-point GVS terms
-  were 2.46× slower (0.587 to 1.445 ms), so `backend="auto"` selects JAX on CPU;
-  see [PR #177](https://github.com/tud-phi/soromox/pull/177).
-
-- Accelerated JAX GVS dynamics-term assembly with compact strain bases,
-  velocity reuse, and four bounded active-DOF prefix buckets. Against the
-  previous full-width scan for a 16-segment, strain-order-5/9-Gauss-point model,
-  warmed runtime fell 36.4% on single-environment CPU (12.65 to 8.04 ms) and
-  35.7% on 256-environment GPU (146.76 to 94.32 ms); see
-  [PR #174](https://github.com/tud-phi/soromox/pull/174).
-- Refreshed the RTX 5090 parallel-rollout results for 216 matched configurations
-  spanning 1–256 environments, with a 1.49× geometric-mean speedup over the
-  previous committed measurements, and synchronized the publication figures.
-
 ### Deprecated
+
+### Breaking changes
+
+### Fixed
+
+### Documentation
+
+### Contributors
+
+## [0.4.0] - 2026-09-01
+
+### Added
+
+- Added explicit JAX and Warp execution backends for `PlanarPCS`, `PCS`, and
+  `GVS`, with automatic backend selection, typed launch parameters, reusable
+  APIs under `soromox.execution`, and arbitrary positive PCS quadrature counts.
+  The Warp implementation provides fused forward-kinematics, full inertial
+  Jacobian, dynamics-term, and forward-dynamics paths; allocation-free,
+  CUDA-graph-capturable launchers; and direct-effort fusion for built-in linear
+  threadlike actuation.
+- Added native matrix-free Warp products for `J(q, s) @ qd` and
+  `sum_s J(q, s).T @ wrench_s`. These paths reuse caller-owned workspace and
+  floating-frame state instead of materializing a Jacobian at every spatial
+  sample.
+- Added fixed and floating-base configurations across all system families,
+  including planar and quaternion base poses, distinct configuration and
+  velocity dimensions, world-frame base velocities and wrenches, vectorized
+  JAX composition, and specialized Warp execution; see
+  [Floating-base systems](../user-guide/floating-base-systems.md).
+
+### Changed
+
+- Reworked the execution layer around shared quaternion, `SO(2)`, `SO(3)`,
+  `SE(2)`, and `SE(3)` primitives and explicit operand/output contracts, so the
+  same public model methods can dispatch to optimized JAX or Warp paths without
+  changing the model definition.
+- Reduced GVS dynamics assembly to compact strain bases and bounded active-DOF
+  prefixes, and reused intermediate velocity and floating-root rotation terms.
+- Made effort laws declare which transmission states they need. `DirectEffort`
+  now skips unused actuator-coordinate and velocity evaluation, and each
+  actuator moment matrix is assembled only once.
+- Made the system-method and parallel-rollout benchmarks device-selectable and
+  reproducible. Results now record source revision, software versions,
+  precision, accelerator, CPU affinity, warmup, and synchronized sample data;
+  GPU requests no longer fall back silently to CPU.
+
+### Performance
+
+- Fresh FP64 comparisons against v0.3.0 used Python 3.12.13, JAX 0.11.0, and
+  Warp 1.16.0. CPU runs were restricted to an otherwise-idle performance core
+  of an Intel Core Ultra 9 285K with all library thread counts set to one; GPU
+  runs used an otherwise-idle NVIDIA RTX 5090. The main grid covered
+  `PlanarPCS`, `PCS`, and order-1 `GVS`; 1, 2, 8, 16, and 32 segments; batches
+  1, 16, 64, 256, and 1024; five-point quadrature; and forward kinematics,
+  full inertial Jacobians, fused pose-plus-Jacobian evaluation, JVP, VJP,
+  dynamics terms, and forward dynamics. Kinematics cases evaluated 60 spatial
+  samples per system, whereas each dynamics case evaluated one batched state,
+  so their absolute times are not directly comparable. Results are medians of
+  seven synchronized samples after five warmups.
+- Relative to v0.3.0 across the 25 segment/batch combinations, JAX GVS
+  dynamics terms and forward dynamics improved by geometric means of 1.17× and
+  1.14× on CPU and 1.10× and 1.08× on GPU. At 32 segments and batch 1024,
+  terms/forward time fell 15.5%/14.1% on CPU and 21.2%/17.7% on GPU. GVS
+  kinematics, JVP, and VJP remained near parity, as did the corresponding
+  release-over-release `PlanarPCS` and `PCS` paths.
+- An eight-segment discretization sweep used batches 1, 256, and 1024; three-
+  and nine-point quadrature for `PlanarPCS` and `PCS`; and GVS strain-order/
+  quadrature pairs 0/5, 3/7, and 5/9. At batch 1024, order-5 GVS JAX dynamics
+  terms/forward dynamics improved 15.0%/14.1% on CPU and 29.8%/22.8% on GPU
+  relative to v0.3.0. `PlanarPCS` and `PCS` quadrature sweeps showed no
+  consistent release-over-release shift beyond run-to-run variation.
+- For the main grid, current Warp versus current JAX improved full inertial
+  GVS Jacobians by a 3.38× geometric mean on CPU and 10.88× across the 24
+  matched GPU cases; fused GVS pose-plus-Jacobian evaluation improved 3.37×
+  and 11.17×. GPU Warp also
+  improved full Jacobians by 1.35× for `PlanarPCS` and 2.53× for `PCS`. Across
+  all 25 matched GPU segment/batch cases, Warp/JAX geometric-mean speedups for
+  dynamics terms/forward dynamics were 1.00×/1.62× for `PlanarPCS`,
+  0.94×/1.16× for `PCS`, and 2.00×/1.77× for `GVS`; the value below one means
+  that PCS dynamics terms alone were about 7% slower under Warp even though PCS
+  forward dynamics was 16% faster. At 32 segments and batch 1024, the dense JAX
+  GVS Jacobian case exhausted the RTX 5090's 32-GB memory while Warp completed
+  it; Warp also improved terms/forward time by 1.27×/1.20×.
+  In the quadrature sweep, GPU Warp terms/forward geometric-mean speedups were
+  1.93×/2.66× at three points and 1.87×/1.80× at nine points for `PlanarPCS`,
+  and 1.46×/2.05× and 1.42×/1.78× for `PCS`. Small GPU workloads can still
+  favor JAX.
+- CPU Warp is primarily a dense-kinematics optimization: its full Jacobian
+  geometric means improved 1.46× for `PlanarPCS`, 1.50× for `PCS`, and 3.38×
+  for `GVS`, but JAX was 1.82×/1.78× faster overall for GVS dynamics terms /
+  forward dynamics. In the high-order sweep at batch 1024, Warp improved
+  order-0 terms/forward dynamics by 1.38×/1.34×, but was 1.46×/1.41× slower at
+  order 3 and 1.79×/1.70× slower at order 5. The CPU `auto` policy therefore
+  continues to select JAX. On GPU at the same batch, Warp's terms/forward
+  speedups tapered from 4.25×/3.68× at order 0 to 2.02×/1.64× at order 3 and
+  1.21×/1.14× at order 5; the smallest order-5 cases still favored JAX.
+- Native matrix-free Warp JVP/VJP was compared with dense Warp Jacobian
+  materialization at eight segments, 60 samples, and batches 1, 16, 64, 256,
+  and 1024. CPU JVP/VJP speedups ranged from 1.60–4.22×/1.31–5.47× for
+  `PlanarPCS`, 4.05–6.90×/3.02–5.18× for `PCS`, and
+  3.27–5.58×/1.59–1.98× for `GVS`; GPU ranges were
+  3.43–4.62×/3.22–4.67×, 1.77–7.22×/1.91–5.15×, and
+  2.08–7.89×/2.00–5.29×, respectively. Directional workspace was 21.5×,
+  43.0×, and 83.6× smaller than dense materialization. These measurements used
+  five warmups and the median of seven runs with 20 synchronized iterations.
 
 ### Breaking changes
 
@@ -154,6 +169,20 @@ and include benchmark baseline and measurement context for performance claims.
   interfaces.
 
 ### Contributors
+
+- Thanks to [@vdperfetta01](https://github.com/vdperfetta01) for sustained
+  review of the GVS optimization, execution-backend, floating-base, and API
+  changes in [PR #174](https://github.com/tud-phi/soromox/pull/174),
+  [#177](https://github.com/tud-phi/soromox/pull/177),
+  [#181](https://github.com/tud-phi/soromox/pull/181),
+  [#183](https://github.com/tud-phi/soromox/pull/183),
+  [#184](https://github.com/tud-phi/soromox/pull/184),
+  [#185](https://github.com/tud-phi/soromox/pull/185), and
+  [#186](https://github.com/tud-phi/soromox/pull/186), including identifying a
+  test failure before merge.
+- Thanks to [@mohammedtarnini](https://github.com/mohammedtarnini) and
+  [@Johannap1](https://github.com/Johannap1) for reviewing the GVS assembly
+  optimization in [PR #174](https://github.com/tud-phi/soromox/pull/174).
 
 ## [0.3.0] - 2026-08-25
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -100,15 +100,13 @@ and include benchmark baseline and measurement context for performance claims.
   that PCS dynamics terms alone were about 7% slower under Warp even though PCS
   forward dynamics was 16% faster. Individual terms/forward cases ranged from
   0.22–3.29×/0.89–2.80× for `PlanarPCS`, 0.33–2.47×/0.33–2.24× for `PCS`, and
-  0.35–5.53×/0.41–4.44× for `GVS`. These all-grid means are broader than the
-  earlier four-segment, batch-256 headline comparisons: at batch 256 across the
-  five new segment counts, the corresponding geometric means were
-  1.11×/1.93×, 1.25×/1.43×, and 2.70×/2.22×. The minima principally expose
-  fixed launch cost for one-segment terms and under-occupied persistent chain
-  kernels at 32 segments and batch 1; the maxima occurred at batch 1024. At 32
-  segments and batch 1024, the dense JAX GVS Jacobian case exhausted the RTX
-  5090's 32-GB memory while Warp completed it; Warp also improved terms/forward
-  time by 1.27×/1.20×.
+  0.35–5.53×/0.41–4.44× for `GVS`. At batch 256 across the five segment counts,
+  the corresponding geometric means were 1.11×/1.93×, 1.25×/1.43×, and
+  2.70×/2.22×. The minima principally expose fixed launch cost for one-segment
+  terms and under-occupied persistent chain kernels at 32 segments and batch 1;
+  the maxima occurred at batch 1024. At 32 segments and batch 1024, the dense
+  JAX GVS Jacobian case exhausted the RTX 5090's 32-GB memory while Warp
+  completed it; Warp also improved terms/forward time by 1.27×/1.20×.
   In the quadrature sweep, GPU Warp terms/forward geometric-mean speedups were
   1.93×/2.66× at three points and 1.87×/1.80× at nine points for `PlanarPCS`,
   and 1.46×/2.05× and 1.42×/1.78× for `PCS`. Small GPU workloads can still

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -98,9 +98,17 @@ and include benchmark baseline and measurement context for performance claims.
   dynamics terms/forward dynamics were 1.00×/1.62× for `PlanarPCS`,
   0.94×/1.16× for `PCS`, and 2.00×/1.77× for `GVS`; the value below one means
   that PCS dynamics terms alone were about 7% slower under Warp even though PCS
-  forward dynamics was 16% faster. At 32 segments and batch 1024, the dense JAX
-  GVS Jacobian case exhausted the RTX 5090's 32-GB memory while Warp completed
-  it; Warp also improved terms/forward time by 1.27×/1.20×.
+  forward dynamics was 16% faster. Individual terms/forward cases ranged from
+  0.22–3.29×/0.89–2.80× for `PlanarPCS`, 0.33–2.47×/0.33–2.24× for `PCS`, and
+  0.35–5.53×/0.41–4.44× for `GVS`. These all-grid means are broader than the
+  earlier four-segment, batch-256 headline comparisons: at batch 256 across the
+  five new segment counts, the corresponding geometric means were
+  1.11×/1.93×, 1.25×/1.43×, and 2.70×/2.22×. The minima principally expose
+  fixed launch cost for one-segment terms and under-occupied persistent chain
+  kernels at 32 segments and batch 1; the maxima occurred at batch 1024. At 32
+  segments and batch 1024, the dense JAX GVS Jacobian case exhausted the RTX
+  5090's 32-GB memory while Warp completed it; Warp also improved terms/forward
+  time by 1.27×/1.20×.
   In the quadrature sweep, GPU Warp terms/forward geometric-mean speedups were
   1.93×/2.66× at three points and 1.87×/1.80× at nine points for `PlanarPCS`,
   and 1.46×/2.05× and 1.42×/1.78× for `PCS`. Small GPU workloads can still

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ name = "soromox"  # Required
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "0.3.0"  # Required
+version = "0.4.0"  # Required
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -766,11 +766,14 @@ class GVS(SoftRobot):
         Ms = rho * vmap(jnp.diag)(Ms_diag)  # Shape: (np, 6, 6)
 
         # Pad the arrays to the maximum number of integration points and DOFs
+        # Repeat the normalized terminal node so heterogeneous quadrature rows
+        # remain nondecreasing and add only zero-width cells. Zero padding would
+        # turn ``[..., 1]`` into ``[..., 1, 0, ...]`` and create a spurious
+        # negative-width cell for runtime sample lookup.
         integration_points_full = jnp.pad(
             integration_points,
             (0, max_num_integration_points - num_integration_points_i),
-            mode="constant",
-            constant_values=1.0,
+            mode="edge",
         )
         integration_weights_full = jnp.pad(
             integration_weights,

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -770,6 +770,7 @@ class GVS(SoftRobot):
             integration_points,
             (0, max_num_integration_points - num_integration_points_i),
             mode="constant",
+            constant_values=1.0,
         )
         integration_weights_full = jnp.pad(
             integration_weights,
@@ -5976,7 +5977,10 @@ class GVS(SoftRobot):
             start = self.segment_end_positions[start_segment_index]
             end = self.segment_end_positions[end_segment_index + 1]
             s_clamped = jnp.clip(s, start, end)
-            pose = self.forward_kinematics(q, s_clamped)
+            # This hook is vectorized by renderer-side actuator adapters. Use
+            # the protected JAX primitive so nested vmaps do not re-enter the
+            # device-selected scalar execution adapter.
+            pose = self._absolute_forward_kinematics(q, s_clamped)
             point = pose @ jnp.append(routing.offset(path_params, s_clamped), 1.0)
             return point[:-1]
 

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -3218,7 +3218,10 @@ class PCS(SoftRobot):
             start = self.L_cum[start_segment_index]
             end = self.L_cum[end_segment_index + 1]
             s_clamped = jnp.clip(s, start, end)
-            pose = self.forward_kinematics(q, s_clamped)
+            # This hook is vectorized by renderer-side actuator adapters. Use
+            # the protected JAX primitive so nested vmaps do not re-enter the
+            # device-selected scalar execution adapter.
+            pose = self._absolute_forward_kinematics(q, s_clamped)
             point = pose @ jnp.append(routing.offset(path_params, s_clamped), 1.0)
             return point[:-1]
 

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -3093,7 +3093,10 @@ class PlanarPCS(SoftRobot):
             start = self.L_cum[start_segment_index]
             end = self.L_cum[end_segment_index + 1]
             s_clamped = jnp.clip(s, start, end)
-            pose = self.forward_kinematics(q, s_clamped)
+            # This hook is vectorized by renderer-side actuator adapters. Use
+            # the protected JAX primitive so nested vmaps do not re-enter the
+            # device-selected scalar execution adapter.
+            pose = self._absolute_forward_kinematics(q, s_clamped)
             normal = jnp.asarray([-jnp.sin(pose[0]), jnp.cos(pose[0])])
             offset = routing.offset(path_params, s_clamped)[1]
             return pose[1:] + offset * normal

--- a/tests/coordinate_transformations/test_actuation_space_dynamics.py
+++ b/tests/coordinate_transformations/test_actuation_space_dynamics.py
@@ -837,9 +837,11 @@ class TestActuationSpaceDynamicsSystemIndependent:
 
         M_y, Cyd, G_y = asd.dynamics_terms(q, qd)
 
-        assert_allclose(M_y, asd.inertia_matrix(q), rtol=1e-9, atol=1e-12)
-        assert_allclose(Cyd, asd.coriolis_force(q, qd), rtol=1e-9, atol=1e-12)
-        assert_allclose(G_y, asd.gravitational_force(q), rtol=1e-9, atol=1e-12)
+        # Fused Warp reductions need not reproduce the unfused accumulation
+        # order bit-for-bit on GPU.
+        assert_allclose(M_y, asd.inertia_matrix(q), rtol=1e-7, atol=1e-12)
+        assert_allclose(Cyd, asd.coriolis_force(q, qd), rtol=1e-7, atol=1e-12)
+        assert_allclose(G_y, asd.gravitational_force(q), rtol=1e-7, atol=1e-12)
 
     def test_h_unactuated_shape(self, robot):
         """Test that H_unactuated has correct shape."""

--- a/tests/coordinate_transformations/test_actuation_space_dynamics.py
+++ b/tests/coordinate_transformations/test_actuation_space_dynamics.py
@@ -837,11 +837,18 @@ class TestActuationSpaceDynamicsSystemIndependent:
 
         M_y, Cyd, G_y = asd.dynamics_terms(q, qd)
 
-        # Fused Warp reductions need not reproduce the unfused accumulation
-        # order bit-for-bit on GPU.
-        assert_allclose(M_y, asd.inertia_matrix(q), rtol=1e-7, atol=1e-12)
-        assert_allclose(Cyd, asd.coriolis_force(q, qd), rtol=1e-7, atol=1e-12)
-        assert_allclose(G_y, asd.gravitational_force(q), rtol=1e-7, atol=1e-12)
+        # Only GPU PCS uses the fused Warp reduction whose accumulation order
+        # differs from the individual JAX methods. Keep CPU/JAX and pendulum
+        # comparisons at the original stricter tolerance.
+        uses_gpu_warp = (
+            isinstance(robot, PCS)
+            and robot.backend in ("auto", "warp")
+            and jax.default_backend() == "gpu"
+        )
+        rtol = 1e-7 if uses_gpu_warp else 1e-9
+        assert_allclose(M_y, asd.inertia_matrix(q), rtol=rtol, atol=1e-12)
+        assert_allclose(Cyd, asd.coriolis_force(q, qd), rtol=rtol, atol=1e-12)
+        assert_allclose(G_y, asd.gravitational_force(q), rtol=rtol, atol=1e-12)
 
     def test_h_unactuated_shape(self, robot):
         """Test that H_unactuated has correct shape."""

--- a/tests/execution/warp/test_gvs.py
+++ b/tests/execution/warp/test_gvs.py
@@ -61,7 +61,7 @@ def _all_basis_family_model() -> GVS:
                 strain_selector=[False, True, False, False, False, False],
                 basis_order=[0, 6, 0, 0, 0, 0],
             ),
-            num_gauss_points=5,
+            num_gauss_points=5 + index % 3,
         )
         for index, basis_type in enumerate(basis_types)
     )
@@ -217,7 +217,7 @@ def test_gvs_warp_kinematics_supports_every_basis_family_and_high_order(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
-    """Match all runtime basis evaluators with basis order greater than five."""
+    """Match high-order basis evaluators with heterogeneous quadrature counts."""
 
     pytest.importorskip("warp")
     monkeypatch.setenv(

--- a/tests/lie_algebra/test_se3.py
+++ b/tests/lie_algebra/test_se3.py
@@ -223,7 +223,7 @@ def test_log_se3_matches_analytic_reverse_mode_derivative_near_identity(
     ("dtype", "rtol", "atol"),
     [
         (jnp.float64, 2e-8, 2e-10),
-        (jnp.float32, 3e-4, 3e-6),
+        (jnp.float32, 3e-4, 1e-5),
     ],
 )
 def test_log_se3_arbitrary_axis_hessian_at_series_boundary(

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -1952,6 +1952,30 @@ def test_execution_runtime_maps_follow_serial_active_coordinate_prefixes() -> No
                     assert global_column == -1
 
 
+def test_heterogeneous_quadrature_padding_repeats_terminal_node() -> None:
+    robot = build_varied_basis_gvs(num_segments=3)
+
+    for segment, num_points in enumerate(
+        onp.asarray(robot.num_integration_points, dtype=int)
+    ):
+        padded_points = robot.integration_points[segment, num_points - 1 :]
+        padded_widths = robot.cell_widths[segment, num_points - 1 :]
+
+        assert_allclose(
+            padded_points,
+            jnp.full_like(padded_points, padded_points[0]),
+            rtol=0.0,
+            atol=0.0,
+        )
+        assert_allclose(
+            padded_widths,
+            jnp.zeros_like(padded_widths),
+            rtol=0.0,
+            atol=0.0,
+        )
+        assert bool(jnp.all(jnp.diff(robot.integration_points[segment]) >= 0.0))
+
+
 def test_cached_dynamics_operands_reconstruct_dense_model_data() -> None:
     robots = (
         build_varied_basis_gvs(num_segments=3),

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -1095,7 +1095,9 @@ def test_pcs_custom_jvp_primal_methods_match_protected_hooks() -> None:
     s = model.L_cum[-1]
 
     assert_allclose(model.forward_kinematics(q, s), model._forward_kinematics(q, s))
-    assert_allclose(model.jacobian(q, s), model.jacobian_inertialframe(q, s))
+    assert_allclose(
+        model.jacobian(q, s), model.jacobian_inertialframe(q, s), atol=1e-14
+    )
     assert_allclose(model.gravitational_energy(q), model._gravitational_energy(q))
 
 

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -74,7 +74,7 @@ def test_changelog_template_matches_release_sections():
     changelog = Path(__file__).parents[1] / "docs/development/changelog.md"
     content = changelog.read_text()
     unreleased_body = content.split("## [Unreleased]\n\n", 1)[1].split(
-        "## [0.3.0]", 1
+        "\n## [", 1
     )[0]
 
     assert re.findall(r"^### (.+)$", unreleased_body, flags=re.MULTILINE) == list(

--- a/uv.lock
+++ b/uv.lock
@@ -4003,7 +4003,7 @@ wheels = [
 
 [[package]]
 name = "soromox"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "diffrax" },


### PR DESCRIPTION
## Summary

- bump the SoRoMoX release metadata from 0.3.0 to 0.4.0
- replace the PR-by-PR unreleased notes with a user-facing delta against v0.3.0
- document the JAX/Warp execution backends, matrix-free products, fixed and floating bases, breaking API changes, and reviewer contributions
- include fresh controlled CPU/GPU performance comparisons for PlanarPCS, PCS, and GVS
- fix heterogeneous GVS quadrature padding and keep renderer-vectorized threadlike geometry on the protected JAX primitive
- adjust narrow GPU numerical tolerances and release-metadata tests

## Benchmark coverage

The FP64 benchmark grid uses Python 3.12.13, JAX 0.11.0, and Warp 1.16.0:

- systems: PlanarPCS, PCS, and GVS
- segments: 1, 2, 8, 16, and 32
- batches: 1, 16, 64, 256, and 1024
- operations: forward kinematics, full inertial Jacobians, fused pose plus Jacobian, JVP, VJP, dynamics terms, and forward dynamics
- discretization sweep: PCS quadrature counts 3 and 9; GVS strain-order/quadrature pairs 0/5, 3/7, and 5/9

CPU measurements were pinned to an otherwise-idle performance core of an Intel Core Ultra 9 285K with library thread counts set to one. GPU measurements used an otherwise-idle RTX 5090. Reported main-grid results use five warmups and medians of seven synchronized samples.

Across the 25 GPU segment/batch cases, Warp/JAX geometric-mean speedups for dynamics terms/forward dynamics are:

- PlanarPCS: 1.00x / 1.62x
- PCS: 0.94x / 1.16x
- GVS: 2.00x / 1.77x

The reported directional-product measurements use the native SoRoMoX implementation and do not depend on Newton.

## Full performance benchmark tables

These tables archive the complete comparison grid used for the v0.4.0 release notes. Main-grid cells are ratios of median synchronized runtime: `v0.3.0 JAX / v0.4.0 JAX` for release deltas and `v0.4.0 JAX / v0.4.0 Warp` for backend comparisons. Values above 1× mean v0.4.0 or Warp is faster, respectively. Kinematics evaluate 60 spatial samples per system; dynamics evaluate one batched state. `—` means that comparison is unsupported or did not complete. The GPU GVS dense Jacobian and fused cases at 32 segments/batch 1024 exhausted 32 GB and therefore have 24 rather than 25 matched cases.

### Main-grid aggregate statistics

| Comparison | System | Operation | n | Geomean | Min | Median | Max |
| :-- | :-- | :-- | --: | --: | --: | --: | --: |
| CPU · JAX v0.3/v0.4 | GVS | Forward | 25 | 1.139× | 1.008× | 1.116× | 1.398× |
| CPU · JAX v0.3/v0.4 | GVS | Fused | 25 | 1.008× | 0.900× | 1.011× | 1.067× |
| CPU · JAX v0.3/v0.4 | GVS | Jacobian | 25 | 1.017× | 0.969× | 1.011× | 1.118× |
| CPU · JAX v0.3/v0.4 | GVS | JVP | 25 | 1.000× | 0.956× | 1.002× | 1.036× |
| CPU · JAX v0.3/v0.4 | GVS | FK | 25 | 1.000× | 0.944× | 0.999× | 1.079× |
| CPU · JAX v0.3/v0.4 | GVS | Terms | 25 | 1.172× | 0.914× | 1.119× | 2.146× |
| CPU · JAX v0.3/v0.4 | GVS | VJP | 25 | 0.998× | 0.961× | 0.997× | 1.032× |
| CPU · JAX v0.3/v0.4 | PCS | Forward | 25 | 1.025× | 0.975× | 1.006× | 1.553× |
| CPU · JAX v0.3/v0.4 | PCS | Fused | 25 | 1.007× | 0.929× | 1.006× | 1.068× |
| CPU · JAX v0.3/v0.4 | PCS | Jacobian | 25 | 1.011× | 0.964× | 1.004× | 1.173× |
| CPU · JAX v0.3/v0.4 | PCS | JVP | 25 | 1.001× | 0.974× | 1.000× | 1.027× |
| CPU · JAX v0.3/v0.4 | PCS | FK | 25 | 1.013× | 0.961× | 1.000× | 1.362× |
| CPU · JAX v0.3/v0.4 | PCS | Terms | 25 | 1.000× | 0.882× | 1.001× | 1.048× |
| CPU · JAX v0.3/v0.4 | PCS | VJP | 25 | 0.995× | 0.909× | 1.000× | 1.085× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | Forward | 25 | 1.024× | 0.931× | 1.000× | 2.192× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | Fused | 25 | 0.998× | 0.963× | 0.999× | 1.022× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | Jacobian | 25 | 0.995× | 0.849× | 0.998× | 1.140× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | JVP | 25 | 0.983× | 0.757× | 0.999× | 1.034× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | FK | 25 | 0.993× | 0.781× | 1.000× | 1.356× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | Terms | 25 | 1.001× | 0.857× | 1.002× | 1.135× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | VJP | 25 | 0.998× | 0.926× | 1.000× | 1.082× |
| GPU · JAX v0.3/v0.4 | GVS | Forward | 25 | 1.076× | 0.946× | 1.071× | 1.214× |
| GPU · JAX v0.3/v0.4 | GVS | Fused | 24 | 1.003× | 0.974× | 1.003× | 1.042× |
| GPU · JAX v0.3/v0.4 | GVS | Jacobian | 24 | 1.001× | 0.984× | 0.998× | 1.035× |
| GPU · JAX v0.3/v0.4 | GVS | JVP | 25 | 1.003× | 0.959× | 1.000× | 1.054× |
| GPU · JAX v0.3/v0.4 | GVS | FK | 25 | 0.999× | 0.931× | 1.002× | 1.025× |
| GPU · JAX v0.3/v0.4 | GVS | Terms | 25 | 1.105× | 0.958× | 1.094× | 1.270× |
| GPU · JAX v0.3/v0.4 | GVS | VJP | 25 | 0.995× | 0.920× | 0.996× | 1.027× |
| GPU · JAX v0.3/v0.4 | PCS | Forward | 25 | 0.997× | 0.748× | 1.003× | 1.108× |
| GPU · JAX v0.3/v0.4 | PCS | Fused | 25 | 0.990× | 0.918× | 0.994× | 1.104× |
| GPU · JAX v0.3/v0.4 | PCS | Jacobian | 25 | 1.005× | 0.895× | 0.998× | 1.086× |
| GPU · JAX v0.3/v0.4 | PCS | JVP | 25 | 0.998× | 0.911× | 0.999× | 1.099× |
| GPU · JAX v0.3/v0.4 | PCS | FK | 25 | 1.008× | 0.755× | 1.005× | 1.577× |
| GPU · JAX v0.3/v0.4 | PCS | Terms | 25 | 1.007× | 0.856× | 1.010× | 1.128× |
| GPU · JAX v0.3/v0.4 | PCS | VJP | 25 | 0.998× | 0.897× | 1.001× | 1.120× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | Forward | 25 | 1.008× | 0.759× | 1.014× | 1.230× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | Fused | 25 | 1.004× | 0.842× | 1.000× | 1.177× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | Jacobian | 25 | 1.008× | 0.808× | 1.006× | 1.167× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | JVP | 25 | 0.985× | 0.820× | 0.991× | 1.229× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | FK | 25 | 1.083× | 0.694× | 1.061× | 2.101× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | Terms | 25 | 1.010× | 0.769× | 1.002× | 1.189× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | VJP | 25 | 0.997× | 0.813× | 0.997× | 1.229× |
| CPU · JAX/Warp | GVS | Forward | 25 | 0.562× | 0.154× | 0.605× | 1.885× |
| CPU · JAX/Warp | GVS | Fused | 25 | 3.372× | 1.403× | 4.193× | 7.386× |
| CPU · JAX/Warp | GVS | Jacobian | 25 | 3.376× | 1.406× | 4.267× | 7.407× |
| CPU · JAX/Warp | GVS | FK | 25 | 0.629× | 0.236× | 0.500× | 2.337× |
| CPU · JAX/Warp | GVS | Terms | 25 | 0.550× | 0.165× | 0.587× | 2.032× |
| CPU · JAX/Warp | PCS | Fused | 25 | 1.461× | 0.709× | 1.602× | 4.087× |
| CPU · JAX/Warp | PCS | Jacobian | 25 | 1.502× | 0.708× | 1.582× | 4.046× |
| CPU · JAX/Warp | PCS | FK | 25 | 0.448× | 0.173× | 0.481× | 0.573× |
| CPU · JAX/Warp | PlanarPCS | Fused | 25 | 1.565× | 0.223× | 1.748× | 4.469× |
| CPU · JAX/Warp | PlanarPCS | Jacobian | 25 | 1.463× | 0.150× | 1.733× | 4.504× |
| CPU · JAX/Warp | PlanarPCS | FK | 25 | 0.460× | 0.103× | 0.586× | 1.400× |
| GPU · JAX/Warp | GVS | Forward | 25 | 1.773× | 0.411× | 1.892× | 4.438× |
| GPU · JAX/Warp | GVS | Fused | 24 | 11.165× | 5.201× | 11.657× | 22.543× |
| GPU · JAX/Warp | GVS | Jacobian | 24 | 10.880× | 5.121× | 10.765× | 22.073× |
| GPU · JAX/Warp | GVS | FK | 25 | 10.255× | 2.724× | 11.235× | 21.113× |
| GPU · JAX/Warp | GVS | Terms | 25 | 2.005× | 0.352× | 2.268× | 5.526× |
| GPU · JAX/Warp | PCS | Forward | 25 | 1.160× | 0.329× | 1.123× | 2.237× |
| GPU · JAX/Warp | PCS | Fused | 25 | 2.335× | 0.325× | 2.103× | 17.649× |
| GPU · JAX/Warp | PCS | Jacobian | 25 | 2.534× | 0.522× | 2.095× | 18.814× |
| GPU · JAX/Warp | PCS | FK | 25 | 1.216× | 0.262× | 1.324× | 3.546× |
| GPU · JAX/Warp | PCS | Terms | 25 | 0.935× | 0.326× | 1.083× | 2.472× |
| GPU · JAX/Warp | PlanarPCS | Forward | 25 | 1.617× | 0.885× | 1.681× | 2.796× |
| GPU · JAX/Warp | PlanarPCS | Fused | 25 | 1.504× | 0.386× | 1.514× | 10.967× |
| GPU · JAX/Warp | PlanarPCS | Jacobian | 25 | 1.353× | 0.480× | 1.343× | 9.310× |
| GPU · JAX/Warp | PlanarPCS | FK | 25 | 1.025× | 0.198× | 1.263× | 3.814× |
| GPU · JAX/Warp | PlanarPCS | Terms | 25 | 0.999× | 0.219× | 1.414× | 3.293× |

<details>
<summary>CPU: JAX v0.3.0 / JAX v0.4.0 — every main-grid case</summary>


| System | Segments | Batch | FK | Jacobian | Fused | JVP | VJP | Terms | Forward |
| :-- | --: | --: | --: | --: | --: | --: | --: | --: | --: |
| PlanarPCS | 1 | 1 | 1.356× | 1.006× | 0.999× | 0.757× | 0.990× | 1.009× | 1.027× |
| PlanarPCS | 1 | 16 | 0.781× | 1.026× | 1.022× | 0.999× | 0.995× | 0.857× | 1.000× |
| PlanarPCS | 1 | 64 | 1.002× | 1.000× | 0.995× | 0.993× | 1.003× | 1.033× | 1.018× |
| PlanarPCS | 1 | 256 | 1.014× | 1.005× | 0.977× | 1.001× | 0.995× | 0.993× | 0.980× |
| PlanarPCS | 1 | 1024 | 0.995× | 0.998× | 1.011× | 1.001× | 1.000× | 0.994× | 0.998× |
| PlanarPCS | 2 | 1 | 1.003× | 0.950× | 1.001× | 0.990× | 1.082× | 1.135× | 1.025× |
| PlanarPCS | 2 | 16 | 0.968× | 0.995× | 0.992× | 1.006× | 1.008× | 0.995× | 1.019× |
| PlanarPCS | 2 | 64 | 0.998× | 0.996× | 0.997× | 1.003× | 0.926× | 1.027× | 0.932× |
| PlanarPCS | 2 | 256 | 1.015× | 1.012× | 1.003× | 1.010× | 1.019× | 1.014× | 1.005× |
| PlanarPCS | 2 | 1024 | 0.993× | 1.020× | 1.020× | 1.002× | 0.964× | 1.009× | 1.000× |
| PlanarPCS | 8 | 1 | 1.008× | 0.849× | 1.011× | 1.034× | 1.032× | 0.996× | 0.981× |
| PlanarPCS | 8 | 16 | 0.855× | 0.993× | 1.001× | 1.001× | 1.002× | 1.000× | 2.192× |
| PlanarPCS | 8 | 64 | 0.988× | 0.998× | 1.004× | 1.013× | 0.999× | 1.002× | 1.031× |
| PlanarPCS | 8 | 256 | 1.033× | 1.011× | 1.011× | 1.007× | 1.018× | 1.039× | 0.996× |
| PlanarPCS | 8 | 1024 | 0.991× | 0.990× | 0.970× | 0.988× | 1.000× | 0.998× | 0.989× |
| PlanarPCS | 16 | 1 | 0.963× | 0.991× | 1.018× | 0.980× | 1.067× | 0.982× | 1.008× |
| PlanarPCS | 16 | 16 | 1.004× | 1.000× | 0.997× | 0.937× | 0.973× | 1.004× | 0.975× |
| PlanarPCS | 16 | 64 | 0.950× | 0.988× | 0.990× | 0.943× | 0.978× | 1.000× | 0.960× |
| PlanarPCS | 16 | 256 | 1.007× | 1.002× | 0.985× | 0.999× | 0.983× | 0.989× | 1.003× |
| PlanarPCS | 16 | 1024 | 0.979× | 1.140× | 0.963× | 0.990× | 1.004× | 1.008× | 1.000× |
| PlanarPCS | 32 | 1 | 1.025× | 1.023× | 0.989× | 0.969× | 1.002× | 1.013× | 1.003× |
| PlanarPCS | 32 | 16 | 1.000× | 0.992× | 0.993× | 1.010× | 0.969× | 1.014× | 0.969× |
| PlanarPCS | 32 | 64 | 1.000× | 0.926× | 0.989× | 0.997× | 1.006× | 0.947× | 0.931× |
| PlanarPCS | 32 | 256 | 0.997× | 0.995× | 1.003× | 0.999× | 0.992× | 1.005× | 0.985× |
| PlanarPCS | 32 | 1024 | 1.001× | 0.990× | 1.013× | 0.987× | 0.945× | 0.987× | 0.974× |
| PCS | 1 | 1 | 1.362× | 1.003× | 1.001× | 0.992× | 1.002× | 0.983× | 1.001× |
| PCS | 1 | 16 | 1.029× | 1.000× | 1.020× | 1.016× | 1.009× | 1.048× | 0.987× |
| PCS | 1 | 64 | 0.998× | 1.011× | 0.999× | 0.999× | 1.001× | 0.882× | 0.992× |
| PCS | 1 | 256 | 1.003× | 1.004× | 1.003× | 0.974× | 1.006× | 1.001× | 1.018× |
| PCS | 1 | 1024 | 1.000× | 1.001× | 0.997× | 1.000× | 1.085× | 0.998× | 1.002× |
| PCS | 2 | 1 | 1.011× | 1.025× | 1.011× | 1.019× | 1.021× | 1.021× | 1.027× |
| PCS | 2 | 16 | 0.995× | 0.995× | 1.001× | 1.002× | 0.909× | 0.996× | 1.012× |
| PCS | 2 | 64 | 0.999× | 0.999× | 1.026× | 0.990× | 1.016× | 0.999× | 1.006× |
| PCS | 2 | 256 | 1.006× | 1.016× | 1.009× | 1.014× | 1.048× | 1.006× | 1.014× |
| PCS | 2 | 1024 | 1.008× | 1.001× | 1.006× | 1.006× | 0.997× | 1.018× | 1.014× |
| PCS | 8 | 1 | 0.993× | 1.016× | 1.018× | 1.007× | 0.929× | 1.037× | 1.003× |
| PCS | 8 | 16 | 0.976× | 1.002× | 1.016× | 1.000× | 1.020× | 0.990× | 0.994× |
| PCS | 8 | 64 | 1.007× | 0.977× | 1.068× | 0.999× | 1.000× | 0.992× | 1.553× |
| PCS | 8 | 256 | 1.011× | 1.013× | 1.011× | 1.018× | 0.972× | 1.003× | 1.008× |
| PCS | 8 | 1024 | 1.012× | 1.028× | 1.003× | 1.003× | 0.978× | 0.991× | 1.041× |
| PCS | 16 | 1 | 0.961× | 1.019× | 0.990× | 1.006× | 0.988× | 1.002× | 1.008× |
| PCS | 16 | 16 | 1.051× | 1.004× | 1.000× | 0.995× | 1.002× | 0.997× | 0.975× |
| PCS | 16 | 64 | 1.008× | 1.173× | 1.032× | 0.975× | 0.995× | 1.015× | 0.991× |
| PCS | 16 | 256 | 0.991× | 0.964× | 1.012× | 1.003× | 1.000× | 0.997× | 1.079× |
| PCS | 16 | 1024 | 0.976× | 1.006× | 1.036× | 1.027× | 0.964× | 1.003× | 0.999× |
| PCS | 32 | 1 | 1.006× | 0.996× | 1.012× | 0.999× | 0.965× | 1.014× | 1.010× |
| PCS | 32 | 16 | 0.998× | 0.998× | 0.929× | 1.008× | 1.000× | 1.001× | 1.022× |
| PCS | 32 | 64 | 0.995× | 1.032× | 0.986× | 0.998× | 0.987× | 1.020× | 0.992× |
| PCS | 32 | 256 | 0.986× | 1.015× | 1.000× | 0.988× | 0.991× | 0.998× | 1.001× |
| PCS | 32 | 1024 | 0.990× | 0.998× | 0.997× | 0.990× | 1.000× | 0.999× | 0.997× |
| GVS | 1 | 1 | 0.994× | 0.987× | 1.030× | 1.004× | 0.990× | 2.146× | 1.013× |
| GVS | 1 | 16 | 1.008× | 1.012× | 1.010× | 0.996× | 0.968× | 1.086× | 1.076× |
| GVS | 1 | 64 | 1.003× | 1.024× | 1.032× | 1.003× | 0.995× | 1.077× | 1.086× |
| GVS | 1 | 256 | 1.001× | 1.028× | 1.008× | 0.989× | 0.992× | 1.079× | 1.079× |
| GVS | 1 | 1024 | 1.002× | 1.029× | 1.029× | 0.956× | 0.997× | 1.101× | 1.070× |
| GVS | 2 | 1 | 0.999× | 1.021× | 1.067× | 1.002× | 0.993× | 1.053× | 1.055× |
| GVS | 2 | 16 | 0.982× | 1.052× | 1.020× | 0.989× | 1.011× | 1.108× | 1.094× |
| GVS | 2 | 64 | 0.978× | 1.073× | 0.900× | 0.995× | 1.002× | 1.088× | 1.072× |
| GVS | 2 | 256 | 1.012× | 0.997× | 1.020× | 1.000× | 1.009× | 1.058× | 1.075× |
| GVS | 2 | 1024 | 1.079× | 1.010× | 1.023× | 1.000× | 0.996× | 0.914× | 1.008× |
| GVS | 8 | 1 | 0.944× | 1.013× | 1.014× | 1.010× | 0.961× | 1.274× | 1.236× |
| GVS | 8 | 16 | 1.008× | 1.012× | 1.011× | 0.982× | 1.000× | 1.286× | 1.248× |
| GVS | 8 | 64 | 0.966× | 1.006× | 0.989× | 1.017× | 0.972× | 1.248× | 1.234× |
| GVS | 8 | 256 | 0.987× | 1.001× | 1.004× | 1.005× | 1.004× | 1.117× | 1.099× |
| GVS | 8 | 1024 | 0.987× | 1.001× | 1.007× | 1.002× | 1.006× | 1.144× | 1.141× |
| GVS | 16 | 1 | 1.018× | 1.011× | 1.006× | 1.029× | 1.002× | 1.094× | 1.281× |
| GVS | 16 | 16 | 0.994× | 1.008× | 1.021× | 0.982× | 0.997× | 1.316× | 1.323× |
| GVS | 16 | 64 | 0.999× | 1.016× | 1.021× | 0.994× | 1.009× | 1.119× | 1.114× |
| GVS | 16 | 256 | 1.001× | 1.011× | 1.013× | 0.999× | 0.995× | 1.118× | 1.116× |
| GVS | 16 | 1024 | 1.050× | 1.005× | 1.007× | 1.008× | 0.986× | 1.169× | 1.152× |
| GVS | 32 | 1 | 0.991× | 0.969× | 0.977× | 1.036× | 1.008× | 1.457× | 1.398× |
| GVS | 32 | 16 | 0.990× | 1.025× | 1.012× | 1.008× | 0.993× | 1.141× | 1.133× |
| GVS | 32 | 64 | 0.992× | 1.118× | 1.004× | 1.003× | 1.032× | 1.144× | 1.140× |
| GVS | 32 | 256 | 1.011× | 1.003× | 1.002× | 0.991× | 1.025× | 1.160× | 1.153× |
| GVS | 32 | 1024 | 1.017× | 0.999× | 0.995× | 1.002× | 1.000× | 1.183× | 1.164× |

</details>

<details>
<summary>GPU: JAX v0.3.0 / JAX v0.4.0 — every main-grid case</summary>


| System | Segments | Batch | FK | Jacobian | Fused | JVP | VJP | Terms | Forward |
| :-- | --: | --: | --: | --: | --: | --: | --: | --: | --: |
| PlanarPCS | 1 | 1 | 0.974× | 1.001× | 1.159× | 1.040× | 1.172× | 0.991× | 0.905× |
| PlanarPCS | 1 | 16 | 1.169× | 0.991× | 1.036× | 0.989× | 0.813× | 0.994× | 0.991× |
| PlanarPCS | 1 | 64 | 0.909× | 1.028× | 1.000× | 1.033× | 1.086× | 1.189× | 1.079× |
| PlanarPCS | 1 | 256 | 1.395× | 1.018× | 1.012× | 1.026× | 0.940× | 1.152× | 0.984× |
| PlanarPCS | 1 | 1024 | 1.061× | 0.991× | 0.995× | 0.820× | 0.999× | 0.988× | 0.944× |
| PlanarPCS | 2 | 1 | 0.985× | 0.973× | 1.039× | 1.037× | 0.997× | 1.060× | 1.019× |
| PlanarPCS | 2 | 16 | 0.867× | 1.027× | 0.991× | 1.021× | 1.057× | 1.056× | 1.014× |
| PlanarPCS | 2 | 64 | 0.971× | 1.013× | 0.987× | 0.991× | 0.949× | 0.988× | 0.971× |
| PlanarPCS | 2 | 256 | 0.959× | 0.993× | 1.002× | 0.954× | 0.971× | 0.975× | 0.966× |
| PlanarPCS | 2 | 1024 | 0.970× | 0.999× | 1.006× | 1.043× | 0.982× | 1.006× | 1.008× |
| PlanarPCS | 8 | 1 | 1.108× | 1.005× | 1.056× | 0.954× | 1.012× | 0.990× | 1.018× |
| PlanarPCS | 8 | 16 | 1.166× | 0.995× | 0.994× | 0.953× | 1.004× | 1.046× | 0.972× |
| PlanarPCS | 8 | 64 | 1.124× | 0.952× | 0.945× | 0.972× | 0.989× | 0.964× | 1.065× |
| PlanarPCS | 8 | 256 | 0.983× | 1.030× | 0.973× | 0.980× | 0.937× | 1.001× | 1.040× |
| PlanarPCS | 8 | 1024 | 0.977× | 1.006× | 1.009× | 1.026× | 1.022× | 1.009× | 1.036× |
| PlanarPCS | 16 | 1 | 1.169× | 1.167× | 0.842× | 1.006× | 0.993× | 0.769× | 1.000× |
| PlanarPCS | 16 | 16 | 1.265× | 0.808× | 1.147× | 1.010× | 1.082× | 0.856× | 0.759× |
| PlanarPCS | 16 | 64 | 1.105× | 1.114× | 1.177× | 1.229× | 1.229× | 1.098× | 1.230× |
| PlanarPCS | 16 | 256 | 1.243× | 1.092× | 0.940× | 0.858× | 0.866× | 1.126× | 1.132× |
| PlanarPCS | 16 | 1024 | 2.101× | 1.023× | 1.048× | 0.978× | 0.926× | 1.002× | 0.966× |
| PlanarPCS | 32 | 1 | 0.989× | 0.821× | 0.915× | 0.888× | 1.166× | 1.092× | 1.047× |
| PlanarPCS | 32 | 16 | 0.808× | 1.000× | 1.011× | 0.932× | 0.872× | 0.954× | 1.021× |
| PlanarPCS | 32 | 64 | 1.471× | 1.100× | 0.901× | 0.823× | 1.070× | 0.974× | 1.084× |
| PlanarPCS | 32 | 256 | 1.267× | 1.066× | 0.982× | 1.092× | 0.872× | 1.052× | 1.007× |
| PlanarPCS | 32 | 1024 | 0.694× | 1.068× | 0.990× | 1.071× | 1.030× | 1.012× | 1.023× |
| PCS | 1 | 1 | 0.829× | 0.986× | 1.004× | 1.073× | 0.897× | 1.095× | 0.975× |
| PCS | 1 | 16 | 1.436× | 1.080× | 0.974× | 1.024× | 1.039× | 1.128× | 1.108× |
| PCS | 1 | 64 | 1.006× | 0.987× | 0.999× | 0.969× | 0.946× | 0.955× | 1.044× |
| PCS | 1 | 256 | 1.062× | 0.996× | 0.982× | 1.010× | 1.015× | 1.067× | 0.978× |
| PCS | 1 | 1024 | 1.024× | 0.998× | 1.001× | 0.996× | 1.005× | 0.990× | 1.016× |
| PCS | 2 | 1 | 1.019× | 0.979× | 0.996× | 1.007× | 1.002× | 1.042× | 1.022× |
| PCS | 2 | 16 | 1.005× | 0.998× | 1.014× | 0.998× | 1.001× | 0.950× | 0.978× |
| PCS | 2 | 64 | 1.024× | 1.008× | 0.977× | 0.999× | 1.010× | 0.990× | 1.007× |
| PCS | 2 | 256 | 0.970× | 0.996× | 1.008× | 0.994× | 1.001× | 0.977× | 1.009× |
| PCS | 2 | 1024 | 1.005× | 1.000× | 1.003× | 0.995× | 1.002× | 1.010× | 1.001× |
| PCS | 8 | 1 | 0.842× | 1.062× | 0.971× | 1.060× | 1.007× | 1.026× | 1.003× |
| PCS | 8 | 16 | 0.993× | 0.977× | 0.994× | 1.003× | 0.991× | 1.020× | 0.992× |
| PCS | 8 | 64 | 1.058× | 0.976× | 0.961× | 0.977× | 0.993× | 0.964× | 0.992× |
| PCS | 8 | 256 | 0.848× | 1.010× | 0.977× | 1.000× | 1.003× | 0.982× | 1.022× |
| PCS | 8 | 1024 | 0.903× | 0.996× | 1.007× | 1.003× | 0.995× | 1.012× | 1.003× |
| PCS | 16 | 1 | 0.755× | 1.086× | 0.938× | 0.987× | 1.089× | 1.041× | 0.748× |
| PCS | 16 | 16 | 0.892× | 0.966× | 0.983× | 0.911× | 0.971× | 1.042× | 1.005× |
| PCS | 16 | 64 | 1.577× | 0.895× | 0.978× | 1.029× | 1.120× | 0.981× | 1.089× |
| PCS | 16 | 256 | 0.912× | 1.007× | 0.974× | 1.016× | 1.047× | 1.041× | 1.049× |
| PCS | 16 | 1024 | 0.917× | 1.012× | 0.975× | 0.932× | 0.995× | 0.981× | 1.008× |
| PCS | 32 | 1 | 1.344× | 0.996× | 0.918× | 0.941× | 0.953× | 0.856× | 0.940× |
| PCS | 32 | 16 | 0.825× | 1.080× | 1.018× | 1.010× | 0.975× | 1.066× | 0.977× |
| PCS | 32 | 64 | 1.192× | 1.054× | 1.104× | 0.939× | 0.986× | 0.976× | 0.997× |
| PCS | 32 | 256 | 1.162× | 1.005× | 1.001× | 1.099× | 0.949× | 1.017× | 1.017× |
| PCS | 32 | 1024 | 1.004× | 0.999× | 1.007× | 0.992× | 0.976× | 0.996× | 1.001× |
| GVS | 1 | 1 | 0.992× | 0.997× | 1.006× | 0.994× | 0.990× | 1.250× | 1.173× |
| GVS | 1 | 16 | 0.995× | 1.003× | 1.003× | 0.993× | 1.013× | 1.142× | 1.092× |
| GVS | 1 | 64 | 1.025× | 1.009× | 1.012× | 1.031× | 1.014× | 1.066× | 1.071× |
| GVS | 1 | 256 | 0.988× | 0.999× | 0.983× | 0.998× | 0.920× | 1.089× | 1.066× |
| GVS | 1 | 1024 | 1.011× | 1.011× | 1.013× | 0.980× | 0.981× | 1.078× | 1.067× |
| GVS | 2 | 1 | 1.001× | 1.004× | 1.003× | 0.987× | 0.988× | 1.094× | 1.073× |
| GVS | 2 | 16 | 0.989× | 0.992× | 0.990× | 0.997× | 1.027× | 1.117× | 1.095× |
| GVS | 2 | 64 | 1.022× | 1.009× | 1.013× | 1.025× | 1.008× | 1.026× | 0.997× |
| GVS | 2 | 256 | 0.992× | 0.991× | 0.974× | 1.002× | 1.012× | 1.096× | 1.086× |
| GVS | 2 | 1024 | 1.014× | 1.022× | 1.017× | 1.030× | 1.015× | 1.067× | 1.063× |
| GVS | 8 | 1 | 1.017× | 1.001× | 1.042× | 1.054× | 0.977× | 1.014× | 0.979× |
| GVS | 8 | 16 | 1.000× | 1.000× | 0.996× | 1.010× | 0.975× | 0.971× | 0.960× |
| GVS | 8 | 64 | 0.983× | 0.992× | 0.997× | 0.990× | 0.977× | 1.060× | 1.055× |
| GVS | 8 | 256 | 1.010× | 1.035× | 1.024× | 1.013× | 1.011× | 1.133× | 1.139× |
| GVS | 8 | 1024 | 1.010× | 0.993× | 1.004× | 1.004× | 0.996× | 1.179× | 1.160× |
| GVS | 16 | 1 | 0.975× | 0.997× | 1.017× | 1.008× | 0.996× | 1.027× | 0.977× |
| GVS | 16 | 16 | 1.010× | 1.013× | 1.006× | 1.002× | 0.991× | 1.031× | 1.010× |
| GVS | 16 | 64 | 1.009× | 0.994× | 0.991× | 0.991× | 0.986× | 1.073× | 1.069× |
| GVS | 16 | 256 | 0.931× | 0.995× | 0.996× | 0.993× | 0.988× | 1.210× | 1.126× |
| GVS | 16 | 1024 | 1.004× | 0.995× | 0.989× | 0.959× | 0.994× | 1.166× | 1.147× |
| GVS | 32 | 1 | 1.010× | 0.984× | 0.996× | 1.025× | 0.999× | 0.958× | 0.946× |
| GVS | 32 | 16 | 0.994× | 0.998× | 1.003× | 1.016× | 1.009× | 1.118× | 1.055× |
| GVS | 32 | 64 | 1.011× | 0.984× | 0.997× | 0.988× | 1.015× | 1.200× | 1.134× |
| GVS | 32 | 256 | 0.976× | 1.004× | 0.991× | 1.000× | 1.007× | 1.267× | 1.207× |
| GVS | 32 | 1024 | 1.002× | — | — | 0.990× | 1.002× | 1.270× | 1.214× |

</details>

<details>
<summary>CPU: JAX / Warp at v0.4.0 — every matched main-grid case</summary>


| System | Segments | Batch | FK | Jacobian | Fused | Terms | Forward |
| :-- | --: | --: | --: | --: | --: | --: | --: |
| PlanarPCS | 1 | 1 | 0.103× | 0.150× | 0.223× | — | — |
| PlanarPCS | 1 | 16 | 0.266× | 0.613× | 0.653× | — | — |
| PlanarPCS | 1 | 64 | 0.398× | 0.915× | 0.966× | — | — |
| PlanarPCS | 1 | 256 | 0.596× | 1.075× | 1.053× | — | — |
| PlanarPCS | 1 | 1024 | 0.593× | 1.089× | 1.214× | — | — |
| PlanarPCS | 2 | 1 | 0.123× | 0.273× | 0.302× | — | — |
| PlanarPCS | 2 | 16 | 0.380× | 0.942× | 1.000× | — | — |
| PlanarPCS | 2 | 64 | 0.787× | 1.329× | 1.363× | — | — |
| PlanarPCS | 2 | 256 | 1.197× | 1.550× | 1.606× | — | — |
| PlanarPCS | 2 | 1024 | 1.400× | 1.750× | 1.797× | — | — |
| PlanarPCS | 8 | 1 | 0.164× | 0.603× | 0.597× | — | — |
| PlanarPCS | 8 | 16 | 0.322× | 1.778× | 1.762× | — | — |
| PlanarPCS | 8 | 64 | 0.510× | 1.733× | 1.748× | — | — |
| PlanarPCS | 8 | 256 | 0.660× | 1.925× | 1.974× | — | — |
| PlanarPCS | 8 | 1024 | 0.765× | 3.245× | 3.289× | — | — |
| PlanarPCS | 16 | 1 | 0.203× | 0.877× | 0.867× | — | — |
| PlanarPCS | 16 | 16 | 0.350× | 1.799× | 2.547× | — | — |
| PlanarPCS | 16 | 64 | 0.586× | 2.253× | 2.278× | — | — |
| PlanarPCS | 16 | 256 | 0.713× | 3.169× | 4.469× | — | — |
| PlanarPCS | 16 | 1024 | 0.803× | 3.646× | 3.737× | — | — |
| PlanarPCS | 32 | 1 | 0.222× | 1.566× | 1.581× | — | — |
| PlanarPCS | 32 | 16 | 0.469× | 3.740× | 3.733× | — | — |
| PlanarPCS | 32 | 64 | 0.647× | 4.504× | 4.241× | — | — |
| PlanarPCS | 32 | 256 | 0.816× | 3.639× | 4.070× | — | — |
| PlanarPCS | 32 | 1024 | 0.875× | 3.224× | 3.370× | — | — |
| PCS | 1 | 1 | 0.173× | 0.807× | 0.794× | — | — |
| PCS | 1 | 16 | 0.388× | 2.028× | 1.940× | — | — |
| PCS | 1 | 64 | 0.446× | 2.377× | 2.297× | — | — |
| PCS | 1 | 256 | 0.473× | 3.840× | 2.604× | — | — |
| PCS | 1 | 1024 | 0.485× | 4.046× | 4.087× | — | — |
| PCS | 2 | 1 | 0.264× | 0.734× | 0.720× | — | — |
| PCS | 2 | 16 | 0.412× | 1.513× | 1.451× | — | — |
| PCS | 2 | 64 | 0.472× | 1.720× | 1.686× | — | — |
| PCS | 2 | 256 | 0.509× | 3.051× | 2.237× | — | — |
| PCS | 2 | 1024 | 0.549× | 2.751× | 2.854× | — | — |
| PCS | 8 | 1 | 0.306× | 0.708× | 0.709× | — | — |
| PCS | 8 | 16 | 0.441× | 0.960× | 0.959× | — | — |
| PCS | 8 | 64 | 0.477× | 0.948× | 1.041× | — | — |
| PCS | 8 | 256 | 0.507× | 1.726× | 1.721× | — | — |
| PCS | 8 | 1024 | 0.541× | 1.865× | 1.875× | — | — |
| PCS | 16 | 1 | 0.405× | 0.813× | 0.823× | — | — |
| PCS | 16 | 16 | 0.471× | 0.910× | 0.909× | — | — |
| PCS | 16 | 64 | 0.481× | 1.560× | 1.578× | — | — |
| PCS | 16 | 256 | 0.509× | 1.709× | 1.651× | — | — |
| PCS | 16 | 1024 | 0.573× | 1.661× | 1.641× | — | — |
| PCS | 32 | 1 | 0.495× | 0.971× | 0.942× | — | — |
| PCS | 32 | 16 | 0.516× | 1.067× | 1.138× | — | — |
| PCS | 32 | 64 | 0.518× | 1.450× | 1.472× | — | — |
| PCS | 32 | 256 | 0.532× | 1.582× | 1.602× | — | — |
| PCS | 32 | 1024 | 0.570× | 1.667× | 1.672× | — | — |
| GVS | 1 | 1 | 2.319× | 2.175× | 2.075× | 0.165× | 0.154× |
| GVS | 1 | 16 | 0.910× | 1.441× | 1.449× | 0.406× | 0.409× |
| GVS | 1 | 64 | 0.520× | 1.406× | 1.403× | 0.627× | 0.639× |
| GVS | 1 | 256 | 0.435× | 2.940× | 2.915× | 0.790× | 0.808× |
| GVS | 1 | 1024 | 0.453× | 2.803× | 2.772× | 0.985× | 1.002× |
| GVS | 2 | 1 | 2.256× | 2.277× | 2.214× | 0.271× | 0.257× |
| GVS | 2 | 16 | 0.877× | 1.636× | 1.602× | 0.553× | 0.559× |
| GVS | 2 | 64 | 0.500× | 1.743× | 1.990× | 0.691× | 0.714× |
| GVS | 2 | 256 | 0.419× | 4.267× | 4.193× | 0.876× | 0.887× |
| GVS | 2 | 1024 | 0.670× | 3.498× | 3.482× | 2.032× | 1.885× |
| GVS | 8 | 1 | 2.290× | 2.904× | 2.823× | 0.371× | 0.377× |
| GVS | 8 | 16 | 0.694× | 3.075× | 3.087× | 0.381× | 0.411× |
| GVS | 8 | 64 | 0.425× | 6.143× | 6.373× | 0.451× | 0.479× |
| GVS | 8 | 256 | 0.356× | 4.403× | 4.375× | 0.925× | 0.909× |
| GVS | 8 | 1024 | 0.428× | 4.295× | 4.269× | 0.967× | 0.978× |
| GVS | 16 | 1 | 2.337× | 3.584× | 3.532× | 0.352× | 0.377× |
| GVS | 16 | 16 | 0.608× | 7.407× | 7.386× | 0.338× | 0.368× |
| GVS | 16 | 64 | 0.381× | 4.596× | 4.624× | 0.567× | 0.602× |
| GVS | 16 | 256 | 0.329× | 4.362× | 4.397× | 0.704× | 0.718× |
| GVS | 16 | 1024 | 0.347× | 4.410× | 4.413× | 0.750× | 0.771× |
| GVS | 32 | 1 | 1.930× | 4.602× | 4.587× | 0.229× | 0.248× |
| GVS | 32 | 16 | 0.526× | 4.410× | 4.297× | 0.489× | 0.516× |
| GVS | 32 | 64 | 0.353× | 4.290× | 4.321× | 0.587× | 0.605× |
| GVS | 32 | 256 | 0.236× | 4.493× | 4.480× | 0.623× | 0.633× |
| GVS | 32 | 1024 | 0.282× | 4.841× | 4.846× | 0.636× | 0.654× |

</details>

<details>
<summary>GPU: JAX / Warp at v0.4.0 — every matched main-grid case</summary>


| System | Segments | Batch | FK | Jacobian | Fused | Terms | Forward |
| :-- | --: | --: | --: | --: | --: | --: | --: |
| PlanarPCS | 1 | 1 | 0.246× | 0.480× | 0.386× | 0.291× | 1.044× |
| PlanarPCS | 1 | 16 | 0.198× | 0.482× | 0.636× | 0.219× | 1.179× |
| PlanarPCS | 1 | 64 | 0.199× | 0.684× | 1.035× | 0.286× | 0.953× |
| PlanarPCS | 1 | 256 | 0.273× | 2.326× | 2.604× | 0.359× | 1.498× |
| PlanarPCS | 1 | 1024 | 0.294× | 5.262× | 7.774× | 0.436× | 1.345× |
| PlanarPCS | 2 | 1 | 0.584× | 1.086× | 1.514× | 0.599× | 1.998× |
| PlanarPCS | 2 | 16 | 0.470× | 1.648× | 1.748× | 0.890× | 2.272× |
| PlanarPCS | 2 | 64 | 0.448× | 1.467× | 2.245× | 0.710× | 2.388× |
| PlanarPCS | 2 | 256 | 0.826× | 3.930× | 3.375× | 1.016× | 2.627× |
| PlanarPCS | 2 | 1024 | 0.832× | 9.310× | 10.967× | 1.825× | 2.784× |
| PlanarPCS | 8 | 1 | 1.199× | 1.970× | 1.931× | 1.609× | 1.909× |
| PlanarPCS | 8 | 16 | 1.717× | 2.016× | 2.155× | 1.707× | 1.681× |
| PlanarPCS | 8 | 64 | 2.028× | 2.082× | 1.920× | 1.694× | 1.785× |
| PlanarPCS | 8 | 256 | 2.006× | 1.667× | 2.075× | 2.261× | 2.124× |
| PlanarPCS | 8 | 1024 | 1.955× | 2.649× | 2.771× | 3.293× | 2.796× |
| PlanarPCS | 16 | 1 | 3.289× | 1.000× | 2.063× | 1.659× | 1.979× |
| PlanarPCS | 16 | 16 | 3.164× | 1.862× | 1.152× | 1.538× | 1.228× |
| PlanarPCS | 16 | 64 | 1.065× | 0.894× | 0.870× | 1.414× | 1.449× |
| PlanarPCS | 16 | 256 | 2.454× | 0.719× | 1.068× | 1.473× | 2.033× |
| PlanarPCS | 16 | 1024 | 1.263× | 1.343× | 1.298× | 2.087× | 2.113× |
| PlanarPCS | 32 | 1 | 1.780× | 0.848× | 0.917× | 0.715× | 0.885× |
| PlanarPCS | 32 | 16 | 3.814× | 0.766× | 0.671× | 0.991× | 0.937× |
| PlanarPCS | 32 | 64 | 1.568× | 0.551× | 0.579× | 0.878× | 0.958× |
| PlanarPCS | 32 | 256 | 2.243× | 0.530× | 0.531× | 1.414× | 1.580× |
| PlanarPCS | 32 | 1024 | 2.093× | 0.918× | 0.964× | 1.421× | 1.355× |
| PCS | 1 | 1 | 0.294× | 0.522× | 0.325× | 0.414× | 0.942× |
| PCS | 1 | 16 | 0.262× | 0.985× | 0.941× | 0.440× | 0.869× |
| PCS | 1 | 64 | 0.487× | 2.547× | 2.558× | 0.465× | 0.875× |
| PCS | 1 | 256 | 1.038× | 8.638× | 5.095× | 0.565× | 1.047× |
| PCS | 1 | 1024 | 3.458× | 18.814× | 17.649× | 1.257× | 1.634× |
| PCS | 2 | 1 | 0.669× | 1.472× | 1.593× | 0.860× | 1.370× |
| PCS | 2 | 16 | 0.501× | 1.657× | 1.654× | 0.749× | 1.297× |
| PCS | 2 | 64 | 0.931× | 3.576× | 2.151× | 1.083× | 1.472× |
| PCS | 2 | 256 | 1.485× | 8.906× | 7.951× | 1.358× | 1.772× |
| PCS | 2 | 1024 | 3.546× | 12.270× | 11.980× | 2.472× | 2.237× |
| PCS | 8 | 1 | 1.974× | 1.347× | 1.276× | 0.985× | 1.092× |
| PCS | 8 | 16 | 1.331× | 1.459× | 1.567× | 1.159× | 1.123× |
| PCS | 8 | 64 | 1.324× | 2.002× | 2.103× | 1.596× | 1.566× |
| PCS | 8 | 256 | 1.261× | 4.187× | 4.012× | 2.118× | 2.015× |
| PCS | 8 | 1024 | 2.611× | 3.567× | 3.497× | 2.100× | 1.988× |
| PCS | 16 | 1 | 1.293× | 1.136× | 1.191× | 0.514× | 1.193× |
| PCS | 16 | 16 | 2.048× | 1.380× | 1.455× | 0.817× | 0.915× |
| PCS | 16 | 64 | 1.548× | 1.836× | 1.429× | 1.248× | 0.967× |
| PCS | 16 | 256 | 2.069× | 3.571× | 3.512× | 1.670× | 1.439× |
| PCS | 16 | 1024 | 1.470× | 2.849× | 3.011× | 1.907× | 1.695× |
| PCS | 32 | 1 | 1.311× | 1.291× | 1.252× | 0.326× | 0.329× |
| PCS | 32 | 16 | 1.630× | 1.232× | 1.281× | 0.331× | 0.493× |
| PCS | 32 | 64 | 1.289× | 2.095× | 1.616× | 0.693× | 0.800× |
| PCS | 32 | 256 | 0.975× | 3.710× | 3.619× | 1.120× | 1.115× |
| PCS | 32 | 1024 | 1.573× | 2.891× | 2.919× | 1.152× | 1.121× |
| GVS | 1 | 1 | 21.113× | 20.150× | 20.471× | 1.816× | 1.714× |
| GVS | 1 | 16 | 20.142× | 19.135× | 19.181× | 1.930× | 1.712× |
| GVS | 1 | 64 | 17.811× | 19.270× | 19.291× | 2.260× | 1.870× |
| GVS | 1 | 256 | 16.304× | 22.073× | 22.543× | 2.750× | 2.431× |
| GVS | 1 | 1024 | 14.016× | 18.855× | 19.692× | 4.256× | 3.780× |
| GVS | 2 | 1 | 20.223× | 16.153× | 16.531× | 2.629× | 2.328× |
| GVS | 2 | 16 | 18.299× | 14.122× | 14.201× | 2.579× | 2.054× |
| GVS | 2 | 64 | 16.937× | 14.337× | 14.581× | 3.198× | 2.542× |
| GVS | 2 | 256 | 14.507× | 16.493× | 17.314× | 4.211× | 3.144× |
| GVS | 2 | 1024 | 11.235× | 12.320× | 12.847× | 5.526× | 4.438× |
| GVS | 8 | 1 | 14.695× | 10.004× | 10.377× | 2.030× | 1.974× |
| GVS | 8 | 16 | 13.690× | 8.956× | 8.886× | 2.323× | 1.823× |
| GVS | 8 | 64 | 12.253× | 9.199× | 9.744× | 3.393× | 2.538× |
| GVS | 8 | 256 | 7.502× | 11.852× | 12.131× | 3.709× | 2.634× |
| GVS | 8 | 1024 | 5.498× | 7.263× | 7.481× | 3.476× | 2.645× |
| GVS | 16 | 1 | 9.311× | 6.457× | 6.755× | 1.062× | 1.019× |
| GVS | 16 | 16 | 6.625× | 6.518× | 6.320× | 1.151× | 1.134× |
| GVS | 16 | 64 | 8.695× | 7.482× | 7.251× | 1.806× | 1.522× |
| GVS | 16 | 256 | 6.120× | 9.921× | 11.183× | 2.461× | 2.102× |
| GVS | 16 | 1024 | 3.700× | 7.468× | 7.680× | 2.268× | 1.892× |
| GVS | 32 | 1 | 11.200× | 5.121× | 5.201× | 0.352× | 0.411× |
| GVS | 32 | 16 | 8.091× | 5.212× | 5.506× | 0.466× | 0.644× |
| GVS | 32 | 64 | 8.110× | 7.232× | 7.221× | 1.072× | 1.068× |
| GVS | 32 | 256 | 4.297× | 11.525× | 12.262× | 1.350× | 1.283× |
| GVS | 32 | 1024 | 2.724× | — | — | 1.269× | 1.199× |

</details>

### Eight-segment discretization sweep

| Comparison | System | Discretization | Operation | n | Geomean | Min | Median | Max |
| :-- | :-- | :-- | :-- | --: | --: | --: | --: | --: |
| CPU · JAX v0.3/v0.4 | GVS | order 0, Q5 | Forward | 3 | 1.133× | 1.074× | 1.157× | 1.172× |
| CPU · JAX v0.3/v0.4 | GVS | order 0, Q5 | Terms | 3 | 1.118× | 1.058× | 1.108× | 1.193× |
| CPU · JAX v0.3/v0.4 | GVS | order 3, Q7 | Forward | 3 | 1.266× | 1.131× | 1.152× | 1.557× |
| CPU · JAX v0.3/v0.4 | GVS | order 3, Q7 | Terms | 3 | 1.147× | 1.136× | 1.151× | 1.153× |
| CPU · JAX v0.3/v0.4 | GVS | order 5, Q9 | Forward | 3 | 1.199× | 1.163× | 1.165× | 1.273× |
| CPU · JAX v0.3/v0.4 | GVS | order 5, Q9 | Terms | 3 | 1.332× | 1.177× | 1.301× | 1.542× |
| CPU · JAX v0.3/v0.4 | PCS | Q3 | Forward | 3 | 1.031× | 0.961× | 1.039× | 1.096× |
| CPU · JAX v0.3/v0.4 | PCS | Q3 | Terms | 3 | 0.994× | 0.952× | 1.004× | 1.027× |
| CPU · JAX v0.3/v0.4 | PCS | Q9 | Forward | 3 | 1.003× | 0.990× | 1.000× | 1.018× |
| CPU · JAX v0.3/v0.4 | PCS | Q9 | Terms | 3 | 1.003× | 0.975× | 0.996× | 1.038× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | Q3 | Forward | 3 | 0.990× | 0.981× | 0.994× | 0.996× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | Q3 | Terms | 3 | 1.057× | 1.033× | 1.065× | 1.073× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | Q9 | Forward | 3 | 1.012× | 1.003× | 1.017× | 1.017× |
| CPU · JAX v0.3/v0.4 | PlanarPCS | Q9 | Terms | 3 | 0.960× | 0.920× | 0.965× | 0.994× |
| GPU · JAX v0.3/v0.4 | GVS | order 0, Q5 | Forward | 3 | 1.024× | 0.950× | 1.034× | 1.092× |
| GPU · JAX v0.3/v0.4 | GVS | order 0, Q5 | Terms | 3 | 0.994× | 0.938× | 1.008× | 1.038× |
| GPU · JAX v0.3/v0.4 | GVS | order 3, Q7 | Forward | 3 | 1.077× | 0.938× | 1.137× | 1.173× |
| GPU · JAX v0.3/v0.4 | GVS | order 3, Q7 | Terms | 3 | 1.152× | 0.956× | 1.227× | 1.302× |
| GPU · JAX v0.3/v0.4 | GVS | order 5, Q9 | Forward | 3 | 1.167× | 0.938× | 1.295× | 1.308× |
| GPU · JAX v0.3/v0.4 | GVS | order 5, Q9 | Terms | 3 | 1.239× | 0.936× | 1.423× | 1.429× |
| GPU · JAX v0.3/v0.4 | PCS | Q3 | Forward | 3 | 0.775× | 0.468× | 0.946× | 1.051× |
| GPU · JAX v0.3/v0.4 | PCS | Q3 | Terms | 3 | 0.980× | 0.892× | 0.950× | 1.109× |
| GPU · JAX v0.3/v0.4 | PCS | Q9 | Forward | 3 | 1.115× | 0.994× | 1.007× | 1.385× |
| GPU · JAX v0.3/v0.4 | PCS | Q9 | Terms | 3 | 1.031× | 0.970× | 0.986× | 1.146× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | Q3 | Forward | 3 | 1.103× | 1.043× | 1.128× | 1.142× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | Q3 | Terms | 3 | 1.056× | 0.961× | 1.097× | 1.115× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | Q9 | Forward | 3 | 0.923× | 0.729× | 0.981× | 1.101× |
| GPU · JAX v0.3/v0.4 | PlanarPCS | Q9 | Terms | 3 | 0.828× | 0.644× | 0.875× | 1.007× |
| CPU · JAX/Warp | GVS | order 0, Q5 | Forward | 3 | 0.928× | 0.487× | 1.228× | 1.337× |
| CPU · JAX/Warp | GVS | order 0, Q5 | Terms | 3 | 0.927× | 0.475× | 1.209× | 1.385× |
| CPU · JAX/Warp | GVS | order 3, Q7 | Forward | 3 | 0.504× | 0.279× | 0.643× | 0.712× |
| CPU · JAX/Warp | GVS | order 3, Q7 | Terms | 3 | 0.507× | 0.301× | 0.631× | 0.686× |
| CPU · JAX/Warp | GVS | order 5, Q9 | Forward | 3 | 0.440× | 0.265× | 0.546× | 0.587× |
| CPU · JAX/Warp | GVS | order 5, Q9 | Terms | 3 | 0.385× | 0.197× | 0.521× | 0.558× |
| GPU · JAX/Warp | GVS | order 0, Q5 | Forward | 3 | 3.436× | 2.822× | 3.676× | 3.909× |
| GPU · JAX/Warp | GVS | order 0, Q5 | Terms | 3 | 3.463× | 2.885× | 3.387× | 4.251× |
| GPU · JAX/Warp | GVS | order 3, Q7 | Forward | 3 | 1.465× | 1.048× | 1.636× | 1.835× |
| GPU · JAX/Warp | GVS | order 3, Q7 | Terms | 3 | 1.618× | 0.973× | 2.021× | 2.152× |
| GPU · JAX/Warp | GVS | order 5, Q9 | Forward | 3 | 0.945× | 0.611× | 1.142× | 1.209× |
| GPU · JAX/Warp | GVS | order 5, Q9 | Terms | 3 | 0.954× | 0.538× | 1.207× | 1.336× |
| GPU · JAX/Warp | PCS | Q3 | Forward | 3 | 2.046× | 1.593× | 2.298× | 2.341× |
| GPU · JAX/Warp | PCS | Q3 | Terms | 3 | 1.458× | 0.729× | 1.888× | 2.249× |
| GPU · JAX/Warp | PCS | Q9 | Forward | 3 | 1.775× | 1.267× | 1.936× | 2.279× |
| GPU · JAX/Warp | PCS | Q9 | Terms | 3 | 1.423× | 0.661× | 1.795× | 2.429× |
| GPU · JAX/Warp | PlanarPCS | Q3 | Forward | 3 | 2.661× | 1.678× | 3.279× | 3.424× |
| GPU · JAX/Warp | PlanarPCS | Q3 | Terms | 3 | 1.931× | 1.175× | 1.712× | 3.576× |
| GPU · JAX/Warp | PlanarPCS | Q9 | Forward | 3 | 1.799× | 1.615× | 1.769× | 2.037× |
| GPU · JAX/Warp | PlanarPCS | Q9 | Terms | 3 | 1.871× | 0.937× | 2.483× | 2.817× |

At batch 1024, the exact GVS high-order medians were:

| Comparison | Order | Quadrature | Operation | Numerator ms | Denominator ms | Speedup | Runtime change |
| :-- | --: | --: | :-- | --: | --: | --: | --: |
| CPU · JAX v0.3→v0.4 | 0 | 5 | Terms | 256.858 | 231.850 | 1.108× | -9.74% |
| CPU · JAX v0.3→v0.4 | 0 | 5 | Forward | 279.032 | 241.166 | 1.157× | -13.57% |
| CPU · JAX v0.3→v0.4 | 3 | 7 | Terms | 1691.526 | 1469.410 | 1.151× | -13.13% |
| CPU · JAX v0.3→v0.4 | 3 | 7 | Forward | 1892.648 | 1643.087 | 1.152× | -13.19% |
| CPU · JAX v0.3→v0.4 | 5 | 9 | Terms | 3711.413 | 3154.233 | 1.177× | -15.01% |
| CPU · JAX v0.3→v0.4 | 5 | 9 | Forward | 4177.831 | 3587.033 | 1.165× | -14.14% |
| GPU · JAX v0.3→v0.4 | 0 | 5 | Terms | 9.844 | 9.481 | 1.038× | -3.69% |
| GPU · JAX v0.3→v0.4 | 0 | 5 | Forward | 10.607 | 9.712 | 1.092× | -8.44% |
| GPU · JAX v0.3→v0.4 | 3 | 7 | Terms | 37.481 | 30.539 | 1.227× | -18.52% |
| GPU · JAX v0.3→v0.4 | 3 | 7 | Forward | 46.078 | 39.285 | 1.173× | -14.74% |
| GPU · JAX v0.3→v0.4 | 5 | 9 | Terms | 85.640 | 60.164 | 1.423× | -29.75% |
| GPU · JAX v0.3→v0.4 | 5 | 9 | Forward | 111.371 | 85.998 | 1.295× | -22.78% |
| CPU · JAX→Warp | 0 | 5 | Terms | 231.850 | 167.346 | 1.385× | -27.82% |
| CPU · JAX→Warp | 0 | 5 | Forward | 241.166 | 180.350 | 1.337× | -25.22% |
| CPU · JAX→Warp | 3 | 7 | Terms | 1469.410 | 2141.866 | 0.686× | +45.76% |
| CPU · JAX→Warp | 3 | 7 | Forward | 1643.087 | 2308.613 | 0.712× | +40.50% |
| CPU · JAX→Warp | 5 | 9 | Terms | 3154.233 | 5657.223 | 0.558× | +79.35% |
| CPU · JAX→Warp | 5 | 9 | Forward | 3587.033 | 6114.988 | 0.587× | +70.47% |
| GPU · JAX→Warp | 0 | 5 | Terms | 9.481 | 2.230 | 4.251× | -76.48% |
| GPU · JAX→Warp | 0 | 5 | Forward | 9.712 | 2.642 | 3.676× | -72.79% |
| GPU · JAX→Warp | 3 | 7 | Terms | 30.539 | 15.110 | 2.021× | -50.52% |
| GPU · JAX→Warp | 3 | 7 | Forward | 39.285 | 24.019 | 1.636× | -38.86% |
| GPU · JAX→Warp | 5 | 9 | Terms | 60.164 | 49.835 | 1.207× | -17.17% |
| GPU · JAX→Warp | 5 | 9 | Forward | 85.998 | 75.323 | 1.142× | -12.41% |

### Native matrix-free Warp JVP/VJP

Eight segments, 60 samples, five warmups, and medians of seven runs with 20 synchronized iterations. Speedup is dense Warp Jacobian materialization divided by the native directional path; workspace is dense divided by directional workspace.

| Device | System | Batch | Dense JVP ms | Native JVP ms | JVP speedup | Dense VJP ms | Native VJP ms | VJP speedup | Workspace |
| :-- | :-- | --: | --: | --: | --: | --: | --: | --: | --: |
| CPU | PlanarPCS | 1 | 0.038 | 0.024 | 1.601× | 0.037 | 0.028 | 1.312× | 21.5× |
| CPU | PlanarPCS | 16 | 0.244 | 0.078 | 3.120× | 0.251 | 0.072 | 3.509× | 21.5× |
| CPU | PlanarPCS | 64 | 0.924 | 0.252 | 3.673× | 0.961 | 0.209 | 4.590× | 21.5× |
| CPU | PlanarPCS | 256 | 3.579 | 0.953 | 3.757× | 3.770 | 0.759 | 4.964× | 21.5× |
| CPU | PlanarPCS | 1024 | 15.797 | 3.747 | 4.216× | 16.261 | 2.975 | 5.466× | 21.5× |
| CPU | PCS | 1 | 0.159 | 0.039 | 4.047× | 0.160 | 0.053 | 3.018× | 43.0× |
| CPU | PCS | 16 | 2.202 | 0.354 | 6.216× | 2.250 | 0.485 | 4.639× | 43.0× |
| CPU | PCS | 64 | 8.780 | 1.363 | 6.440× | 9.161 | 1.870 | 4.900× | 43.0× |
| CPU | PCS | 256 | 37.294 | 5.407 | 6.897× | 37.772 | 7.400 | 5.105× | 43.0× |
| CPU | PCS | 1024 | 148.788 | 21.607 | 6.886× | 153.205 | 29.566 | 5.182× | 43.0× |
| CPU | GVS | 1 | 0.190 | 0.058 | 3.266× | 0.193 | 0.121 | 1.588× | 83.6× |
| CPU | GVS | 16 | 2.582 | 0.554 | 4.664× | 2.753 | 1.460 | 1.886× | 83.6× |
| CPU | GVS | 64 | 10.933 | 2.140 | 5.109× | 11.377 | 5.739 | 1.982× | 83.6× |
| CPU | GVS | 256 | 47.415 | 8.500 | 5.578× | 47.011 | 24.278 | 1.936× | 83.6× |
| CPU | GVS | 1024 | 187.639 | 34.576 | 5.427× | 188.940 | 97.106 | 1.946× | 83.6× |
| GPU | PlanarPCS | 1 | 0.162 | 0.047 | 3.428× | 0.179 | 0.056 | 3.218× | 21.5× |
| GPU | PlanarPCS | 16 | 0.173 | 0.048 | 3.574× | 0.189 | 0.057 | 3.340× | 21.5× |
| GPU | PlanarPCS | 64 | 0.229 | 0.050 | 4.623× | 0.247 | 0.056 | 4.389× | 21.5× |
| GPU | PlanarPCS | 256 | 0.370 | 0.097 | 3.818× | 0.388 | 0.096 | 4.020× | 21.5× |
| GPU | PlanarPCS | 1024 | 0.496 | 0.113 | 4.384× | 0.506 | 0.108 | 4.675× | 21.5× |
| GPU | PCS | 1 | 0.283 | 0.076 | 3.732× | 0.298 | 0.126 | 2.361× | 43.0× |
| GPU | PCS | 16 | 0.324 | 0.081 | 4.005× | 0.328 | 0.128 | 2.562× | 43.0× |
| GPU | PCS | 64 | 0.324 | 0.089 | 3.647× | 0.329 | 0.131 | 2.523× | 43.0× |
| GPU | PCS | 256 | 0.333 | 0.189 | 1.768× | 0.338 | 0.177 | 1.906× | 43.0× |
| GPU | PCS | 1024 | 1.541 | 0.213 | 7.221× | 1.318 | 0.256 | 5.147× | 43.0× |
| GPU | GVS | 1 | 0.750 | 0.196 | 3.823× | 0.735 | 0.303 | 2.427× | 83.6× |
| GPU | GVS | 16 | 0.866 | 0.205 | 4.222× | 0.830 | 0.320 | 2.597× | 83.6× |
| GPU | GVS | 64 | 0.878 | 0.233 | 3.769× | 0.842 | 0.343 | 2.454× | 83.6× |
| GPU | GVS | 256 | 0.949 | 0.455 | 2.084× | 0.914 | 0.458 | 1.997× | 83.6× |
| GPU | GVS | 1024 | 3.983 | 0.505 | 7.894× | 3.608 | 0.682 | 5.293× | 83.6× |

## Validation

- full test run before the final renderer fix: 2003 passed, 1 skipped, 1 failed
- affected cross-family CUDA tests after the renderer fix: 40 passed
- release metadata/changelog tests: 12 passed
- Ruff checks
- clean Zensical documentation build
- check-manifest
- wheel and source-distribution build
- Twine package checks

The historical v0.3.0 changelog section remains byte-for-byte unchanged.
