### PR TITLE
Fix the PlanarPCS threadlike sign convention

### DIFF
--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -57,7 +57,24 @@ routing = ThreadlikeRouting.linear(
 ```
 
 Planar PCS uses the local `y` offset and requires the local `x` and `z`
-components to be zero.
+components to be zero. Its material `+x` axis points along the undeformed
+backbone, material `+y` is the transverse direction, and positive
+`kappa_z` rotates `+x` toward `+y` (counter-clockwise in a right-handed
+`xy` frame). Therefore a path at positive offset `d_y` has local tangent
+
+\[
+a(s) =
+\begin{bmatrix}
+\sigma_x-d_y\kappa_z \\
+\sigma_y+d_y'
+\end{bmatrix}.
+\]
+
+In particular, a positive-`y` path lies on the inside of a
+positive-curvature bend and shortens relative to the backbone. A renderer
+whose screen `y` coordinate points downward may display the same positive
+rotation as clockwise; that display convention does not change the model's
+right-handed material-frame convention.
 
 ### Custom routing laws
 

--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -71,10 +71,7 @@ a(s) =
 \]
 
 In particular, a positive-`y` path lies on the inside of a
-positive-curvature bend and shortens relative to the backbone. A renderer
-whose screen `y` coordinate points downward may display the same positive
-rotation as clockwise; that display convention does not change the model's
-right-handed material-frame convention.
+positive-curvature bend and shortens relative to the backbone.
 
 ### Custom routing laws
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -27,6 +27,10 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Breaking changes
 
+- Corrected the `PlanarPCS` threadlike routing convention so a positive
+  material-`y` offset shortens under positive `kappa_z`. Existing planar
+  threadlike models that compensated for the previous sign must update their
+  routing offsets or actuator directions.
 - Renamed the Viser `cylinder_sections` and Open3D `tube_resolution` options to
   the geometry-neutral `cross_section_resolution`.
 

--- a/src/soromox/execution/warp/pcs/actuation/cooperative.py
+++ b/src/soromox/execution/warp/pcs/actuation/cooperative.py
@@ -36,7 +36,7 @@ def _planar_contribution(
     """Evaluate one weighted PlanarPCS path-point contribution."""
     s = physical_points[segment, point]
     offset = routing_intercepts[path, 1] + s * routing_slopes[path, 1]
-    axial = strain[1] + offset * strain[0]
+    axial = strain[1] - offset * strain[0]
     shear = strain[2] + routing_slopes[path, 1]
     norm = wp.sqrt(axial * axial + shear * shear)
     axial_ratio = wp.float64(0.0)
@@ -46,7 +46,7 @@ def _planar_contribution(
         shear_ratio = shear / norm
     weight = physical_weights[segment, point]
     return wp.vec3d(
-        weight * offset * axial_ratio,
+        -weight * offset * axial_ratio,
         weight * axial_ratio,
         weight * shear_ratio,
     )

--- a/src/soromox/execution/warp/pcs/actuation/threadlike.py
+++ b/src/soromox/execution/warp/pcs/actuation/threadlike.py
@@ -68,7 +68,7 @@ def planar_threadlike_matrix_kernel(
         if active_path:
             s = physical_points[segment, point]
             offset = routing_intercepts[path, 1] + s * routing_slopes[path, 1]
-            axial = strain[1] + offset * strain[0]
+            axial = strain[1] - offset * strain[0]
             shear = strain[2] + routing_slopes[path, 1]
             norm = wp.sqrt(axial * axial + shear * shear)
             axial_ratio = wp.float64(0.0)
@@ -77,7 +77,7 @@ def planar_threadlike_matrix_kernel(
                 axial_ratio = axial / norm
                 shear_ratio = shear / norm
             weight = physical_weights[segment, point]
-            integrated[0] += weight * offset * axial_ratio
+            integrated[0] -= weight * offset * axial_ratio
             integrated[1] += weight * axial_ratio
             integrated[2] += weight * shear_ratio
         point += 1
@@ -134,7 +134,7 @@ def planar_threadlike_force_kernel(
             while point < physical_points.shape[1]:
                 s = physical_points[segment, point]
                 offset = routing_intercepts[path, 1] + s * routing_slopes[path, 1]
-                axial = strain[1] + offset * strain[0]
+                axial = strain[1] - offset * strain[0]
                 shear = strain[2] + routing_slopes[path, 1]
                 norm = wp.sqrt(axial * axial + shear * shear)
                 axial_ratio = wp.float64(0.0)
@@ -143,7 +143,7 @@ def planar_threadlike_force_kernel(
                     axial_ratio = axial / norm
                     shear_ratio = shear / norm
                 weight = physical_weights[segment, point] * effort
-                accumulated[0] += weight * offset * axial_ratio
+                accumulated[0] -= weight * offset * axial_ratio
                 accumulated[1] += weight * axial_ratio
                 accumulated[2] += weight * shear_ratio
                 point += 1

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -2977,20 +2977,50 @@ class PlanarPCS(SoftRobot):
         start_segment_index: Array,
         end_segment_index: Array,
     ) -> Array:
+        """Return the routed-path length gradient in one planar segment.
+
+        The planar strain is ordered as ``[kappa_z, sigma_x, sigma_y]`` and
+        the routing offset is positive along material ``+y``. With the
+        backbone directed along material ``+x``, the local path tangent is
+        ``[sigma_x - offset * kappa_z, sigma_y + offset_derivative]``.
+
+        Args:
+            segment_index: Index of the segment containing ``s``.
+            strain: Planar material strain for the segment.
+            s: Arc-length coordinate in the undeformed backbone.
+            routing: Threadlike routing law.
+            path_params: Parameters for one routed path.
+            start_segment_index: First segment traversed by the path.
+            end_segment_index: Last segment traversed by the path.
+
+        Returns:
+            The local path-length gradient with respect to planar strain,
+            ordered as ``[kappa_z, sigma_x, sigma_y]``. The result is zero
+            outside the path's inclusive segment range.
+        """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
         )
         offset = routing.offset(path_params, s)[1]
         offset_derivative = routing.derivative(path_params, s)[1]
-        axial = strain[1] + offset * strain[0]
+        axial = strain[1] - offset * strain[0]
         shear = strain[2] + offset_derivative
         norm = safe_norm(jnp.stack([axial, shear]))
         axial_ratio = safe_divide(axial, norm, self.global_eps)
         shear_ratio = safe_divide(shear, norm, self.global_eps)
-        return active * jnp.asarray([offset * axial_ratio, axial_ratio, shear_ratio])
+        return active * jnp.asarray([-offset * axial_ratio, axial_ratio, shear_ratio])
 
     def _threadlike_moment_matrix(self, q: Array, routing: ThreadlikeRouting) -> Array:
-        """Integrate raw routed-length moment arms in the planar PCS basis."""
+        """Integrate raw routed-length moment arms in the planar PCS basis.
+
+        Args:
+            q: Generalized configuration of the robot.
+            routing: Threadlike routing whose paths are integrated.
+
+        Returns:
+            Matrix whose columns are routed-path length gradients with respect
+            to the generalized coordinates.
+        """
         params = routing.params
         count = params.num_paths
         if count == 0:
@@ -3031,7 +3061,15 @@ class PlanarPCS(SoftRobot):
         return self.B_xi.T @ full_matrix
 
     def _threadlike_path_lengths(self, q: Array, routing: ThreadlikeRouting) -> Array:
-        """Integrate raw planar threadlike path lengths."""
+        """Integrate raw planar threadlike path lengths.
+
+        Args:
+            q: Generalized configuration of the robot.
+            routing: Threadlike routing whose paths are integrated.
+
+        Returns:
+            One physical length for each routed path.
+        """
         params = routing.params
         if params.num_paths == 0:
             return jnp.zeros((0,), dtype=q.dtype)
@@ -3059,7 +3097,7 @@ class PlanarPCS(SoftRobot):
                     offset = routing.offset(path_params, s)[1]
                     derivative = routing.derivative(path_params, s)[1]
                     axial = (
-                        strains[segment_index, 1] + offset * strains[segment_index, 0]
+                        strains[segment_index, 1] - offset * strains[segment_index, 0]
                     )
                     shear = strains[segment_index, 2] + derivative
                     return active * safe_norm(jnp.stack([axial, shear]))

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -117,6 +117,35 @@ def _routing(*, count=2):
     )
 
 
+def test_planar_positive_y_path_shortens_under_positive_curvature():
+    """Regress the right-handed PlanarPCS threadlike sign convention."""
+    offset = 0.02
+    routing = ThreadlikeRouting.linear(
+        intercept=jnp.array([0.0, offset, 0.0]),
+        slope=jnp.zeros((3,)),
+        start_segment_index=(0,),
+        end_segment_index=(0,),
+    )
+    robot = _planar_pcs(actuators=ThreadlikeActuator.tendons(routing))
+    curvature = 2.0
+    q = jnp.array([curvature, 0.0, 0.0])
+
+    path_length = robot._threadlike_path_lengths(q, routing)[0]
+    expected_length = robot.L[0] * (1.0 - offset * curvature)
+    assert_allclose(path_length, expected_length)
+
+    # Tendon coordinates are negative path lengths, so positive tendon effort
+    # produces a positive generalized bending force for this routing.
+    assert_allclose(robot.actuation_matrix(q)[0, 0], offset * robot.L[0])
+
+    s = jnp.linspace(0.0, robot.L[0], 2001)
+    positions = jax.vmap(
+        lambda current_s: robot._threadlike_path_positions(q, current_s, routing)[0]
+    )(s)
+    rendered_length = jnp.sum(jnp.linalg.norm(jnp.diff(positions, axis=0), axis=1))
+    assert_allclose(rendered_length, path_length, rtol=2e-7, atol=2e-9)
+
+
 def _threadlike_components():
     routing = _routing()
     actuator = ThreadlikeActuator.tendons(routing)

--- a/tests/systems/test_pcs_2d_vs_3d_coherence.py
+++ b/tests/systems/test_pcs_2d_vs_3d_coherence.py
@@ -10,6 +10,7 @@ from system_param_builders import (
     spatial_base_pose,
 )
 
+from soromox.actuation import ThreadlikeActuator, ThreadlikeRouting
 from soromox.systems import PCS, PCSStructure, PlanarPCS, PlanarPCSStructure
 from soromox.utils.tolerance import Tolerance
 
@@ -24,8 +25,12 @@ NUM_RANDOM_SAMPLES = 5
 
 
 def make_planar_model(
-    num_segments: int, total_length: float = TOTAL_LENGTH
+    num_segments: int,
+    total_length: float = TOTAL_LENGTH,
+    *,
+    actuators=None,
 ) -> PlanarPCS:
+    """Construct a planar PCS model for planar/spatial coherence tests."""
     segment_length = total_length / num_segments
     L = segment_length * jnp.ones((num_segments,))
     diag_entries = (
@@ -45,10 +50,17 @@ def make_planar_model(
         params=params,
         structure=PlanarPCSStructure(num_gauss_points=3),
         base_pose=planar_base_pose(),
+        actuators=actuators,
     )
 
 
-def make_spatial_model(num_segments: int, total_length: float = TOTAL_LENGTH) -> PCS:
+def make_spatial_model(
+    num_segments: int,
+    total_length: float = TOTAL_LENGTH,
+    *,
+    actuators=None,
+) -> PCS:
+    """Construct a spatial PCS model for planar/spatial coherence tests."""
     segment_length = total_length / num_segments
     L = segment_length * jnp.ones((num_segments,))
     diag_entries = (
@@ -69,6 +81,7 @@ def make_spatial_model(num_segments: int, total_length: float = TOTAL_LENGTH) ->
         params=params,
         structure=PCSStructure(num_gauss_points=3),
         base_pose=spatial_base_pose(),
+        actuators=actuators,
     )
 
 
@@ -429,6 +442,36 @@ def test_forward_dynamics_coherence(num_segments):
 
         assert_allclose(qd_spatial_next[indices], qd_planar_next, rtol=RTOL, atol=ATOL)
         assert_allclose(qdd_spatial[indices], qdd_planar, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize("num_segments", [1, 2, 3])
+def test_threadlike_actuation_coherence(num_segments):
+    """Match planar routing to the corresponding in-plane spatial routing."""
+    routing = ThreadlikeRouting.linear(
+        intercept=jnp.array([0.0, 0.012, 0.0]),
+        slope=jnp.array([0.0, 0.015, 0.0]),
+        start_segment_index=(0,),
+        end_segment_index=(num_segments - 1,),
+    )
+    actuator = ThreadlikeActuator.tendons(routing)
+    planar_model = make_planar_model(num_segments, actuators=actuator)
+    spatial_model = make_spatial_model(num_segments, actuators=actuator)
+    indices = spatial_planar_indices(num_segments)
+    q_planar = jnp.linspace(-0.04, 0.03, planar_model.num_internal_dofs)
+    q_spatial = lift_planar_configuration(planar_model, spatial_model, q_planar)
+
+    assert_allclose(
+        planar_model.actuator_coordinates(q_planar),
+        spatial_model.actuator_coordinates(q_spatial),
+        rtol=RTOL,
+        atol=ATOL,
+    )
+    assert_allclose(
+        planar_model.actuation_matrix(q_planar),
+        spatial_model.actuation_matrix(q_spatial)[indices],
+        rtol=RTOL,
+        atol=ATOL,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR corrects the planar threadlike routing convention so it is consistent
with the spatial `PCS` formulation and the right-handed planar material frame.
It is intentionally separated from the tendon-friction work in #190 so the
convention fix can be reviewed and merged independently.

- use material `+x` as the longitudinal direction and material `+y` as the
  transverse routing direction
- define positive `kappa_z` as rotating `+x` toward `+y`
- make a positive-`y` routed path shorten under positive curvature
- apply the same convention to routed lengths, JAX generalized forces, and
  serial and cooperative Warp kernels
- document the convention and its distinction from screen coordinates

## Implementation

For planar strain ordered as
`[kappa_z, sigma_x, sigma_y]` and routing offset `d_y(s)`, the material-frame
path tangent is

```text
a(s) = [sigma_x - d_y kappa_z, sigma_y + d_y_prime].
```

The routed-length gradient with respect to planar strain is therefore

```text
[-d_y a_x / ||a||, a_x / ||a||, a_y / ||a||].
```

The previous implementation used the opposite curvature sign in both
expressions. The corrected expressions now agree with the spatial identity
`omega cross d`, specialized to `omega = kappa_z e_z` and `d = d_y e_y`.

## Breaking change

Existing `PlanarPCS` threadlike models that negated routing offsets or actuator
directions to compensate for the previous sign must remove that compensation.
The change is listed under breaking changes in the changelog.

## Regression coverage

- positive-`y` path length under positive constant curvature
- tendon generalized-force direction
- integrated length versus densely sampled rendered path geometry
- threadlike coordinates and actuation matrices for lifted planar and spatial
  PCS models with one, two, and three segments
- JAX versus Warp threadlike execution paths

## Validation

- focused actuation, planar/spatial coherence, and Warp threadlike suites:
  `103 passed, 4 skipped`
- Ruff lint and formatting checks: passed
- `git diff --check`: passed