### PR TITLE
Add Soromox semi-implicit Euler integration

### DIFF
--- a/docs/api/simulation/integrators.md
+++ b/docs/api/simulation/integrators.md
@@ -1,0 +1,97 @@
+# Simulation Integrators
+
+Soromox provides Diffrax-compatible solvers for state layouts and dynamics that
+need integration behavior beyond Diffrax's generic solver collection.
+
+## Diffrax solvers
+
+Soromox rollouts accept any compatible `diffrax.AbstractSolver` through the
+`solver` argument. This includes standard Diffrax methods such as `Tsit5`,
+`Dopri5`, `Bosh3`, `Heun`, and `Euler`; `Tsit5` remains the default when no
+solver is supplied. See Diffrax's
+[ODE solver catalog](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/)
+for the complete collection. Use a compatible
+[step-size controller](https://docs.kidger.site/diffrax/api/stepsize_controller/)
+when adaptive stepping is desired.
+
+Standard Diffrax solvers operate on the complete first-order Soromox state, so
+they support `[q, qd, auxiliary]` layouts, including unequal spatial
+floating-base configuration and velocity dimensions. Before every dynamics
+evaluation and on saved output, Soromox projects the state through the system's
+`project_state` hook. Spatial floating-base robots therefore present a
+normalized quaternion to the dynamics and return normalized saved states.
+
+!!! warning "Floating-base quaternion integration"
+    Standard Diffrax solvers advance the stored quaternion in its ambient
+    coordinates. Soromox projects the quaternion before dynamics evaluations
+    and on saved output, but these solvers do not perform a Lie-group retraction
+    at each Runge--Kutta stage. Validate the timestep or adaptive tolerances for
+    the floating-base model and operating range.
+
+```python
+from diffrax import PIDController, Tsit5
+
+trajectory = robot.rollout_to(
+    initial_state=initial_state,
+    t1=1.0,
+    solver_dt=1e-4,
+    save_dt=1e-2,
+    solver=Tsit5(),
+    stepsize_controller=PIDController(rtol=1e-5, atol=1e-7),
+)
+```
+
+## Semi-implicit Euler
+
+`SemiImplicitEuler` is a deterministic, first-order kick–drift integrator for
+Soromox systems whose state is ordered as
+
+\[
+y = \begin{bmatrix}q & qd & auxiliary\end{bmatrix}^{\mathsf T}.
+\]
+
+For a fixed step \(h\), it evaluates the complete forward dynamics at the old
+state and updates velocity before configuration:
+
+\[
+qd_{n+1} = qd_n + h\,qdd(q_n, qd_n),
+\qquad
+q_{n+1} = \operatorname{retract}(q_n, h\,qd_{n+1}).
+\]
+
+This kick–drift ordering is generally more stable for oscillatory mechanical
+systems than forward Euler. It remains a conditionally stable, first-order
+method, so the timestep must still be validated for the model family and
+operating range.
+
+```python
+from soromox.simulation import SemiImplicitEuler
+from soromox.systems import SystemState
+
+trajectory = robot.rollout_to(
+    initial_state=SystemState(t=0.0, y=y0),
+    t1=1.0,
+    solver_dt=1e-5,
+    save_dt=1e-2,
+    solver=SemiImplicitEuler(robot),
+)
+```
+
+!!! warning "Soromox-specific state and dynamics contract"
+    The primary integrated state must follow the system's `[q, qd, auxiliary]`
+    contract. The solver calls the system's state and retraction helpers, which
+    support unequal floating-base configuration and velocity dimensions and
+    preserve spatial quaternion geometry. It is not a general-purpose
+    semi-implicit method for arbitrary Diffrax PyTrees. Unlike
+    `diffrax.SemiImplicitEuler`, which requires a separable two-term vector
+    field, the Soromox implementation evaluates the full derivative because its
+    acceleration can depend on both configuration and velocity. It then applies
+    the mechanical kick--drift update to the `[q, qd, auxiliary]` leaf. Optional
+    Diffrax-level control and environment states are advanced with forward Euler.
+
+::: soromox.simulation.SemiImplicitEuler
+    options:
+      show_root_heading: true
+      show_source: false
+      heading_level: 2
+      members_order: source

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,8 @@ nav:
           - GVS Systems:
             - Overview: api/systems/gvs/index.md
             - GVS: api/systems/gvs/gvs.md
+      - Simulation:
+          - Integrators: api/simulation/integrators.md
       - Execution Backends:
           - Overview: api/execution/index.md
           - Configuration: api/execution/configuration.md

--- a/paper_results/secIVb_parallel_rollouts_gpu/README.md
+++ b/paper_results/secIVb_parallel_rollouts_gpu/README.md
@@ -23,6 +23,14 @@ PlanarPCS. Run each backend in a separate process for a controlled comparison;
 JAX-only systems continue to use JAX. The CSV records the requested backend,
 the backend resolved for each system, and whether backend selection applies.
 
+Each `(system, size, Gauss-point setting, batch size)` case runs in a fresh
+process. Successful rows are checkpointed to the results CSV immediately, so
+an out-of-memory failure cannot discard earlier measurements. Failed cases are
+skipped and summarized after the remaining cases finish; the machine-readable
+report defaults to `data/benchmark_results_failures.csv`. Pass
+`--failures-csv PATH` to choose another location. Expected OOM-only failures do
+not make the generator exit unsuccessfully, while unexpected worker errors do.
+
 Use `--solver` to select `euler`, `semi-implicit-euler`, `heun`, `bosh3`,
 `tsit5`, or `dopri5`; the default remains `tsit5`. The selected solver applies
 to every requested system and model size. The CSV records the solver together

--- a/paper_results/secIVb_parallel_rollouts_gpu/README.md
+++ b/paper_results/secIVb_parallel_rollouts_gpu/README.md
@@ -23,6 +23,12 @@ PlanarPCS. Run each backend in a separate process for a controlled comparison;
 JAX-only systems continue to use JAX. The CSV records the requested backend,
 the backend resolved for each system, and whether backend selection applies.
 
+Use `--solver` to select `euler`, `semi-implicit-euler`, `heun`, `bosh3`,
+`tsit5`, or `dopri5`; the default remains `tsit5`. The selected solver applies
+to every requested system and model size. The CSV records the solver together
+with `rollout_finite` and `max_abs_state`, so throughput measurements can be
+screened for numerical divergence rather than interpreted on timing alone.
+
 Install dependencies and confirm that JAX sees the intended GPU:
 
 ```bash
@@ -37,7 +43,7 @@ uv run python paper_results/secIVb_parallel_rollouts_gpu/code/generate_parallel_
   --systems articulated_soft_robot planar_pcs pcs gvs \
   --gvs-scaling segments --segment-counts 1 2 4 8 16 32 \
   --batch-sizes 1 2 4 8 16 32 64 128 256 \
-  --duration 1 --solver-dt 1e-4 --save-dt 1e-2
+  --duration 1 --solver tsit5 --solver-dt 1e-4 --save-dt 1e-2
 ```
 
 Generate the GVS strain-basis-order sweep:

--- a/paper_results/secIVb_parallel_rollouts_gpu/code/generate_parallel_rollout_benchmark.py
+++ b/paper_results/secIVb_parallel_rollouts_gpu/code/generate_parallel_rollout_benchmark.py
@@ -46,9 +46,11 @@ _EARLY_DEVICE_CHOICE = (
 
 import jax
 import jax.numpy as jnp
+from diffrax import Bosh3, Dopri5, Euler, Heun, Tsit5
 
 jax.config.update("jax_enable_x64", True)
 
+from soromox.simulation import SemiImplicitEuler  # noqa: E402
 from soromox.systems import DynamicalSystem, SystemState  # noqa: E402
 from tools.benchmarks._benchmark_common import (  # noqa: E402
     add_backend_arg,
@@ -76,6 +78,36 @@ DEFAULT_CSV_PATH = DATA_DIR / "benchmark_results.csv"
 DEFAULT_SYSTEMS = ["articulated_soft_robot", "planar_pcs", "pcs", "gvs"]
 DEFAULT_SEGMENT_COUNTS = [1, 2, 4, 8, 16, 32]
 DEFAULT_GVS_BASIS_ORDERS = [0, 1, 2, 3, 4, 5]
+DEFAULT_SOLVER = "tsit5"
+SOLVER_NAMES = (
+    "euler",
+    "semi-implicit-euler",
+    "heun",
+    "bosh3",
+    "tsit5",
+    "dopri5",
+)
+
+
+def _make_solver(name: str, system: DynamicalSystem | None = None):
+    """Construct one of the fixed-step solvers supported by this benchmark."""
+
+    if name == "semi-implicit-euler":
+        if system is None:
+            raise ValueError("semi-implicit-euler requires a Soromox system.")
+        return SemiImplicitEuler(system)
+
+    factories = {
+        "euler": Euler,
+        "heun": Heun,
+        "bosh3": Bosh3,
+        "tsit5": Tsit5,
+        "dopri5": Dopri5,
+    }
+    try:
+        return factories[name]()
+    except KeyError as exc:  # pragma: no cover - argparse validates CLI input
+        raise ValueError(f"Unknown solver {name!r}.") from exc
 
 
 @dataclass
@@ -83,6 +115,7 @@ class RuntimeConfig:
     duration: float
     solver_dt: float
     save_dt: float
+    solver: str = DEFAULT_SOLVER
     t0: float = 0.0
 
 
@@ -160,6 +193,7 @@ def _build_batched_solver(
     system: DynamicalSystem, runtime: RuntimeConfig
 ) -> Callable[..., tuple[Array, Array, Array]]:
     t1 = runtime.t0 + runtime.duration
+    solver = _make_solver(runtime.solver, system)
 
     def single_env(
         q0: Array, qd0: Array, u: Array, tau_ext: Array
@@ -172,6 +206,7 @@ def _build_batched_solver(
             t1=t1,
             solver_dt=runtime.solver_dt,
             save_dt=runtime.save_dt,
+            solver=solver,
         )
         qs, qds = jnp.split(trajectory.y, 2, axis=1)
         return trajectory.t[-1], qs[-1], qds[-1]
@@ -222,6 +257,7 @@ def _write_csv(results: Sequence[Mapping[str, Any]], path: Path) -> None:
         "dof",
         "batch_size",
         "duration_s",
+        "solver",
         "solver_dt",
         "save_dt",
         "wall_time_s",
@@ -234,6 +270,8 @@ def _write_csv(results: Sequence[Mapping[str, Any]], path: Path) -> None:
         "noise_scale",
         "warmup_runs",
         "timing_repeats",
+        "rollout_finite",
+        "max_abs_state",
         "backend",
         "resolved_backend",
         "backend_applies",
@@ -381,6 +419,15 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     add_gauss_point_args(parser)
     add_integration_args(parser)
     parser.add_argument(
+        "--solver",
+        choices=SOLVER_NAMES,
+        default=DEFAULT_SOLVER,
+        help=(
+            "Fixed-step numerical integrator used for every rollout "
+            f"(default: {DEFAULT_SOLVER})."
+        ),
+    )
+    parser.add_argument(
         "--gvs-scaling",
         "--gvs-variant",
         choices=("segments", "basis-order"),
@@ -424,7 +471,7 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         "--noise-scale",
         type=float,
         default=1e-3,
-        help="Standard deviation of per-environment perturbations applied to q/qdot",
+        help="Standard deviation of per-environment perturbations applied to q/qd",
     )
     parser.add_argument(
         "--seed",
@@ -505,6 +552,7 @@ def _run_benchmarks(args: argparse.Namespace, device: jax.Device) -> int:
         duration=args.duration,
         solver_dt=args.solver_dt,
         save_dt=args.save_dt,
+        solver=args.solver,
     )
     registry = dict(get_system_registry())
     if args.gvs_scaling == "basis-order":
@@ -572,6 +620,13 @@ def _run_benchmarks(args: argparse.Namespace, device: jax.Device) -> int:
                         repeats=args.repeats,
                     )
                     ts_last, *_ = outputs
+                    state_outputs = outputs[1:]
+                    rollout_finite = bool(
+                        all(jnp.all(jnp.isfinite(value)) for value in state_outputs)
+                    )
+                    max_abs_state = float(
+                        max(jnp.max(jnp.abs(value)) for value in state_outputs)
+                    )
                     sim_time = float(jnp.mean(ts_last) - runtime.t0)
                     total_sim_time = sim_time * batch
                     per_env_speed = (
@@ -582,11 +637,12 @@ def _run_benchmarks(args: argparse.Namespace, device: jax.Device) -> int:
                     )
                     per_env_wall = wall_time / batch
 
+                    stability_note = "" if rollout_finite else " | NON-FINITE STATE"
                     print(
                         f"     batch={batch:>4d} | wall={wall_time:.4f}s | "
                         f"per-env sim/wall={per_env_speed:.2f}x | "
                         f"total sim/wall={total_speed:.2f}x | "
-                        f"per-env wall={per_env_wall:.5f}s"
+                        f"per-env wall={per_env_wall:.5f}s{stability_note}"
                     )
 
                     results.append(
@@ -603,6 +659,7 @@ def _run_benchmarks(args: argparse.Namespace, device: jax.Device) -> int:
                             "dof": dof,
                             "batch_size": batch,
                             "duration_s": args.duration,
+                            "solver": args.solver,
                             "solver_dt": args.solver_dt,
                             "save_dt": args.save_dt,
                             "wall_time_s": wall_time,
@@ -615,6 +672,8 @@ def _run_benchmarks(args: argparse.Namespace, device: jax.Device) -> int:
                             "noise_scale": args.noise_scale,
                             "warmup_runs": args.warmup_runs,
                             "timing_repeats": args.repeats,
+                            "rollout_finite": rollout_finite,
+                            "max_abs_state": max_abs_state,
                             "backend": args.backend,
                             "resolved_backend": resolved_backend,
                             "backend_applies": config.supports_backend,

--- a/paper_results/secIVb_parallel_rollouts_gpu/code/generate_parallel_rollout_benchmark.py
+++ b/paper_results/secIVb_parallel_rollouts_gpu/code/generate_parallel_rollout_benchmark.py
@@ -14,9 +14,13 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import os
+import subprocess
 import sys
+import tempfile
 import time
+import traceback
 import warnings
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -117,6 +121,18 @@ class RuntimeConfig:
     save_dt: float
     solver: str = DEFAULT_SOLVER
     t0: float = 0.0
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """One process-isolated point in the requested benchmark sweep."""
+
+    system: str
+    size_label: str
+    size_value: int
+    gauss_points: int | None
+    batch_size: int
+    seed: int
 
 
 def _select_device(requested_device: str) -> jax.Device | None:
@@ -259,7 +275,9 @@ def _rollout_state_diagnostics(
     return bool(rollout_finite), float(max_abs_state)
 
 
-def _write_csv(results: Sequence[Mapping[str, Any]], path: Path) -> None:
+def _write_csv(
+    results: Sequence[Mapping[str, Any]], path: Path, *, announce: bool = True
+) -> None:
     if not results:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -307,11 +325,54 @@ def _write_csv(results: Sequence[Mapping[str, Any]], path: Path) -> None:
         "platform_version",
         "device_count",
     ]
-    with path.open("w", encoding="utf-8", newline="") as fp:
-        writer = csv.DictWriter(fp, fieldnames=headers, extrasaction="ignore")
-        writer.writeheader()
-        writer.writerows(results)
-    print(f"[+] Wrote CSV results to {path}")
+    temporary_path = path.with_name(f".{path.name}.tmp")
+    try:
+        with temporary_path.open("w", encoding="utf-8", newline="") as fp:
+            writer = csv.DictWriter(fp, fieldnames=headers, extrasaction="ignore")
+            writer.writeheader()
+            writer.writerows(results)
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    if announce:
+        print(f"[+] Wrote CSV results to {path}")
+
+
+def _write_failure_csv(failures: Sequence[Mapping[str, Any]], path: Path) -> None:
+    """Write the complete case-failure report, including an empty report."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    headers = [
+        "system",
+        "gvs_scaling",
+        "size_label",
+        "size_value",
+        "gauss_points",
+        "batch_size",
+        "device",
+        "backend",
+        "solver",
+        "failure_kind",
+        "error_type",
+        "error_message",
+        "worker_exit_code",
+    ]
+    temporary_path = path.with_name(f".{path.name}.tmp")
+    try:
+        with temporary_path.open("w", encoding="utf-8", newline="") as fp:
+            writer = csv.DictWriter(fp, fieldnames=headers, extrasaction="ignore")
+            writer.writeheader()
+            writer.writerows(failures)
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _write_json(payload: Mapping[str, Any], path: Path) -> None:
+    """Write a small worker outcome file consumed by the parent process."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
 
 
 def _size_value(row: Mapping[str, Any]) -> int:
@@ -503,6 +564,15 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         help=f"Path to write the result table as CSV (default: {DEFAULT_CSV_PATH})",
     )
     parser.add_argument(
+        "--failures-csv",
+        type=Path,
+        default=None,
+        help=(
+            "Path to write the failed-case report. By default, '_failures' is "
+            "appended to the --csv filename."
+        ),
+    )
+    parser.add_argument(
         "--plot",
         type=Path,
         help="Optional path for a quick diagnostic plot",
@@ -521,6 +591,17 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         "--log-y",
         action="store_true",
         help="Use a logarithmic scale for the speed ratio axis",
+    )
+    parser.add_argument(
+        "--_worker",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--_outcome-json",
+        type=Path,
+        default=None,
+        help=argparse.SUPPRESS,
     )
     args = parser.parse_args(argv)
     try:
@@ -551,10 +632,19 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     args.segment_counts = sorted(dict.fromkeys(args.segment_counts))
     args.gvs_basis_orders = sorted(dict.fromkeys(args.gvs_basis_orders))
     args.gauss_points = normalize_gauss_point_values(args.gauss_points)
+    if args.failures_csv is None:
+        args.failures_csv = args.csv.with_name(f"{args.csv.stem}_failures.csv")
+    if args._worker and args._outcome_json is None:
+        parser.error("Internal benchmark workers require --_outcome-json.")
     return args
 
 
-def _run_benchmarks(args: argparse.Namespace, device: jax.Device) -> int:
+def _run_benchmarks(
+    args: argparse.Namespace,
+    device: jax.Device,
+    *,
+    write_artifacts: bool = True,
+) -> list[dict[str, Any]]:
     """Run all requested benchmark cases on one explicitly selected device.
 
     Args:
@@ -562,7 +652,8 @@ def _run_benchmarks(args: argparse.Namespace, device: jax.Device) -> int:
         device: JAX device selected from the requested platform.
 
     Returns:
-        Zero after writing the requested artifacts.
+        The successful benchmark rows. Artifacts are written when
+        ``write_artifacts`` is true.
     """
 
     runtime = RuntimeConfig(
@@ -695,10 +786,311 @@ def _run_benchmarks(args: argparse.Namespace, device: jax.Device) -> int:
                         }
                     )
 
-    _write_csv(results, args.csv)
+    if write_artifacts:
+        _write_csv(results, args.csv)
+        if args.plot or args.show_plot:
+            _plot_results(results, args.plot, args.show_plot, args.log_x, args.log_y)
+
+    return results
+
+
+def _build_benchmark_cases(args: argparse.Namespace) -> list[BenchmarkCase]:
+    """Expand CLI sweep arguments into independently executable cases."""
+
+    registry = dict(get_system_registry())
+    if args.gvs_scaling == "basis-order":
+        registry["gvs"] = get_gvs_basis_order_system_config()
+
+    cases: list[BenchmarkCase] = []
+    for system_name in args.systems:
+        config = registry[system_name]
+        size_values = (
+            args.gvs_basis_orders
+            if system_name == "gvs" and args.gvs_scaling == "basis-order"
+            else args.segment_counts
+        )
+        gauss_values = gauss_point_sweep_values(config, args.gauss_points)
+        if not gauss_values:
+            print(
+                f"\n[!] Skipping {system_name}: --gauss-points is not applicable "
+                "or all requested values are below the system minimum."
+            )
+            continue
+
+        for size in size_values:
+            for gauss_points in gauss_values:
+                for batch_size in args.batch_sizes:
+                    # Independent deterministic streams avoid coupling a case's
+                    # inputs to whether any preceding case succeeded.
+                    case_seed = (int(args.seed) + len(cases)) % (2**32)
+                    cases.append(
+                        BenchmarkCase(
+                            system=system_name,
+                            size_label=config.size_label,
+                            size_value=int(size),
+                            gauss_points=gauss_points,
+                            batch_size=int(batch_size),
+                            seed=case_seed,
+                        )
+                    )
+    return cases
+
+
+def _worker_command(
+    args: argparse.Namespace, case: BenchmarkCase, outcome_path: Path
+) -> list[str]:
+    """Build the fresh-interpreter command for one benchmark case."""
+
+    gvs_basis_case = case.system == "gvs" and args.gvs_scaling == "basis-order"
+    segment_count = 1 if gvs_basis_case else case.size_value
+    basis_order = case.size_value if gvs_basis_case else args.gvs_basis_orders[0]
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--device",
+        args.device,
+        "--backend",
+        args.backend,
+        "--systems",
+        case.system,
+        "--segment-counts",
+        str(segment_count),
+        "--gvs-scaling",
+        args.gvs_scaling,
+        "--gvs-basis-orders",
+        str(basis_order),
+        "--batch-sizes",
+        str(case.batch_size),
+        "--duration",
+        repr(args.duration),
+        "--solver",
+        args.solver,
+        "--solver-dt",
+        repr(args.solver_dt),
+        "--save-dt",
+        repr(args.save_dt),
+        "--repeats",
+        str(args.repeats),
+        "--warmup-runs",
+        str(args.warmup_runs),
+        "--noise-scale",
+        repr(args.noise_scale),
+        "--seed",
+        str(case.seed),
+        "--_worker",
+        "--_outcome-json",
+        str(outcome_path),
+    ]
+    if case.gauss_points is not None:
+        command.extend(["--gauss-points", str(case.gauss_points)])
+    return command
+
+
+def _is_out_of_memory_failure(error_type: str, error_message: str) -> bool:
+    """Recognize common JAX, XLA, CUDA, ROCm, and Python OOM failures."""
+
+    if error_type == "MemoryError":
+        return True
+    error_text = f"{error_type}: {error_message}".lower()
+    markers = (
+        "out of memory",
+        "resource_exhausted",
+        "cuda_error_out_of_memory",
+        "cudaerroroutofmemory",
+        "hiperroroutofmemory",
+        "failed to allocate",
+    )
+    return any(marker in error_text for marker in markers)
+
+
+def _failure_row(
+    args: argparse.Namespace,
+    case: BenchmarkCase,
+    outcome: Mapping[str, Any],
+    worker_exit_code: int,
+) -> dict[str, Any]:
+    """Combine a worker's error details with its benchmark coordinates."""
+
+    error_type = str(outcome.get("error_type", "WorkerProcessError"))
+    error_message = str(
+        outcome.get(
+            "error_message",
+            "Worker exited without producing a valid outcome.",
+        )
+    )
+    if error_type == "DeviceUnavailableError":
+        failure_kind = "device_unavailable"
+    elif _is_out_of_memory_failure(error_type, error_message):
+        failure_kind = "out_of_memory"
+    else:
+        failure_kind = "worker_error"
+    return {
+        "system": case.system,
+        "gvs_scaling": args.gvs_scaling if case.system == "gvs" else "",
+        "size_label": case.size_label,
+        "size_value": case.size_value,
+        "gauss_points": case.gauss_points,
+        "batch_size": case.batch_size,
+        "device": args.device,
+        "backend": args.backend,
+        "solver": args.solver,
+        "failure_kind": failure_kind,
+        "error_type": error_type,
+        "error_message": error_message,
+        "worker_exit_code": worker_exit_code,
+    }
+
+
+def _print_failure_report(failures: Sequence[Mapping[str, Any]]) -> None:
+    """Print a compact end-of-run summary of every failed case."""
+
+    if not failures:
+        print("\n[+] All benchmark cases completed; no failed runs.")
+        return
+
+    print(f"\n=== Failed benchmark cases ({len(failures)}) ===")
+    for failure in failures:
+        gauss_note = ""
+        if failure.get("gauss_points") is not None:
+            gauss_note = f", gauss_points={failure['gauss_points']}"
+        message = " ".join(str(failure["error_message"]).split())
+        print(
+            f"  [{str(failure['failure_kind']).upper()}] "
+            f"{failure['system']} {failure['size_label']}="
+            f"{failure['size_value']}{gauss_note}, "
+            f"batch={failure['batch_size']}: {failure['error_type']}: {message}"
+        )
+
+
+def _run_benchmark_worker(args: argparse.Namespace) -> int:
+    """Execute one case and serialize its result or caught exception."""
+
+    assert args._outcome_json is not None
+    try:
+        device = _select_device(args.device)
+        if device is None:
+            _write_json(
+                {
+                    "status": "failed",
+                    "error_type": "DeviceUnavailableError",
+                    "error_message": f"No compatible {args.device} device is visible.",
+                },
+                args._outcome_json,
+            )
+            return 2
+        if jax.default_backend() != args.device:
+            raise RuntimeError(
+                f"Requested {args.device!r}, but JAX selected "
+                f"{jax.default_backend()!r}."
+            )
+        with jax.default_device(device):
+            results = _run_benchmarks(args, device, write_artifacts=False)
+        if len(results) != 1:
+            raise RuntimeError(
+                f"An isolated worker produced {len(results)} rows instead of one."
+            )
+        _write_json({"status": "success", "results": results}, args._outcome_json)
+        return 0
+    except Exception as error:
+        traceback.print_exc()
+        _write_json(
+            {
+                "status": "failed",
+                "error_type": type(error).__name__,
+                "error_message": str(error),
+                "traceback": traceback.format_exc(),
+            },
+            args._outcome_json,
+        )
+        return 1
+
+
+def _run_isolated_benchmarks(args: argparse.Namespace) -> int:
+    """Run every case in a disposable process and checkpoint successes."""
+
+    cases = _build_benchmark_cases(args)
+    results: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    device_unavailable = False
+
+    print(
+        f"\n=== Running {len(cases)} process-isolated benchmark cases ===",
+        flush=True,
+    )
+    with tempfile.TemporaryDirectory(prefix="soromox-rollout-benchmark-") as temp_dir:
+        temp_path = Path(temp_dir)
+        for case_index, case in enumerate(cases, start=1):
+            gauss_note = (
+                ""
+                if case.gauss_points is None
+                else f", gauss_points={case.gauss_points}"
+            )
+            print(
+                f"\n[{case_index}/{len(cases)}] {case.system} "
+                f"{case.size_label}={case.size_value}{gauss_note}, "
+                f"batch={case.batch_size}",
+                flush=True,
+            )
+            outcome_path = temp_path / f"case-{case_index}.json"
+            try:
+                completed = subprocess.run(
+                    _worker_command(args, case, outcome_path),
+                    check=False,
+                )
+            except OSError as error:
+                outcome: Mapping[str, Any] = {
+                    "error_type": type(error).__name__,
+                    "error_message": str(error),
+                }
+                worker_exit_code = 1
+            else:
+                worker_exit_code = completed.returncode
+                try:
+                    outcome = json.loads(outcome_path.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError) as error:
+                    outcome = {
+                        "error_type": "WorkerProcessError",
+                        "error_message": (
+                            f"Worker exited with code {worker_exit_code} and did not "
+                            f"produce a readable outcome: {error}"
+                        ),
+                    }
+
+            worker_results = outcome.get("results")
+            if (
+                worker_exit_code == 0
+                and outcome.get("status") == "success"
+                and isinstance(worker_results, list)
+                and len(worker_results) == 1
+                and isinstance(worker_results[0], dict)
+            ):
+                results.append(worker_results[0])
+                # Checkpoint after every success so a later OOM cannot discard it.
+                _write_csv(results, args.csv, announce=False)
+                continue
+
+            failure = _failure_row(args, case, outcome, worker_exit_code)
+            failures.append(failure)
+            _write_failure_csv(failures, args.failures_csv)
+            if failure["failure_kind"] == "device_unavailable":
+                device_unavailable = True
+                break
+
+    _write_failure_csv(failures, args.failures_csv)
+    if results:
+        print(f"\n[+] Wrote {len(results)} successful rows to {args.csv}")
+    else:
+        print("\n[!] No benchmark cases completed successfully.")
+    print(f"[+] Wrote failed-case report to {args.failures_csv}")
+    _print_failure_report(failures)
+
     if args.plot or args.show_plot:
         _plot_results(results, args.plot, args.show_plot, args.log_x, args.log_y)
 
+    if device_unavailable:
+        return 2
+    if any(row["failure_kind"] == "worker_error" for row in failures):
+        return 1
     return 0
 
 
@@ -711,17 +1103,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             "The --device choice changed after JAX was imported. Pass it on the "
             "process command line so CPU selection can occur before initialization."
         )
-    device = _select_device(args.device)
-    if device is None:
-        return 2
-    if jax.default_backend() != args.device:
-        raise RuntimeError(
-            f"Requested {args.device!r}, but JAX selected "
-            f"{jax.default_backend()!r}. Run the generator in a fresh process "
-            "with the intended --device option."
-        )
-    with jax.default_device(device):
-        return _run_benchmarks(args, device)
+    if args._worker:
+        return _run_benchmark_worker(args)
+    return _run_isolated_benchmarks(args)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/paper_results/secIVb_parallel_rollouts_gpu/code/generate_parallel_rollout_benchmark.py
+++ b/paper_results/secIVb_parallel_rollouts_gpu/code/generate_parallel_rollout_benchmark.py
@@ -469,7 +469,7 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         "--batch-sizes",
         nargs="+",
         type=int,
-        default=[1, 2, 4, 8, 16, 32, 64, 128, 256],
+        default=[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
         help="Parallel environment counts to benchmark",
     )
     parser.add_argument(

--- a/paper_results/secIVb_parallel_rollouts_gpu/code/generate_parallel_rollout_benchmark.py
+++ b/paper_results/secIVb_parallel_rollouts_gpu/code/generate_parallel_rollout_benchmark.py
@@ -242,6 +242,23 @@ def _measure_wall_time(
     return avg_time, last_output
 
 
+def _rollout_state_diagnostics(
+    state_outputs: Sequence[Array],
+) -> tuple[bool, float]:
+    """Reduce rollout stability metrics on-device before one host transfer."""
+
+    rollout_finite_device = jnp.all(
+        jnp.stack([jnp.all(jnp.isfinite(value)) for value in state_outputs])
+    )
+    max_abs_state_device = jnp.max(
+        jnp.stack([jnp.max(jnp.abs(value)) for value in state_outputs])
+    )
+    rollout_finite, max_abs_state = jax.device_get(
+        (rollout_finite_device, max_abs_state_device)
+    )
+    return bool(rollout_finite), float(max_abs_state)
+
+
 def _write_csv(results: Sequence[Mapping[str, Any]], path: Path) -> None:
     if not results:
         return
@@ -620,12 +637,8 @@ def _run_benchmarks(args: argparse.Namespace, device: jax.Device) -> int:
                         repeats=args.repeats,
                     )
                     ts_last, *_ = outputs
-                    state_outputs = outputs[1:]
-                    rollout_finite = bool(
-                        all(jnp.all(jnp.isfinite(value)) for value in state_outputs)
-                    )
-                    max_abs_state = float(
-                        max(jnp.max(jnp.abs(value)) for value in state_outputs)
+                    rollout_finite, max_abs_state = _rollout_state_diagnostics(
+                        outputs[1:]
                     )
                     sim_time = float(jnp.mean(ts_last) - runtime.t0)
                     total_sim_time = sim_time * batch

--- a/src/soromox/__init__.py
+++ b/src/soromox/__init__.py
@@ -3,6 +3,7 @@ import importlib.metadata
 
 from .autodiff import *  # noqa: F403
 from .systems import *  # noqa: F403
+from .simulation import *  # noqa: F403
 from .execution import (
     ExecutionBackend as ExecutionBackend,
     GVSBackendParams as GVSBackendParams,

--- a/src/soromox/simulation/__init__.py
+++ b/src/soromox/simulation/__init__.py
@@ -1,0 +1,5 @@
+"""Numerical integration helpers for Soromox simulations."""
+
+from soromox.simulation.integrators import SemiImplicitEuler
+
+__all__ = ["SemiImplicitEuler"]

--- a/src/soromox/simulation/integrators.py
+++ b/src/soromox/simulation/integrators.py
@@ -112,7 +112,12 @@ class SemiImplicitEuler(AbstractSolver):
         del solver_state, made_jump
         control = terms.contr(t0, t1)
         increment = terms.vf_prod(t0, y0, args, control)
-        y1 = jax.tree.map(lambda initial, delta: initial + delta, y0, increment)
+        y1 = jax.tree.map(
+            lambda initial, delta: None if initial is None else initial + delta,
+            y0,
+            increment,
+            is_leaf=lambda value: value is None,
+        )
 
         q0, qd0, auxiliary0 = self.system.split_state(y0.y)
         _, qd_increment, auxiliary_increment = self.system.split_state(increment.y)

--- a/src/soromox/simulation/integrators.py
+++ b/src/soromox/simulation/integrators.py
@@ -1,0 +1,143 @@
+"""Diffrax-compatible numerical integrators for Soromox state layouts."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable
+from typing import Any, ClassVar
+
+import jax
+from diffrax import (
+    RESULTS,
+    AbstractSolver,
+    AbstractTerm,
+    LocalLinearInterpolation,
+)
+
+from soromox.systems.dynamical_system import DynamicalSystem
+
+
+class SemiImplicitEuler(AbstractSolver):
+    """Kick-drift Euler for a Soromox ``[q, qd, auxiliary]`` state.
+
+    Diffrax's generic :class:`diffrax.SemiImplicitEuler` requires a separable
+    two-term vector field. Soromox dynamics generally include
+    velocity-dependent forces, so this solver evaluates the full state
+    derivative at ``(q_n, qd_n)`` and applies
+
+    ``qd_{n+1} = qd_n + dt * qdd_n`` and
+    ``q_{n+1} = retract(q_n, dt * qd_{n+1})``.
+
+    The solver is intended for :class:`soromox.systems.DynamicalSystem`
+    rollouts. It uses the supplied system's state helpers rather than splitting
+    the state in half, so unequal floating-base configuration and velocity
+    dimensions, manifold retraction, and trailing system auxiliary states are
+    supported. Diffrax-level control and environment state leaves are advanced
+    with explicit Euler.
+
+    Attributes:
+        system: Soromox system that supplies ``split_state``, ``pack_state``,
+            and ``retract_configuration``.
+    """
+
+    system: DynamicalSystem
+    term_structure: ClassVar = AbstractTerm
+    interpolation_cls: ClassVar[Callable[..., LocalLinearInterpolation]] = (
+        LocalLinearInterpolation
+    )
+
+    def order(self, terms: AbstractTerm) -> int:
+        """Return the deterministic convergence order.
+
+        Args:
+            terms: Diffrax term describing the vector field. The order is one
+                for every compatible term.
+
+        Returns:
+            The deterministic convergence order, which is one.
+        """
+        del terms
+        return 1
+
+    def init(
+        self,
+        terms: AbstractTerm,
+        t0: Any,
+        t1: Any,
+        y0: Any,
+        args: Any,
+    ) -> None:
+        """Initialize the solver state.
+
+        Args:
+            terms: Diffrax term describing the vector field.
+            t0: Initial time of the integration interval.
+            t1: Final time of the integration interval.
+            y0: Initial Diffrax state.
+            args: Additional arguments supplied to the vector field.
+
+        Returns:
+            ``None`` because the method has no persistent solver state.
+        """
+        del terms, t0, t1, y0, args
+        return None
+
+    def step(
+        self,
+        terms: AbstractTerm,
+        t0: Any,
+        t1: Any,
+        y0: Any,
+        args: Any,
+        solver_state: Any,
+        made_jump: Any,
+    ) -> tuple[Any, None, dict[str, Any], None, RESULTS]:
+        """Advance the state by one kick--drift step.
+
+        Args:
+            terms: Diffrax term describing the vector field.
+            t0: Start time of the step.
+            t1: End time of the step.
+            y0: Diffrax state at ``t0``.
+            args: Additional arguments supplied to the vector field.
+            solver_state: Persistent solver state. This method does not use it.
+            made_jump: Whether the solution jumped at ``t0``. This method does
+                not require special jump handling.
+
+        Returns:
+            A Diffrax step tuple containing the state at ``t1``, no local error
+            estimate, linear-interpolation data, no persistent solver state,
+            and a successful result code.
+        """
+        del solver_state, made_jump
+        control = terms.contr(t0, t1)
+        increment = terms.vf_prod(t0, y0, args, control)
+        y1 = jax.tree.map(lambda initial, delta: initial + delta, y0, increment)
+
+        q0, qd0, auxiliary0 = self.system.split_state(y0.y)
+        _, qd_increment, auxiliary_increment = self.system.split_state(increment.y)
+        qd1 = qd0 + qd_increment
+        q1 = self.system.retract_configuration(q0, (t1 - t0) * qd1)
+        auxiliary1 = auxiliary0 + auxiliary_increment
+        primary_state1 = self.system.pack_state(q1, qd1, auxiliary1)
+        y1 = dataclasses.replace(y1, y=primary_state1)
+
+        dense_info = {"y0": y0, "y1": y1}
+        return y1, None, dense_info, None, RESULTS.successful
+
+    def func(self, terms: AbstractTerm, t0: Any, y0: Any, args: Any) -> Any:
+        """Evaluate the underlying vector field.
+
+        Args:
+            terms: Diffrax term describing the vector field.
+            t0: Time at which to evaluate the vector field.
+            y0: Diffrax state at ``t0``.
+            args: Additional arguments supplied to the vector field.
+
+        Returns:
+            Vector-field evaluation with the same PyTree structure as ``y0``.
+        """
+        return terms.vf(t0, y0, args)
+
+
+__all__ = ["SemiImplicitEuler"]

--- a/tests/paper_results/secIVb/test_generate_parallel_rollout_benchmark.py
+++ b/tests/paper_results/secIVb/test_generate_parallel_rollout_benchmark.py
@@ -122,6 +122,28 @@ def test_semi_implicit_euler_applies_kick_before_drift():
     assert benchmark.jnp.allclose(trajectory.y[-1], expected)
 
 
+def test_rollout_state_diagnostics_use_one_host_transfer(monkeypatch):
+    device_get_calls = []
+    original_device_get = benchmark.jax.device_get
+
+    def record_device_get(value):
+        device_get_calls.append(value)
+        return original_device_get(value)
+
+    monkeypatch.setattr(benchmark.jax, "device_get", record_device_get)
+
+    rollout_finite, max_abs_state = benchmark._rollout_state_diagnostics(
+        (
+            benchmark.jnp.array([[1.0, -2.0]]),
+            benchmark.jnp.array([[benchmark.jnp.inf, 3.0]]),
+        )
+    )
+
+    assert rollout_finite is False
+    assert max_abs_state == float("inf")
+    assert len(device_get_calls) == 1
+
+
 def test_csv_records_environment_metadata(tmp_path):
     path = tmp_path / "results.csv"
     benchmark._write_csv([{}], path)

--- a/tests/paper_results/secIVb/test_generate_parallel_rollout_benchmark.py
+++ b/tests/paper_results/secIVb/test_generate_parallel_rollout_benchmark.py
@@ -1,5 +1,8 @@
+import csv
+import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -28,6 +31,7 @@ def test_output_paths_default_to_case_data_directory():
     args = benchmark.parse_args([])
 
     assert args.csv == benchmark.DATA_DIR / "benchmark_results.csv"
+    assert args.failures_csv == benchmark.DATA_DIR / "benchmark_results_failures.csv"
     assert args.device == "gpu"
     assert args.backend == "auto"
     assert args.solver == "tsit5"
@@ -39,6 +43,15 @@ def test_csv_output_path_can_be_overridden(tmp_path):
     args = benchmark.parse_args(["--csv", str(csv_path)])
 
     assert args.csv == csv_path
+    assert args.failures_csv == tmp_path / "custom_failures.csv"
+
+
+def test_failures_csv_output_path_can_be_overridden(tmp_path):
+    failures_path = tmp_path / "failed-cases.csv"
+
+    args = benchmark.parse_args(["--failures-csv", str(failures_path)])
+
+    assert args.failures_csv == failures_path
 
 
 def test_npz_output_option_is_not_supported():
@@ -160,3 +173,96 @@ def test_csv_records_environment_metadata(tmp_path):
     assert "solver" in header
     assert "rollout_finite" in header
     assert "max_abs_state" in header
+
+
+@pytest.mark.parametrize(
+    ("error_type", "error_message"),
+    [
+        ("XlaRuntimeError", "RESOURCE_EXHAUSTED: Out of memory allocating buffer"),
+        ("RuntimeError", "CUDA_ERROR_OUT_OF_MEMORY"),
+        ("MemoryError", ""),
+    ],
+)
+def test_out_of_memory_failures_are_recognized(error_type, error_message):
+    assert benchmark._is_out_of_memory_failure(error_type, error_message)
+
+
+def test_basis_order_zero_worker_uses_a_valid_segment_count(tmp_path):
+    args = benchmark.parse_args(
+        [
+            "--systems",
+            "gvs",
+            "--gvs-scaling",
+            "basis-order",
+            "--gvs-basis-orders",
+            "0",
+        ]
+    )
+    case = benchmark._build_benchmark_cases(args)[0]
+
+    command = benchmark._worker_command(args, case, tmp_path / "outcome.json")
+
+    assert command[command.index("--segment-counts") + 1] == "1"
+    assert command[command.index("--gvs-basis-orders") + 1] == "0"
+
+
+def test_isolated_runner_checkpoints_and_continues_after_oom(tmp_path, monkeypatch):
+    csv_path = tmp_path / "results.csv"
+    args = benchmark.parse_args(
+        [
+            "--device",
+            "cpu",
+            "--systems",
+            "pendulum",
+            "--segment-counts",
+            "1",
+            "--batch-sizes",
+            "1",
+            "2",
+            "4",
+            "--csv",
+            str(csv_path),
+        ]
+    )
+    attempted_batches = []
+
+    def fake_worker(command, check):
+        assert check is False
+        batch = int(command[command.index("--batch-sizes") + 1])
+        outcome_path = Path(command[command.index("--_outcome-json") + 1])
+        attempted_batches.append(batch)
+
+        if batch == 2:
+            with csv_path.open(encoding="utf-8", newline="") as fp:
+                checkpointed = list(csv.DictReader(fp))
+            assert [int(row["batch_size"]) for row in checkpointed] == [1]
+            outcome = {
+                "status": "failed",
+                "error_type": "XlaRuntimeError",
+                "error_message": "RESOURCE_EXHAUSTED: Out of memory",
+            }
+            return_code = 1
+        else:
+            outcome = {
+                "status": "success",
+                "results": [{"system": "pendulum", "batch_size": batch}],
+            }
+            return_code = 0
+
+        outcome_path.write_text(json.dumps(outcome), encoding="utf-8")
+        return SimpleNamespace(returncode=return_code)
+
+    monkeypatch.setattr(benchmark.subprocess, "run", fake_worker)
+
+    return_code = benchmark._run_isolated_benchmarks(args)
+
+    assert return_code == 0
+    assert attempted_batches == [1, 2, 4]
+    with csv_path.open(encoding="utf-8", newline="") as fp:
+        rows = list(csv.DictReader(fp))
+    assert [int(row["batch_size"]) for row in rows] == [1, 4]
+    with args.failures_csv.open(encoding="utf-8", newline="") as fp:
+        failures = list(csv.DictReader(fp))
+    assert len(failures) == 1
+    assert failures[0]["batch_size"] == "2"
+    assert failures[0]["failure_kind"] == "out_of_memory"

--- a/tests/paper_results/secIVb/test_generate_parallel_rollout_benchmark.py
+++ b/tests/paper_results/secIVb/test_generate_parallel_rollout_benchmark.py
@@ -30,6 +30,7 @@ def test_output_paths_default_to_case_data_directory():
     assert args.csv == benchmark.DATA_DIR / "benchmark_results.csv"
     assert args.device == "gpu"
     assert args.backend == "auto"
+    assert args.solver == "tsit5"
 
 
 def test_csv_output_path_can_be_overridden(tmp_path):
@@ -77,6 +78,50 @@ def test_invalid_backend_is_rejected():
         benchmark.parse_args(["--backend", "cuda"])
 
 
+@pytest.mark.parametrize("solver", benchmark.SOLVER_NAMES)
+def test_solver_option_is_parsed(solver):
+    args = benchmark.parse_args(["--solver", solver])
+
+    assert args.solver == solver
+    if solver != "semi-implicit-euler":
+        assert benchmark._make_solver(solver) is not None
+
+
+def test_invalid_solver_is_rejected():
+    with pytest.raises(SystemExit):
+        benchmark.parse_args(["--solver", "verlet"])
+
+
+def test_semi_implicit_euler_applies_kick_before_drift():
+    config = benchmark.get_system_registry()["articulated_soft_robot"]
+    system = config.factory(1)
+    ctx = config.build_context(system)
+    dt = 1e-4
+    initial_y = benchmark.jnp.concatenate([ctx["q"], ctx["qd"]])
+    initial_state = benchmark.SystemState(t=0.0, y=initial_y)
+
+    derivative = system.forward_dynamics(
+        benchmark.jnp.asarray(0.0),
+        initial_y,
+        (ctx["u"], ctx["tau_ext"]),
+    )
+    _, qdd0 = benchmark.jnp.split(derivative, 2)
+    qd1 = ctx["qd"] + dt * qdd0
+    expected = benchmark.jnp.concatenate([ctx["q"] + dt * qd1, qd1])
+
+    trajectory = system.rollout_to(
+        initial_state=initial_state,
+        u=ctx["u"],
+        tau_ext=ctx["tau_ext"],
+        t1=dt,
+        solver_dt=dt,
+        save_ts=benchmark.jnp.array([0.0, dt]),
+        solver=benchmark.SemiImplicitEuler(system),
+    )
+
+    assert benchmark.jnp.allclose(trajectory.y[-1], expected)
+
+
 def test_csv_records_environment_metadata(tmp_path):
     path = tmp_path / "results.csv"
     benchmark._write_csv([{}], path)
@@ -90,3 +135,6 @@ def test_csv_records_environment_metadata(tmp_path):
     assert "resolved_backend" in header
     assert "backend_applies" in header
     assert "warp_version" in header
+    assert "solver" in header
+    assert "rollout_finite" in header
+    assert "max_abs_state" in header

--- a/tests/simulation/test_integrators.py
+++ b/tests/simulation/test_integrators.py
@@ -130,6 +130,21 @@ def test_semi_implicit_euler_rollout_is_jittable_and_vmappable():
     assert jnp.all(jnp.isfinite(trajectories))
 
 
+def test_semi_implicit_euler_preserves_absent_optional_rollout_states():
+    robot = _pendulum()
+
+    trajectory = robot.rollout_to(
+        initial_state=SystemState(t=0.0, y=jnp.array([0.1, 0.0])),
+        t1=1e-4,
+        solver_dt=1e-4,
+        save_ts=jnp.array([0.0, 1e-4]),
+        solver=SemiImplicitEuler(robot),
+    )
+
+    assert trajectory.control_state is None
+    assert trajectory.environment_state is None
+
+
 def test_semi_implicit_euler_supports_spatial_floating_base_state():
     robot = _floating_spatial_pcs()
     q0 = robot.pack_configuration(

--- a/tests/simulation/test_integrators.py
+++ b/tests/simulation/test_integrators.py
@@ -176,8 +176,8 @@ def test_semi_implicit_euler_supports_spatial_floating_base_state():
     q1, actual_qd1, auxiliary1 = robot.split_state(trajectory.y[-1])
 
     assert robot.num_coordinates != robot.num_velocities
-    assert_allclose(q1, expected_q1)
-    assert_allclose(actual_qd1, qd1)
+    assert_allclose(q1, expected_q1, atol=1e-18)
+    assert_allclose(actual_qd1, qd1, atol=1e-15)
     assert auxiliary1.shape == (0,)
     assert_allclose(jnp.linalg.norm(q1[:4]), 1.0)
 

--- a/tests/simulation/test_integrators.py
+++ b/tests/simulation/test_integrators.py
@@ -173,7 +173,7 @@ def test_semi_implicit_euler_supports_spatial_floating_base_state():
     q1, actual_qd1, auxiliary1 = robot.split_state(trajectory.y[-1])
 
     assert robot.num_coordinates != robot.num_velocities
-    assert_allclose(q1, expected_q1)
+    assert_allclose(q1, expected_q1, atol=1e-18)
     assert_allclose(actual_qd1, qd1)
     assert auxiliary1.shape == (0,)
     assert_allclose(jnp.linalg.norm(q1[:4]), 1.0)

--- a/tests/simulation/test_integrators.py
+++ b/tests/simulation/test_integrators.py
@@ -155,16 +155,19 @@ def test_semi_implicit_euler_supports_spatial_floating_base_state():
         jnp.zeros((robot.num_internal_dofs,)),
         base_velocity=jnp.array([0.01, -0.02, 0.005, 0.03, -0.01, 0.02]),
     )
-    y0 = robot.pack_state(q0, qd0)
+    initial_y = robot.pack_state(q0, qd0)
     dt = 1e-5
 
-    derivative = robot.forward_dynamics(jnp.asarray(0.0), y0)
+    solver_y0 = robot.project_state(initial_y)
+    solver_q0, solver_qd0, _ = robot.split_state(solver_y0)
+    dynamics_y0 = robot.project_state(solver_y0)
+    derivative = robot.forward_dynamics(jnp.asarray(0.0), dynamics_y0)
     _, qdd0, _ = robot.split_state(derivative)
-    qd1 = qd0 + dt * qdd0
-    expected_q1 = robot.retract_configuration(q0, dt * qd1)
+    qd1 = solver_qd0 + dt * qdd0
+    expected_q1 = robot.retract_configuration(solver_q0, dt * qd1)
 
     trajectory = robot.rollout_to(
-        initial_state=SystemState(t=0.0, y=y0),
+        initial_state=SystemState(t=0.0, y=initial_y),
         t1=dt,
         solver_dt=dt,
         save_ts=jnp.array([0.0, dt]),
@@ -173,7 +176,7 @@ def test_semi_implicit_euler_supports_spatial_floating_base_state():
     q1, actual_qd1, auxiliary1 = robot.split_state(trajectory.y[-1])
 
     assert robot.num_coordinates != robot.num_velocities
-    assert_allclose(q1, expected_q1, atol=1e-18)
+    assert_allclose(q1, expected_q1)
     assert_allclose(actual_qd1, qd1)
     assert auxiliary1.shape == (0,)
     assert_allclose(jnp.linalg.norm(q1[:4]), 1.0)

--- a/tests/simulation/test_integrators.py
+++ b/tests/simulation/test_integrators.py
@@ -1,0 +1,228 @@
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+from diffrax import AbstractSolver, Euler, Tsit5
+from numpy.testing import assert_allclose
+from system_param_builders import pcs_params, pendulum_params
+
+from soromox.simulation import SemiImplicitEuler
+from soromox.systems import (
+    PCS,
+    PCSStructure,
+    Pendulum,
+    PlanarHSA,
+    PlanarHSAParams,
+    PlanarHSAStructure,
+    SystemState,
+)
+
+
+def _pendulum() -> Pendulum:
+    return Pendulum(
+        pendulum_params(
+            length=jnp.array([0.5]),
+            center_of_mass_length=jnp.array([0.25]),
+            mass=jnp.array([1.0]),
+            moment_inertia=jnp.array([0.1]),
+            gravity=jnp.array([0.0, -9.81]),
+            joint_stiffness=jnp.array([[2.0]]),
+            joint_damping=jnp.array([[0.1]]),
+        )
+    )
+
+
+def _floating_spatial_pcs() -> PCS:
+    return PCS(
+        params=pcs_params(
+            length=jnp.array([0.1]),
+            radius=jnp.array([0.01]),
+            density=jnp.array([1000.0]),
+            young_modulus=jnp.array([1.0e5]),
+            shear_modulus=jnp.array([4.0e4]),
+            damping_matrix=jnp.eye(6),
+            gravity=jnp.array([0.0, 0.0, -9.81]),
+        ),
+        structure=PCSStructure(num_gauss_points=3),
+        floating_base=True,
+        backend="jax",
+    )
+
+
+def _floating_hysteretic_planar_hsa() -> PlanarHSA:
+    params_path = (
+        Path(__file__).resolve().parents[2]
+        / "assets"
+        / "robot_parameters"
+        / "planar_hsa"
+        / "fpu_control.npz"
+    )
+    params = PlanarHSAParams.from_npz(params_path)
+    num_strains = 3 * params.length.shape[0]
+    params = params.replace(
+        hysteresis_basis=jnp.ones((num_strains, 1)),
+        hysteresis_alpha=0.5 * jnp.ones((num_strains,)),
+        hysteresis_A=jnp.ones((1,)),
+        hysteresis_n=jnp.ones((1,)),
+        hysteresis_beta=0.5 * jnp.ones((1,)),
+        hysteresis_gamma=0.5 * jnp.ones((1,)),
+    )
+    return PlanarHSA(
+        params=params,
+        structure=PlanarHSAStructure(consider_hysteresis=True),
+        floating_base=True,
+    )
+
+
+def test_semi_implicit_euler_is_a_deterministic_diffrax_solver():
+    solver = SemiImplicitEuler(_pendulum())
+
+    assert isinstance(solver, AbstractSolver)
+    assert not isinstance(solver, Euler)
+
+
+def test_semi_implicit_euler_applies_kick_before_drift():
+    robot = _pendulum()
+    q0 = jnp.array([0.2])
+    qd0 = jnp.array([0.3])
+    u = jnp.zeros((robot.num_actuators,))
+    tau_ext = jnp.zeros_like(q0)
+    y0 = jnp.concatenate([q0, qd0])
+    dt = 1e-4
+
+    derivative = robot.forward_dynamics(jnp.asarray(0.0), y0, (u, tau_ext))
+    _, qdd0 = jnp.split(derivative, 2)
+    qd1 = qd0 + dt * qdd0
+    expected = jnp.concatenate([q0 + dt * qd1, qd1])
+
+    trajectory = robot.rollout_to(
+        initial_state=SystemState(t=0.0, y=y0),
+        u=u,
+        tau_ext=tau_ext,
+        t1=dt,
+        solver_dt=dt,
+        save_ts=jnp.array([0.0, dt]),
+        solver=SemiImplicitEuler(robot),
+    )
+
+    assert jnp.allclose(trajectory.y[-1], expected)
+
+
+def test_semi_implicit_euler_rollout_is_jittable_and_vmappable():
+    robot = _pendulum()
+    solver = SemiImplicitEuler(robot)
+    q0s = jnp.array([[0.1], [0.2], [-0.15]])
+    qd0s = jnp.array([[0.0], [0.1], [-0.05]])
+
+    def rollout(q0, qd0):
+        trajectory = robot.rollout_to(
+            initial_state=SystemState(t=0.0, y=jnp.concatenate([q0, qd0])),
+            t1=0.002,
+            solver_dt=1e-4,
+            save_ts=jnp.array([0.0, 0.001, 0.002]),
+            solver=solver,
+        )
+        return trajectory.y
+
+    trajectories = jax.jit(jax.vmap(rollout))(q0s, qd0s)
+
+    assert trajectories.shape == (3, 3, 2)
+    assert jnp.all(jnp.isfinite(trajectories))
+
+
+def test_semi_implicit_euler_supports_spatial_floating_base_state():
+    robot = _floating_spatial_pcs()
+    q0 = robot.pack_configuration(
+        jnp.zeros((robot.num_internal_dofs,)),
+        base_pose=jnp.array([0.1, -0.2, 0.3, 0.9, 0.2, -0.1, 0.4]),
+    )
+    qd0 = robot.pack_velocity(
+        jnp.zeros((robot.num_internal_dofs,)),
+        base_velocity=jnp.array([0.01, -0.02, 0.005, 0.03, -0.01, 0.02]),
+    )
+    y0 = robot.pack_state(q0, qd0)
+    dt = 1e-5
+
+    derivative = robot.forward_dynamics(jnp.asarray(0.0), y0)
+    _, qdd0, _ = robot.split_state(derivative)
+    qd1 = qd0 + dt * qdd0
+    expected_q1 = robot.retract_configuration(q0, dt * qd1)
+
+    trajectory = robot.rollout_to(
+        initial_state=SystemState(t=0.0, y=y0),
+        t1=dt,
+        solver_dt=dt,
+        save_ts=jnp.array([0.0, dt]),
+        solver=SemiImplicitEuler(robot),
+    )
+    q1, actual_qd1, auxiliary1 = robot.split_state(trajectory.y[-1])
+
+    assert robot.num_coordinates != robot.num_velocities
+    assert_allclose(q1, expected_q1)
+    assert_allclose(actual_qd1, qd1)
+    assert auxiliary1.shape == (0,)
+    assert_allclose(jnp.linalg.norm(q1[:4]), 1.0)
+
+
+def test_semi_implicit_euler_advances_system_auxiliary_state():
+    robot = _floating_hysteretic_planar_hsa()
+    q0 = robot.pack_configuration(
+        jnp.zeros((robot.num_internal_dofs,)),
+        base_pose=jnp.zeros((robot.num_base_coordinates,)),
+    )
+    qd0 = robot.pack_velocity(
+        1e-3 * jnp.ones((robot.num_internal_dofs,)),
+        base_velocity=jnp.zeros((robot.num_base_velocities,)),
+    )
+    auxiliary0 = 0.1 * jnp.ones((robot.num_auxiliary_states,))
+    y0 = robot.pack_state(q0, qd0, auxiliary0)
+    dt = 1e-7
+
+    derivative = robot.forward_dynamics(jnp.asarray(0.0), y0)
+    _, qdd0, auxiliary_derivative0 = robot.split_state(derivative)
+    expected_qd1 = qd0 + dt * qdd0
+    expected_q1 = robot.retract_configuration(q0, dt * expected_qd1)
+    expected_auxiliary1 = auxiliary0 + dt * auxiliary_derivative0
+
+    trajectory = robot.rollout_to(
+        initial_state=SystemState(t=0.0, y=y0),
+        t1=dt,
+        solver_dt=dt,
+        save_ts=jnp.array([0.0, dt]),
+        solver=SemiImplicitEuler(robot),
+    )
+    q1, qd1, auxiliary1 = robot.split_state(trajectory.y[-1])
+
+    assert robot.num_auxiliary_states == 1
+    assert_allclose(q1, expected_q1)
+    assert_allclose(qd1, expected_qd1)
+    assert_allclose(auxiliary1, expected_auxiliary1)
+
+
+def test_tsit5_supports_spatial_floating_base_state():
+    robot = _floating_spatial_pcs()
+    q0 = robot.pack_configuration(
+        jnp.zeros((robot.num_internal_dofs,)),
+        base_pose=jnp.array([0.1, -0.2, 0.3, 0.9, 0.2, -0.1, 0.4]),
+    )
+    qd0 = robot.pack_velocity(
+        jnp.zeros((robot.num_internal_dofs,)),
+        base_velocity=jnp.array([0.01, -0.02, 0.005, 0.03, -0.01, 0.02]),
+    )
+
+    dt = 1e-7
+    trajectory = robot.rollout_to(
+        initial_state=SystemState(t=0.0, y=robot.pack_state(q0, qd0)),
+        t1=dt,
+        solver_dt=dt,
+        save_ts=jnp.array([0.0, dt]),
+        solver=Tsit5(),
+    )
+    q, qd, auxiliary = robot.split_state(trajectory.y)
+
+    assert trajectory.y.shape[-1] == robot.state_size
+    assert q.shape[-1] == robot.num_coordinates
+    assert qd.shape[-1] == robot.num_velocities
+    assert auxiliary.shape[-1] == robot.num_auxiliary_states
+    assert jnp.all(jnp.isfinite(trajectory.y))
+    assert_allclose(jnp.linalg.norm(q[..., :4], axis=-1), 1.0)


### PR DESCRIPTION
## Summary

- add a Diffrax-compatible, system-bound `SemiImplicitEuler` solver for
  Soromox `[q, qd, auxiliary]` states
- extend the Section IVb parallel-rollout benchmark with solver selection and
  explicit finite-state diagnostics
- validate one shared solver/timestep across ArticulatedSoftRobot, PlanarPCS,
  PCS, and GVS models with 1, 2, 4, 8, 16, and 32 segments
- retain `Tsit5` with `sim_dt=1e-4` as the benchmark default because it was
  stable throughout the matched sweep and 40.3% cheaper in aggregate than
  `SemiImplicitEuler` with `sim_dt=1e-5`
- document standard Diffrax solver support, adaptive step-size controllers,
  and floating-base quaternion integration assumptions

## Implementation

### Soromox semi-implicit Euler

`soromox.simulation.SemiImplicitEuler` implements a deterministic first-order
kick--drift update through the Diffrax `AbstractSolver` interface. It evaluates
the complete Soromox derivative once, updates `qd`, and retracts the resulting
velocity increment onto configuration space before repacking the state.

The solver is bound to a `DynamicalSystem` and uses its `split_state`,
`pack_state`, and `retract_configuration` helpers. It therefore supports
unequal spatial floating-base configuration and velocity dimensions,
quaternion retraction, and trailing system auxiliary state rather than relying
on an equal half-split. Diffrax-level control and environment leaves retain an
explicit-Euler update.

The regression suite covers the kick--drift ordering, JIT and `vmap`, a
spatial floating-base PCS state with unequal dimensions, quaternion
normalization, and a floating PlanarHSA hysteresis state.

### Benchmark solver and stability reporting

The Section IVb generator now accepts `--solver` with `euler`,
`semi-implicit-euler`, `heun`, `bosh3`, `tsit5`, and `dopri5`. The selected
solver is shared across every requested system and size; `tsit5` remains the
default.

Each CSV row records the solver, whether the final rollout state is finite, and
the maximum absolute final-state value. Non-finite rollouts are also marked in
the terminal output so unstable timings cannot be mistaken for useful
throughput.

### Diffrax and floating-base documentation

The new simulation-integrator API page links to Diffrax's solver and step-size
controller catalogs and shows both adaptive `Tsit5` and fixed-step
`SemiImplicitEuler` usage. It documents that standard Diffrax solvers support
the complete Soromox first-order state and receive projected quaternions before
dynamics evaluations and on saved output, while still advancing quaternion
storage in ambient coordinates rather than retracting every Runge--Kutta stage.

## GPU rollout evaluation

The matched comparison used an NVIDIA RTX 5090 in FP64 with a 1 s horizon,
batch size 4, perturbation scale `1e-3`, seed 0, no warmup, and one timed repeat
for all four model families and all six segment counts. These are cold
end-to-end timings and therefore include JIT compilation equally for both
configurations.

| Shared configuration | Finite cases | Aggregate wall time | Relative cost |
| --- | ---: | ---: | ---: |
| `Tsit5`, `sim_dt=1e-4` | 24/24 | 1517.86 s | 1.000x |
| `SemiImplicitEuler`, `sim_dt=1e-5` | 24/24 | 2542.47 s | 1.675x |

All 96 perturbed environments were finite for both configurations. The
semi-implicit configuration was 1.58--1.74x slower in every paired case, with
a median slowdown of 1.667x. Separate limiting-case probes found non-finite
GVS behavior for `Tsit5` at `2e-4` and non-finite long-horizon PCS behavior for
`SemiImplicitEuler` at `2.5e-5`; the selected steps are respectively 2x and
2.5x smaller than those tested failing points.

## Validation

- focused integrator and benchmark suite: `26 passed`
- Ruff lint and formatting checks on every changed Python file: passed
- Zensical documentation build: passed
- `git diff --check`: passed
- complete matched GPU sweeps: 24/24 finite cases for each configuration
