### PR TITLE
Add continuum Capstan friction to threadlike actuation

### DIFF
--- a/docs/api/actuation/index.md
+++ b/docs/api/actuation/index.md
@@ -6,22 +6,31 @@ or articulated hosts without introducing an actuator-specific robot subclass.
 
 ## Work-conjugate formulation
 
-A `Transmission` defines actuator coordinates \(y_\mathrm{a}(q)\). Their Jacobian is the
-transpose of the moment matrix:
+A `Transmission` defines actuator coordinates \(y_\mathrm{a}(q)\), their
+kinematic Jacobian \(J_\mathrm{a}\), and an effort-to-generalized-force map
+\(A\):
 
 \[
-A(q) = \left(\frac{\partial y_\mathrm{a}}{\partial q}\right)^T,
-\qquad \dot y_\mathrm{a} = A(q)^T \dot q.
+J_\mathrm{a}(q)=\frac{\partial y_\mathrm{a}}{\partial q},
+\qquad
+\dot y_\mathrm{a}=J_\mathrm{a}(q)\dot q,
+\qquad
+\tau_u=A(q)e.
 \]
 
 An `EffortModel` maps user controls \(u\) to efforts \(e\) conjugate to
 \(y_\mathrm{a}\).
-The generalized force and power are
+For an ideal lossless transmission, virtual work gives
 
 \[
-\tau_u = A(q)e,
-\qquad \dot q^T\tau_u = \dot y_\mathrm{a}^T e.
+A(q)=J_\mathrm{a}(q)^T,
+\qquad
+\dot q^T\tau_u=\dot y_\mathrm{a}^T e.
 \]
+
+Loss models may make \(A\ne J_\mathrm{a}^T\). Keeping the two methods
+separate prevents force attenuation from corrupting actuator-coordinate
+velocities.
 
 `DirectEffort`, the currently available effort law, implements `e = u`.
 The split leaves room for later activation, pressure-flow, force-length,
@@ -39,8 +48,8 @@ robot = PCS(
 )
 ```
 
-Tuple order defines control slices, actuator coordinates, moment-matrix columns,
-metadata, and rendered layers.
+Tuple order defines control slices, actuator coordinates, coordinate-Jacobian
+rows, actuation-matrix columns, metadata, and rendered layers.
 
 - `actuators=None` installs direct identity actuation, preserving the ordinary
   `PCS`, `PlanarPCS`, and `GVS` behavior.
@@ -73,6 +82,7 @@ The common robot interface is:
 ```python
 y_a = robot.actuator_coordinates(q)
 y_a_dot = robot.actuator_velocities(q, qd)
+J_a = robot.actuator_coordinate_jacobian(q)
 A = robot.actuation_matrix(q)
 e = robot.actuator_efforts(q, u, qd=qd)
 tau = robot.actuation_force(q, u, qd=qd)
@@ -83,8 +93,9 @@ metadata = robot.actuator_input_metadata
 requires velocity, omitting it evaluates the law at zero actuator velocity.
 
 [Actuation-space controllers](../control/actuation-space.md) consume the same
-`actuator_coordinates(q)` contract. The coordinate transformation requires the
-moment matrix to have full column rank at its reference configuration.
+`actuator_coordinates(q)` contract. The coordinate transformation requires
+`actuator_coordinate_jacobian(q)` to have full row rank at its reference
+configuration.
 
 ## Active and passive components
 

--- a/docs/api/actuation/joint-space.md
+++ b/docs/api/actuation/joint-space.md
@@ -81,7 +81,7 @@ entries must be zero. These checks belong to the tendon preset; the generic
 affine transmission does not impose them.
 
 Multiple actuator families can be installed as an ordered tuple. Their control
-slices, coordinates, moment-matrix columns, and metadata follow tuple order.
+slices, coordinates, actuation-matrix columns, and metadata follow tuple order.
 
 ## Passive tendon impedance
 

--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -6,11 +6,18 @@ contractile muscles, and pressure chambers represented by an equivalent axial
 volume coordinate. A path may span any contiguous inclusive range of body
 segments.
 
-Following the general routed-path formulation of
-[Renda et al. (2022)](https://doi.org/10.1109/LRA.2022.3183248), a routing is a
-material-frame offset from the backbone. `PCS`, `PlanarPCS`, and `GVS` combine
-that routing with their native strain kinematics to evaluate path length,
-coordinate velocity, and generalized actuator force.
+!!! info "Threadlike-routing reference"
+    The routing geometry follows:
+
+    > Renda, F., Armanini, C., Mathew, A. T., & Boyer, F. (2022).
+    > *Geometrically-Exact Inverse Kinematic Control of Soft Manipulators With
+    > General Threadlike Actuators' Routing*. IEEE Robotics and Automation
+    > Letters, 7(3), 7311–7318.
+    > [https://doi.org/10.1109/LRA.2022.3183248](https://doi.org/10.1109/LRA.2022.3183248)
+
+A routing is a material-frame offset from the backbone. `PCS`, `PlanarPCS`, and
+`GVS` combine that routing with their native strain kinematics to evaluate path
+length, coordinate velocity, and generalized actuator force.
 
 The model assumes fixed material-frame routing, one scalar coordinate and
 effort per path, and an optional static effort loss along active paths. It does
@@ -18,6 +25,8 @@ not model configuration-dependent rerouting, slack, actuator dynamics, or
 changes in pressure-chamber cross-section.
 
 ## Routing
+
+### Linear routing
 
 `ThreadlikeRouting` stores a vectorized path family. Linear paths use
 
@@ -78,25 +87,53 @@ class SinusoidalRoutingParams(BaseThreadlikeRoutingParams):
     end_segment_index: tuple[int, ...] = eqx.field(static=True)
 
     @property
-    def num_paths(self):
-        """Return the number of paths in this parameter batch."""
+    def num_paths(self) -> int:
+        """Return the number of paths in this parameter batch.
+
+        Returns:
+            Number of routed paths.
+        """
         return self.amplitude.shape[0]
 
 
-def offset(params, s):
-    """Return material-frame sinusoidal routing offsets at ``s``."""
+def offset(params: SinusoidalRoutingParams, s: jax.Array) -> jax.Array:
+    """Return material-frame sinusoidal routing offsets.
+
+    Args:
+        params: Batched sinusoidal routing parameters.
+        s: Scalar backbone abscissa.
+
+    Returns:
+        Material-frame offsets with shape ``(num_paths, 3)``.
+    """
     y = params.amplitude * jnp.sin(params.frequency * s)
     return jnp.stack((jnp.zeros_like(y), y, jnp.zeros_like(y)), axis=-1)
 
 
-def derivative(params, s):
-    """Return the first arc-length derivative of ``offset``."""
+def derivative(params: SinusoidalRoutingParams, s: jax.Array) -> jax.Array:
+    """Return the first derivative of the routing offset.
+
+    Args:
+        params: Batched sinusoidal routing parameters.
+        s: Scalar backbone abscissa.
+
+    Returns:
+        First derivatives with shape ``(num_paths, 3)``.
+    """
     y_s = params.amplitude * params.frequency * jnp.cos(params.frequency * s)
     return jnp.stack((jnp.zeros_like(y_s), y_s, jnp.zeros_like(y_s)), axis=-1)
 
 
-def second_derivative(params, s):
-    """Return the second arc-length derivative of ``offset``."""
+def second_derivative(params: SinusoidalRoutingParams, s: jax.Array) -> jax.Array:
+    """Return the second derivative of the routing offset.
+
+    Args:
+        params: Batched sinusoidal routing parameters.
+        s: Scalar backbone abscissa.
+
+    Returns:
+        Second derivatives with shape ``(num_paths, 3)``.
+    """
     y_ss = -(params.frequency**2) * params.amplitude * jnp.sin(
         params.frequency * s
     )
@@ -159,9 +196,6 @@ coordinate_jacobian = robot.actuator_coordinate_jacobian(q)
 actuation_matrix = robot.actuation_matrix(q)
 ```
 
-The singular `coordinate` in `coordinate_jacobian` follows the usual compound
-noun: it is the Jacobian of the vector returned by `actuator_coordinates`.
-The robot-level prefix is plural because all installed actuators are stacked.
 The two matrix contracts are
 
 \[
@@ -179,14 +213,14 @@ coordinates or velocities.
 ## Continuum Capstan friction
 
 `ThreadlikeFriction.capstan(coefficient=mu)` attenuates active threadlike effort
-along increasing backbone coordinate, starting at each path's configured
+along increasing backbone abscissa, starting at each path's configured
 anchor. It is available for `PCS`, `PlanarPCS`, and `GVS`. The default
 `ThreadlikeFriction.frictionless()` returns unit effort ratio.
 
 ### Path-turn derivation
 
-Let \(s\) be undeformed backbone arc length, \(R(s)\in SO(3)\) the material
-orientation, \(p(s)\in\mathbb{R}^3\) the backbone position, and
+Let \(s\) be the backbone abscissa in the undeformed configuration,
+\(R(s)\in SO(3)\) the material orientation, \(p(s)\in\mathbb{R}^3\) the backbone position, and
 \(\xi=(\omega,v)\) the angular and linear Cosserat strain. Then
 
 \[
@@ -224,9 +258,10 @@ Consequently,
 `turn_rate` is \(\rho\), in radians per metre of undeformed backbone. It
 includes both material-frame rotation and change of the tangent inside that
 frame. Omitting \(u'\) is valid only when the normalized material tangent is
-constant. Inside a PCS segment, \(\omega'=v'=0\), but routing derivatives can
-still make \(u'\ne0\). GVS computes \(\omega'\) and \(v'\) analytically from
-the derivative of its strain basis.
+constant. Inside a PCS segment, \(\omega'=v'=0\), so SoRoMoX uses the
+constant-strain specialization \(a'=\omega\times r'+r''\). Routing derivatives
+can still make \(u'\ne0\). GVS retains the full expression and computes
+\(\omega'\) and \(v'\) analytically from the derivative of its strain basis.
 
 The `accumulated_turn` from anchor \(s_0\) is
 
@@ -241,10 +276,17 @@ unsigned angle at the interface.
 ### Relation to the cited discrete model
 
 The exponential Capstan relation is established for ropes, belts, and tendons
-sliding over contact. SoRoMoX takes inspiration from the discrete spacer-disk
-tendon model of
-[Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3581774), in
-which each disk obeys
+sliding over contact. SoRoMoX takes inspiration from a discrete spacer-disk
+tendon model:
+
+!!! info "Capstan-model reference"
+    > Feliu-Talegon, D., Alkayas, A. Y., Adamu, Y. A., Mathew, A. T., &
+    > Renda, F. (2025). *Actuation Reading Insights: Estimating Shape and
+    > Forces in Tendon-Driven Slender Soft Robots*. IEEE/ASME Transactions on
+    > Mechatronics, 30(6), 7878–7888.
+    > [https://doi.org/10.1109/TMECH.2025.3581774](https://doi.org/10.1109/TMECH.2025.3581774)
+
+In that model, each disk obeys
 
 \[
 T_i=T_{i-1}e^{-\mu\varphi_i},
@@ -302,8 +344,19 @@ class HyperbolicFrictionParams(BaseThreadlikeFrictionParams):
     coefficient: Array
 
 
-def hyperbolic_effort_ratio(params, accumulated_turn):
-    """Return a custom effort ratio as a function of accumulated turn."""
+def hyperbolic_effort_ratio(
+    params: HyperbolicFrictionParams,
+    accumulated_turn: Array,
+) -> Array:
+    """Return a custom effort ratio as a function of accumulated turn.
+
+    Args:
+        params: Hyperbolic friction parameters.
+        accumulated_turn: Accumulated path turn with shape ``(num_paths,)``.
+
+    Returns:
+        Surviving effort ratios with shape ``(num_paths,)``.
+    """
     return 1.0 / (1.0 + params.coefficient * accumulated_turn)
 
 
@@ -358,8 +411,7 @@ static topology and require reconstruction.
 
 ## Rendering
 
-Renderer adapters turn path queries into semantic visual layers. Physics
-objects do not import renderer primitives or store visual style. Generic
+Renderer adapters turn path queries into semantic visual layers. Generic
 renderers draw swept geometry when a radius is configured and use polylines
 otherwise. I-SUPPORT retains its detailed bellows renderer.
 

--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -182,7 +182,7 @@ coordinates = robot.actuator_coordinates(q)
 For tendons, `coordinates == -lengths`; for a pressure preset, coordinates are
 equivalent volumes. Without guide friction,
 `jax.jacrev(robot.actuator_coordinates)(q) == robot.actuation_matrix(q).T` up
-to quadrature tolerance. A nonzero friction coefficient breaks that identity by
+to quadrature tolerance. A lossy friction law breaks that identity by
 design, because the moment matrix then carries a transmission loss that path
 length does not; see [Guide friction](#guide-friction).
 
@@ -192,9 +192,21 @@ behavior is common, while each host keeps its native evaluation path.
 
 ## Guide friction
 
-By default a path transmits its effort undiminished along its whole route. Set
-`friction_coefficient` to model Coulomb friction against the guides the path
-runs through, following the force model of
+By default a path transmits its effort undiminished along its whole route. Pass
+a `friction=` law to model a transmission loss. The law is an object, so a new
+loss model needs no change to any host, and a third-party model needs no change
+to soromox.
+
+soromox ships three:
+
+| Law | Ratio | Hosts |
+|---|---|---|
+| `Frictionless` | \(1\) | all; the default |
+| `CapstanFriction` | \(e^{-\mu\Theta}\) | `PCS`, `PlanarPCS` |
+| `ExponentialLengthFriction` | \(e^{-ks}\) | all, including `GVS` |
+
+`CapstanFriction` models Coulomb friction against the guides a path runs
+through, following the force model of
 [Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3550846). A
 tendon threaded through spacer disks loses tension at every contact, and the
 loss at each contact obeys the classical Capstan (Euler) law
@@ -217,10 +229,11 @@ contributes less than the proximal part:
 A_\mu(q) = B_\xi^\top \int_0^L \eta(q, s)\,\Phi(q, s)\,\mathrm{d}s
 \]
 
-\(\eta\) depends on the configuration only, so the actuation force stays linear
-in the effort and every controller keeps working. Since \(\eta \in (0, 1]\), the
-model can only ever remove effort, never add it, and a coefficient of zero
-reproduces the frictionless matrix exactly.
+Every law obeys the same two rules. \(\eta\) depends on the configuration only,
+never on the effort, so the actuation force stays linear in the effort and every
+controller keeps working; and \(\eta \in (0, 1]\), so a law can only ever remove
+effort, never add it. The lossless default reproduces the frictionless matrix
+exactly and is skipped entirely, at no cost.
 
 The wrap density reduces to \(\lvert\kappa\rvert\) identically in the plane, for
 any offset and any strain. Under torsion it recovers the helix curvature of an
@@ -231,27 +244,39 @@ robot = PCS.from_links(
     links,
     structure=PCSStructure(num_gauss_points=5),
     # a scalar shares one coefficient; pass shape (num_paths,) for per-path values
-    actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.2),
+    actuators=ThreadlikeActuator.tendons(
+        routing, friction=CapstanFriction(coefficient=0.2)
+    ),
 )
 
 tau = robot.actuation_force(q, jnp.array([5.0, 0.0]))
 ```
 
-`PCS` and `PlanarPCS` implement the wrap-angle model. `GVS` strain varies along
-arc length, so its wrap angle is not piecewise linear; it rejects a nonzero
-coefficient during construction with a descriptive `TypeError`.
+`friction_coefficient=0.2` is kept as sugar for the same thing. Passing both it
+and `friction=` raises, because the two would silently disagree.
 
-### Identifying the coefficient
+A law declares what it needs, and a host refuses a law it cannot serve.
+`CapstanFriction` sets `requires_wrap_angle`, which `PCS` and `PlanarPCS`
+supply. `GVS` strain varies along arc length, so its wrap angle is not
+piecewise linear and it supplies none; it rejects a wrap-angle law during
+construction with a descriptive `TypeError`, at any coefficient including zero,
+because capability follows the law you install rather than the value you gave
+it. `ExponentialLengthFriction` reads only arc length, so it runs on `GVS` too.
 
-The coefficient is an ordinary dynamic leaf, so it is traceable and
+### Identifying a loss parameter
+
+Loss parameters are ordinary dynamic leaves, so they are traceable and
 differentiable under `jit`:
 
 ```python
 def with_friction(mu):
-    transmission = robot.actuators[0].params.transmission.replace(
-        friction_coefficient=mu
+    transmission = robot.actuators[0].params.transmission
+    return robot.update_actuator_params(
+        0,
+        transmission=transmission.replace(
+            friction=transmission.friction.replace(coefficient=mu)
+        ),
     )
-    return robot.update_actuator_params(0, transmission=transmission)
 
 
 @jax.jit
@@ -268,15 +293,64 @@ def loss(mu):
 value, grad = jax.value_and_grad(loss)(jnp.array(0.2))
 ```
 
-Zero is a valid optimizer start, but \(\mathrm{d}A/\mathrm{d}\mu\) vanishes
-wherever \(\Theta = 0\), so a perfectly straight pose carries no information
-about \(\mu\). Set `wrap_angle_smoothing` on the host structure to replace
+Swapping the law changes the parameter PyTree structure and so retraces, while
+replacing a value inside a law does not. Start identification from a lossy law
+at a zero parameter, `CapstanFriction(coefficient=0.0)`, rather than from
+`Frictionless()`. Zero is a valid optimizer start, but
+\(\mathrm{d}A/\mathrm{d}\mu\) vanishes wherever \(\Theta = 0\), so a perfectly
+straight pose carries no information about \(\mu\). Set `wrap_angle_smoothing` on the host structure to replace
 \(\lvert\kappa\rvert\) with \(\sqrt{\kappa^2 + \epsilon^2}\) if the fit can
 approach a straight configuration. It never under-estimates the wrap angle and
 over-estimates it by at most \(\epsilon L\), and it also removes the \(C^0\)
 kink at zero curvature.
 
-### What changes at a nonzero coefficient
+### Custom friction laws
+
+The hosts depend only on the law contract, not on the shipped models. A custom
+law supplies the parameters it needs, declares its requirements, and returns the
+surviving effort fraction per path:
+
+```python
+from soromox.actuation import ThreadlikeFriction
+
+
+class HyperbolicFriction(ThreadlikeFriction):
+    a: Array
+
+    def transmission_ratio(self, context):
+        return 1.0 / (1.0 + self.a * context.wrap_angle)
+
+
+actuator = ThreadlikeActuator.tendons(
+    routing, friction=HyperbolicFriction(a=jnp.asarray(0.5))
+)
+```
+
+The `context` is a `ThreadlikeQuadratureContext` describing the routed path at
+one quadrature node, batched over paths. Some of its fields mean the same thing
+on every host and some do not:
+
+| Field | Meaning | Portable |
+|---|---|---|
+| `arc_length` | backbone coordinate \(s\) | yes |
+| `segment_index` | segment containing the node | yes |
+| `offset`, `offset_derivative` | material-frame offset `(n, 3)` and its \(s\)-derivative | yes |
+| `tangent_norm` | routed-path stretch relative to the backbone | yes |
+| `active` | whether the node lies in each path's span | yes |
+| `unit_tangent` | normalized tangent, `(n, 2)` planar and `(n, 3)` spatial | no |
+| `strain` | `(n, 3)` planar and `(n, 6)` spatial | no |
+| `wrap_angle` | accumulated turn \(\Theta\), or `None` | only where supplied |
+
+A law reading only the portable fields runs unchanged on every host. A law
+reading `strain` or `unit_tangent` must document which host it targets.
+
+Set `requires_wrap_angle = False` if the law does not read `wrap_angle`, and the
+hosts will neither compute it nor refuse the law. Set `is_lossless = True` for a
+law that always returns one, and the hosts will skip it entirely. A law must
+keep its ratio in \((0, 1]\) and must not read the effort, which would make the
+actuation force nonlinear in the control.
+
+### What changes under a lossy law
 
 - `moment_matrix` is no longer the transpose of the length gradient, so
   `actuation_space` conversions that assume the identity do not apply.
@@ -319,7 +393,7 @@ robot = PCS(
 
 The passive element contributes to elastic force, damping, and elastic energy;
 it never consumes an active control channel. A passive path may also declare a
-`friction_coefficient`, in which case part of its spring force becomes
+`friction=` law, in which case part of its spring force becomes
 non-conservative and is applied through `actuation_force`; see
 [Guide friction](#guide-friction).
 

--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -19,7 +19,7 @@ The transmission model assumes that:
 - the actuator coordinate is determined by path length, scaled by a constant
   effective area for the pressure-chamber preset; and
 - each path carries one scalar work-conjugate effort, attenuated along its
-  route only by the optional Capstan friction model described below.
+  route by an optional friction model described below.
 
 Consequently, configuration- or time-dependent rerouting, changes in chamber
 cross-section, path slack, and internal actuator dynamics are outside the
@@ -182,76 +182,106 @@ coordinates = robot.actuator_coordinates(q)
 For tendons, `coordinates == -lengths`; for a pressure preset, coordinates are
 equivalent volumes. Without guide friction,
 `jax.jacrev(robot.actuator_coordinates)(q) == robot.actuation_matrix(q).T` up
-to quadrature tolerance. A lossy friction law breaks that identity by
-design, because the moment matrix then carries a transmission loss that path
-length does not; see [Guide friction](#guide-friction).
+to quadrature tolerance. A friction model breaks that identity by design,
+because the moment matrix then carries an attenuation that path length does
+not; see [Routing friction](#routing-friction).
 
-PCS integrates the local path basis and performs the constant-strain projection
+PCS integrates the local length gradient and performs the constant-strain projection
 once. GVS applies its strain basis inside the existing quadrature. The public
 behavior is common, while each host keeps its native evaluation path.
 
-## Guide friction
+## Routing friction
 
-By default a path transmits its effort undiminished along its whole route. Pass
-a `friction=` law to model a transmission loss. The law is an object, so a new
-loss model needs no change to any host, and a third-party model needs no change
-to soromox.
+Ideally, effort is transmitted undiminished along its route, from the motor
+until its attachment point. However, friction between the routing and the
+robot body is often non-negligible in real applications, and attenuates the
+effort along the path. It is possible to simulate this behavior via the
+`ThreadlikeFriction` model, which is installed on a `ThreadlikeTransmission`
+through the `friction=` keyword of `ThreadlikeActuator` and
+`ThreadlikeImpedance`.
+The current implemented models are the following:
 
-soromox ships three:
-
-| Law | Ratio | Parameter | Hosts |
+| Model | Ratio | Parameter | Hosts |
 |---|---|---|---|
-| `Frictionless` | \(1\) | none | all; the default |
-| `CapstanFriction` | \(e^{-\mu\Theta}\) | \(\mu\), Coulomb coefficient | `PCS`, `PlanarPCS` |
-| `ExponentialLengthFriction` | \(e^{-ks}\) | \(k\), per metre | all, including `GVS` |
+| `ThreadlikeFriction.frictionless()` | \(1\) | none | all; the default |
+| `ThreadlikeFriction.exponential_length(...)` | \(e^{-k\ell}\) | `rate` \(k\), per metre | all |
+| `ThreadlikeFriction.capstan(...)` | \(e^{-\mu\Theta}\) | `coefficient` \(\mu\), Coulomb; `eps` \(\epsilon\), per metre | `PCS`, `PlanarPCS` |
 
-Both lossy laws solve the same tension ODE
-\(\mathrm{d}T/\mathrm{d}s = -\lambda(s)T\), whose solution is
-\(\eta = e^{-\int\lambda\,\mathrm{d}s}\). They differ only in where the normal
-load pressing the path against its guide comes from. Under `CapstanFriction`
-it is curvature-induced, \(N = Tw\), giving \(\lambda = \mu w\). Under
-`ExponentialLengthFriction` it comes from a snug sheath gripping in proportion
-to tension, \(N = cT\), giving a constant \(\lambda = \mu c = k\), so loss
-accrues with distance travelled rather than with turning.
 
-That makes \(k\) phenomenological in a way \(\mu\) is not: it lumps the
-friction coefficient together with the radial grip, so it has to be fitted
-rather than looked up. It suits a tendon in a close-fitting sheath or lumen,
-and because it never reads the wrap angle it is the one law `GVS` can host.
+### Friction models
 
-`CapstanFriction` models Coulomb friction against the guides a path runs
-through, following the force model of
-[Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3550846). A
-tendon threaded through spacer disks loses tension at every contact, and the
-loss at each contact obeys the classical Capstan (Euler) law
-\(T_{out} = T_{in}e^{-\mu\varphi}\), which depends on the accumulated turn
-\(\varphi\) alone and not on the guide radius.
-
-Taking the guide spacing to zero turns the product of per-contact losses into
+The exponential length and Capstan models follow from the same tension balance along the routed path, with \(T\) the tension, \(\lambda\) the attenuation rate per unit arc length, and \(s_0\) the abscissa of the path anchor:
 
 \[
-\eta(q, s) = e^{-\mu\Theta(q, s)}, \qquad
-\Theta(q, s) = \int_0^s \lVert\omega \times \hat{u}\rVert\,\mathrm{d}s'
+\frac{\mathrm{d}T}{\mathrm{d}s} = -\lambda\,T,
+\qquad
+\eta(s) = \frac{T(s)}{T(s_0)} = \exp\!\left(-\int_{s_0}^{s}\lambda\,
+\mathrm{d}s'\right)
 \]
 
-the fraction of the base effort that survives to arc length \(s\), with
-\(\hat{u}\) the unit routed-path tangent. Because \(\eta\) weights the integrand
-of the moment matrix rather than scaling its result, the distal part of a path
-contributes less than the proximal part:
+They differ in the origin of the normal load \(N\) pressing the path against the
+body.
+
+**Configuration-independent friction.** A first approximation scales uniformly the tension along the path, \(N = cT\), so \(\lambda = \mu c \equiv k\) is
+constant and the attenuation depends only on the arc length \(\ell = s - s_0\)
+travelled from the anchor:
 
 \[
-A_\mu(q) = B_\xi^\top \int_0^L \eta(q, s)\,\Phi(q, s)\,\mathrm{d}s
+\eta(\ell) = e^{-k\ell}
 \]
 
-Every law obeys the same two rules. \(\eta\) depends on the configuration only,
-never on the effort, so the actuation force stays linear in the effort and every
-controller keeps working; and \(\eta \in (0, 1]\), so a law can only ever remove
-effort, never add it. The lossless default reproduces the frictionless matrix
-exactly and is skipped entirely, at no cost.
+**Configuration-dependent friction (Capstan).** The normal load is induced by
+the curvature of the path, \(N = Tk_p\), so \(\lambda = \mu k_p(q, s)\):
 
-The wrap density reduces to \(\lvert\kappa\rvert\) identically in the plane, for
-any offset and any strain. Under torsion it recovers the helix curvature of an
-off-axis path, so a twisted robot correctly reports a nonzero wrap angle.
+\[
+k_p(q, s) = \lVert\omega \times \hat{u}\rVert,
+\qquad
+\eta(q, s) = e^{-\mu\Theta(q, s)},
+\quad
+\Theta(q, s) = \int_{s_0}^{s} k_p(q, s')\,\mathrm{d}s'
+\]
+
+Here \(\omega\) is the angular strain, \(\hat{u}\) the unit routed-path tangent,
+and \(\Theta\) the wrap angle accumulated from the anchor. Since
+\(\mathrm{d}\hat{u}/\mathrm{d}s = \omega \times \hat{u}\), only the component of
+\(\omega\) orthogonal to \(\hat{u}\) contributes, so torsion about the axis of
+the path does not attenuate. In the plane \(k_p\) reduces to
+\(\lvert\kappa_z\rvert\); under torsion an off-axis path traces a helix, whose
+curvature \(k_p\) recovers.
+
+Because \(\Theta\) vanishes at a straight configuration, so does
+\(\partial\eta/\partial\mu\), and \(\mu\) is not identifiable there. The `eps`
+argument floors the curvature at \(\epsilon\), replacing \(k_p\) by
+\(\sqrt{k_p^2 + \epsilon^2}\). It never under-estimates \(\Theta\) and
+over-estimates it by at most \(\epsilon L\); the default \(\epsilon = 0\)
+reproduces the exact curvature.
+
+This model is the continuum limit of the discrete tendon force model of
+[Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3550846), in
+which the tendon passes through a finite set of spacer disks and each contact
+attenuates the tension by the classical Capstan (Euler) relation
+
+\[
+T_i = T_{i-1}\,e^{-\mu\varphi_i}
+\qquad\Longrightarrow\qquad
+T_n = T_0\,\exp\!\left(-\mu\sum_{i=1}^{n}\varphi_i\right)
+\]
+
+with \(\varphi_i\) the turn at the \(i\)-th contact, independent of the guide
+radius. As the disk spacing tends to zero at fixed total turning,
+\(\sum_i \varphi_i \to \Theta\) and the product recovers \(\eta\) above, which
+can then be evaluated at every quadrature node rather than at discrete guides.
+
+### Applying the friction
+
+\(\eta\) weights the integrand of the moment matrix rather than scaling its
+result, so the distal part of a path contributes less than the proximal part:
+
+\[
+A_\mu(q) = B_\xi^\top \int_0^L \eta(q, s)\,
+\frac{\partial\lVert t\rVert}{\partial\xi}(q, s)\,\mathrm{d}s
+\]
+
 
 ```python
 robot = PCS.from_links(
@@ -259,94 +289,54 @@ robot = PCS.from_links(
     structure=PCSStructure(num_gauss_points=5),
     # a scalar shares one coefficient; pass shape (num_paths,) for per-path values
     actuators=ThreadlikeActuator.tendons(
-        routing, friction=CapstanFriction(coefficient=0.2)
+        routing, friction=ThreadlikeFriction.capstan(coefficient=0.2)
     ),
 )
 
 tau = robot.actuation_force(q, jnp.array([5.0, 0.0]))
 ```
 
-`friction_coefficient=0.2` is kept as sugar for the same thing. Passing both it
-and `friction=` raises, because the two would silently disagree.
+### Custom friction models
 
-A law declares what it needs, and a host refuses a law it cannot serve.
-`CapstanFriction` sets `requires_wrap_angle`, which `PCS` and `PlanarPCS`
-supply. `GVS` strain varies along arc length, so its wrap angle is not
-piecewise linear and it supplies none; it rejects a wrap-angle law during
-construction with a descriptive `TypeError`, at any coefficient including zero,
-because capability follows the law you install rather than the value you gave
-it. `ExponentialLengthFriction` reads only arc length, so it runs on `GVS` too.
-
-### Identifying a loss parameter
-
-Loss parameters are ordinary dynamic leaves, so they are traceable and
-differentiable under `jit`:
+A model is a plain function of `(params, context)`, paired with its parameters by
+`ThreadlikeFriction`. The hosts depend only on that contract, not on the shipped
+models:
 
 ```python
-def with_friction(mu):
-    transmission = robot.actuators[0].params.transmission
-    return robot.update_actuator_params(
-        0,
-        transmission=transmission.replace(
-            friction=transmission.friction.replace(coefficient=mu)
-        ),
-    )
+from soromox.actuation import BaseThreadlikeFrictionParams, ThreadlikeFriction
 
 
-@jax.jit
-def loss(mu):
-    identified = with_friction(mu)
-    residual = (
-        identified.elastic_force(q_meas)
-        + identified.gravitational_force(q_meas)
-        - identified.actuation_force(q_meas, u_meas)
-    )
-    return jnp.sum(residual**2)
-
-
-value, grad = jax.value_and_grad(loss)(jnp.array(0.2))
-```
-
-Swapping the law changes the parameter PyTree structure and so retraces, while
-replacing a value inside a law does not. Start identification from a lossy law
-at a zero parameter, `CapstanFriction(coefficient=0.0)`, rather than from
-`Frictionless()`. Zero is a valid optimizer start, but
-\(\mathrm{d}A/\mathrm{d}\mu\) vanishes wherever \(\Theta = 0\), so a perfectly
-straight pose carries no information about \(\mu\). Set `wrap_angle_smoothing` on the host structure to replace
-\(\lvert\kappa\rvert\) with \(\sqrt{\kappa^2 + \epsilon^2}\) if the fit can
-approach a straight configuration. It never under-estimates the wrap angle and
-over-estimates it by at most \(\epsilon L\), and it also removes the \(C^0\)
-kink at zero curvature.
-
-### Custom friction laws
-
-The hosts depend only on the law contract, not on the shipped models. A custom
-law supplies the parameters it needs, declares its requirements, and returns the
-surviving effort fraction per path:
-
-```python
-from soromox.actuation import ThreadlikeFriction
-
-
-class HyperbolicFriction(ThreadlikeFriction):
+class HyperbolicFrictionParams(BaseThreadlikeFrictionParams):
     a: Array
 
-    def transmission_ratio(self, context):
-        return 1.0 / (1.0 + self.a * context.wrap_angle)
+
+def hyperbolic_transmission_ratio(params, context):
+    return 1.0 / (1.0 + params.a * context.wrap_angle)
 
 
 actuator = ThreadlikeActuator.tendons(
-    routing, friction=HyperbolicFriction(a=jnp.asarray(0.5))
+    routing,
+    friction=ThreadlikeFriction(
+        params=HyperbolicFrictionParams(a=jnp.asarray(0.5)),
+        ratio_fn=hyperbolic_transmission_ratio,
+        requires_wrap_angle=True,
+        is_frictionless=False,
+    ),
 )
 ```
 
+Parameters live in the transmission parameter tree, so they stay differentiable
+and replaceable; the model itself is static, so swapping it leads to retracing.
+This mirrors how `ThreadlikeRouting` pairs routing parameters with a static
+offset function.
+
 The `context` is a `ThreadlikeQuadratureContext` describing the routed path at
-one quadrature node, batched over paths. Some of its fields mean the same thing
-on every host and some do not:
+one quadrature node.
 
 | Field | Meaning | Portable |
 |---|---|---|
-| `arc_length` | backbone coordinate \(s\) | yes |
+| `abscissa` | backbone coordinate \(s\), from the robot base | yes |
+| `path_abscissa` | arc length travelled from this path's anchor | yes |
 | `segment_index` | segment containing the node | yes |
 | `offset`, `offset_derivative` | material-frame offset `(n, 3)` and its \(s\)-derivative | yes |
 | `tangent_norm` | routed-path stretch relative to the backbone | yes |
@@ -355,16 +345,14 @@ on every host and some do not:
 | `strain` | `(n, 3)` planar and `(n, 6)` spatial | no |
 | `wrap_angle` | accumulated turn \(\Theta\), or `None` | only where supplied |
 
-A law reading only the portable fields runs unchanged on every host. A law
-reading `strain` or `unit_tangent` must document which host it targets.
+Set `requires_wrap_angle=False` if the model does not read `wrap_angle`, and the
+hosts will neither compute it nor refuse the model. Set `is_frictionless=True`
+only
+for a model that always returns one, and the hosts will skip it entirely. A model
+must keep its ratio in \((0, 1]\) and must not read the effort, which would make
+the actuation force nonlinear in the control.
 
-Set `requires_wrap_angle = False` if the law does not read `wrap_angle`, and the
-hosts will neither compute it nor refuse the law. Set `is_lossless = True` for a
-law that always returns one, and the hosts will skip it entirely. A law must
-keep its ratio in \((0, 1]\) and must not read the effort, which would make the
-actuation force nonlinear in the control.
-
-### What changes under a lossy law
+### What changes under a friction model
 
 - `moment_matrix` is no longer the transpose of the length gradient, so
   `actuation_space` conversions that assume the identity do not apply.
@@ -377,7 +365,7 @@ actuation force nonlinear in the control.
 - The moment matrix acquires a mild dependence on `num_gauss_points`, because
   the attenuated integrand is no longer polynomial.
 - `path_lengths`, `path_velocities`, and `path_poses` are unchanged. They are
-  pure geometry at any coefficient.
+  pure geometry under any friction model.
 - The model assumes the effort drives the path. A back-driven path is still
   modelled with the driving branch of Euler's law, so keep the passive
   coefficient conservative or zero for long dynamic rollouts with
@@ -407,9 +395,9 @@ robot = PCS(
 
 The passive element contributes to elastic force, damping, and elastic energy;
 it never consumes an active control channel. A passive path may also declare a
-`friction=` law, in which case part of its spring force becomes
+`friction=` model, in which case part of its spring force becomes
 non-conservative and is applied through `actuation_force`; see
-[Guide friction](#guide-friction).
+[Routing friction](#routing-friction).
 
 ## Updating routing and actuator parameters
 

--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -199,11 +199,25 @@ to soromox.
 
 soromox ships three:
 
-| Law | Ratio | Hosts |
-|---|---|---|
-| `Frictionless` | \(1\) | all; the default |
-| `CapstanFriction` | \(e^{-\mu\Theta}\) | `PCS`, `PlanarPCS` |
-| `ExponentialLengthFriction` | \(e^{-ks}\) | all, including `GVS` |
+| Law | Ratio | Parameter | Hosts |
+|---|---|---|---|
+| `Frictionless` | \(1\) | none | all; the default |
+| `CapstanFriction` | \(e^{-\mu\Theta}\) | \(\mu\), Coulomb coefficient | `PCS`, `PlanarPCS` |
+| `ExponentialLengthFriction` | \(e^{-ks}\) | \(k\), per metre | all, including `GVS` |
+
+Both lossy laws solve the same tension ODE
+\(\mathrm{d}T/\mathrm{d}s = -\lambda(s)T\), whose solution is
+\(\eta = e^{-\int\lambda\,\mathrm{d}s}\). They differ only in where the normal
+load pressing the path against its guide comes from. Under `CapstanFriction`
+it is curvature-induced, \(N = Tw\), giving \(\lambda = \mu w\). Under
+`ExponentialLengthFriction` it comes from a snug sheath gripping in proportion
+to tension, \(N = cT\), giving a constant \(\lambda = \mu c = k\), so loss
+accrues with distance travelled rather than with turning.
+
+That makes \(k\) phenomenological in a way \(\mu\) is not: it lumps the
+friction coefficient together with the radial grip, so it has to be fitted
+rather than looked up. It suits a tendon in a close-fitting sheath or lumen,
+and because it never reads the wrap angle it is the one law `GVS` can host.
 
 `CapstanFriction` models Coulomb friction against the guides a path runs
 through, following the force model of

--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -18,12 +18,13 @@ The transmission model assumes that:
 - the routing is fixed in the material frame and depends only on arc length;
 - the actuator coordinate is determined by path length, scaled by a constant
   effective area for the pressure-chamber preset; and
-- each path carries one scalar work-conjugate effort, uniform along its route.
+- each path carries one scalar work-conjugate effort, attenuated along its
+  route only by the optional Capstan friction model described below.
 
 Consequently, configuration- or time-dependent rerouting, changes in chamber
-cross-section, along-path friction or slack, and internal actuator dynamics are
-outside the transmission model. Representing these effects requires an extended
-routing, transmission, or effort model.
+cross-section, path slack, and internal actuator dynamics are outside the
+transmission model. Representing these effects requires an extended routing,
+transmission, or effort model.
 
 Threadlike components require continuum segment topology and the host's native
 path-integration hooks. `PCS`, `PlanarPCS`, and `GVS` provide this contract.
@@ -179,13 +180,120 @@ coordinates = robot.actuator_coordinates(q)
 ```
 
 For tendons, `coordinates == -lengths`; for a pressure preset, coordinates are
-equivalent volumes. In every case,
+equivalent volumes. Without guide friction,
 `jax.jacrev(robot.actuator_coordinates)(q) == robot.actuation_matrix(q).T` up
-to quadrature tolerance.
+to quadrature tolerance. A nonzero friction coefficient breaks that identity by
+design, because the moment matrix then carries a transmission loss that path
+length does not; see [Guide friction](#guide-friction).
 
 PCS integrates the local path basis and performs the constant-strain projection
 once. GVS applies its strain basis inside the existing quadrature. The public
 behavior is common, while each host keeps its native evaluation path.
+
+## Guide friction
+
+By default a path transmits its effort undiminished along its whole route. Set
+`friction_coefficient` to model Coulomb friction against the guides the path
+runs through, following the force model of
+[Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3550846). A
+tendon threaded through spacer disks loses tension at every contact, and the
+loss at each contact obeys the classical Capstan (Euler) law
+\(T_{out} = T_{in}e^{-\mu\varphi}\), which depends on the accumulated turn
+\(\varphi\) alone and not on the guide radius.
+
+Taking the guide spacing to zero turns the product of per-contact losses into
+
+\[
+\eta(q, s) = e^{-\mu\Theta(q, s)}, \qquad
+\Theta(q, s) = \int_0^s \lVert\omega \times \hat{u}\rVert\,\mathrm{d}s'
+\]
+
+the fraction of the base effort that survives to arc length \(s\), with
+\(\hat{u}\) the unit routed-path tangent. Because \(\eta\) weights the integrand
+of the moment matrix rather than scaling its result, the distal part of a path
+contributes less than the proximal part:
+
+\[
+A_\mu(q) = B_\xi^\top \int_0^L \eta(q, s)\,\Phi(q, s)\,\mathrm{d}s
+\]
+
+\(\eta\) depends on the configuration only, so the actuation force stays linear
+in the effort and every controller keeps working. Since \(\eta \in (0, 1]\), the
+model can only ever remove effort, never add it, and a coefficient of zero
+reproduces the frictionless matrix exactly.
+
+The wrap density reduces to \(\lvert\kappa\rvert\) identically in the plane, for
+any offset and any strain. Under torsion it recovers the helix curvature of an
+off-axis path, so a twisted robot correctly reports a nonzero wrap angle.
+
+```python
+robot = PCS.from_links(
+    links,
+    structure=PCSStructure(num_gauss_points=5),
+    # a scalar shares one coefficient; pass shape (num_paths,) for per-path values
+    actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.2),
+)
+
+tau = robot.actuation_force(q, jnp.array([5.0, 0.0]))
+```
+
+`PCS` and `PlanarPCS` implement the wrap-angle model. `GVS` strain varies along
+arc length, so its wrap angle is not piecewise linear; it rejects a nonzero
+coefficient during construction with a descriptive `TypeError`.
+
+### Identifying the coefficient
+
+The coefficient is an ordinary dynamic leaf, so it is traceable and
+differentiable under `jit`:
+
+```python
+def with_friction(mu):
+    transmission = robot.actuators[0].params.transmission.replace(
+        friction_coefficient=mu
+    )
+    return robot.update_actuator_params(0, transmission=transmission)
+
+
+@jax.jit
+def loss(mu):
+    identified = with_friction(mu)
+    residual = (
+        identified.elastic_force(q_meas)
+        + identified.gravitational_force(q_meas)
+        - identified.actuation_force(q_meas, u_meas)
+    )
+    return jnp.sum(residual**2)
+
+
+value, grad = jax.value_and_grad(loss)(jnp.array(0.2))
+```
+
+Zero is a valid optimizer start, but \(\mathrm{d}A/\mathrm{d}\mu\) vanishes
+wherever \(\Theta = 0\), so a perfectly straight pose carries no information
+about \(\mu\). Set `wrap_angle_smoothing` on the host structure to replace
+\(\lvert\kappa\rvert\) with \(\sqrt{\kappa^2 + \epsilon^2}\) if the fit can
+approach a straight configuration. It never under-estimates the wrap angle and
+over-estimates it by at most \(\epsilon L\), and it also removes the \(C^0\)
+kink at zero curvature.
+
+### What changes at a nonzero coefficient
+
+- `moment_matrix` is no longer the transpose of the length gradient, so
+  `actuation_space` conversions that assume the identity do not apply.
+- The generalized actuation force has no potential: work around a closed
+  configuration loop at constant effort is nonzero and orientation dependent.
+- For a loaded passive path, `actuation_force(q, u)` is affine in `u` rather
+  than linear, and `actuation_force(q, 0)` is nonzero. Prefer
+  `actuation_force(q, u)` over `actuation_matrix(q) @ e` wherever passive
+  elements exist.
+- The moment matrix acquires a mild dependence on `num_gauss_points`, because
+  the attenuated integrand is no longer polynomial.
+- `path_lengths`, `path_velocities`, and `path_poses` are unchanged. They are
+  pure geometry at any coefficient.
+- The model assumes the effort drives the path. A back-driven path is still
+  modelled with the driving branch of Euler's law, so keep the passive
+  coefficient conservative or zero for long dynamic rollouts with
+  sign-changing path rates.
 
 ## Passive paths
 
@@ -210,7 +318,10 @@ robot = PCS(
 ```
 
 The passive element contributes to elastic force, damping, and elastic energy;
-it never consumes an active control channel.
+it never consumes an active control channel. A passive path may also declare a
+`friction_coefficient`, in which case part of its spring force becomes
+non-conservative and is applied through `actuation_force`; see
+[Guide friction](#guide-friction).
 
 ## Updating routing and actuator parameters
 

--- a/docs/api/actuation/threadlike.md
+++ b/docs/api/actuation/threadlike.md
@@ -1,50 +1,33 @@
 # Threadlike actuation
 
-Threadlike actuation models fixed paths routed through the material-frame
-cross-section of a continuum robot. A routing may span any contiguous inclusive
-range of body segments. The same geometry supports pulling tendons, pushing
-rods, simplified contractile muscles, and pressure chambers represented by an
-equivalent axial volume coordinate.
+Threadlike actuation models paths embedded in a continuum robot's material
+frame. The same geometry supports pulling tendons, pushing rods, simplified
+contractile muscles, and pressure chambers represented by an equivalent axial
+volume coordinate. A path may span any contiguous inclusive range of body
+segments.
 
-Following the general threadlike-routing formulation of
-[Renda et al. (2022)](https://doi.org/10.1109/LRA.2022.3183248), each actuator
-is represented by a path embedded in the continuum body. SoRoMoX specifies the
-path by its material-frame offset \(d(s)\) from the backbone and its derivative
-with respect to arc length. The host combines these routing fields with its
-backbone kinematics when evaluating path length and the moment matrix.
+Following the general routed-path formulation of
+[Renda et al. (2022)](https://doi.org/10.1109/LRA.2022.3183248), a routing is a
+material-frame offset from the backbone. `PCS`, `PlanarPCS`, and `GVS` combine
+that routing with their native strain kinematics to evaluate path length,
+coordinate velocity, and generalized actuator force.
 
-The transmission model assumes that:
-
-- the routing is fixed in the material frame and depends only on arc length;
-- the actuator coordinate is determined by path length, scaled by a constant
-  effective area for the pressure-chamber preset; and
-- each path carries one scalar work-conjugate effort, attenuated along its
-  route by an optional friction model described below.
-
-Consequently, configuration- or time-dependent rerouting, changes in chamber
-cross-section, path slack, and internal actuator dynamics are outside the
-transmission model. Representing these effects requires an extended routing,
-transmission, or effort model.
-
-Threadlike components require continuum segment topology and the host's native
-path-integration hooks. `PCS`, `PlanarPCS`, and `GVS` provide this contract.
-Articulated hosts do not, so installing a threadlike component on them raises a
-descriptive `TypeError` during construction.
+The model assumes fixed material-frame routing, one scalar coordinate and
+effort per path, and an optional static effort loss along active paths. It does
+not model configuration-dependent rerouting, slack, actuator dynamics, or
+changes in pressure-chamber cross-section.
 
 ## Routing
 
-`ThreadlikeRouting` stores a vectorized family of paths. Linear paths use
+`ThreadlikeRouting` stores a vectorized path family. Linear paths use
 
 \[
-d(s) = d_0 + d_1s
+r(s)=r_0+r_1s,
 \]
 
-in the local material frame. The `intercept` and `slope` arrays have shape
-`(num_paths, 3)`, with the final axis ordered along the local material-frame
-axes. SoRoMoX aligns the backbone with the local `x` axis; the local-`x`
-component of both arrays must therefore be zero, while the `y` and `z`
-components locate the path in the cross-section. A `(3,)` vector defines a
-single path.
+where `intercept` and `slope` have shape `(num_paths, 3)` and use local
+material-frame `[x, y, z]` order. The undeformed backbone follows local `+x`,
+so both local-`x` components must be zero.
 
 ```python
 from soromox.actuation import ThreadlikeRouting
@@ -76,9 +59,9 @@ positive-curvature bend and shortens relative to the backbone.
 
 ### Custom routing laws
 
-The continuum hosts depend only on the routing contract, not on the linear
-parameterization. A custom fixed material-frame routing supplies an immutable
-parameter type plus offset and arc-length-derivative functions:
+A custom routing supplies immutable parameters and analytical offset
+functions. Friction also needs the second derivative; production code does not
+differentiate routing functions with autodiff.
 
 ```python
 import equinox as eqx
@@ -96,21 +79,28 @@ class SinusoidalRoutingParams(BaseThreadlikeRoutingParams):
 
     @property
     def num_paths(self):
+        """Return the number of paths in this parameter batch."""
         return self.amplitude.shape[0]
-
-    def validate(self):
-        if self.frequency.shape != self.amplitude.shape:
-            raise ValueError("frequency must match amplitude")
 
 
 def offset(params, s):
+    """Return material-frame sinusoidal routing offsets at ``s``."""
     y = params.amplitude * jnp.sin(params.frequency * s)
     return jnp.stack((jnp.zeros_like(y), y, jnp.zeros_like(y)), axis=-1)
 
 
 def derivative(params, s):
+    """Return the first arc-length derivative of ``offset``."""
     y_s = params.amplitude * params.frequency * jnp.cos(params.frequency * s)
     return jnp.stack((jnp.zeros_like(y_s), y_s, jnp.zeros_like(y_s)), axis=-1)
+
+
+def second_derivative(params, s):
+    """Return the second arc-length derivative of ``offset``."""
+    y_ss = -(params.frequency**2) * params.amplitude * jnp.sin(
+        params.frequency * s
+    )
+    return jnp.stack((jnp.zeros_like(y_ss), y_ss, jnp.zeros_like(y_ss)), axis=-1)
 
 
 routing = ThreadlikeRouting(
@@ -122,17 +112,17 @@ routing = ThreadlikeRouting(
     ),
     offset_fn=offset,
     derivative_fn=derivative,
+    second_derivative_fn=second_derivative,
 )
 ```
 
-`PCS`, `PlanarPCS`, and `GVS` evaluate these two methods through the same host
-integration hooks. Custom parameter types must retain the common contiguous
-`start_segment_index` / `end_segment_index` topology contract.
+Path count and segment spans are static topology. Updating either requires
+reconstructing the routing and robot.
 
 ## Modality presets
 
-Raw path length is ℓ. Presets select the signed or scaled coordinate while
-positive input always means the named physical action.
+Let \(\ell\) be raw physical path length. Presets choose the signed or scaled
+coordinate while positive input retains its named physical meaning.
 
 | Preset | Coordinate | Positive effort | Unit |
 | --- | --- | --- | --- |
@@ -141,239 +131,200 @@ positive input always means the named physical action.
 | `muscles` | \(-\ell\) | contraction/tension | N |
 | `pressure_chambers` | \(A_\mathrm{eff}\ell\) | pressure | Pa |
 
-The pressure coordinate is volume (V=A_\mathrm{eff}\ell), so pressure and
-volume remain a work-conjugate pair.
+Pressure and equivalent volume \(V=A_\mathrm{eff}\ell\) form a
+work-conjugate pair.
 
 ```python
 from soromox.actuation import ThreadlikeActuator
-from soromox.systems import PCS
 
 actuator = ThreadlikeActuator.tendons(routing)
 robot = PCS(body_params, structure=structure, actuators=actuator)
 ```
 
-The same construction works with `PlanarPCS` and `GVS`. Mixed modalities are an
-ordered tuple:
+Pass a tuple to combine ordered actuator groups or modalities.
 
-```python
-robot = PCS(
-    body_params,
-    structure=structure,
-    actuators=(
-        ThreadlikeActuator.tendons(tendon_routing),
-        ThreadlikeActuator.push_rods(rod_routing),
-    ),
-)
-```
+## Coordinates, Jacobians, and force maps
 
-## Geometry and work coordinates
-
-Raw geometry is intentionally separate from the signed/scaled actuator
-coordinate:
+Raw geometry is separate from the actuator coordinate and force map:
 
 ```python
 actuator = robot.actuators[0]
 lengths = actuator.path_lengths(robot, q)
 length_rates = actuator.path_velocities(robot, q, qd)
+path_length_jacobian = actuator.transmission.path_length_jacobian(robot, q)
 points = actuator.path_poses(robot, q, s)
+
 coordinates = robot.actuator_coordinates(q)
+coordinate_jacobian = robot.actuator_coordinate_jacobian(q)
+actuation_matrix = robot.actuation_matrix(q)
 ```
 
-For tendons, `coordinates == -lengths`; for a pressure preset, coordinates are
-equivalent volumes. Without guide friction,
-`jax.jacrev(robot.actuator_coordinates)(q) == robot.actuation_matrix(q).T` up
-to quadrature tolerance. A friction model breaks that identity by design,
-because the moment matrix then carries an attenuation that path length does
-not; see [Routing friction](#routing-friction).
-
-PCS integrates the local length gradient and performs the constant-strain projection
-once. GVS applies its strain basis inside the existing quadrature. The public
-behavior is common, while each host keeps its native evaluation path.
-
-## Routing friction
-
-Ideally, effort is transmitted undiminished along its route, from the motor
-until its attachment point. However, friction between the routing and the
-robot body is often non-negligible in real applications, and attenuates the
-effort along the path. It is possible to simulate this behavior via the
-`ThreadlikeFriction` model, which is installed on a `ThreadlikeTransmission`
-through the `friction=` keyword of `ThreadlikeActuator` and
-`ThreadlikeImpedance`.
-The current implemented models are the following:
-
-| Model | Ratio | Parameter | Hosts |
-|---|---|---|---|
-| `ThreadlikeFriction.frictionless()` | \(1\) | none | all; the default |
-| `ThreadlikeFriction.exponential_length(...)` | \(e^{-k\ell}\) | `rate` \(k\), per metre | all |
-| `ThreadlikeFriction.capstan(...)` | \(e^{-\mu\Theta}\) | `coefficient` \(\mu\), Coulomb; `eps` \(\epsilon\), per metre | `PCS`, `PlanarPCS` |
-
-
-### Friction models
-
-The exponential length and Capstan models follow from the same tension balance along the routed path, with \(T\) the tension, \(\lambda\) the attenuation rate per unit arc length, and \(s_0\) the abscissa of the path anchor:
+The singular `coordinate` in `coordinate_jacobian` follows the usual compound
+noun: it is the Jacobian of the vector returned by `actuator_coordinates`.
+The robot-level prefix is plural because all installed actuators are stacked.
+The two matrix contracts are
 
 \[
-\frac{\mathrm{d}T}{\mathrm{d}s} = -\lambda\,T,
+\dot y_a=J_a(q)\dot q,
 \qquad
-\eta(s) = \frac{T(s)}{T(s_0)} = \exp\!\left(-\int_{s_0}^{s}\lambda\,
-\mathrm{d}s'\right)
+\tau_u=A(q)e,
 \]
 
-They differ in the origin of the normal load \(N\) pressing the path against the
-body.
+where `coordinate_jacobian` is \(J_a=\partial y_a/\partial q\) with shape
+`(num_actuators, num_velocities)`, and `actuation_matrix` is \(A\) with shape
+`(num_velocities, num_actuators)`. For a lossless transmission, virtual work
+gives \(A=J_a^T\). Friction can make them differ without changing path
+coordinates or velocities.
 
-**Configuration-independent friction.** A first approximation scales uniformly the tension along the path, \(N = cT\), so \(\lambda = \mu c \equiv k\) is
-constant and the attenuation depends only on the arc length \(\ell = s - s_0\)
-travelled from the anchor:
+## Continuum Capstan friction
+
+`ThreadlikeFriction.capstan(coefficient=mu)` attenuates active threadlike effort
+along increasing backbone coordinate, starting at each path's configured
+anchor. It is available for `PCS`, `PlanarPCS`, and `GVS`. The default
+`ThreadlikeFriction.frictionless()` returns unit effort ratio.
+
+### Path-turn derivation
+
+Let \(s\) be undeformed backbone arc length, \(R(s)\in SO(3)\) the material
+orientation, \(p(s)\in\mathbb{R}^3\) the backbone position, and
+\(\xi=(\omega,v)\) the angular and linear Cosserat strain. Then
 
 \[
-\eta(\ell) = e^{-k\ell}
-\]
-
-**Configuration-dependent friction (Capstan).** The normal load is induced by
-the curvature of the path, \(N = Tk_p\), so \(\lambda = \mu k_p(q, s)\):
-
-\[
-k_p(q, s) = \lVert\omega \times \hat{u}\rVert,
+R'=R[\omega]_\times,
 \qquad
-\eta(q, s) = e^{-\mu\Theta(q, s)},
-\quad
-\Theta(q, s) = \int_{s_0}^{s} k_p(q, s')\,\mathrm{d}s'
+p'=Rv.
 \]
 
-Here \(\omega\) is the angular strain, \(\hat{u}\) the unit routed-path tangent,
-and \(\Theta\) the wrap angle accumulated from the anchor. Since
-\(\mathrm{d}\hat{u}/\mathrm{d}s = \omega \times \hat{u}\), only the component of
-\(\omega\) orthogonal to \(\hat{u}\) contributes, so torsion about the axis of
-the path does not attenuate. In the plane \(k_p\) reduces to
-\(\lvert\kappa_z\rvert\); under torsion an off-axis path traces a helix, whose
-curvature \(k_p\) recovers.
-
-Because \(\Theta\) vanishes at a straight configuration, so does
-\(\partial\eta/\partial\mu\), and \(\mu\) is not identifiable there. The `eps`
-argument floors the curvature at \(\epsilon\), replacing \(k_p\) by
-\(\sqrt{k_p^2 + \epsilon^2}\). It never under-estimates \(\Theta\) and
-over-estimates it by at most \(\epsilon L\); the default \(\epsilon = 0\)
-reproduces the exact curvature.
-
-This model is the continuum limit of the discrete tendon force model of
-[Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3550846), in
-which the tendon passes through a finite set of spacer disks and each contact
-attenuates the tension by the classical Capstan (Euler) relation
+For material routing offset \(r(s)\), the spatial path is
+\(x(s)=p(s)+R(s)r(s)\). Its derivative is
 
 \[
-T_i = T_{i-1}\,e^{-\mu\varphi_i}
-\qquad\Longrightarrow\qquad
-T_n = T_0\,\exp\!\left(-\mu\sum_{i=1}^{n}\varphi_i\right)
+x'=Ra,
+\qquad
+a=v+\omega\times r+r'.
 \]
 
-with \(\varphi_i\) the turn at the \(i\)-th contact, independent of the guide
-radius. As the disk spacing tends to zero at fixed total turning,
-\(\sum_i \varphi_i \to \Theta\) and the product recovers \(\eta\) above, which
-can then be evaluated at every quadrature node rather than at discrete guides.
-
-### Applying the friction
-
-\(\eta\) weights the integrand of the moment matrix rather than scaling its
-result, so the distal part of a path contributes less than the proximal part:
+Define \(\nu=\lVert a\rVert\), material unit tangent \(u=a/\nu\), and
+spatial unit tangent \(\hat t=Ru\). Analytical differentiation gives
 
 \[
-A_\mu(q) = B_\xi^\top \int_0^L \eta(q, s)\,
-\frac{\partial\lVert t\rVert}{\partial\xi}(q, s)\,\mathrm{d}s
+a'=v'+\omega'\times r+\omega\times r'+r'',
+\qquad
+u'=\frac{(I-uu^T)a'}{\nu}.
 \]
 
+Consequently,
+
+\[
+\frac{d\hat t}{ds}=R(\omega\times u+u'),
+\qquad
+\rho(s)=\left\lVert\omega\times u+u'\right\rVert.
+\]
+
+`turn_rate` is \(\rho\), in radians per metre of undeformed backbone. It
+includes both material-frame rotation and change of the tangent inside that
+frame. Omitting \(u'\) is valid only when the normalized material tangent is
+constant. Inside a PCS segment, \(\omega'=v'=0\), but routing derivatives can
+still make \(u'\ne0\). GVS computes \(\omega'\) and \(v'\) analytically from
+the derivative of its strain basis.
+
+The `accumulated_turn` from anchor \(s_0\) is
+
+\[
+\Theta(s)=\int_{s_0}^{s}\rho(\sigma)\,d\sigma.
+\]
+
+SoRoMoX evaluates this integral using the host quadrature. Genuine one-sided
+tangent jumps introduced by a piecewise host discretization contribute their
+unsigned angle at the interface.
+
+### Relation to the cited discrete model
+
+The exponential Capstan relation is established for ropes, belts, and tendons
+sliding over contact. SoRoMoX takes inspiration from the discrete spacer-disk
+tendon model of
+[Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3581774), in
+which each disk obeys
+
+\[
+T_i=T_{i-1}e^{-\mu\varphi_i},
+\qquad
+T_n=T_0\exp\left(-\mu\sum_i\varphi_i\right).
+\]
+
+SoRoMoX adapts that idea to distributed contact along an embedded continuum
+path:
+
+\[
+\eta(s)=\frac{e(s)}{e(s_0)}=e^{-\mu\Theta(s)}.
+\]
+
+This is not an implementation of discrete spacer disks. The current API does
+not represent discrete guide locations, guide radii, or individual guide
+reactions.
+
+### Generalized-force integration
+
+For spatial strain, the local unscaled length-gradient density is
+\(g_\xi=[r\times u;u]\). If \(B(s)\) maps generalized coordinates to strain
+and \(c\) is the modality coordinate scale, the active force map is
+
+\[
+A_\mu(q)=c\int_{s_0}^{s_1}
+\eta(q,s)B(s)^Tg_\xi(q,s)\,ds.
+\]
+
+The ratio weights every quadrature contribution; it does not merely scale the
+final matrix. Distal contributions therefore receive less of the anchor effort
+than proximal contributions.
 
 ```python
-robot = PCS.from_links(
-    links,
-    structure=PCSStructure(num_gauss_points=5),
-    # a scalar shares one coefficient; pass shape (num_paths,) for per-path values
-    actuators=ThreadlikeActuator.tendons(
-        routing, friction=ThreadlikeFriction.capstan(coefficient=0.2)
-    ),
-)
+from soromox.actuation import ThreadlikeFriction
 
-tau = robot.actuation_force(q, jnp.array([5.0, 0.0]))
+actuator = ThreadlikeActuator.tendons(
+    routing,
+    friction=ThreadlikeFriction.capstan(coefficient=0.2),
+)
 ```
 
-### Custom friction models
+The coefficient may be a scalar shared by the family or an array of shape
+`(num_paths,)`.
 
-A model is a plain function of `(params, context)`, paired with its parameters by
-`ThreadlikeFriction`. The hosts depend only on that contract, not on the shipped
-models:
+### Custom effort-ratio laws
+
+Custom laws receive only explicit friction state, not a host-specific context:
 
 ```python
 from soromox.actuation import BaseThreadlikeFrictionParams, ThreadlikeFriction
 
 
 class HyperbolicFrictionParams(BaseThreadlikeFrictionParams):
-    a: Array
+    coefficient: Array
 
 
-def hyperbolic_transmission_ratio(params, context):
-    return 1.0 / (1.0 + params.a * context.wrap_angle)
+def hyperbolic_effort_ratio(params, accumulated_turn):
+    """Return a custom effort ratio as a function of accumulated turn."""
+    return 1.0 / (1.0 + params.coefficient * accumulated_turn)
 
 
-actuator = ThreadlikeActuator.tendons(
-    routing,
-    friction=ThreadlikeFriction(
-        params=HyperbolicFrictionParams(a=jnp.asarray(0.5)),
-        ratio_fn=hyperbolic_transmission_ratio,
-        requires_wrap_angle=True,
-        is_frictionless=False,
-    ),
+friction = ThreadlikeFriction(
+    params=HyperbolicFrictionParams(coefficient=jnp.asarray(0.5)),
+    effort_ratio_fn=hyperbolic_effort_ratio,
+    is_frictionless=False,
 )
 ```
 
-Parameters live in the transmission parameter tree, so they stay differentiable
-and replaceable; the model itself is static, so swapping it leads to retracing.
-This mirrors how `ThreadlikeRouting` pairs routing parameters with a static
-offset function.
+Parameters are differentiable leaves; the law itself is static. A custom law
+should return values in \((0,1]\) and must not read the applied effort.
 
-The `context` is a `ThreadlikeQuadratureContext` describing the routed path at
-one quadrature node.
-
-| Field | Meaning | Portable |
-|---|---|---|
-| `abscissa` | backbone coordinate \(s\), from the robot base | yes |
-| `path_abscissa` | arc length travelled from this path's anchor | yes |
-| `segment_index` | segment containing the node | yes |
-| `offset`, `offset_derivative` | material-frame offset `(n, 3)` and its \(s\)-derivative | yes |
-| `tangent_norm` | routed-path stretch relative to the backbone | yes |
-| `active` | whether the node lies in each path's span | yes |
-| `unit_tangent` | normalized tangent, `(n, 2)` planar and `(n, 3)` spatial | no |
-| `strain` | `(n, 3)` planar and `(n, 6)` spatial | no |
-| `wrap_angle` | accumulated turn \(\Theta\), or `None` | only where supplied |
-
-Set `requires_wrap_angle=False` if the model does not read `wrap_angle`, and the
-hosts will neither compute it nor refuse the model. Set `is_frictionless=True`
-only
-for a model that always returns one, and the hosts will skip it entirely. A model
-must keep its ratio in \((0, 1]\) and must not read the effort, which would make
-the actuation force nonlinear in the control.
-
-### What changes under a friction model
-
-- `moment_matrix` is no longer the transpose of the length gradient, so
-  `actuation_space` conversions that assume the identity do not apply.
-- The generalized actuation force has no potential: work around a closed
-  configuration loop at constant effort is nonzero and orientation dependent.
-- For a loaded passive path, `actuation_force(q, u)` is affine in `u` rather
-  than linear, and `actuation_force(q, 0)` is nonzero. Prefer
-  `actuation_force(q, u)` over `actuation_matrix(q) @ e` wherever passive
-  elements exist.
-- The moment matrix acquires a mild dependence on `num_gauss_points`, because
-  the attenuated integrand is no longer polynomial.
-- `path_lengths`, `path_velocities`, and `path_poses` are unchanged. They are
-  pure geometry under any friction model.
-- The model assumes the effort drives the path. A back-driven path is still
-  modelled with the driving branch of Euler's law, so keep the passive
-  coefficient conservative or zero for long dynamic rollouts with
-  sign-changing path rates.
+The current model uses the driven anchor-to-distal Capstan branch. It does not
+model sticking, direction-dependent backdriving, frictional hysteresis, or
+slack. Warp threadlike kernels currently accept only frictionless linear
+routing; automatic backend selection evaluates frictional actuation with JAX.
 
 ## Passive paths
 
-Use `ThreadlikeImpedance` for routed spring-damper mechanics:
+`ThreadlikeImpedance` implements conservative routed spring-damper mechanics:
 
 ```python
 from soromox.actuation import ThreadlikeImpedance
@@ -384,70 +335,37 @@ passive = ThreadlikeImpedance(
     damping=jnp.array([2.0]),
     rest_length=jnp.array([0.19]),
 )
-
-robot = PCS(
-    body_params,
-    structure=structure,
-    actuators=actuator,
-    passive_elements=(passive,),
-)
 ```
 
-The passive element contributes to elastic force, damping, and elastic energy;
-it never consumes an active control channel. A passive path may also declare a
-`friction=` model, in which case part of its spring force becomes
-non-conservative and is applied through `actuation_force`; see
-[Routing friction](#routing-friction).
+It contributes elastic force, damping, and elastic energy without consuming an
+active control channel. Its `.routing` attribute stays distinct from an active
+actuator's `.transmission`; friction is intentionally active-only.
 
-## Updating routing and actuator parameters
+## Parameter updates
 
-Updates follow the same shallow immutable replacement pattern as robot body
-parameters:
+Updates use immutable replacement:
 
 ```python
 params = robot.actuators[0].params
-routing_params = params.transmission.routing.replace(
-    intercept=new_intercepts,
-)
+routing_params = params.transmission.routing.replace(intercept=new_intercepts)
 transmission_params = params.transmission.replace(routing=routing_params)
-robot = robot.update_actuator_params(
-    0,
-    transmission=transmission_params,
-)
+robot = robot.update_actuator_params(0, transmission=transmission_params)
 ```
 
-Routing coefficients, coordinate scales, effort bounds, and passive mechanical
-values are updateable. Segment spans and path counts are static topology and
-require reconstruction. Colors, radii, and line widths belong to renderer
-configuration rather than actuator parameters.
+Routing coefficients, coordinate scales, friction coefficients, effort bounds,
+and passive mechanical values are updateable. Path counts and segment spans are
+static topology and require reconstruction.
 
 ## Rendering
 
-The renderer-side actuation adapter converts threadlike path queries into semantic
-`ActuatorVisualLayer` objects with path points, modality kind, and optional input
-scalar data. Physics objects do not import renderer primitives or store visual
-style. Generic renderers draw swept geometry when a radius is configured and fall
-back to polylines otherwise.
-
-```python
-from soromox.rendering import ActuatorStyleConfig, RendererColorConfig
-
-visuals = RendererColorConfig(
-    actuators=ActuatorStyleConfig(
-        kind_colors={"tendon": (0.85, 0.2, 0.15)},
-        kind_radii={"tendon": 5e-4},
-    )
-)
-renderer.show(q, actuator_inputs=u, color_config=visuals)
-```
-
-I-SUPPORT retains its detailed bellows renderer. Its renderer accepts the same
-`actuator_inputs=` argument and also supports `pressures=` as a mutually
-exclusive convenience alias.
+Renderer adapters turn path queries into semantic visual layers. Physics
+objects do not import renderer primitives or store visual style. Generic
+renderers draw swept geometry when a radius is configured and use polylines
+otherwise. I-SUPPORT retains its detailed bellows renderer.
 
 ## Current limits
 
 Threadlike paths are fixed in the material frame, use contiguous segment spans,
-and have one constant coordinate scale per path. The current implementation uses
-stateless `DirectEffort`; nonlinear and stateful effort laws are future
-extensions.
+and have one constant coordinate scale per path. Active effort loss is static
+and direction-independent. Discrete guides and internal actuator dynamics are
+not implemented.

--- a/docs/api/control/actuation-space.md
+++ b/docs/api/control/actuation-space.md
@@ -2,7 +2,12 @@
 
 The coordinates used here are supplied by the common
 [actuation model](../actuation/index.md), including signed/scaled threadlike
-coordinates rather than raw tendon lengths.
+coordinates rather than raw tendon lengths. The collocated controller formulas
+in this chapter assume an ideal transmission with (A=J_a^T). For a lossy
+transmission, such as continuum Capstan friction,
+`ActuationSpaceDynamics.actuation_matrix(q)` returns the transformed physical
+force map (J^{-T}A), which need not equal ([I;0]); the current controllers do
+not compensate that loss automatically.
 
 Actuation-space controllers operate in a transformed coordinate system where the actuation matrix becomes a simple identity structure. This formulation, developed by [Pustina et al. (2024)](#references) and further elaborated in [Pustina (2025)](#references), provides a clean separation between actuated and unactuated dynamics, making it particularly well-suited for underactuated soft robots.
 

--- a/docs/api/systems/articulated/mckibben-umarm.md
+++ b/docs/api/systems/articulated/mckibben-umarm.md
@@ -58,7 +58,7 @@ y_{\mathrm{a},i}
 = \frac{(B_i^2-\ell_i^2)\ell_i}{4\pi N_i^2},
 \]
 
-so pressure is the direct work-conjugate effort. The analytic moment matrix is
+so pressure is the direct work-conjugate effort. The analytic actuation matrix is
 the transpose of the coordinate Jacobian and retains the cache's group and
 channel ordering.
 

--- a/docs/api/systems/pcs/isupport.md
+++ b/docs/api/systems/pcs/isupport.md
@@ -183,7 +183,7 @@ area
 A_eff = pi * (chamber_outer_radius**2 - chamber_inner_radius**2).
 ```
 
-The pressure-conjugate coordinates, velocities, efforts, moment matrix, and
+The pressure-conjugate coordinates, velocities, efforts, actuation matrix, and
 generalized force use the shared actuation interface:
 
 ```python
@@ -195,7 +195,7 @@ tau = robot.actuation_force(q, pressures, qd=qd)
 ```
 
 For the current `DirectEffort` model, `pressure_efforts == pressures`. The
-effective area is part of the transmission coordinate and moment matrix rather
+effective area is part of the transmission coordinate and actuation matrix rather
 than a separate pressure-to-force conversion API.
 
 I-SUPPORT's specialized renderer continues to draw the detailed bellows and

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -16,38 +16,25 @@ and include benchmark baseline and measurement context for performance claims.
 - Added renderer-neutral cross-section contours and loft construction, with a
   registration hook for extending both swept 3D renderers with new geometries.
 - Added opt-in routing friction to threadlike transmissions, selected with
-  `friction=`. It weights the moment-matrix integrand, so the attenuation
-  accumulates from the path anchor rather than scaling the applied effort.
-  `ThreadlikeFriction.frictionless()` is the default,
-  `.capstan(coefficient=..., eps=...)` applies `exp(-mu * Theta)` with `Theta`
-  the integrated routed-path curvature floored at `eps`, which keeps the
-  coefficient identifiable near a straight configuration, and
-  `.exponential_length(rate=...)` a constant attenuation per unit arc length.
-  Parameters are differentiable leaves, identifiable under `jit`. A model is a
-  parameter container plus a static `ratio_fn`, so adding one needs no host
-  change. See
-  [threadlike actuation](../api/actuation/threadlike.md#routing-friction).
+  `friction=` on active `ThreadlikeActuator` presets. The continuum Capstan
+  model applies `exp(-mu * accumulated_turn)` to each local force contribution
+  and supports `PCS`, `PlanarPCS`, and `GVS`. Routed-path turn includes the
+  analytical material-tangent derivative; custom routings provide an
+  analytical second derivative. Parameters remain differentiable leaves under
+  JAX transformations. See
+  [threadlike actuation](../api/actuation/threadlike.md#continuum-capstan-friction).
 
 ### Changed
 
 - Open3D and Viser swept backbones now preserve circular, elliptical, and
   rectangular cross-sections, including dimensions that vary with abscissa.
-- Replaced `ThreadlikeImpedanceParams.routing` with a nested
-  `transmission` field, so a passive routed path now carries a
-  `ThreadlikeTransmission` like its articulated counterpart. The
-  `ThreadlikeImpedance` constructor keeps its `routing=` keyword; direct
-  construction of `ThreadlikeImpedanceParams` and `update_params(routing=...)`
-  become `transmission=...`.
 - Corrected the planar routed-path offset sign, which used
   `sigma_x + d * kappa` where `PlanarPCS` kinematics require
   `sigma_x - d * kappa`. Planar routings must negate their `y` offsets to
   reproduce previous behavior, which is exactly equivalent when the routing
   slope is zero.
-- Made host support for friction depend on the installed model rather than on
-  its value. `PCS` and `PlanarPCS` supply the wrap angle; `GVS` strain varies
-  along arc length and does not, so it refuses a wrap-angle model at any
-  coefficient, zero included. Use `ThreadlikeFriction.exponential_length(...)`
-  there instead.
+- Made `ActuationSpaceDynamics` use the actuator-coordinate Jacobian for its
+  coordinate map and transform a potentially lossy actuation matrix explicitly.
 
 ### Performance
 
@@ -59,6 +46,11 @@ and include benchmark baseline and measurement context for performance claims.
   material-`y` offset shortens under positive `kappa_z`. Existing planar
   threadlike models that compensated for the previous sign must update their
   routing offsets or actuator directions.
+- Replaced `Transmission.moment_matrix(...)` with the explicit
+  `coordinate_jacobian(...)` and `actuation_matrix(...)` contracts. Added
+  `SoftRobot.actuator_coordinate_jacobian(...)`. For ideal transmissions the
+  two matrices remain transposes; lossy transmissions need not satisfy that
+  identity. No compatibility alias is retained.
 - Renamed the Viser `cylinder_sections` and Open3D `tube_resolution` options to
   the geometry-neutral `cross_section_resolution`.
 
@@ -71,18 +63,16 @@ and include benchmark baseline and measurement context for performance claims.
   shape-morphing funnel when adjacent links used different cross-sections.
 - Fixed Open3D swept meshes reusing the first endpoint cross-section at both
   ends, which previously rendered tapered profiles as piecewise-constant.
-- Fixed planar threadlike path lengths and moment arms disagreeing with `PCS`
+- Fixed planar threadlike path lengths and actuation matrices disagreeing with `PCS`
   and with the path positions the renderer draws. At `kappa = 10`, `L = 0.1`
   and offset `0.02` the model reported `0.120` for a path whose rendered arc
   length is `0.080`; planar and spatial hosts now agree exactly.
 
 ### Documentation
 
-- Documented routing friction on the threadlike actuation page: the two
-  friction models and their derivation, the invariants a friction model
-  deliberately breaks, which quadrature-context fields are portable across
-  hosts, and a custom-model example alongside the existing custom routing one.
-  Replaced the paragraph that listed along-path friction as out of scope.
+- Documented the continuum Capstan adaptation, complete path-turn derivation,
+  all symbols, distinction from discrete spacer disks, explicit matrix
+  contracts, and custom routing and effort-ratio laws.
 
 ### Contributors
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -28,11 +28,6 @@ and include benchmark baseline and measurement context for performance claims.
 
 - Open3D and Viser swept backbones now preserve circular, elliptical, and
   rectangular cross-sections, including dimensions that vary with abscissa.
-- Corrected the planar routed-path offset sign, which used
-  `sigma_x + d * kappa` where `PlanarPCS` kinematics require
-  `sigma_x - d * kappa`. Planar routings must negate their `y` offsets to
-  reproduce previous behavior, which is exactly equivalent when the routing
-  slope is zero.
 - Made `ActuationSpaceDynamics` use the actuator-coordinate Jacobian for its
   coordinate map and transform a potentially lossy actuation matrix explicitly.
 
@@ -63,10 +58,6 @@ and include benchmark baseline and measurement context for performance claims.
   shape-morphing funnel when adjacent links used different cross-sections.
 - Fixed Open3D swept meshes reusing the first endpoint cross-section at both
   ends, which previously rendered tapered profiles as piecewise-constant.
-- Fixed planar threadlike path lengths and actuation matrices disagreeing with `PCS`
-  and with the path positions the renderer draws. At `kappa = 10`, `L = 0.1`
-  and offset `0.02` the model reported `0.120` for a path whose rendered arc
-  length is `0.080`; planar and spatial hosts now agree exactly.
 
 ### Documentation
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -15,11 +15,34 @@ and include benchmark baseline and measurement context for performance claims.
 
 - Added renderer-neutral cross-section contours and loft construction, with a
   registration hook for extending both swept 3D renderers with new geometries.
+- Added opt-in Capstan guide friction to threadlike transmissions. A
+  `friction_coefficient` on `ThreadlikeActuator` and `ThreadlikeImpedance`
+  attenuates effort along a routed path as `exp(-mu * Theta(s))`, where `Theta`
+  is the accumulated turn of the path, instead of applying it uniformly. `PCS`
+  and `PlanarPCS` implement the wrap-angle model; `GVS` rejects a nonzero
+  coefficient during construction. The coefficient is a differentiable leaf and
+  can be identified under `jit`. Zero is the default and reproduces the
+  frictionless model exactly. See
+  [threadlike actuation](../api/actuation/threadlike.md#guide-friction).
+- Added `wrap_angle_smoothing` to `PCSStructure` and `PlanarPCSStructure`, which
+  replaces `|kappa|` with `sqrt(kappa**2 + eps**2)` in the wrap-angle density so
+  the friction coefficient stays identifiable near a straight configuration.
 
 ### Changed
 
 - Open3D and Viser swept backbones now preserve circular, elliptical, and
   rectangular cross-sections, including dimensions that vary with abscissa.
+- Replaced `ThreadlikeImpedanceParams.routing` with a nested
+  `transmission` field, so a passive routed path now carries a
+  `ThreadlikeTransmission` like its articulated counterpart. The
+  `ThreadlikeImpedance` constructor keeps its `routing=` keyword; direct
+  construction of `ThreadlikeImpedanceParams` and `update_params(routing=...)`
+  become `transmission=...`.
+- Corrected the planar routed-path offset sign, which used
+  `sigma_x + d * kappa` where `PlanarPCS` kinematics require
+  `sigma_x - d * kappa`. Planar routings must negate their `y` offsets to
+  reproduce previous behavior, which is exactly equivalent when the routing
+  slope is zero.
 
 ### Performance
 
@@ -43,8 +66,16 @@ and include benchmark baseline and measurement context for performance claims.
   shape-morphing funnel when adjacent links used different cross-sections.
 - Fixed Open3D swept meshes reusing the first endpoint cross-section at both
   ends, which previously rendered tapered profiles as piecewise-constant.
+- Fixed planar threadlike path lengths and moment arms disagreeing with `PCS`
+  and with the path positions the renderer draws. At `kappa = 10`, `L = 0.1`
+  and offset `0.02` the model reported `0.120` for a path whose rendered arc
+  length is `0.080`; planar and spatial hosts now agree exactly.
 
 ### Documentation
+
+- Documented guide friction on the threadlike actuation page, replacing the
+  paragraph that listed along-path friction as outside the transmission model,
+  and recorded the invariants a nonzero coefficient deliberately breaks.
 
 ### Contributors
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -27,6 +27,17 @@ and include benchmark baseline and measurement context for performance claims.
 - Added `wrap_angle_smoothing` to `PCSStructure` and `PlanarPCSStructure`, which
   replaces `|kappa|` with `sqrt(kappa**2 + eps**2)` in the wrap-angle density so
   the friction coefficient stays identifiable near a straight configuration.
+- Made the threadlike transmission loss a pluggable `ThreadlikeFriction` model
+  chosen at construction through `friction=`, so a new loss law needs no host
+  change and a third-party law needs no soromox change. A law receives a
+  `ThreadlikeQuadratureContext` describing the routed path at one quadrature
+  node and returns the surviving effort fraction per path. `Frictionless` is the
+  default, `CapstanFriction` carries the Euler belt law, and
+  `ExponentialLengthFriction` applies a loss per unit arc length. See
+  [threadlike actuation](../api/actuation/threadlike.md#guide-friction).
+- Added `GVS` support for transmission-loss laws that do not need the wrap
+  angle, such as `ExponentialLengthFriction`. `GVS` strain varies along arc
+  length, so it still cannot supply the Capstan wrap angle.
 
 ### Changed
 
@@ -43,6 +54,17 @@ and include benchmark baseline and measurement context for performance claims.
   `sigma_x - d * kappa`. Planar routings must negate their `y` offsets to
   reproduce previous behavior, which is exactly equivalent when the routing
   slope is zero.
+- Replaced `ThreadlikeTransmissionParams.friction_coefficient` with `friction`,
+  which holds a `ThreadlikeFriction` law. The `friction_coefficient=` keyword is
+  kept as sugar for `CapstanFriction` on every preset and on
+  `ThreadlikeImpedance`, and passing it together with `friction=` raises.
+  Identification becomes
+  `transmission.replace(friction=transmission.friction.replace(coefficient=mu))`.
+- Made host support for a transmission loss depend on the law rather than on its
+  value: a wrap-angle law such as `CapstanFriction` is now refused on `GVS` at
+  any coefficient, including zero, where `friction_coefficient=0.0` was
+  previously accepted. Drop the argument or install
+  `ExponentialLengthFriction` instead.
 
 ### Performance
 
@@ -76,6 +98,10 @@ and include benchmark baseline and measurement context for performance claims.
 - Documented guide friction on the threadlike actuation page, replacing the
   paragraph that listed along-path friction as outside the transmission model,
   and recorded the invariants a nonzero coefficient deliberately breaks.
+- Documented the pluggable transmission-loss model, including which
+  quadrature-context fields are portable across hosts and which are host-shaped,
+  and added a custom friction law example alongside the existing custom routing
+  law example.
 
 ### Contributors
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -15,29 +15,18 @@ and include benchmark baseline and measurement context for performance claims.
 
 - Added renderer-neutral cross-section contours and loft construction, with a
   registration hook for extending both swept 3D renderers with new geometries.
-- Added opt-in Capstan guide friction to threadlike transmissions. A
-  `friction_coefficient` on `ThreadlikeActuator` and `ThreadlikeImpedance`
-  attenuates effort along a routed path as `exp(-mu * Theta(s))`, where `Theta`
-  is the accumulated turn of the path, instead of applying it uniformly. `PCS`
-  and `PlanarPCS` implement the wrap-angle model; `GVS` rejects a nonzero
-  coefficient during construction. The coefficient is a differentiable leaf and
-  can be identified under `jit`. Zero is the default and reproduces the
-  frictionless model exactly. See
-  [threadlike actuation](../api/actuation/threadlike.md#guide-friction).
-- Added `wrap_angle_smoothing` to `PCSStructure` and `PlanarPCSStructure`, which
-  replaces `|kappa|` with `sqrt(kappa**2 + eps**2)` in the wrap-angle density so
-  the friction coefficient stays identifiable near a straight configuration.
-- Made the threadlike transmission loss a pluggable `ThreadlikeFriction` model
-  chosen at construction through `friction=`, so a new loss law needs no host
-  change and a third-party law needs no soromox change. A law receives a
-  `ThreadlikeQuadratureContext` describing the routed path at one quadrature
-  node and returns the surviving effort fraction per path. `Frictionless` is the
-  default, `CapstanFriction` carries the Euler belt law, and
-  `ExponentialLengthFriction` applies a loss per unit arc length. See
-  [threadlike actuation](../api/actuation/threadlike.md#guide-friction).
-- Added `GVS` support for transmission-loss laws that do not need the wrap
-  angle, such as `ExponentialLengthFriction`. `GVS` strain varies along arc
-  length, so it still cannot supply the Capstan wrap angle.
+- Added opt-in routing friction to threadlike transmissions, selected with
+  `friction=`. It weights the moment-matrix integrand, so the attenuation
+  accumulates from the path anchor rather than scaling the applied effort.
+  `ThreadlikeFriction.frictionless()` is the default,
+  `.capstan(coefficient=..., eps=...)` applies `exp(-mu * Theta)` with `Theta`
+  the integrated routed-path curvature floored at `eps`, which keeps the
+  coefficient identifiable near a straight configuration, and
+  `.exponential_length(rate=...)` a constant attenuation per unit arc length.
+  Parameters are differentiable leaves, identifiable under `jit`. A model is a
+  parameter container plus a static `ratio_fn`, so adding one needs no host
+  change. See
+  [threadlike actuation](../api/actuation/threadlike.md#routing-friction).
 
 ### Changed
 
@@ -54,17 +43,11 @@ and include benchmark baseline and measurement context for performance claims.
   `sigma_x - d * kappa`. Planar routings must negate their `y` offsets to
   reproduce previous behavior, which is exactly equivalent when the routing
   slope is zero.
-- Replaced `ThreadlikeTransmissionParams.friction_coefficient` with `friction`,
-  which holds a `ThreadlikeFriction` law. The `friction_coefficient=` keyword is
-  kept as sugar for `CapstanFriction` on every preset and on
-  `ThreadlikeImpedance`, and passing it together with `friction=` raises.
-  Identification becomes
-  `transmission.replace(friction=transmission.friction.replace(coefficient=mu))`.
-- Made host support for a transmission loss depend on the law rather than on its
-  value: a wrap-angle law such as `CapstanFriction` is now refused on `GVS` at
-  any coefficient, including zero, where `friction_coefficient=0.0` was
-  previously accepted. Drop the argument or install
-  `ExponentialLengthFriction` instead.
+- Made host support for friction depend on the installed model rather than on
+  its value. `PCS` and `PlanarPCS` supply the wrap angle; `GVS` strain varies
+  along arc length and does not, so it refuses a wrap-angle model at any
+  coefficient, zero included. Use `ThreadlikeFriction.exponential_length(...)`
+  there instead.
 
 ### Performance
 
@@ -95,13 +78,11 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Documentation
 
-- Documented guide friction on the threadlike actuation page, replacing the
-  paragraph that listed along-path friction as outside the transmission model,
-  and recorded the invariants a nonzero coefficient deliberately breaks.
-- Documented the pluggable transmission-loss model, including which
-  quadrature-context fields are portable across hosts and which are host-shaped,
-  and added a custom friction law example alongside the existing custom routing
-  law example.
+- Documented routing friction on the threadlike actuation page: the two
+  friction models and their derivation, the invariants a friction model
+  deliberately breaks, which quadrature-context fields are portable across
+  hosts, and a custom-model example alongside the existing custom routing one.
+  Replaced the paragraph that listed along-path friction as out of scope.
 
 ### Contributors
 

--- a/docs/user-guide/execution-devices-and-backends.md
+++ b/docs/user-guide/execution-devices-and-backends.md
@@ -165,25 +165,32 @@ Coriolis/centrifugal, and gravity terms together, call `dynamics_terms`.
 
 ### Threadlike actuation
 
-Built-in linear threadlike layouts have public Warp-native operands, FP64
-kernels, and allocation-free launchers for actuation matrices `(E, D, A)` and
-fused direct-effort forces `(E, D)`. These low-level APIs are always available
-from `soromox.execution.warp.pcs` and `.gvs` for Newton and other
-Warp-native integrations. They support multiple ordered threadlike actuator
-groups and every built-in modality.
+Built-in frictionless linear threadlike layouts have public Warp-native
+operands, FP64 kernels, and allocation-free launchers for actuation matrices
+`(E, D, A)` and fused direct-effort forces `(E, D)`. These low-level APIs are
+always available from `soromox.execution.warp.pcs` and `.gvs` for Newton and
+other Warp-native integrations. They support multiple ordered threadlike
+actuator groups and every built-in modality; non-frictionless
+`ThreadlikeFriction` models are not yet implemented by these kernels.
 
 For spatial `PCS`, `actuation_matrix` uses the Warp implementation when the GPU
-backend is selected. `PlanarPCS` and `GVS` actuation matrices, and all
-system-level `actuation_force` methods, use JAX. Passing `backend="warp"` for an
-unsupported system-level operation explains how to access the low-level
-Warp-native API. Passive threadlike impedance and actuator path coordinates
-also remain JAX operations.
+backend is selected and all active transmissions are frictionless. Installing
+a non-frictionless `ThreadlikeFriction` keeps the matrix on JAX under
+`backend="auto"`, while an explicit `backend="warp"` request raises an error.
+`PlanarPCS` and `GVS` actuation matrices, and all system-level
+`actuation_force` methods, use JAX. Passing `backend="warp"` for an unsupported
+system-level operation explains how to access the low-level Warp-native API.
+Passive threadlike impedance, non-conservative passive forces, and actuator
+path coordinates also remain JAX operations.
 
-When Warp dynamics is selected, eligible built-in linear threadlike actuation
-is fused with the dynamics evaluation. This fused path supports GVS on CPU and
-GPU, and PlanarPCS and PCS on GPU. Because `"auto"` selects JAX on CPU, CPU GVS
-fusion is used only when Warp is selected explicitly. Other actuation layouts
-use Warp dynamics and evaluate actuation with JAX.
+When Warp dynamics is selected, eligible built-in frictionless linear
+threadlike actuation is fused with the dynamics evaluation. The fused path is
+not used when an active transmission has a non-frictionless
+`ThreadlikeFriction` or a passive element contributes a non-conservative force;
+those models use Warp dynamics and evaluate actuation with JAX. Fusion supports
+GVS on CPU and GPU, and PlanarPCS and PCS on GPU. Because `"auto"` selects JAX
+on CPU, CPU GVS fusion is used only when Warp is selected explicitly. Other
+actuation layouts also use Warp dynamics and evaluate actuation with JAX.
 
 ## Model-level and per-call selection
 

--- a/docs/user-guide/execution-devices-and-backends.md
+++ b/docs/user-guide/execution-devices-and-backends.md
@@ -180,17 +180,17 @@ a non-frictionless `ThreadlikeFriction` keeps the matrix on JAX under
 `PlanarPCS` and `GVS` actuation matrices, and all system-level
 `actuation_force` methods, use JAX. Passing `backend="warp"` for an unsupported
 system-level operation explains how to access the low-level Warp-native API.
-Passive threadlike impedance, non-conservative passive forces, and actuator
-path coordinates also remain JAX operations.
+Passive threadlike impedance and actuator path coordinates also remain JAX
+operations.
 
 When Warp dynamics is selected, eligible built-in frictionless linear
 threadlike actuation is fused with the dynamics evaluation. The fused path is
 not used when an active transmission has a non-frictionless
-`ThreadlikeFriction` or a passive element contributes a non-conservative force;
-those models use Warp dynamics and evaluate actuation with JAX. Fusion supports
-GVS on CPU and GPU, and PlanarPCS and PCS on GPU. Because `"auto"` selects JAX
-on CPU, CPU GVS fusion is used only when Warp is selected explicitly. Other
-actuation layouts also use Warp dynamics and evaluate actuation with JAX.
+`ThreadlikeFriction`; those models use Warp dynamics and evaluate actuation
+with JAX. Fusion supports GVS on CPU and GPU, and PlanarPCS and PCS on GPU.
+Because `"auto"` selects JAX on CPU, CPU GVS fusion is used only when Warp is
+selected explicitly. Other actuation layouts also use Warp dynamics and
+evaluate actuation with JAX.
 
 ## Model-level and per-call selection
 

--- a/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
+++ b/examples/simulation/pendulum/simulate_tendon_actuated_pendulum.py
@@ -116,7 +116,7 @@ def draw_robot(
     # Passive tendons
     try:
         A_pt = onp.asarray(
-            robot.passive_elements[0].transmission.moment_matrix(robot, q)
+            robot.passive_elements[0].transmission.actuation_matrix(robot, q)
         )
         Np = A_pt.shape[1]
     except AttributeError:
@@ -225,7 +225,7 @@ if __name__ == "__main__":
     print("R_at =", active_tendons.params.transmission.routing_matrix)
     print("A_at =", robot.actuation_matrix(q0))
     print("R_pt =", passive_tendons.params.transmission.routing_matrix)
-    print("A_pt =", passive_tendons.transmission.moment_matrix(robot, q0))
+    print("A_pt =", passive_tendons.transmission.actuation_matrix(robot, q0))
     print("k_pt =", passive_tendons.params.stiffness)
     print("d_pt =", passive_tendons.params.damping)
     print("active coordinates at q0 =", robot.actuator_coordinates(q0))

--- a/src/soromox/actuation/__init__.py
+++ b/src/soromox/actuation/__init__.py
@@ -10,6 +10,13 @@ from .core import (
     PassiveElement,
     Transmission,
 )
+from .friction import (
+    CapstanFriction,
+    ExponentialLengthFriction,
+    Frictionless,
+    ThreadlikeFriction,
+    ThreadlikeQuadratureContext,
+)
 from .joint import (
     AffineJointTransmission,
     AffineJointTransmissionParams,
@@ -58,8 +65,13 @@ __all__ = [
     "ArticulatedMcKibbenTransmission",
     "ArticulatedMcKibbenTransmissionParams",
     "BaseThreadlikeRoutingParams",
+    "CapstanFriction",
+    "ExponentialLengthFriction",
+    "Frictionless",
     "LinearThreadlikeRoutingParams",
     "PassiveElement",
+    "ThreadlikeFriction",
+    "ThreadlikeQuadratureContext",
     "ThreadlikeActuator",
     "ThreadlikeActuatorParams",
     "ThreadlikeImpedance",

--- a/src/soromox/actuation/__init__.py
+++ b/src/soromox/actuation/__init__.py
@@ -13,13 +13,14 @@ from .core import (
 from .friction import (
     BaseThreadlikeFrictionParams,
     CapstanFrictionParams,
-    ExponentialLengthFrictionParams,
     FrictionlessParams,
     ThreadlikeFriction,
-    ThreadlikeQuadratureContext,
-    capstan_transmission_ratio,
-    exponential_length_transmission_ratio,
-    frictionless_transmission_ratio,
+    capstan_effort_ratio,
+    frictionless_effort_ratio,
+    threadlike_tangent,
+    threadlike_tangent_derivative,
+    threadlike_turn_rate,
+    threadlike_unit_tangent_derivative,
 )
 from .joint import (
     AffineJointTransmission,
@@ -47,6 +48,7 @@ from .threadlike import (
     ThreadlikeTransmissionParams,
     linear_threadlike_routing,
     linear_threadlike_routing_derivative,
+    linear_threadlike_routing_second_derivative,
 )
 
 __all__ = [
@@ -71,12 +73,10 @@ __all__ = [
     "BaseThreadlikeFrictionParams",
     "BaseThreadlikeRoutingParams",
     "CapstanFrictionParams",
-    "ExponentialLengthFrictionParams",
     "FrictionlessParams",
     "LinearThreadlikeRoutingParams",
     "PassiveElement",
     "ThreadlikeFriction",
-    "ThreadlikeQuadratureContext",
     "ThreadlikeActuator",
     "ThreadlikeActuatorParams",
     "ThreadlikeImpedance",
@@ -85,9 +85,13 @@ __all__ = [
     "ThreadlikeTransmission",
     "ThreadlikeTransmissionParams",
     "Transmission",
-    "capstan_transmission_ratio",
-    "exponential_length_transmission_ratio",
-    "frictionless_transmission_ratio",
+    "capstan_effort_ratio",
+    "frictionless_effort_ratio",
     "linear_threadlike_routing",
     "linear_threadlike_routing_derivative",
+    "linear_threadlike_routing_second_derivative",
+    "threadlike_tangent",
+    "threadlike_tangent_derivative",
+    "threadlike_turn_rate",
+    "threadlike_unit_tangent_derivative",
 ]

--- a/src/soromox/actuation/__init__.py
+++ b/src/soromox/actuation/__init__.py
@@ -11,11 +11,15 @@ from .core import (
     Transmission,
 )
 from .friction import (
-    CapstanFriction,
-    ExponentialLengthFriction,
-    Frictionless,
+    BaseThreadlikeFrictionParams,
+    CapstanFrictionParams,
+    ExponentialLengthFrictionParams,
+    FrictionlessParams,
     ThreadlikeFriction,
     ThreadlikeQuadratureContext,
+    capstan_transmission_ratio,
+    exponential_length_transmission_ratio,
+    frictionless_transmission_ratio,
 )
 from .joint import (
     AffineJointTransmission,
@@ -64,10 +68,11 @@ __all__ = [
     "ArticulatedMcKibbenActuatorParams",
     "ArticulatedMcKibbenTransmission",
     "ArticulatedMcKibbenTransmissionParams",
+    "BaseThreadlikeFrictionParams",
     "BaseThreadlikeRoutingParams",
-    "CapstanFriction",
-    "ExponentialLengthFriction",
-    "Frictionless",
+    "CapstanFrictionParams",
+    "ExponentialLengthFrictionParams",
+    "FrictionlessParams",
     "LinearThreadlikeRoutingParams",
     "PassiveElement",
     "ThreadlikeFriction",
@@ -80,6 +85,9 @@ __all__ = [
     "ThreadlikeTransmission",
     "ThreadlikeTransmissionParams",
     "Transmission",
+    "capstan_transmission_ratio",
+    "exponential_length_transmission_ratio",
+    "frictionless_transmission_ratio",
     "linear_threadlike_routing",
     "linear_threadlike_routing_derivative",
 ]

--- a/src/soromox/actuation/__init__.py
+++ b/src/soromox/actuation/__init__.py
@@ -17,10 +17,9 @@ from .friction import (
     ThreadlikeFriction,
     capstan_effort_ratio,
     frictionless_effort_ratio,
+    threadlike_constant_strain_turn_rate,
     threadlike_tangent,
-    threadlike_tangent_derivative,
     threadlike_turn_rate,
-    threadlike_unit_tangent_derivative,
 )
 from .joint import (
     AffineJointTransmission,
@@ -90,8 +89,7 @@ __all__ = [
     "linear_threadlike_routing",
     "linear_threadlike_routing_derivative",
     "linear_threadlike_routing_second_derivative",
+    "threadlike_constant_strain_turn_rate",
     "threadlike_tangent",
-    "threadlike_tangent_derivative",
     "threadlike_turn_rate",
-    "threadlike_unit_tangent_derivative",
 ]

--- a/src/soromox/actuation/core.py
+++ b/src/soromox/actuation/core.py
@@ -168,6 +168,26 @@ class PassiveElement(eqx.Module):
         del robot
         return jnp.zeros((), dtype=q.dtype)
 
+    def nonconservative_force(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the part of this element's force that has no potential.
+
+        ``elastic_force`` is contracted to be the gradient of
+        ``elastic_energy``, so a force an element transmits but cannot derive
+        from a potential belongs here instead, keeping both contracts
+        truthful. ``SoftRobot.actuation_force`` applies the summed result, so
+        the total generalized force is unchanged by the split.
+
+        Args:
+            robot: Soft robot on which the element is installed.
+            q: Generalized coordinates of shape ``(robot.num_dofs,)``.
+
+        Returns:
+            tau_nc: Generalized force of shape ``(robot.num_dofs,)``, in the
+                same sign convention as :meth:`elastic_force`. Zero unless an
+                element overrides it.
+        """
+        return jnp.zeros((robot.num_dofs,), dtype=q.dtype)
+
 
 class Actuator(eqx.Module):
     """A transmission paired with an effort law and ordered channel metadata."""

--- a/src/soromox/actuation/core.py
+++ b/src/soromox/actuation/core.py
@@ -85,16 +85,53 @@ class Transmission(eqx.Module):
 
     @abstractmethod
     def coordinate_jacobian(self, robot: SoftRobot, q: Array) -> Array:
-        """Return ``dy_a/dq`` with shape ``(num_channels, num_velocities)``."""
+        """Return the transmission-coordinate Jacobian.
+
+        The Jacobian ``J_a(q)`` maps generalized velocity to transmission-
+        coordinate velocity as ``yd_a = J_a(q) @ qd``.
+
+        Args:
+            robot: Soft robot on which the transmission is installed.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            J_a: Coordinate Jacobian with shape
+                ``(self.num_channels, robot.num_velocities)``.
+        """
         ...
 
     @abstractmethod
     def actuation_matrix(self, robot: SoftRobot, q: Array) -> Array:
-        """Return the effort-to-force map with shape ``(num_velocities, num_channels)``."""
+        """Return the effort-to-generalized-force map.
+
+        The actuation matrix ``A(q)`` maps transmission efforts to generalized
+        force as ``tau_u = A(q) @ effort``.
+
+        Args:
+            robot: Soft robot on which the transmission is installed.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            A: Actuation matrix with shape
+                ``(robot.num_velocities, self.num_channels)``.
+        """
         ...
 
     def velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
-        """Return transmission-coordinate velocities ``dy_a/dq @ qd``."""
+        """Map generalized velocities to transmission-coordinate velocities.
+
+        Args:
+            robot: Soft robot on which the transmission is installed.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+            qd: Generalized velocities with shape ``(robot.num_velocities,)``.
+
+        Returns:
+            yd_a: Transmission-coordinate velocities with shape
+                ``(self.num_channels,)``.
+        """
         return self.coordinate_jacobian(robot, q) @ qd
 
 
@@ -200,11 +237,32 @@ class Actuator(eqx.Module):
         return self.transmission.num_channels
 
     def coordinates(self, robot: SoftRobot, q: Array) -> Array:
-        """Return this actuator's work-conjugate coordinates."""
+        """Return this actuator's work-conjugate coordinates.
+
+        Args:
+            robot: Soft robot on which the actuator is installed.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            y_a: Work-conjugate actuator coordinates with shape
+                ``(self.num_channels,)``.
+        """
         return self.transmission.coordinates(robot, q)
 
     def velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
-        """Return this actuator's coordinate velocities."""
+        """Return this actuator's work-conjugate coordinate velocities.
+
+        Args:
+            robot: Soft robot on which the actuator is installed.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+            qd: Generalized velocities with shape ``(robot.num_velocities,)``.
+
+        Returns:
+            yd_a: Actuator-coordinate velocities with shape
+                ``(self.num_channels,)``.
+        """
         return self.transmission.velocities(robot, q, qd)
 
     def efforts(
@@ -316,12 +374,32 @@ class IdentityTransmission(Transmission):
         return q
 
     def coordinate_jacobian(self, robot: SoftRobot, q: Array) -> Array:
-        """Return the identity coordinate Jacobian."""
+        """Return the identity coordinate Jacobian.
+
+        Args:
+            robot: Soft robot on which the transmission is installed.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            J_a: Identity map from generalized to actuator-coordinate
+                velocities with shape ``(self.num_channels, self.num_channels)``.
+        """
         del robot
         return jnp.eye(self.num_channels, dtype=q.dtype)
 
     def actuation_matrix(self, robot: SoftRobot, q: Array) -> Array:
-        """Return the identity effort-to-generalized-force map."""
+        """Return the identity effort-to-generalized-force map.
+
+        Args:
+            robot: Soft robot on which the transmission is installed.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            A: Identity actuation matrix with shape
+                ``(self.num_channels, self.num_channels)``.
+        """
         del robot
         return jnp.eye(self.num_channels, dtype=q.dtype)
 

--- a/src/soromox/actuation/core.py
+++ b/src/soromox/actuation/core.py
@@ -169,24 +169,7 @@ class PassiveElement(eqx.Module):
         return jnp.zeros((), dtype=q.dtype)
 
     def nonconservative_force(self, robot: SoftRobot, q: Array) -> Array:
-        """Return the part of this element's force that has no potential.
-
-        ``elastic_force`` is contracted to be the gradient of
-        ``elastic_energy``, so a force an element transmits but cannot derive
-        from a potential belongs here instead, keeping both contracts
-        truthful. ``SoftRobot.actuation_force`` applies the summed result, so
-        the total generalized force is unchanged by the split.
-
-        Args:
-            robot: Soft robot on which the element is installed.
-            q: Generalized coordinates of shape ``(robot.num_dofs,)``.
-
-        Returns:
-            tau_nc: Generalized force of shape ``(robot.num_dofs,)``, in the
-                same sign convention as :meth:`elastic_force`. Zero unless an
-                element overrides it.
-        """
-        return jnp.zeros((robot.num_dofs,), dtype=q.dtype)
+        return jnp.zeros((robot.num_velocities,), dtype=q.dtype)
 
 
 class Actuator(eqx.Module):

--- a/src/soromox/actuation/core.py
+++ b/src/soromox/actuation/core.py
@@ -1,9 +1,11 @@
 """Composable actuation primitives.
 
 The actuation model follows a work-conjugate formulation. A transmission
-defines actuator coordinates ``y_a(q)`` and their moment matrix
-``A(q) = dy_a/dq.T``. An effort model maps user controls to efforts conjugate to
-those coordinates, and generalized actuation forces are ``A(q) @ effort``.
+defines actuator coordinates ``y_a(q)``, their coordinate Jacobian
+``J_a(q) = dy_a/dq``, and an effort-to-generalized-force map ``A(q)``. For an
+ideal lossless transmission ``A = J_a.T``; lossy transmissions need not obey
+that identity. An effort model maps user controls to efforts conjugate to the
+actuator coordinates, and generalized actuation forces are ``A(q) @ effort``.
 """
 
 from __future__ import annotations
@@ -82,13 +84,18 @@ class Transmission(eqx.Module):
         ...
 
     @abstractmethod
-    def moment_matrix(self, robot: SoftRobot, q: Array) -> Array:
-        """Return ``dy_a/dq.T`` with shape ``(num_dofs, num_channels)``."""
+    def coordinate_jacobian(self, robot: SoftRobot, q: Array) -> Array:
+        """Return ``dy_a/dq`` with shape ``(num_channels, num_velocities)``."""
+        ...
+
+    @abstractmethod
+    def actuation_matrix(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the effort-to-force map with shape ``(num_velocities, num_channels)``."""
         ...
 
     def velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
-        """Return transmission-coordinate velocities."""
-        return self.moment_matrix(robot, q).T @ qd
+        """Return transmission-coordinate velocities ``dy_a/dq @ qd``."""
+        return self.coordinate_jacobian(robot, q) @ qd
 
 
 class EffortModel(eqx.Module):
@@ -168,9 +175,6 @@ class PassiveElement(eqx.Module):
         del robot
         return jnp.zeros((), dtype=q.dtype)
 
-    def nonconservative_force(self, robot: SoftRobot, q: Array) -> Array:
-        return jnp.zeros((robot.num_velocities,), dtype=q.dtype)
-
 
 class Actuator(eqx.Module):
     """A transmission paired with an effort law and ordered channel metadata."""
@@ -196,9 +200,11 @@ class Actuator(eqx.Module):
         return self.transmission.num_channels
 
     def coordinates(self, robot: SoftRobot, q: Array) -> Array:
+        """Return this actuator's work-conjugate coordinates."""
         return self.transmission.coordinates(robot, q)
 
     def velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
+        """Return this actuator's coordinate velocities."""
         return self.transmission.velocities(robot, q, qd)
 
     def efforts(
@@ -208,12 +214,12 @@ class Actuator(eqx.Module):
         control: Array,
         qd: Array | None = None,
         *,
-        transmission_matrix: Array | None = None,
+        coordinate_jacobian: Array | None = None,
     ) -> Array:
         """Map controls to work-conjugate efforts for this actuator.
 
         Only transmission coordinates and velocities required by the installed
-        effort model are evaluated. A precomputed transmission matrix may be
+        effort model are evaluated. A precomputed coordinate Jacobian may be
         supplied to reuse it when evaluating actuator-coordinate velocities.
 
         Args:
@@ -224,24 +230,24 @@ class Actuator(eqx.Module):
             qd: Optional generalized velocities of shape
                 ``(robot.num_velocities,)``. If omitted for a velocity-dependent
                 effort model, zero generalized velocity is used.
-            transmission_matrix: Optional precomputed transmission matrix with
-                shape ``(robot.num_velocities, self.num_channels)``.
+            coordinate_jacobian: Optional precomputed coordinate Jacobian with
+                shape ``(self.num_channels, robot.num_velocities)``.
 
         Returns:
             e: Work-conjugate actuator efforts with shape
                 ``(self.num_channels,)``.
 
         Raises:
-            ValueError: If ``transmission_matrix`` has an incompatible shape.
+            ValueError: If ``coordinate_jacobian`` has an incompatible shape.
         """
-        if transmission_matrix is not None and transmission_matrix.shape != (
-            robot.num_velocities,
+        if coordinate_jacobian is not None and coordinate_jacobian.shape != (
             self.num_channels,
+            robot.num_velocities,
         ):
             raise ValueError(
-                "transmission_matrix must have shape "
-                f"({robot.num_velocities}, {self.num_channels}), got "
-                f"{transmission_matrix.shape}."
+                "coordinate_jacobian must have shape "
+                f"({self.num_channels}, {robot.num_velocities}), got "
+                f"{coordinate_jacobian.shape}."
             )
 
         coordinate = None
@@ -252,10 +258,10 @@ class Actuator(eqx.Module):
         if self.effort_model.requires_velocity:
             if qd is None:
                 qd = jnp.zeros_like(q)
-            if transmission_matrix is None:
+            if coordinate_jacobian is None:
                 velocity = self.velocities(robot, q, qd)
             else:
-                velocity = transmission_matrix.T @ qd
+                velocity = coordinate_jacobian @ qd
 
         return self.effort_model.effort(control, coordinate, velocity)
 
@@ -309,7 +315,13 @@ class IdentityTransmission(Transmission):
         del robot
         return q
 
-    def moment_matrix(self, robot: SoftRobot, q: Array) -> Array:
+    def coordinate_jacobian(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the identity coordinate Jacobian."""
+        del robot
+        return jnp.eye(self.num_channels, dtype=q.dtype)
+
+    def actuation_matrix(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the identity effort-to-generalized-force map."""
         del robot
         return jnp.eye(self.num_channels, dtype=q.dtype)
 

--- a/src/soromox/actuation/friction.py
+++ b/src/soromox/actuation/friction.py
@@ -212,16 +212,28 @@ class CapstanFriction(ThreadlikeFriction):
 class ExponentialLengthFriction(ThreadlikeFriction):
     """Loss accumulating with routed-path length rather than with turning.
 
-    ``eta(q, s) = exp(-rate * s)`` models drag a path accrues per unit length,
-    such as a sheath, a seal, or a lumen, independently of how the path bends.
-    It reads no host-shaped field and needs no wrap angle, so unlike
-    :class:`CapstanFriction` it runs on every threadlike host, ``GVS``
-    included.
+    Both shipped laws solve the same tension ODE ``dT/ds = -lambda(s) T``,
+    whose solution is ``eta = exp(-integral lambda ds)``. They differ only in
+    where the normal load pressing the path against its guide comes from.
+    :class:`CapstanFriction` takes it from curvature, ``N = T w``, giving
+    ``lambda = mu w``. This law takes it from a snug sheath that grips in
+    proportion to tension, ``N = c T``, giving a constant ``lambda = mu c``
+    and
+
+    ``eta(q, s) = exp(-rate * s)``
+
+    so loss accrues with distance travelled rather than with turning. It suits
+    a tendon in a close-fitting sheath or lumen. It reads no host-shaped field
+    and needs no wrap angle, so unlike :class:`CapstanFriction` it runs on
+    every threadlike host, ``GVS`` included.
 
     Attributes:
-        rate: Loss per unit arc length, in inverse metres, either a scalar
-            shared by the family or shaped ``(num_paths,)``. Zero reproduces
-            the frictionless transmission exactly.
+        rate: Loss per unit arc length ``mu c``, in inverse metres, either a
+            scalar shared by the family or shaped ``(num_paths,)``. Unlike a
+            Coulomb coefficient it is phenomenological: it lumps the friction
+            coefficient together with the radial grip and has to be fitted
+            rather than looked up. Zero reproduces the frictionless
+            transmission exactly.
     """
 
     rate: Array = eqx.field(default_factory=lambda: jnp.zeros((), dtype=jnp.float64))

--- a/src/soromox/actuation/friction.py
+++ b/src/soromox/actuation/friction.py
@@ -1,0 +1,247 @@
+"""Transmission-loss laws along threadlike routed paths.
+
+A threadlike transmission carries effort from the base of a routed path toward
+its tip. Guides, seals, and the surrounding material remove some of that effort
+before it reaches the backbone. A :class:`ThreadlikeFriction` model expresses
+how much survives, as a fraction ``eta(q, s)`` of the base effort, and the host
+folds that fraction into the arc-length quadrature that assembles the moment
+matrix.
+
+Because the fraction weights the integrand rather than scaling the result, the
+loss accumulates along the path: distal material contributes less than proximal
+material. The fraction depends on the configuration only, never on the effort,
+which keeps the generalized actuation force linear in the effort and every
+controller structurally unchanged.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, ClassVar
+
+import equinox as eqx
+from jax import Array
+from jax import numpy as jnp
+
+from soromox.systems.params import BaseSystemParams
+
+
+def validate_loss_parameter_shape(value: Any, count: int, name: str) -> None:
+    """Validate a per-path loss parameter shape without concretizing it.
+
+    Args:
+        value: Candidate loss parameter.
+        count: Number of routed paths in the family.
+        name: Field name used in the error message.
+
+    Raises:
+        ValueError: If the value is neither a scalar nor shaped ``(count,)``.
+    """
+    shape = jnp.asarray(value).shape
+    if shape not in ((), (count,)):
+        raise ValueError(
+            f"{name} must be a scalar or have shape ({count},), got {shape}."
+        )
+
+
+class ThreadlikeQuadratureContext(eqx.Module):
+    """Routed-path geometry at one arc-length quadrature node.
+
+    Instances are produced by the host inside its per-path ``vmap``, so every
+    array field carries a leading ``(num_paths,)`` axis.
+
+    Some fields mean the same thing on every host and some do not. A law that
+    reads only the host-agnostic fields runs unchanged on ``PlanarPCS``,
+    ``PCS``, and ``GVS``; a law that reads a host-shaped field must document
+    which host it targets.
+
+    Attributes:
+        arc_length: Backbone coordinate ``s`` of the node, in metres.
+            Host-agnostic.
+        segment_index: Index of the segment containing the node. Host-agnostic.
+        offset: Material-frame path offset of shape ``(num_paths, 3)``, ordered
+            ``[x, y, z]`` with local x along the backbone. Host-agnostic.
+        offset_derivative: Arc-length derivative of ``offset``, same shape.
+            Host-agnostic.
+        tangent_norm: Length of the routed-path tangent, ``(num_paths,)``. This
+            is the local stretch of the path relative to the backbone, so it is
+            the quantity a length-based loss integrates. Host-agnostic.
+        active: Whether the node lies inside each path's segment span, shape
+            ``(num_paths,)``. Host-agnostic.
+        unit_tangent: Normalized routed-path tangent. Host-shaped:
+            ``(num_paths, 2)`` in the plane and ``(num_paths, 3)`` in space.
+        strain: Segment strain at the node. Host-shaped: ``(num_paths, 3)``
+            ordered ``[kappa_z, sigma_x, sigma_y]`` in the plane, and
+            ``(num_paths, 6)`` ordered ``[omega, v]`` in space.
+        wrap_angle: Accumulated turn ``Theta`` of the routed path from the base
+            to this node, in radians, shape ``(num_paths,)``. ``None`` unless
+            the installed law sets ``requires_wrap_angle``, because computing
+            it costs the host extra work.
+
+    Note:
+        There is no path-count field. The host assembles the context inside a
+        ``vmap`` over paths, where a static count could not be set safely, so a
+        law that needs the count reads it from a batched field, for example
+        ``context.tangent_norm.shape[0]``.
+    """
+
+    arc_length: Array
+    segment_index: Array
+    offset: Array
+    offset_derivative: Array
+    tangent_norm: Array
+    active: Array
+    unit_tangent: Array
+    strain: Array
+    wrap_angle: Array | None = None
+
+    def with_wrap_angle(self, wrap_angle: Array) -> ThreadlikeQuadratureContext:
+        """Return a copy carrying the accumulated wrap angle.
+
+        The host builds the geometric fields inside its per-path ``vmap`` and
+        attaches the wrap angle afterwards, because the wrap density is
+        assembled once per segment rather than once per path.
+
+        Args:
+            wrap_angle: Accumulated turn of shape ``(num_paths,)``.
+
+        Returns:
+            context: A copy whose ``wrap_angle`` is populated.
+        """
+        return eqx.tree_at(
+            lambda context: context.wrap_angle,
+            self,
+            wrap_angle,
+            is_leaf=lambda leaf: leaf is None,
+        )
+
+
+class ThreadlikeFriction(BaseSystemParams):
+    """Fraction of routed-path effort that survives to a quadrature node.
+
+    Subclasses declare what they need from the host through the class
+    variables below, so a host computes only what the installed law reads and
+    can refuse a law it cannot serve.
+
+    Attributes:
+        is_lossless: Whether the law returns exactly one everywhere. Hosts skip
+            the friction path entirely when it is set, which keeps the default
+            bit-identical to the frictionless model at no cost.
+        requires_wrap_angle: Whether :meth:`transmission_ratio` reads
+            ``context.wrap_angle``. Hosts that cannot supply an exact
+            accumulated turn refuse such a law at construction.
+    """
+
+    is_lossless: ClassVar[bool] = False
+    requires_wrap_angle: ClassVar[bool] = True
+
+    @abstractmethod
+    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return the surviving effort fraction at one quadrature node.
+
+        Args:
+            context: Routed-path geometry at the node, batched over paths.
+
+        Returns:
+            eta: Surviving fraction of shape ``(num_paths,)``. Implementations
+                must stay within ``(0, 1]`` so a transmission can never
+                generate effort, and must not depend on the applied effort,
+                which would make the actuation force nonlinear in the control.
+        """
+        ...
+
+    def validate_for_paths(self, num_paths: int) -> None:
+        """Validate loss parameters against the routed-path count.
+
+        Args:
+            num_paths: Number of paths in the routing family.
+
+        Returns:
+            ``None``. Subclasses override this hook to check per-path shapes.
+            Implementations must be safe when leaves are JAX tracers.
+        """
+        del num_paths
+
+
+class Frictionless(ThreadlikeFriction):
+    """Ideal transmission that delivers the full effort to every node."""
+
+    is_lossless: ClassVar[bool] = True
+    requires_wrap_angle: ClassVar[bool] = False
+
+    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return ones, the identity of the weighted quadrature."""
+        return jnp.ones_like(context.tangent_norm)
+
+
+class CapstanFriction(ThreadlikeFriction):
+    """Coulomb guide friction following the Capstan (Euler) belt law.
+
+    A band drawn over a guide with total wrap angle ``phi`` transmits
+    ``exp(-mu * phi)`` of its input tension, independently of the guide radius.
+    Accumulating that loss over a continuum of guides gives
+
+    ``eta(q, s) = exp(-mu * Theta(q, s))``
+
+    with ``Theta`` the accumulated turn of the routed path. The law follows the
+    tendon force model of Feliu-Talegon, Alkayas, Adamu, Mathew and Renda,
+    "Actuation Reading Insights: Estimating Shape and Forces in Tendon-Driven
+    Slender Soft Robots", IEEE/ASME Transactions on Mechatronics 30(6), 2025.
+
+    Attributes:
+        coefficient: Coulomb coefficient between a path and its guides, either
+            a scalar shared by the family or shaped ``(num_paths,)``. Zero
+            reproduces the frictionless transmission exactly.
+    """
+
+    coefficient: Array = eqx.field(
+        default_factory=lambda: jnp.zeros((), dtype=jnp.float64)
+    )
+
+    requires_wrap_angle: ClassVar[bool] = True
+
+    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return the Capstan ratio ``exp(-mu * Theta)`` at the node."""
+        return jnp.exp(-jnp.asarray(self.coefficient) * context.wrap_angle)
+
+    def validate_for_paths(self, num_paths: int) -> None:
+        """Validate the coefficient shape against the routed-path count."""
+        validate_loss_parameter_shape(self.coefficient, num_paths, "coefficient")
+
+
+class ExponentialLengthFriction(ThreadlikeFriction):
+    """Loss accumulating with routed-path length rather than with turning.
+
+    ``eta(q, s) = exp(-rate * s)`` models drag a path accrues per unit length,
+    such as a sheath, a seal, or a lumen, independently of how the path bends.
+    It reads no host-shaped field and needs no wrap angle, so unlike
+    :class:`CapstanFriction` it runs on every threadlike host, ``GVS``
+    included.
+
+    Attributes:
+        rate: Loss per unit arc length, in inverse metres, either a scalar
+            shared by the family or shaped ``(num_paths,)``. Zero reproduces
+            the frictionless transmission exactly.
+    """
+
+    rate: Array = eqx.field(default_factory=lambda: jnp.zeros((), dtype=jnp.float64))
+
+    requires_wrap_angle: ClassVar[bool] = False
+
+    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return the length-decay ratio ``exp(-rate * s)`` at the node."""
+        return jnp.exp(-jnp.asarray(self.rate) * context.arc_length)
+
+    def validate_for_paths(self, num_paths: int) -> None:
+        """Validate the rate shape against the routed-path count."""
+        validate_loss_parameter_shape(self.rate, num_paths, "rate")
+
+
+__all__ = [
+    "CapstanFriction",
+    "ExponentialLengthFriction",
+    "Frictionless",
+    "ThreadlikeFriction",
+    "ThreadlikeQuadratureContext",
+    "validate_loss_parameter_shape",
+]

--- a/src/soromox/actuation/friction.py
+++ b/src/soromox/actuation/friction.py
@@ -68,7 +68,8 @@ def threadlike_tangent(
         angular_strain: Material angular strain ``omega`` with shape ``(3,)``.
         linear_strain: Material linear strain ``v`` with shape ``(3,)``.
         offset: Material-frame routing offset ``r`` with shape ``(3,)``.
-        offset_derivative: Arc-length derivative ``r'`` with shape ``(3,)``.
+        offset_derivative: Backbone-abscissa derivative ``r'`` with shape
+            ``(3,)``.
 
     Returns:
         Material-frame path tangent ``a`` with shape ``(3,)``.
@@ -76,73 +77,42 @@ def threadlike_tangent(
     return linear_strain + jnp.cross(angular_strain, offset) + offset_derivative
 
 
-def threadlike_tangent_derivative(
+def _threadlike_turn_rate_from_tangent(
     angular_strain: Array,
-    linear_strain_derivative: Array,
-    angular_strain_derivative: Array,
-    offset: Array,
-    offset_derivative: Array,
-    offset_second_derivative: Array,
-) -> Array:
-    r"""Return the arc-length derivative of the material path tangent.
-
-    Differentiating ``a = v + omega cross r + r'`` analytically gives
-
-    .. math::
-
-        a' = v' + \omega' \times r + \omega \times r' + r''.
-
-    Args:
-        angular_strain: Material angular strain ``omega``.
-        linear_strain_derivative: Arc-length derivative ``v'``.
-        angular_strain_derivative: Arc-length derivative ``omega'``.
-        offset: Material-frame routing offset ``r``.
-        offset_derivative: Arc-length derivative ``r'``.
-        offset_second_derivative: Arc-length derivative ``r''`` of ``r'``.
-
-    Returns:
-        Material-frame tangent derivative ``a'`` with shape ``(3,)``.
-    """
-    return (
-        linear_strain_derivative
-        + jnp.cross(angular_strain_derivative, offset)
-        + jnp.cross(angular_strain, offset_derivative)
-        + offset_second_derivative
-    )
-
-
-def threadlike_unit_tangent_derivative(
     tangent: Array,
     tangent_derivative: Array,
     *,
     eps: Array | float,
 ) -> Array:
-    r"""Return the derivative of a normalized material path tangent.
+    r"""Return spatial turn rate from a material tangent and its derivative.
 
-    With ``u = a / ||a||``, differentiation gives
+    With ``u = a / ||a||``, the material unit-tangent derivative is
 
     .. math::
 
         u' = \frac{(I-u u^T)a'}{\lVert a\rVert}.
 
-    A collapsed path tangent has no defined direction. SoRoMoX returns the
-    finite zero convention there, consistent with its other ``safe_*``
-    numerical helpers.
+    The spatial unit tangent turns at
+    ``rho = ||omega cross u + u'||``. A collapsed path has no defined tangent;
+    the package's finite zero convention is used for both ``u`` and ``u'``.
 
     Args:
-        tangent: Material-frame path tangent ``a``.
-        tangent_derivative: Arc-length derivative ``a'``.
+        angular_strain: Material angular strain ``omega`` with shape ``(3,)``.
+        tangent: Material-frame path tangent ``a`` with shape ``(3,)``.
+        tangent_derivative: Backbone-abscissa derivative ``a'`` with shape
+            ``(3,)``.
         eps: Threshold below which ``||a||`` is treated as zero.
 
     Returns:
-        Material-frame unit-tangent derivative ``u'``.
+        Nonnegative spatial turn rate ``rho`` as a scalar.
     """
     tangent_norm = safe_norm(tangent)
     unit_tangent = safe_divide(tangent, tangent_norm, eps)
     projected = tangent_derivative - unit_tangent * jnp.dot(
         unit_tangent, tangent_derivative
     )
-    return safe_divide(projected, tangent_norm, eps)
+    unit_tangent_derivative = safe_divide(projected, tangent_norm, eps)
+    return safe_norm(jnp.cross(angular_strain, unit_tangent) + unit_tangent_derivative)
 
 
 def threadlike_turn_rate(
@@ -168,18 +138,22 @@ def threadlike_turn_rate(
         \rho = \left\|\omega \times u + u'\right\|.
 
     Rotation preserves the Euclidean norm, so ``rho`` is evaluated entirely
-    in the material frame. It has units of radians per metre of undeformed
-    backbone coordinate and includes both backbone strain variation and
-    routing-offset variation.
+    in the material frame. It has units of radians per metre of backbone
+    abscissa and includes both backbone strain variation and routing-offset
+    variation.
 
     Args:
-        angular_strain: Material angular strain ``omega``.
-        linear_strain: Material linear strain ``v``.
-        angular_strain_derivative: Arc-length derivative ``omega'``.
-        linear_strain_derivative: Arc-length derivative ``v'``.
-        offset: Material-frame routing offset ``r``.
-        offset_derivative: Arc-length derivative ``r'``.
-        offset_second_derivative: Arc-length derivative ``r''``.
+        angular_strain: Material angular strain ``omega`` with shape ``(3,)``.
+        linear_strain: Material linear strain ``v`` with shape ``(3,)``.
+        angular_strain_derivative: Backbone-abscissa derivative ``omega'`` with
+            shape ``(3,)``.
+        linear_strain_derivative: Backbone-abscissa derivative ``v'`` with
+            shape ``(3,)``.
+        offset: Material-frame routing offset ``r`` with shape ``(3,)``.
+        offset_derivative: Backbone-abscissa derivative ``r'`` with shape
+            ``(3,)``.
+        offset_second_derivative: Backbone-abscissa derivative ``r''`` with
+            shape ``(3,)``.
         eps: Threshold used for a collapsed tangent.
 
     Returns:
@@ -188,20 +162,66 @@ def threadlike_turn_rate(
     tangent = threadlike_tangent(
         angular_strain, linear_strain, offset, offset_derivative
     )
-    tangent_derivative = threadlike_tangent_derivative(
+    tangent_derivative = (
+        linear_strain_derivative
+        + jnp.cross(angular_strain_derivative, offset)
+        + jnp.cross(angular_strain, offset_derivative)
+        + offset_second_derivative
+    )
+    return _threadlike_turn_rate_from_tangent(
         angular_strain,
-        linear_strain_derivative,
-        angular_strain_derivative,
-        offset,
-        offset_derivative,
-        offset_second_derivative,
+        tangent,
+        tangent_derivative,
+        eps=eps,
     )
-    tangent_norm = safe_norm(tangent)
-    unit_tangent = safe_divide(tangent, tangent_norm, eps)
-    unit_tangent_derivative = threadlike_unit_tangent_derivative(
-        tangent, tangent_derivative, eps=eps
+
+
+def threadlike_constant_strain_turn_rate(
+    angular_strain: Array,
+    linear_strain: Array,
+    offset: Array,
+    offset_derivative: Array,
+    offset_second_derivative: Array,
+    *,
+    eps: Array | float,
+) -> Array:
+    r"""Return routed-path turn rate for a constant Cosserat strain.
+
+    For PCS, ``omega' = v' = 0`` within every segment, so the material tangent
+    derivative simplifies analytically to
+
+    .. math::
+
+        a' = \omega \times r' + r''.
+
+    Args:
+        angular_strain: Constant material angular strain ``omega`` with shape
+            ``(3,)``.
+        linear_strain: Constant material linear strain ``v`` with shape
+            ``(3,)``.
+        offset: Material-frame routing offset ``r`` with shape ``(3,)``.
+        offset_derivative: Backbone-abscissa derivative ``r'`` with shape
+            ``(3,)``.
+        offset_second_derivative: Backbone-abscissa derivative ``r''`` with
+            shape ``(3,)``.
+        eps: Threshold below which a collapsed tangent uses the finite zero
+            convention.
+
+    Returns:
+        Nonnegative turn rate ``rho`` as a scalar.
+    """
+    tangent = threadlike_tangent(
+        angular_strain, linear_strain, offset, offset_derivative
     )
-    return safe_norm(jnp.cross(angular_strain, unit_tangent) + unit_tangent_derivative)
+    tangent_derivative = (
+        jnp.cross(angular_strain, offset_derivative) + offset_second_derivative
+    )
+    return _threadlike_turn_rate_from_tangent(
+        angular_strain,
+        tangent,
+        tangent_derivative,
+        eps=eps,
+    )
 
 
 def threadlike_turning_angle(
@@ -219,7 +239,10 @@ def threadlike_turning_angle(
     """
     sine = safe_norm(jnp.cross(left_unit_tangent, right_unit_tangent))
     cosine = jnp.clip(jnp.dot(left_unit_tangent, right_unit_tangent), -1.0, 1.0)
-    return jnp.arctan2(sine, cosine)
+    has_direction = (sine > 0.0) | (jnp.abs(cosine) > 0.0)
+    safe_cosine = jnp.where(has_direction, cosine, jnp.ones_like(cosine))
+    angle = jnp.arctan2(sine, safe_cosine)
+    return jnp.where(has_direction, angle, jnp.zeros_like(angle))
 
 
 def integrate_accumulated_turn(
@@ -228,12 +251,12 @@ def integrate_accumulated_turn(
     s: Array,
     segment_starts: Array,
     segment_lengths: Array,
-    normalized_points: Array,
+    normalized_s_ps: Array,
     normalized_weights: Array,
     start_segment_index: Array,
     end_segment_index: Array,
 ) -> Array:
-    """Integrate path turn from each anchor through backbone coordinate ``s``.
+    """Integrate path turn from each anchor through backbone abscissa ``s``.
 
     The integral uses the host quadrature rule on every complete segment and a
     rescaled copy of that rule on the final partial segment. One-sided tangent
@@ -242,17 +265,17 @@ def integrate_accumulated_turn(
     guides.
 
     Args:
-        turn_rate_fn: Function accepting ``(segment_index, physical_points)``
+        turn_rate_fn: Function accepting ``(segment_index, s_ps)``
             and returning turn rates shaped ``(num_points, num_paths)``.
         boundary_turn_fn: Function accepting a left segment index and returning
             one-sided tangent angles shaped ``(num_paths,)``.
-        s: Physical backbone coordinate through which to integrate.
-        segment_starts: Physical start coordinate of every segment.
+        s: Backbone abscissa through which to integrate.
+        segment_starts: Backbone abscissa at the start of every segment.
         segment_lengths: Physical length of every segment.
-        normalized_points: Quadrature nodes in ``[0, 1]`` shaped
+        normalized_s_ps: Normalized quadrature abscissae in ``[0, 1]`` shaped
             ``(num_segments, num_points)``.
         normalized_weights: Corresponding quadrature weights with the same
-            shape as ``normalized_points``.
+            shape as ``normalized_s_ps``.
         start_segment_index: First segment of every routed path.
         end_segment_index: Last segment of every routed path.
 
@@ -268,11 +291,11 @@ def integrate_accumulated_turn(
             0.0,
             segment_lengths[segment_index],
         )
-        points = (
+        s_ps = (
             segment_starts[segment_index]
-            + covered_length * normalized_points[segment_index]
+            + covered_length * normalized_s_ps[segment_index]
         )
-        rates = turn_rate_fn(segment_index, points)
+        rates = turn_rate_fn(segment_index, s_ps)
         return covered_length * jnp.sum(
             normalized_weights[segment_index, :, None] * rates, axis=0
         )
@@ -287,9 +310,9 @@ def integrate_accumulated_turn(
         return accumulated
 
     boundary_indices = jnp.arange(segment_lengths.shape[0] - 1)
-    boundary_coordinates = segment_starts[1:]
+    boundary_s = segment_starts[1:]
     boundary_angles = vmap(boundary_turn_fn)(boundary_indices)
-    crossed = boundary_coordinates[:, None] <= jnp.asarray(s)
+    crossed = boundary_s[:, None] <= jnp.asarray(s)
     spans_boundary = (boundary_indices[:, None] >= start_segment_index[None, :]) & (
         boundary_indices[:, None] + 1 <= end_segment_index[None, :]
     )
@@ -378,7 +401,7 @@ class ThreadlikeFriction(eqx.Module):
 
     The effort supplied by the actuator is defined at each path anchor. The
     model returns the fraction that remains after the path has accumulated a
-    given unsigned turn while moving along increasing backbone coordinate.
+    given unsigned turn while moving along increasing backbone abscissa.
 
     Attributes:
         params: Dynamic friction parameters.
@@ -501,9 +524,8 @@ __all__ = [
     "capstan_effort_ratio",
     "frictionless_effort_ratio",
     "integrate_accumulated_turn",
+    "threadlike_constant_strain_turn_rate",
     "threadlike_tangent",
-    "threadlike_tangent_derivative",
     "threadlike_turn_rate",
     "threadlike_turning_angle",
-    "threadlike_unit_tangent_derivative",
 ]

--- a/src/soromox/actuation/friction.py
+++ b/src/soromox/actuation/friction.py
@@ -1,23 +1,9 @@
-"""Transmission-loss laws along threadlike routed paths.
-
-A threadlike transmission carries effort from the base of a routed path toward
-its tip. Guides, seals, and the surrounding material remove some of that effort
-before it reaches the backbone. A :class:`ThreadlikeFriction` model expresses
-how much survives, as a fraction ``eta(q, s)`` of the base effort, and the host
-folds that fraction into the arc-length quadrature that assembles the moment
-matrix.
-
-Because the fraction weights the integrand rather than scaling the result, the
-loss accumulates along the path: distal material contributes less than proximal
-material. The fraction depends on the configuration only, never on the effort,
-which keeps the generalized actuation force linear in the effort and every
-controller structurally unchanged.
-"""
+"""Friction models along threadlike routed paths that attenuate the effort."""
 
 from __future__ import annotations
 
-from abc import abstractmethod
-from typing import Any, ClassVar
+from collections.abc import Callable
+from typing import Any, cast
 
 import equinox as eqx
 from jax import Array
@@ -26,12 +12,12 @@ from jax import numpy as jnp
 from soromox.systems.params import BaseSystemParams
 
 
-def validate_loss_parameter_shape(value: Any, count: int, name: str) -> None:
-    """Validate a per-path loss parameter shape without concretizing it.
+def validate_friction_parameter_shape(value: Any, count: int, name: str) -> None:
+    """Validate a per-path friction parameter shape.
 
     Args:
-        value: Candidate loss parameter.
-        count: Number of routed paths in the family.
+        value: Candidate friction parameter.
+        count: Number of routed paths.
         name: Field name used in the error message.
 
     Raises:
@@ -44,48 +30,53 @@ def validate_loss_parameter_shape(value: Any, count: int, name: str) -> None:
         )
 
 
+def validate_friction_parameter_values(value: Any, name: str) -> None:
+    """Validate that a friction parameter is finite and non-negative.
+
+    A negative or non-finite parameter pushes the transmission ratio outside
+    ``(0, 1]``, causing the transmission to generate effort.
+
+    Args:
+        value: Concrete friction parameter.
+        name: Field name used in the error message.
+
+    Raises:
+        ValueError: If the value is non-finite or negative.
+    """
+    array = jnp.asarray(value)
+    if not bool(jnp.all(jnp.isfinite(array))):
+        raise ValueError(f"{name} must be finite, got {array}.")
+    if bool(jnp.any(array < 0.0)):
+        raise ValueError(f"{name} must be non-negative, got {array}.")
+
+
 class ThreadlikeQuadratureContext(eqx.Module):
-    """Routed-path geometry at one arc-length quadrature node.
-
-    Instances are produced by the host inside its per-path ``vmap``, so every
-    array field carries a leading ``(num_paths,)`` axis.
-
-    Some fields mean the same thing on every host and some do not. A law that
-    reads only the host-agnostic fields runs unchanged on ``PlanarPCS``,
-    ``PCS``, and ``GVS``; a law that reads a host-shaped field must document
-    which host it targets.
+    """Routed-path geometry at one abscissa quadrature point.
 
     Attributes:
-        arc_length: Backbone coordinate ``s`` of the node, in metres.
-            Host-agnostic.
-        segment_index: Index of the segment containing the node. Host-agnostic.
+        abscissa: Backbone coordinate of the node from the robot base, in
+        metres.
+        path_abscissa: Arc-length covered along the span of each path from
+        the path anchor, in metres.
+        segment_index: Index of the segment containing the node.
         offset: Material-frame path offset of shape ``(num_paths, 3)``, ordered
-            ``[x, y, z]`` with local x along the backbone. Host-agnostic.
-        offset_derivative: Arc-length derivative of ``offset``, same shape.
-            Host-agnostic.
-        tangent_norm: Length of the routed-path tangent, ``(num_paths,)``. This
-            is the local stretch of the path relative to the backbone, so it is
-            the quantity a length-based loss integrates. Host-agnostic.
-        active: Whether the node lies inside each path's segment span, shape
-            ``(num_paths,)``. Host-agnostic.
+            ``[x, y, z]``.
+        offset_derivative: Arc-length derivative of ``offset``.
+        tangent_norm: Length of the routed-path tangent, ``(num_paths,)``.
+        active: True if the node lies inside the segment span of each path,
+            shape ``(num_paths,)``.
         unit_tangent: Normalized routed-path tangent. Host-shaped:
             ``(num_paths, 2)`` in the plane and ``(num_paths, 3)`` in space.
         strain: Segment strain at the node. Host-shaped: ``(num_paths, 3)``
             ordered ``[kappa_z, sigma_x, sigma_y]`` in the plane, and
             ``(num_paths, 6)`` ordered ``[omega, v]`` in space.
-        wrap_angle: Accumulated turn ``Theta`` of the routed path from the base
-            to this node, in radians, shape ``(num_paths,)``. ``None`` unless
-            the installed law sets ``requires_wrap_angle``, because computing
-            it costs the host extra work.
-
-    Note:
-        There is no path-count field. The host assembles the context inside a
-        ``vmap`` over paths, where a static count could not be set safely, so a
-        law that needs the count reads it from a batched field, for example
-        ``context.tangent_norm.shape[0]``.
+        wrap_angle: Routed-path curvature integrated from the path anchor to
+            the node, in radians, shape ``(num_paths,)``. ``None`` unless the
+            installed model sets ``requires_wrap_angle``.
     """
 
-    arc_length: Array
+    abscissa: Array
+    path_abscissa: Array
     segment_index: Array
     offset: Array
     offset_derivative: Array
@@ -98,12 +89,8 @@ class ThreadlikeQuadratureContext(eqx.Module):
     def with_wrap_angle(self, wrap_angle: Array) -> ThreadlikeQuadratureContext:
         """Return a copy carrying the accumulated wrap angle.
 
-        The host builds the geometric fields inside its per-path ``vmap`` and
-        attaches the wrap angle afterwards, because the wrap density is
-        assembled once per segment rather than once per path.
-
         Args:
-            wrap_angle: Accumulated turn of shape ``(num_paths,)``.
+            wrap_angle: Wrap angle of shape ``(num_paths,)``, in radians.
 
         Returns:
             context: A copy whose ``wrap_angle`` is populated.
@@ -116,144 +103,223 @@ class ThreadlikeQuadratureContext(eqx.Module):
         )
 
 
-class ThreadlikeFriction(BaseSystemParams):
-    """Fraction of routed-path effort that survives to a quadrature node.
+class BaseThreadlikeFrictionParams(BaseSystemParams):
+    """Base PyTree contract for threadlike friction parameters."""
 
-    Subclasses declare what they need from the host through the class
-    variables below, so a host computes only what the installed law reads and
-    can refuse a law it cannot serve.
-
-    Attributes:
-        is_lossless: Whether the law returns exactly one everywhere. Hosts skip
-            the friction path entirely when it is set, which keeps the default
-            bit-identical to the frictionless model at no cost.
-        requires_wrap_angle: Whether :meth:`transmission_ratio` reads
-            ``context.wrap_angle``. Hosts that cannot supply an exact
-            accumulated turn refuse such a law at construction.
-    """
-
-    is_lossless: ClassVar[bool] = False
-    requires_wrap_angle: ClassVar[bool] = True
-
-    @abstractmethod
-    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return the surviving effort fraction at one quadrature node.
-
-        Args:
-            context: Routed-path geometry at the node, batched over paths.
-
-        Returns:
-            eta: Surviving fraction of shape ``(num_paths,)``. Implementations
-                must stay within ``(0, 1]`` so a transmission can never
-                generate effort, and must not depend on the applied effort,
-                which would make the actuation force nonlinear in the control.
-        """
-        ...
-
-    def validate_for_paths(self, num_paths: int) -> None:
-        """Validate loss parameters against the routed-path count.
+    def validate_structure_compatibility(self, num_paths: int) -> None:
+        """Validate per-path friction parameter shapes against the path count.
 
         Args:
             num_paths: Number of paths in the routing family.
-
-        Returns:
-            ``None``. Subclasses override this hook to check per-path shapes.
-            Implementations must be safe when leaves are JAX tracers.
         """
         del num_paths
 
 
-class Frictionless(ThreadlikeFriction):
-    """Ideal transmission that delivers the full effort to every node."""
-
-    is_lossless: ClassVar[bool] = True
-    requires_wrap_angle: ClassVar[bool] = False
-
-    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return ones, the identity of the weighted quadrature."""
-        return jnp.ones_like(context.tangent_norm)
+class FrictionlessParams(BaseThreadlikeFrictionParams):
+    """Parameters of the ideal transmission. None."""
 
 
-class CapstanFriction(ThreadlikeFriction):
-    """Coulomb guide friction following the Capstan (Euler) belt law.
-
-    A band drawn over a guide with total wrap angle ``phi`` transmits
-    ``exp(-mu * phi)`` of its input tension, independently of the guide radius.
-    Accumulating that loss over a continuum of guides gives
-
-    ``eta(q, s) = exp(-mu * Theta(q, s))``
-
-    with ``Theta`` the accumulated turn of the routed path. The law follows the
-    tendon force model of Feliu-Talegon, Alkayas, Adamu, Mathew and Renda,
-    "Actuation Reading Insights: Estimating Shape and Forces in Tendon-Driven
-    Slender Soft Robots", IEEE/ASME Transactions on Mechatronics 30(6), 2025.
+class CapstanFrictionParams(BaseThreadlikeFrictionParams):
+    """Parameters of the Capstan (Euler) belt model.
 
     Attributes:
-        coefficient: Coulomb coefficient between a path and its guides, either
-            a scalar shared by the family or shaped ``(num_paths,)``. Zero
-            reproduces the frictionless transmission exactly.
+        coefficient: Coulomb coefficient between a routing and the robot, either
+            a scalar shared by the family or shaped ``(num_paths,)``.
+        eps: Curvature floor in radians per metre.
     """
 
     coefficient: Array = eqx.field(
         default_factory=lambda: jnp.zeros((), dtype=jnp.float64)
     )
+    eps: Array = eqx.field(default_factory=lambda: jnp.zeros((), dtype=jnp.float64))
 
-    requires_wrap_angle: ClassVar[bool] = True
+    def __check_init__(self) -> None:
+        self.validate_for_update()
 
-    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return the Capstan ratio ``exp(-mu * Theta)`` at the node."""
-        return jnp.exp(-jnp.asarray(self.coefficient) * context.wrap_angle)
-
-    def validate_for_paths(self, num_paths: int) -> None:
+    def validate_structure_compatibility(self, num_paths: int) -> None:
         """Validate the coefficient shape against the routed-path count."""
-        validate_loss_parameter_shape(self.coefficient, num_paths, "coefficient")
+        validate_friction_parameter_shape(self.coefficient, num_paths, "coefficient")
+
+    def validate_values(self) -> None:
+        """Validate eager Capstan parameter values."""
+        validate_friction_parameter_values(self.coefficient, "coefficient")
+        validate_friction_parameter_values(self.eps, "eps")
 
 
-class ExponentialLengthFriction(ThreadlikeFriction):
-    """Loss accumulating with routed-path length rather than with turning.
-
-    Both shipped laws solve the same tension ODE ``dT/ds = -lambda(s) T``,
-    whose solution is ``eta = exp(-integral lambda ds)``. They differ only in
-    where the normal load pressing the path against its guide comes from.
-    :class:`CapstanFriction` takes it from curvature, ``N = T w``, giving
-    ``lambda = mu w``. This law takes it from a snug sheath that grips in
-    proportion to tension, ``N = c T``, giving a constant ``lambda = mu c``
-    and
-
-    ``eta(q, s) = exp(-rate * s)``
-
-    so loss accrues with distance travelled rather than with turning. It suits
-    a tendon in a close-fitting sheath or lumen. It reads no host-shaped field
-    and needs no wrap angle, so unlike :class:`CapstanFriction` it runs on
-    every threadlike host, ``GVS`` included.
+class ExponentialLengthFrictionParams(BaseThreadlikeFrictionParams):
+    """Parameters of a configuration-independent friction proportional
+    to the routed-path length.
 
     Attributes:
-        rate: Loss per unit arc length ``mu c``, in inverse metres, either a
-            scalar shared by the family or shaped ``(num_paths,)``. Unlike a
-            Coulomb coefficient it is phenomenological: it lumps the friction
-            coefficient together with the radial grip and has to be fitted
-            rather than looked up. Zero reproduces the frictionless
-            transmission exactly.
+        rate: Attenuation per unit arc length, in inverse metres, either a scalar
+            shared by the family or shaped ``(num_paths,)``.
     """
 
     rate: Array = eqx.field(default_factory=lambda: jnp.zeros((), dtype=jnp.float64))
 
-    requires_wrap_angle: ClassVar[bool] = False
+    def __check_init__(self) -> None:
+        self.validate_for_update()
+
+    def validate_structure_compatibility(self, num_paths: int) -> None:
+        """Validate the rate shape against the routed-path count."""
+        validate_friction_parameter_shape(self.rate, num_paths, "rate")
+
+    def validate_values(self) -> None:
+        """Validate eager exponential-length parameter values."""
+        validate_friction_parameter_values(self.rate, "rate")
+
+
+def frictionless_transmission_ratio(
+    params: FrictionlessParams, context: ThreadlikeQuadratureContext
+) -> Array:
+    """Return ones, the identity of the weighted quadrature."""
+    del params
+    return jnp.ones_like(context.tangent_norm)
+
+
+def capstan_transmission_ratio(
+    params: CapstanFrictionParams, context: ThreadlikeQuadratureContext
+) -> Array:
+    """Return ``exp(-coefficient * wrap_angle)`` at the node."""
+    if context.wrap_angle is None:
+        raise ValueError(
+            "the Capstan law reads context.wrap_angle, which this host did not "
+            "supply. Declare requires_wrap_angle on the installed law."
+        )
+    return jnp.exp(-jnp.asarray(params.coefficient) * context.wrap_angle)
+
+
+def exponential_length_transmission_ratio(
+    params: ExponentialLengthFrictionParams, context: ThreadlikeQuadratureContext
+) -> Array:
+    """Return ``exp(-rate * path_abscissa)`` at the node."""
+    return jnp.exp(-jnp.asarray(params.rate) * context.path_abscissa)
+
+
+class ThreadlikeFriction(eqx.Module):
+    """Runtime friction model for a routed-path family.
+
+    Attributes:
+        params: Friction parameters.
+        ratio_fn: Model mapping ``(params, context)`` to the surviving fraction
+            of shape ``(num_paths,)``.
+        requires_wrap_angle: True if ``ratio_fn`` reads ``context.wrap_angle``.
+        is_frictionless: True if the law returns exactly one everywhere.
+    """
+
+    params: BaseThreadlikeFrictionParams = eqx.field(default_factory=FrictionlessParams)
+    ratio_fn: Callable = eqx.field(static=True, default=frictionless_transmission_ratio)
+    requires_wrap_angle: bool = eqx.field(static=True, default=False)
+    is_frictionless: bool = eqx.field(static=True, default=True)
+
+    def __check_init__(self) -> None:
+        if (
+            self.is_frictionless
+            and self.ratio_fn is not frictionless_transmission_ratio
+        ):
+            raise ValueError(
+                "is_frictionless=True requires frictionless_transmission_ratio. "
+                "A friction model requires is_frictionless=False."
+            )
+
+    @classmethod
+    def frictionless(cls) -> ThreadlikeFriction:
+        """Build the ideal transmission."""
+        return cls()
+
+    @classmethod
+    def capstan(cls, *, coefficient: Any = 0.0, eps: Any = 0.0) -> ThreadlikeFriction:
+        """Build the Capstan belt model.
+
+        Args:
+            coefficient: Coulomb coefficient, scalar or shaped ``(num_paths,)``.
+            eps: Curvature floor in radians per metre.
+
+        Returns:
+            friction: Capstan model.
+        """
+        return cls(
+            params=CapstanFrictionParams(
+                coefficient=jnp.asarray(coefficient), eps=jnp.asarray(eps)
+            ),
+            ratio_fn=capstan_transmission_ratio,
+            requires_wrap_angle=True,
+            is_frictionless=False,
+        )
+
+    @classmethod
+    def exponential_length(cls, *, rate: Any = 0.0) -> ThreadlikeFriction:
+        """Build the length-decay model.
+
+        Args:
+            rate: Attenuation per unit arc length, scalar or ``(num_paths,)``.
+
+        Returns:
+            friction: Length-decay law.
+        """
+        return cls(
+            params=ExponentialLengthFrictionParams(rate=jnp.asarray(rate)),
+            ratio_fn=exponential_length_transmission_ratio,
+            requires_wrap_angle=False,
+            is_frictionless=False,
+        )
 
     def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return the length-decay ratio ``exp(-rate * s)`` at the node."""
-        return jnp.exp(-jnp.asarray(self.rate) * context.arc_length)
+        """Return the transmission ratio at one quadrature node.
 
-    def validate_for_paths(self, num_paths: int) -> None:
-        """Validate the rate shape against the routed-path count."""
-        validate_loss_parameter_shape(self.rate, num_paths, "rate")
+        Args:
+            context: Routed-path geometry at the node, batched over paths.
+
+        Returns:
+            transmission_ratio: shape ``(num_paths,)``.
+        """
+        return self.ratio_fn(self.params, context)
+
+    def with_params(self, params: BaseThreadlikeFrictionParams) -> ThreadlikeFriction:
+        """Return a copy carrying replacement friction parameters."""
+        if not isinstance(params, BaseThreadlikeFrictionParams):
+            raise TypeError("params must be BaseThreadlikeFrictionParams.")
+        if type(params) is not type(self.params):
+            raise TypeError(
+                "friction params must keep their type; got "
+                f"{type(params).__name__} for an installed "
+                f"{type(self.params).__name__} model."
+            )
+        params.validate_for_update()
+        return ThreadlikeFriction(
+            params=params,
+            ratio_fn=self.ratio_fn,
+            requires_wrap_angle=self.requires_wrap_angle,
+            is_frictionless=self.is_frictionless,
+        )
+
+    def update_params(self, **updates: Any) -> ThreadlikeFriction:
+        """Return a copy with replaced friction parameter leaves."""
+        return self.with_params(
+            cast(BaseThreadlikeFrictionParams, self.params.replace(**updates))
+        )
+
+
+def validate_friction_for_robot(friction: ThreadlikeFriction, robot) -> None:
+    if friction.is_frictionless or not friction.requires_wrap_angle:
+        return
+    if not callable(getattr(robot, "_threadlike_path_curvature", None)):
+        raise TypeError(
+            f"{type(robot).__name__} does not support the threadlike wrap-angle model."
+        )
 
 
 __all__ = [
-    "CapstanFriction",
-    "ExponentialLengthFriction",
-    "Frictionless",
+    "BaseThreadlikeFrictionParams",
+    "CapstanFrictionParams",
+    "ExponentialLengthFrictionParams",
+    "FrictionlessParams",
     "ThreadlikeFriction",
     "ThreadlikeQuadratureContext",
-    "validate_loss_parameter_shape",
+    "capstan_transmission_ratio",
+    "exponential_length_transmission_ratio",
+    "frictionless_transmission_ratio",
+    "validate_friction_for_robot",
+    "validate_friction_parameter_shape",
+    "validate_friction_parameter_values",
 ]

--- a/src/soromox/actuation/friction.py
+++ b/src/soromox/actuation/friction.py
@@ -1,4 +1,4 @@
-"""Friction models along threadlike routed paths that attenuate the effort."""
+"""Friction models and geometry helpers for threadlike actuation."""
 
 from __future__ import annotations
 
@@ -6,22 +6,23 @@ from collections.abc import Callable
 from typing import Any, cast
 
 import equinox as eqx
-from jax import Array
+from jax import Array, vmap
 from jax import numpy as jnp
 
 from soromox.systems.params import BaseSystemParams
+from soromox.utils.numerics import safe_divide, safe_norm
 
 
-def validate_friction_parameter_shape(value: Any, count: int, name: str) -> None:
-    """Validate a per-path friction parameter shape.
+def _validate_parameter_shape(value: Any, count: int, name: str) -> None:
+    """Validate a scalar or per-path parameter shape.
 
     Args:
-        value: Candidate friction parameter.
+        value: Candidate parameter value.
         count: Number of routed paths.
         name: Field name used in the error message.
 
     Raises:
-        ValueError: If the value is neither a scalar nor shaped ``(count,)``.
+        ValueError: If ``value`` is neither scalar nor shaped ``(count,)``.
     """
     shape = jnp.asarray(value).shape
     if shape not in ((), (count,)):
@@ -30,18 +31,15 @@ def validate_friction_parameter_shape(value: Any, count: int, name: str) -> None
         )
 
 
-def validate_friction_parameter_values(value: Any, name: str) -> None:
-    """Validate that a friction parameter is finite and non-negative.
-
-    A negative or non-finite parameter pushes the transmission ratio outside
-    ``(0, 1]``, causing the transmission to generate effort.
+def _validate_nonnegative_values(value: Any, name: str) -> None:
+    """Validate that a concrete friction parameter is finite and nonnegative.
 
     Args:
-        value: Concrete friction parameter.
+        value: Candidate parameter value.
         name: Field name used in the error message.
 
     Raises:
-        ValueError: If the value is non-finite or negative.
+        ValueError: If any value is negative or non-finite.
     """
     array = jnp.asarray(value)
     if not bool(jnp.all(jnp.isfinite(array))):
@@ -50,64 +48,259 @@ def validate_friction_parameter_values(value: Any, name: str) -> None:
         raise ValueError(f"{name} must be non-negative, got {array}.")
 
 
-class ThreadlikeQuadratureContext(eqx.Module):
-    """Routed-path geometry at one abscissa quadrature point.
+def threadlike_tangent(
+    angular_strain: Array,
+    linear_strain: Array,
+    offset: Array,
+    offset_derivative: Array,
+) -> Array:
+    r"""Return the material-frame tangent of a routed path.
 
-    Attributes:
-        abscissa: Backbone coordinate of the node from the robot base, in
-        metres.
-        path_abscissa: Arc-length covered along the span of each path from
-        the path anchor, in metres.
-        segment_index: Index of the segment containing the node.
-        offset: Material-frame path offset of shape ``(num_paths, 3)``, ordered
-            ``[x, y, z]``.
-        offset_derivative: Arc-length derivative of ``offset``.
-        tangent_norm: Length of the routed-path tangent, ``(num_paths,)``.
-        active: True if the node lies inside the segment span of each path,
-            shape ``(num_paths,)``.
-        unit_tangent: Normalized routed-path tangent. Host-shaped:
-            ``(num_paths, 2)`` in the plane and ``(num_paths, 3)`` in space.
-        strain: Segment strain at the node. Host-shaped: ``(num_paths, 3)``
-            ordered ``[kappa_z, sigma_x, sigma_y]`` in the plane, and
-            ``(num_paths, 6)`` ordered ``[omega, v]`` in space.
-        wrap_angle: Routed-path curvature integrated from the path anchor to
-            the node, in radians, shape ``(num_paths,)``. ``None`` unless the
-            installed model sets ``requires_wrap_angle``.
+    For backbone pose ``g(s) = (R(s), p(s))`` and material-frame routing
+    offset ``r(s)``, the spatial path is ``x(s) = p(s) + R(s) r(s)``. The
+    Cosserat relations ``R' = R hat(omega)`` and ``p' = R v`` give
+
+    .. math::
+
+        x' = R a, \qquad a = v + \omega \times r + r'.
+
+    Args:
+        angular_strain: Material angular strain ``omega`` with shape ``(3,)``.
+        linear_strain: Material linear strain ``v`` with shape ``(3,)``.
+        offset: Material-frame routing offset ``r`` with shape ``(3,)``.
+        offset_derivative: Arc-length derivative ``r'`` with shape ``(3,)``.
+
+    Returns:
+        Material-frame path tangent ``a`` with shape ``(3,)``.
     """
+    return linear_strain + jnp.cross(angular_strain, offset) + offset_derivative
 
-    abscissa: Array
-    path_abscissa: Array
-    segment_index: Array
-    offset: Array
-    offset_derivative: Array
-    tangent_norm: Array
-    active: Array
-    unit_tangent: Array
-    strain: Array
-    wrap_angle: Array | None = None
 
-    def with_wrap_angle(self, wrap_angle: Array) -> ThreadlikeQuadratureContext:
-        """Return a copy carrying the accumulated wrap angle.
+def threadlike_tangent_derivative(
+    angular_strain: Array,
+    linear_strain_derivative: Array,
+    angular_strain_derivative: Array,
+    offset: Array,
+    offset_derivative: Array,
+    offset_second_derivative: Array,
+) -> Array:
+    r"""Return the arc-length derivative of the material path tangent.
 
-        Args:
-            wrap_angle: Wrap angle of shape ``(num_paths,)``, in radians.
+    Differentiating ``a = v + omega cross r + r'`` analytically gives
 
-        Returns:
-            context: A copy whose ``wrap_angle`` is populated.
-        """
-        return eqx.tree_at(
-            lambda context: context.wrap_angle,
-            self,
-            wrap_angle,
-            is_leaf=lambda leaf: leaf is None,
+    .. math::
+
+        a' = v' + \omega' \times r + \omega \times r' + r''.
+
+    Args:
+        angular_strain: Material angular strain ``omega``.
+        linear_strain_derivative: Arc-length derivative ``v'``.
+        angular_strain_derivative: Arc-length derivative ``omega'``.
+        offset: Material-frame routing offset ``r``.
+        offset_derivative: Arc-length derivative ``r'``.
+        offset_second_derivative: Arc-length derivative ``r''`` of ``r'``.
+
+    Returns:
+        Material-frame tangent derivative ``a'`` with shape ``(3,)``.
+    """
+    return (
+        linear_strain_derivative
+        + jnp.cross(angular_strain_derivative, offset)
+        + jnp.cross(angular_strain, offset_derivative)
+        + offset_second_derivative
+    )
+
+
+def threadlike_unit_tangent_derivative(
+    tangent: Array,
+    tangent_derivative: Array,
+    *,
+    eps: Array | float,
+) -> Array:
+    r"""Return the derivative of a normalized material path tangent.
+
+    With ``u = a / ||a||``, differentiation gives
+
+    .. math::
+
+        u' = \frac{(I-u u^T)a'}{\lVert a\rVert}.
+
+    A collapsed path tangent has no defined direction. SoRoMoX returns the
+    finite zero convention there, consistent with its other ``safe_*``
+    numerical helpers.
+
+    Args:
+        tangent: Material-frame path tangent ``a``.
+        tangent_derivative: Arc-length derivative ``a'``.
+        eps: Threshold below which ``||a||`` is treated as zero.
+
+    Returns:
+        Material-frame unit-tangent derivative ``u'``.
+    """
+    tangent_norm = safe_norm(tangent)
+    unit_tangent = safe_divide(tangent, tangent_norm, eps)
+    projected = tangent_derivative - unit_tangent * jnp.dot(
+        unit_tangent, tangent_derivative
+    )
+    return safe_divide(projected, tangent_norm, eps)
+
+
+def threadlike_turn_rate(
+    angular_strain: Array,
+    linear_strain: Array,
+    angular_strain_derivative: Array,
+    linear_strain_derivative: Array,
+    offset: Array,
+    offset_derivative: Array,
+    offset_second_derivative: Array,
+    *,
+    eps: Array | float,
+) -> Array:
+    r"""Return how quickly the routed path direction turns in space.
+
+    The spatial unit tangent is ``t_hat = R u``, where ``u`` is the normalized
+    material tangent. Since ``R' = R hat(omega)``,
+
+    .. math::
+
+        \frac{d\hat t}{ds}
+        = R(\omega \times u + u'), \qquad
+        \rho = \left\|\omega \times u + u'\right\|.
+
+    Rotation preserves the Euclidean norm, so ``rho`` is evaluated entirely
+    in the material frame. It has units of radians per metre of undeformed
+    backbone coordinate and includes both backbone strain variation and
+    routing-offset variation.
+
+    Args:
+        angular_strain: Material angular strain ``omega``.
+        linear_strain: Material linear strain ``v``.
+        angular_strain_derivative: Arc-length derivative ``omega'``.
+        linear_strain_derivative: Arc-length derivative ``v'``.
+        offset: Material-frame routing offset ``r``.
+        offset_derivative: Arc-length derivative ``r'``.
+        offset_second_derivative: Arc-length derivative ``r''``.
+        eps: Threshold used for a collapsed tangent.
+
+    Returns:
+        Nonnegative turn rate ``rho`` as a scalar.
+    """
+    tangent = threadlike_tangent(
+        angular_strain, linear_strain, offset, offset_derivative
+    )
+    tangent_derivative = threadlike_tangent_derivative(
+        angular_strain,
+        linear_strain_derivative,
+        angular_strain_derivative,
+        offset,
+        offset_derivative,
+        offset_second_derivative,
+    )
+    tangent_norm = safe_norm(tangent)
+    unit_tangent = safe_divide(tangent, tangent_norm, eps)
+    unit_tangent_derivative = threadlike_unit_tangent_derivative(
+        tangent, tangent_derivative, eps=eps
+    )
+    return safe_norm(jnp.cross(angular_strain, unit_tangent) + unit_tangent_derivative)
+
+
+def threadlike_turning_angle(
+    left_unit_tangent: Array,
+    right_unit_tangent: Array,
+) -> Array:
+    """Return the unsigned turning angle between two unit tangents.
+
+    Args:
+        left_unit_tangent: Unit tangent immediately before a segment boundary.
+        right_unit_tangent: Unit tangent immediately after the boundary.
+
+    Returns:
+        Angle in radians in the closed interval ``[0, pi]``.
+    """
+    sine = safe_norm(jnp.cross(left_unit_tangent, right_unit_tangent))
+    cosine = jnp.clip(jnp.dot(left_unit_tangent, right_unit_tangent), -1.0, 1.0)
+    return jnp.arctan2(sine, cosine)
+
+
+def integrate_accumulated_turn(
+    turn_rate_fn: Callable[[Array, Array], Array],
+    boundary_turn_fn: Callable[[Array], Array],
+    s: Array,
+    segment_starts: Array,
+    segment_lengths: Array,
+    normalized_points: Array,
+    normalized_weights: Array,
+    start_segment_index: Array,
+    end_segment_index: Array,
+) -> Array:
+    """Integrate path turn from each anchor through backbone coordinate ``s``.
+
+    The integral uses the host quadrature rule on every complete segment and a
+    rescaled copy of that rule on the final partial segment. One-sided tangent
+    jumps caused by the host discretization are added at crossed segment
+    boundaries. These are continuum-model interfaces, not discrete friction
+    guides.
+
+    Args:
+        turn_rate_fn: Function accepting ``(segment_index, physical_points)``
+            and returning turn rates shaped ``(num_points, num_paths)``.
+        boundary_turn_fn: Function accepting a left segment index and returning
+            one-sided tangent angles shaped ``(num_paths,)``.
+        s: Physical backbone coordinate through which to integrate.
+        segment_starts: Physical start coordinate of every segment.
+        segment_lengths: Physical length of every segment.
+        normalized_points: Quadrature nodes in ``[0, 1]`` shaped
+            ``(num_segments, num_points)``.
+        normalized_weights: Corresponding quadrature weights with the same
+            shape as ``normalized_points``.
+        start_segment_index: First segment of every routed path.
+        end_segment_index: Last segment of every routed path.
+
+    Returns:
+        Accumulated unsigned turn, in radians, shaped ``(num_paths,)``.
+    """
+    segment_indices = jnp.arange(segment_lengths.shape[0])
+
+    def integrate_segment(segment_index: Array) -> Array:
+        """Integrate turn over the covered part of one segment."""
+        covered_length = jnp.clip(
+            jnp.asarray(s) - segment_starts[segment_index],
+            0.0,
+            segment_lengths[segment_index],
         )
+        points = (
+            segment_starts[segment_index]
+            + covered_length * normalized_points[segment_index]
+        )
+        rates = turn_rate_fn(segment_index, points)
+        return covered_length * jnp.sum(
+            normalized_weights[segment_index, :, None] * rates, axis=0
+        )
+
+    distributed = vmap(integrate_segment)(segment_indices)
+    active_segments = (segment_indices[:, None] >= start_segment_index[None, :]) & (
+        segment_indices[:, None] <= end_segment_index[None, :]
+    )
+    accumulated = jnp.sum(distributed * active_segments, axis=0)
+
+    if segment_lengths.shape[0] <= 1:
+        return accumulated
+
+    boundary_indices = jnp.arange(segment_lengths.shape[0] - 1)
+    boundary_coordinates = segment_starts[1:]
+    boundary_angles = vmap(boundary_turn_fn)(boundary_indices)
+    crossed = boundary_coordinates[:, None] <= jnp.asarray(s)
+    spans_boundary = (boundary_indices[:, None] >= start_segment_index[None, :]) & (
+        boundary_indices[:, None] + 1 <= end_segment_index[None, :]
+    )
+    return accumulated + jnp.sum(boundary_angles * crossed * spans_boundary, axis=0)
 
 
 class BaseThreadlikeFrictionParams(BaseSystemParams):
     """Base PyTree contract for threadlike friction parameters."""
 
     def validate_structure_compatibility(self, num_paths: int) -> None:
-        """Validate per-path friction parameter shapes against the path count.
+        """Validate parameter shapes against the number of routed paths.
 
         Args:
             num_paths: Number of paths in the routing family.
@@ -116,167 +309,141 @@ class BaseThreadlikeFrictionParams(BaseSystemParams):
 
 
 class FrictionlessParams(BaseThreadlikeFrictionParams):
-    """Parameters of the ideal transmission. None."""
+    """Parameter-free ideal threadlike transmission."""
 
 
 class CapstanFrictionParams(BaseThreadlikeFrictionParams):
-    """Parameters of the Capstan (Euler) belt model.
+    """Coulomb coefficient of the continuum Capstan model.
 
     Attributes:
-        coefficient: Coulomb coefficient between a routing and the robot, either
-            a scalar shared by the family or shaped ``(num_paths,)``.
-        eps: Curvature floor in radians per metre.
+        coefficient: Nonnegative friction coefficient, either scalar or one
+            value per routed path.
     """
 
     coefficient: Array = eqx.field(
         default_factory=lambda: jnp.zeros((), dtype=jnp.float64)
     )
-    eps: Array = eqx.field(default_factory=lambda: jnp.zeros((), dtype=jnp.float64))
 
     def __check_init__(self) -> None:
+        """Validate newly constructed Capstan parameters."""
         self.validate_for_update()
 
     def validate_structure_compatibility(self, num_paths: int) -> None:
-        """Validate the coefficient shape against the routed-path count."""
-        validate_friction_parameter_shape(self.coefficient, num_paths, "coefficient")
+        """Validate the coefficient shape against the path count.
+
+        Args:
+            num_paths: Number of paths in the routing family.
+        """
+        _validate_parameter_shape(self.coefficient, num_paths, "coefficient")
 
     def validate_values(self) -> None:
-        """Validate eager Capstan parameter values."""
-        validate_friction_parameter_values(self.coefficient, "coefficient")
-        validate_friction_parameter_values(self.eps, "eps")
+        """Validate concrete Capstan coefficient values."""
+        _validate_nonnegative_values(self.coefficient, "coefficient")
 
 
-class ExponentialLengthFrictionParams(BaseThreadlikeFrictionParams):
-    """Parameters of a configuration-independent friction proportional
-    to the routed-path length.
+def frictionless_effort_ratio(
+    params: FrictionlessParams, accumulated_turn: Array
+) -> Array:
+    """Return the unit effort ratio for an ideal transmission.
 
-    Attributes:
-        rate: Attenuation per unit arc length, in inverse metres, either a scalar
-            shared by the family or shaped ``(num_paths,)``.
+    Args:
+        params: Parameter-free frictionless model parameters.
+        accumulated_turn: Accumulated routed-path turn in radians.
+
+    Returns:
+        Ones with the same shape as ``accumulated_turn``.
     """
-
-    rate: Array = eqx.field(default_factory=lambda: jnp.zeros((), dtype=jnp.float64))
-
-    def __check_init__(self) -> None:
-        self.validate_for_update()
-
-    def validate_structure_compatibility(self, num_paths: int) -> None:
-        """Validate the rate shape against the routed-path count."""
-        validate_friction_parameter_shape(self.rate, num_paths, "rate")
-
-    def validate_values(self) -> None:
-        """Validate eager exponential-length parameter values."""
-        validate_friction_parameter_values(self.rate, "rate")
-
-
-def frictionless_transmission_ratio(
-    params: FrictionlessParams, context: ThreadlikeQuadratureContext
-) -> Array:
-    """Return ones, the identity of the weighted quadrature."""
     del params
-    return jnp.ones_like(context.tangent_norm)
+    return jnp.ones_like(accumulated_turn)
 
 
-def capstan_transmission_ratio(
-    params: CapstanFrictionParams, context: ThreadlikeQuadratureContext
+def capstan_effort_ratio(
+    params: CapstanFrictionParams, accumulated_turn: Array
 ) -> Array:
-    """Return ``exp(-coefficient * wrap_angle)`` at the node."""
-    if context.wrap_angle is None:
-        raise ValueError(
-            "the Capstan law reads context.wrap_angle, which this host did not "
-            "supply. Declare requires_wrap_angle on the installed law."
-        )
-    return jnp.exp(-jnp.asarray(params.coefficient) * context.wrap_angle)
+    r"""Return the surviving effort fraction ``exp(-mu * Theta)``.
 
+    Args:
+        params: Capstan parameters containing ``mu``.
+        accumulated_turn: Unsigned turn ``Theta`` from each path anchor to the
+            evaluation point, in radians.
 
-def exponential_length_transmission_ratio(
-    params: ExponentialLengthFrictionParams, context: ThreadlikeQuadratureContext
-) -> Array:
-    """Return ``exp(-rate * path_abscissa)`` at the node."""
-    return jnp.exp(-jnp.asarray(params.rate) * context.path_abscissa)
+    Returns:
+        Effort ratio in ``(0, 1]`` with one value per routed path.
+    """
+    return jnp.exp(-jnp.asarray(params.coefficient) * accumulated_turn)
 
 
 class ThreadlikeFriction(eqx.Module):
-    """Runtime friction model for a routed-path family.
+    """Runtime effort-loss law for a routed-path family.
+
+    The effort supplied by the actuator is defined at each path anchor. The
+    model returns the fraction that remains after the path has accumulated a
+    given unsigned turn while moving along increasing backbone coordinate.
 
     Attributes:
-        params: Friction parameters.
-        ratio_fn: Model mapping ``(params, context)`` to the surviving fraction
-            of shape ``(num_paths,)``.
-        requires_wrap_angle: True if ``ratio_fn`` reads ``context.wrap_angle``.
-        is_frictionless: True if the law returns exactly one everywhere.
+        params: Dynamic friction parameters.
+        effort_ratio_fn: Function of ``(params, accumulated_turn)``.
+        is_frictionless: Whether the ratio is identically one.
     """
 
     params: BaseThreadlikeFrictionParams = eqx.field(default_factory=FrictionlessParams)
-    ratio_fn: Callable = eqx.field(static=True, default=frictionless_transmission_ratio)
-    requires_wrap_angle: bool = eqx.field(static=True, default=False)
+    effort_ratio_fn: Callable = eqx.field(
+        static=True, default=frictionless_effort_ratio
+    )
     is_frictionless: bool = eqx.field(static=True, default=True)
 
     def __check_init__(self) -> None:
+        """Validate consistency between the law and frictionless marker."""
         if (
             self.is_frictionless
-            and self.ratio_fn is not frictionless_transmission_ratio
+            and self.effort_ratio_fn is not frictionless_effort_ratio
         ):
-            raise ValueError(
-                "is_frictionless=True requires frictionless_transmission_ratio. "
-                "A friction model requires is_frictionless=False."
-            )
+            raise ValueError("is_frictionless=True requires frictionless_effort_ratio.")
 
     @classmethod
     def frictionless(cls) -> ThreadlikeFriction:
-        """Build the ideal transmission."""
+        """Construct the ideal threadlike transmission."""
         return cls()
 
     @classmethod
-    def capstan(cls, *, coefficient: Any = 0.0, eps: Any = 0.0) -> ThreadlikeFriction:
-        """Build the Capstan belt model.
+    def capstan(cls, *, coefficient: Any = 0.0) -> ThreadlikeFriction:
+        """Construct the continuum Capstan effort-loss model.
 
         Args:
-            coefficient: Coulomb coefficient, scalar or shaped ``(num_paths,)``.
-            eps: Curvature floor in radians per metre.
+            coefficient: Nonnegative scalar or one value per routed path.
 
         Returns:
-            friction: Capstan model.
+            A Capstan friction model.
         """
         return cls(
-            params=CapstanFrictionParams(
-                coefficient=jnp.asarray(coefficient), eps=jnp.asarray(eps)
-            ),
-            ratio_fn=capstan_transmission_ratio,
-            requires_wrap_angle=True,
+            params=CapstanFrictionParams(coefficient=jnp.asarray(coefficient)),
+            effort_ratio_fn=capstan_effort_ratio,
             is_frictionless=False,
         )
 
-    @classmethod
-    def exponential_length(cls, *, rate: Any = 0.0) -> ThreadlikeFriction:
-        """Build the length-decay model.
+    def effort_ratio(self, accumulated_turn: Array) -> Array:
+        """Return the surviving effort fraction after accumulated turn.
 
         Args:
-            rate: Attenuation per unit arc length, scalar or ``(num_paths,)``.
+            accumulated_turn: Unsigned turn from each path anchor in radians.
 
         Returns:
-            friction: Length-decay law.
+            One effort ratio per routed path.
         """
-        return cls(
-            params=ExponentialLengthFrictionParams(rate=jnp.asarray(rate)),
-            ratio_fn=exponential_length_transmission_ratio,
-            requires_wrap_angle=False,
-            is_frictionless=False,
-        )
-
-    def transmission_ratio(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return the transmission ratio at one quadrature node.
-
-        Args:
-            context: Routed-path geometry at the node, batched over paths.
-
-        Returns:
-            transmission_ratio: shape ``(num_paths,)``.
-        """
-        return self.ratio_fn(self.params, context)
+        return self.effort_ratio_fn(self.params, accumulated_turn)
 
     def with_params(self, params: BaseThreadlikeFrictionParams) -> ThreadlikeFriction:
-        """Return a copy carrying replacement friction parameters."""
+        """Return a copy carrying replacement friction parameters.
+
+        Args:
+            params: Replacement parameters of the installed model type.
+
+        Returns:
+            A friction model with updated dynamic leaves.
+
+        Raises:
+            TypeError: If the parameter type changes.
+        """
         if not isinstance(params, BaseThreadlikeFrictionParams):
             raise TypeError("params must be BaseThreadlikeFrictionParams.")
         if type(params) is not type(self.params):
@@ -288,38 +455,55 @@ class ThreadlikeFriction(eqx.Module):
         params.validate_for_update()
         return ThreadlikeFriction(
             params=params,
-            ratio_fn=self.ratio_fn,
-            requires_wrap_angle=self.requires_wrap_angle,
+            effort_ratio_fn=self.effort_ratio_fn,
             is_frictionless=self.is_frictionless,
         )
 
     def update_params(self, **updates: Any) -> ThreadlikeFriction:
-        """Return a copy with replaced friction parameter leaves."""
+        """Return a copy with replaced friction-parameter leaves.
+
+        Args:
+            **updates: Named parameter-leaf replacements.
+
+        Returns:
+            A friction model with updated parameter leaves.
+        """
         return self.with_params(
             cast(BaseThreadlikeFrictionParams, self.params.replace(**updates))
         )
 
 
-def validate_friction_for_robot(friction: ThreadlikeFriction, robot) -> None:
-    if friction.is_frictionless or not friction.requires_wrap_angle:
+def _validate_friction_model(friction: ThreadlikeFriction, routing: Any) -> None:
+    """Validate a friction model against a routing family.
+
+    Args:
+        friction: Installed threadlike friction model.
+        routing: Installed threadlike routing family.
+
+    Raises:
+        ValueError: If nonzero friction is paired with a custom routing that
+            does not provide an analytical second derivative.
+    """
+    if friction.is_frictionless:
         return
-    if not callable(getattr(robot, "_threadlike_path_curvature", None)):
-        raise TypeError(
-            f"{type(robot).__name__} does not support the threadlike wrap-angle model."
+    if not routing.has_analytical_second_derivative:
+        raise ValueError(
+            "threadlike friction requires an analytical routing second_derivative_fn."
         )
 
 
 __all__ = [
     "BaseThreadlikeFrictionParams",
     "CapstanFrictionParams",
-    "ExponentialLengthFrictionParams",
     "FrictionlessParams",
     "ThreadlikeFriction",
-    "ThreadlikeQuadratureContext",
-    "capstan_transmission_ratio",
-    "exponential_length_transmission_ratio",
-    "frictionless_transmission_ratio",
-    "validate_friction_for_robot",
-    "validate_friction_parameter_shape",
-    "validate_friction_parameter_values",
+    "_validate_friction_model",
+    "capstan_effort_ratio",
+    "frictionless_effort_ratio",
+    "integrate_accumulated_turn",
+    "threadlike_tangent",
+    "threadlike_tangent_derivative",
+    "threadlike_turn_rate",
+    "threadlike_turning_angle",
+    "threadlike_unit_tangent_derivative",
 ]

--- a/src/soromox/actuation/joint.py
+++ b/src/soromox/actuation/joint.py
@@ -143,7 +143,13 @@ class AffineJointTransmission(Transmission):
             + self.params.coordinate_offset
         )
 
-    def moment_matrix(self, robot, q: Array) -> Array:
+    def coordinate_jacobian(self, robot, q: Array) -> Array:
+        """Return the constant actuator-coordinate Jacobian."""
+        del robot, q
+        return self.params.routing_matrix
+
+    def actuation_matrix(self, robot, q: Array) -> Array:
+        """Return the ideal transpose map from effort to generalized force."""
         del robot, q
         return self.params.routing_matrix.T
 
@@ -446,13 +452,15 @@ class ArticulatedTendonImpedance(PassiveElement):
         return self.transmission.velocities(robot, q, qd)
 
     def elastic_force(self, robot, q: Array) -> Array:
+        """Return generalized elastic force from the routed joint tendons."""
         coordinate = self.coordinates(robot, q)
-        return self.transmission.moment_matrix(robot, q) @ (
+        return self.transmission.actuation_matrix(robot, q) @ (
             self.params.stiffness * coordinate
         )
 
     def damping_matrix(self, robot, q: Array) -> Array:
-        matrix = self.transmission.moment_matrix(robot, q)
+        """Return generalized viscous damping from the routed joint tendons."""
+        matrix = self.transmission.actuation_matrix(robot, q)
         return matrix @ (self.params.damping[:, None] * matrix.T)
 
     def elastic_energy(self, robot, q: Array) -> Array:

--- a/src/soromox/actuation/joint.py
+++ b/src/soromox/actuation/joint.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import equinox as eqx
 from jax import Array
 from jax import numpy as jnp
 
 from soromox.systems.params import BaseSystemParams
+
+if TYPE_CHECKING:
+    from soromox.systems.soft_robot import SoftRobot
 
 from .core import (
     Actuator,
@@ -136,20 +139,41 @@ class AffineJointTransmission(Transmission):
     def num_channels(self) -> int:
         return self.params.num_channels
 
-    def coordinates(self, robot, q: Array) -> Array:
+    def coordinates(self, robot: SoftRobot, q: Array) -> Array:
         del robot
         return (
             self.params.routing_matrix @ (q - self.params.reference_configuration)
             + self.params.coordinate_offset
         )
 
-    def coordinate_jacobian(self, robot, q: Array) -> Array:
-        """Return the constant actuator-coordinate Jacobian."""
+    def coordinate_jacobian(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the constant actuator-coordinate Jacobian.
+
+        Args:
+            robot: Articulated robot hosting the transmission.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            J_a: Matrix mapping generalized velocities to actuator-coordinate
+                velocities, with shape
+                ``(self.num_channels, robot.num_velocities)``.
+        """
         del robot, q
         return self.params.routing_matrix
 
-    def actuation_matrix(self, robot, q: Array) -> Array:
-        """Return the ideal transpose map from effort to generalized force."""
+    def actuation_matrix(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the ideal effort-to-generalized-force map.
+
+        Args:
+            robot: Articulated robot hosting the transmission.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            A: Actuation matrix with shape
+                ``(robot.num_velocities, self.num_channels)``.
+        """
         del robot, q
         return self.params.routing_matrix.T
 

--- a/src/soromox/actuation/mckibben.py
+++ b/src/soromox/actuation/mckibben.py
@@ -142,7 +142,7 @@ class ArticulatedMcKibbenTransmission(Transmission):
     The transmission owns fixed and moving attachment geometry for grouped
     universal joints on a spatial articulated host. It computes effective
     muscle lengths, the volume-like coordinate work-conjugate to pressure, its
-    analytic moment matrix, and renderer-facing endpoint segments without
+    analytic actuation matrix, and renderer-facing endpoint segments without
     embedding those mechanics in a particular articulated robot class.
     """
 
@@ -303,7 +303,7 @@ class ArticulatedMcKibbenTransmission(Transmission):
         )
         return effective_length, jnp.stack([dlength_dqx, dlength_dqy], axis=-1)
 
-    def _moment_matrix_group(self, robot, q: Array, group_index: Array) -> Array:
+    def _actuation_matrix_group(self, robot, q: Array, group_index: Array) -> Array:
         """Scatter one group's analytic pressure-to-generalized-force block.
 
         The local block is ``d(y_a)/d(length) * d(length)/d(q_pair)`` and is
@@ -325,14 +325,18 @@ class ArticulatedMcKibbenTransmission(Transmission):
             .set(local_block.T)
         )
 
-    def moment_matrix(self, robot, q: Array) -> Array:
+    def coordinate_jacobian(self, robot, q: Array) -> Array:
+        """Return the pressure-work coordinate Jacobian."""
+        return self.actuation_matrix(robot, q).T
+
+    def actuation_matrix(self, robot, q: Array) -> Array:
         """Return the analytic pressure-to-generalized-force matrix ``A(q)``."""
         if self.num_channels == 0:
             return jnp.zeros((robot.num_velocities, 0), dtype=q.dtype)
         indices = jnp.arange(self.params.num_groups)
-        matrices = jax.vmap(lambda index: self._moment_matrix_group(robot, q, index))(
-            indices
-        )
+        matrices = jax.vmap(
+            lambda index: self._actuation_matrix_group(robot, q, index)
+        )(indices)
         return jnp.sum(matrices, axis=0)
 
     def axial_forces(self, q: Array, pressures: Array) -> Array:

--- a/src/soromox/actuation/mckibben.py
+++ b/src/soromox/actuation/mckibben.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import equinox as eqx
 import jax
@@ -27,6 +28,9 @@ from soromox.utils.geometry.rotations import (
 from soromox.utils.numerics import safe_norm, safe_normalize
 
 from .core import Actuator, ActuatorMetadata, DirectEffort, Transmission
+
+if TYPE_CHECKING:
+    from soromox.systems.soft_robot import SoftRobot
 
 
 class ArticulatedMcKibbenTransmissionParams(BaseSystemParams):
@@ -245,7 +249,7 @@ class ArticulatedMcKibbenTransmission(Transmission):
         )
         return length.reshape((self.num_channels,))
 
-    def coordinates(self, robot, q: Array) -> Array:
+    def coordinates(self, robot: SoftRobot, q: Array) -> Array:
         """Return pressure-work coordinates for all McKibben muscles.
 
         The coordinate is ``(B**2 - length**2) * length / (4*pi*N**2)`` and has
@@ -325,12 +329,35 @@ class ArticulatedMcKibbenTransmission(Transmission):
             .set(local_block.T)
         )
 
-    def coordinate_jacobian(self, robot, q: Array) -> Array:
-        """Return the pressure-work coordinate Jacobian."""
+    def coordinate_jacobian(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the pressure-work coordinate Jacobian.
+
+        The Jacobian maps generalized velocity to the rates of the volume-like
+        coordinates work-conjugate to pressure.
+
+        Args:
+            robot: Articulated robot hosting the transmission.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            J_a: Coordinate Jacobian with shape
+                ``(self.num_channels, robot.num_velocities)``.
+        """
         return self.actuation_matrix(robot, q).T
 
-    def actuation_matrix(self, robot, q: Array) -> Array:
-        """Return the analytic pressure-to-generalized-force matrix ``A(q)``."""
+    def actuation_matrix(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the analytical pressure-to-generalized-force matrix.
+
+        Args:
+            robot: Articulated robot hosting the transmission.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            A: Actuation matrix with shape
+                ``(robot.num_velocities, self.num_channels)``.
+        """
         if self.num_channels == 0:
             return jnp.zeros((robot.num_velocities, 0), dtype=q.dtype)
         indices = jnp.arange(self.params.num_groups)

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -18,6 +18,16 @@ from .core import (
     PassiveElement,
     Transmission,
 )
+from .friction import (
+    CapstanFriction,
+    Frictionless,
+    ThreadlikeFriction,
+)
+
+# Sentinel distinguishing "caller passed nothing" from an explicit friction
+# law, so the deprecated friction_coefficient sugar can be rejected when both
+# spellings are supplied.
+_UNSET: Any = object()
 
 ThreadlikeKind = Literal["tendon", "push_rod", "muscle", "pneumatic", "generic"]
 
@@ -101,49 +111,64 @@ def _channel_array(value: Any, count: int, name: str) -> Array:
     return array
 
 
-def _zero_friction_coefficient() -> Array:
-    """Return the frictionless default Capstan coefficient.
+def _resolve_friction(
+    friction: ThreadlikeFriction | None,
+    friction_coefficient: Any,
+) -> ThreadlikeFriction:
+    """Resolve the two spellings of a transmission-loss law into one model.
 
-    A zero *scalar*, not a ``(0,)`` array: consumers replace this leaf inside
-    differentiated closures, and a per-path default would change leaf shape on
-    the first replacement and force a retrace. It is also not ``None``, because
-    ``BaseSystemParams.replace`` reaches fields through ``eqx.tree_at`` and JAX
-    treats ``None`` as an empty subtree.
+    ``friction_coefficient`` is retained sugar for the common Capstan case and
+    builds a :class:`CapstanFriction`. Supplying both spellings is a mistake
+    rather than a merge, because the two would silently disagree.
+
+    Args:
+        friction: Explicit transmission-loss law, or ``None`` for the default.
+        friction_coefficient: Capstan coefficient sugar, or ``_UNSET``.
+
+    Returns:
+        model: The law to install. Defaults to :class:`Frictionless`.
+
+    Raises:
+        TypeError: If ``friction`` is not a :class:`ThreadlikeFriction`.
+        ValueError: If both spellings are supplied.
     """
-    return jnp.zeros((), dtype=jnp.float64)
-
-
-def _validate_friction_shape(value: Any, count: int, name: str) -> None:
-    """Validate a Capstan coefficient shape without concretizing its value."""
-    shape = jnp.asarray(value).shape
-    if shape not in ((), (count,)):
-        raise ValueError(
-            f"{name} must be a scalar or have shape ({count},), got {shape}."
+    if friction_coefficient is not _UNSET:
+        if friction is not None:
+            raise ValueError(
+                "Pass either friction= or friction_coefficient=, not both. "
+                "friction_coefficient is sugar for "
+                "CapstanFriction(coefficient=...)."
+            )
+        return CapstanFriction(coefficient=jnp.asarray(friction_coefficient))
+    if friction is None:
+        return Frictionless()
+    if not isinstance(friction, ThreadlikeFriction):
+        raise TypeError(
+            "friction must be a ThreadlikeFriction instance, got "
+            f"{type(friction).__name__}."
         )
+    return friction
 
 
-def _broadcast_friction(value: Any, count: int) -> Array:
-    """Broadcast a scalar or batched Capstan coefficient to one entry per path."""
-    return jnp.broadcast_to(jnp.asarray(value), (count,))
+def _validate_friction_for_robot(friction: ThreadlikeFriction, robot) -> None:
+    """Reject a transmission-loss law the host cannot serve.
 
-
-def _validate_friction_for_robot(friction_coefficient: Any, robot) -> None:
-    """Reject a nonzero Capstan coefficient on a host with no wrap-angle model.
-
-    The transmission ratio needs the accumulated turn of the routed path, which
-    only a host implementing ``_threadlike_wrap_density`` can supply. Hosts
-    without it silently ignore the coefficient, so a nonzero value is refused
-    here rather than being dropped. This runs only when the coefficient is
-    concrete, through the tracer guard in ``validate_for_robot``.
+    A law reading the accumulated turn of the routed path needs a host that
+    implements ``_threadlike_wrap_density``. Hosts without it would silently
+    ignore the law, so it is refused here rather than dropped. Laws that read
+    only host-agnostic geometry, such as a length-based loss, are accepted
+    everywhere. This runs only on concrete values, through the tracer guard in
+    ``validate_for_robot``.
     """
-    if not bool(jnp.any(jnp.asarray(friction_coefficient) != 0.0)):
+    if friction.is_lossless or not friction.requires_wrap_angle:
         return
     if not callable(getattr(robot, "_threadlike_wrap_density", None)):
         raise TypeError(
             f"{type(robot).__name__} does not implement the threadlike "
-            "wrap-angle model, so a nonzero friction_coefficient cannot be "
-            "honoured. Install the component on PCS or PlanarPCS, or leave the "
-            "coefficient at zero."
+            f"wrap-angle model, so {type(friction).__name__} cannot be "
+            "honoured. Install the component on PCS or PlanarPCS, or choose a "
+            "law that does not require the wrap angle, such as "
+            "ExponentialLengthFriction."
         )
 
 
@@ -379,20 +404,24 @@ class ThreadlikeRouting(eqx.Module):
 
 
 class ThreadlikeTransmissionParams(BaseSystemParams):
-    """Routing parameters, work-coordinate scale, and guide friction per path.
+    """Routing parameters, work-coordinate scale, and the transmission loss.
 
-    ``friction_coefficient`` is the Capstan coefficient between a path and its
-    guides. Effort applied at the base is transmitted to arc length ``s``
-    through ``exp(-mu * Theta(q, s))``, where ``Theta`` is the accumulated turn
-    of the routed path, so the loss builds up along the path instead of scaling
-    the input. It is either a scalar shared by every path of the family or
-    batched with shape ``(num_paths,)``. Zero is the default and reproduces the
-    frictionless transmission exactly.
+    ``friction`` is the law describing how much of the effort applied at the
+    base of a path survives to arc length ``s``. It weights the integrand of
+    the moment matrix, so a loss accumulates along the path instead of scaling
+    the input. The default :class:`~soromox.actuation.friction.Frictionless`
+    delivers the full effort everywhere and reproduces the frictionless
+    transmission exactly.
+
+    Swapping the law changes the parameter PyTree structure and so triggers a
+    retrace; replacing a value inside a law does not. Identification should
+    therefore start from a lossy law at a zero parameter, such as
+    ``CapstanFriction(coefficient=0.0)``, rather than from ``Frictionless()``.
     """
 
     routing: BaseThreadlikeRoutingParams
     coordinate_scale: Array
-    friction_coefficient: Array = eqx.field(default_factory=_zero_friction_coefficient)
+    friction: ThreadlikeFriction = eqx.field(default_factory=Frictionless)
 
     def __check_init__(self) -> None:
         self.validate_for_update()
@@ -406,15 +435,18 @@ class ThreadlikeTransmissionParams(BaseSystemParams):
                 "coordinate_scale must have shape "
                 f"({self.routing.num_paths},), got {scale.shape}."
             )
-        _validate_friction_shape(
-            self.friction_coefficient,
-            self.routing.num_paths,
-            "friction_coefficient",
-        )
+        if not isinstance(self.friction, ThreadlikeFriction):
+            raise TypeError(
+                "friction must be a ThreadlikeFriction instance, got "
+                f"{type(self.friction).__name__}."
+            )
+        self.friction.validate_structure()
+        self.friction.validate_for_paths(self.routing.num_paths)
 
     def validate_values(self) -> None:
-        """Validate eager nested routing values."""
+        """Validate eager nested routing and transmission-loss values."""
         self.routing.validate_values()
+        self.friction.validate_values()
 
 
 class ThreadlikeTransmission(Transmission):
@@ -454,13 +486,13 @@ class ThreadlikeTransmission(Transmission):
         )
 
     @property
-    def friction_coefficient(self) -> Array:
-        """Capstan coefficient of each path, broadcast to ``(num_channels,)``."""
-        return _broadcast_friction(self.params.friction_coefficient, self.num_channels)
+    def friction(self) -> ThreadlikeFriction:
+        """Transmission-loss law installed on this path family."""
+        return self.params.friction
 
     def moment_matrix(self, robot, q: Array) -> Array:
         raw_matrix = robot._threadlike_moment_matrix(
-            q, self.routing, friction_coefficient=self.friction_coefficient
+            q, self.routing, friction=self.friction
         )
         return raw_matrix * self.params.coordinate_scale[None, :]
 
@@ -591,7 +623,8 @@ class ThreadlikeActuator(Actuator):
         lower_bounds: Array | float = 0.0,
         upper_bounds: Array | float = jnp.inf,
         labels: tuple[str, ...] | None = None,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         count = routing.num_paths
@@ -601,7 +634,7 @@ class ThreadlikeActuator(Actuator):
                 coordinate_scale=_channel_array(
                     coordinate_scale, count, "coordinate_scale"
                 ),
-                friction_coefficient=jnp.asarray(friction_coefficient),
+                friction=_resolve_friction(friction, friction_coefficient),
             ),
             lower_bounds=_channel_array(lower_bounds, count, "lower_bounds"),
             upper_bounds=_channel_array(upper_bounds, count, "upper_bounds"),
@@ -623,7 +656,8 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -634,6 +668,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="tendon_tension",
             labels=labels,
+            friction=friction,
             friction_coefficient=friction_coefficient,
         )
 
@@ -643,7 +678,8 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -654,6 +690,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="rod_compression",
             labels=labels,
+            friction=friction,
             friction_coefficient=friction_coefficient,
         )
 
@@ -663,7 +700,8 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -674,6 +712,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="muscle_tension",
             labels=labels,
+            friction=friction,
             friction_coefficient=friction_coefficient,
         )
 
@@ -684,7 +723,8 @@ class ThreadlikeActuator(Actuator):
         *,
         effective_areas: Array,
         labels: tuple[str, ...] | None = None,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -697,6 +737,7 @@ class ThreadlikeActuator(Actuator):
             unit="Pa",
             label_prefix="chamber_pressure",
             labels=labels,
+            friction=friction,
             friction_coefficient=friction_coefficient,
         )
 
@@ -737,9 +778,7 @@ class ThreadlikeActuator(Actuator):
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.transmission.routing, robot)
-        _validate_friction_for_robot(
-            self.params.transmission.friction_coefficient, robot
-        )
+        _validate_friction_for_robot(self.params.transmission.friction, robot)
 
     def _robot_value_validation_tree(self):
         # The friction coefficient must be part of this subtree: validate_for_robot
@@ -747,7 +786,7 @@ class ThreadlikeActuator(Actuator):
         # routing would otherwise let the eager value checks run on a tracer.
         return (
             self.transmission.routing.params,
-            self.params.transmission.friction_coefficient,
+            self.params.transmission.friction,
         )
 
     def path_lengths(self, robot, q: Array) -> Array:
@@ -812,7 +851,8 @@ class ThreadlikeImpedance(PassiveElement):
         stiffness: Array,
         damping: Array,
         rest_length: Array,
-        friction_coefficient: Array | float = 0.0,
+        friction: ThreadlikeFriction | None = None,
+        friction_coefficient: Any = _UNSET,
         name: str = "passive_threadlike",
     ) -> None:
         routing = ThreadlikeActuator._normalize_routing(routing)
@@ -821,7 +861,7 @@ class ThreadlikeImpedance(PassiveElement):
             transmission=ThreadlikeTransmissionParams(
                 routing=routing.params,
                 coordinate_scale=jnp.ones((count,)),
-                friction_coefficient=jnp.asarray(friction_coefficient),
+                friction=_resolve_friction(friction, friction_coefficient),
             ),
             stiffness=_channel_array(stiffness, count, "stiffness"),
             damping=_channel_array(damping, count, "damping"),
@@ -845,7 +885,7 @@ class ThreadlikeImpedance(PassiveElement):
             stiffness=params.stiffness,
             damping=params.damping,
             rest_length=params.rest_length,
-            friction_coefficient=params.transmission.friction_coefficient,
+            friction=params.transmission.friction,
             name=name,
         )
 
@@ -876,16 +916,14 @@ class ThreadlikeImpedance(PassiveElement):
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.routing, robot)
-        _validate_friction_for_robot(
-            self.params.transmission.friction_coefficient, robot
-        )
+        _validate_friction_for_robot(self.params.transmission.friction, robot)
 
     def _robot_value_validation_tree(self):
         # See ThreadlikeActuator._robot_value_validation_tree: the coefficient
         # belongs here so a traced value is detected by validate_for_robot.
         return (
             self.routing.params,
-            self.params.transmission.friction_coefficient,
+            self.params.transmission.friction,
         )
 
     def path_lengths(self, robot, q: Array) -> Array:

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -101,6 +101,52 @@ def _channel_array(value: Any, count: int, name: str) -> Array:
     return array
 
 
+def _zero_friction_coefficient() -> Array:
+    """Return the frictionless default Capstan coefficient.
+
+    A zero *scalar*, not a ``(0,)`` array: consumers replace this leaf inside
+    differentiated closures, and a per-path default would change leaf shape on
+    the first replacement and force a retrace. It is also not ``None``, because
+    ``BaseSystemParams.replace`` reaches fields through ``eqx.tree_at`` and JAX
+    treats ``None`` as an empty subtree.
+    """
+    return jnp.zeros((), dtype=jnp.float64)
+
+
+def _validate_friction_shape(value: Any, count: int, name: str) -> None:
+    """Validate a Capstan coefficient shape without concretizing its value."""
+    shape = jnp.asarray(value).shape
+    if shape not in ((), (count,)):
+        raise ValueError(
+            f"{name} must be a scalar or have shape ({count},), got {shape}."
+        )
+
+
+def _broadcast_friction(value: Any, count: int) -> Array:
+    """Broadcast a scalar or batched Capstan coefficient to one entry per path."""
+    return jnp.broadcast_to(jnp.asarray(value), (count,))
+
+
+def _validate_friction_for_robot(friction_coefficient: Any, robot) -> None:
+    """Reject a nonzero Capstan coefficient on a host with no wrap-angle model.
+
+    The transmission ratio needs the accumulated turn of the routed path, which
+    only a host implementing ``_threadlike_wrap_density`` can supply. Hosts
+    without it silently ignore the coefficient, so a nonzero value is refused
+    here rather than being dropped. This runs only when the coefficient is
+    concrete, through the tracer guard in ``validate_for_robot``.
+    """
+    if not bool(jnp.any(jnp.asarray(friction_coefficient) != 0.0)):
+        return
+    if not callable(getattr(robot, "_threadlike_wrap_density", None)):
+        raise TypeError(
+            f"{type(robot).__name__} does not implement the threadlike "
+            "wrap-angle model, so a nonzero friction_coefficient cannot be "
+            "honoured. Install the component on PCS or PlanarPCS, or leave the "
+            "coefficient at zero."
+        )
+
+
 def _path_vector_array(value: Any, name: str, *, count: int | None = None) -> Array:
     """Normalize material-frame vectors to shape ``(num_paths, 3)``."""
     array = jnp.asarray(value)
@@ -333,10 +379,20 @@ class ThreadlikeRouting(eqx.Module):
 
 
 class ThreadlikeTransmissionParams(BaseSystemParams):
-    """Routing parameters and constant work-coordinate scale per path."""
+    """Routing parameters, work-coordinate scale, and guide friction per path.
+
+    ``friction_coefficient`` is the Capstan coefficient between a path and its
+    guides. Effort applied at the base is transmitted to arc length ``s``
+    through ``exp(-mu * Theta(q, s))``, where ``Theta`` is the accumulated turn
+    of the routed path, so the loss builds up along the path instead of scaling
+    the input. It is either a scalar shared by every path of the family or
+    batched with shape ``(num_paths,)``. Zero is the default and reproduces the
+    frictionless transmission exactly.
+    """
 
     routing: BaseThreadlikeRoutingParams
     coordinate_scale: Array
+    friction_coefficient: Array = eqx.field(default_factory=_zero_friction_coefficient)
 
     def __check_init__(self) -> None:
         self.validate_for_update()
@@ -350,6 +406,11 @@ class ThreadlikeTransmissionParams(BaseSystemParams):
                 "coordinate_scale must have shape "
                 f"({self.routing.num_paths},), got {scale.shape}."
             )
+        _validate_friction_shape(
+            self.friction_coefficient,
+            self.routing.num_paths,
+            "friction_coefficient",
+        )
 
     def validate_values(self) -> None:
         """Validate eager nested routing values."""
@@ -392,15 +453,32 @@ class ThreadlikeTransmission(Transmission):
             q, self.routing
         )
 
+    @property
+    def friction_coefficient(self) -> Array:
+        """Capstan coefficient of each path, broadcast to ``(num_channels,)``."""
+        return _broadcast_friction(self.params.friction_coefficient, self.num_channels)
+
     def moment_matrix(self, robot, q: Array) -> Array:
-        raw_matrix = robot._threadlike_moment_matrix(q, self.routing)
+        raw_matrix = robot._threadlike_moment_matrix(
+            q, self.routing, friction_coefficient=self.friction_coefficient
+        )
         return raw_matrix * self.params.coordinate_scale[None, :]
+
+    def kinematic_matrix(self, robot, q: Array) -> Array:
+        """Return the frictionless length gradient ``(dl/dq).T`` of the paths.
+
+        This is the exact geometric Jacobian at any friction coefficient,
+        because path length is pure geometry. It coincides with
+        :meth:`moment_matrix` only when the coefficient is zero and the
+        coordinate scale is one.
+        """
+        return robot._threadlike_moment_matrix(q, self.routing)
 
     def path_lengths(self, robot, q: Array) -> Array:
         return robot._threadlike_path_lengths(q, self.routing)
 
     def path_velocities(self, robot, q: Array, qd: Array) -> Array:
-        return robot._threadlike_moment_matrix(q, self.routing).T @ qd
+        return self.kinematic_matrix(robot, q).T @ qd
 
     def path_poses(self, robot, q: Array, s: Array) -> Array:
         return robot._threadlike_path_positions(q, s, self.routing)
@@ -513,6 +591,7 @@ class ThreadlikeActuator(Actuator):
         lower_bounds: Array | float = 0.0,
         upper_bounds: Array | float = jnp.inf,
         labels: tuple[str, ...] | None = None,
+        friction_coefficient: Array | float = 0.0,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         count = routing.num_paths
@@ -522,6 +601,7 @@ class ThreadlikeActuator(Actuator):
                 coordinate_scale=_channel_array(
                     coordinate_scale, count, "coordinate_scale"
                 ),
+                friction_coefficient=jnp.asarray(friction_coefficient),
             ),
             lower_bounds=_channel_array(lower_bounds, count, "lower_bounds"),
             upper_bounds=_channel_array(upper_bounds, count, "upper_bounds"),
@@ -543,6 +623,7 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
+        friction_coefficient: Array | float = 0.0,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -553,6 +634,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="tendon_tension",
             labels=labels,
+            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -561,6 +643,7 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
+        friction_coefficient: Array | float = 0.0,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -571,6 +654,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="rod_compression",
             labels=labels,
+            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -579,6 +663,7 @@ class ThreadlikeActuator(Actuator):
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
         *,
         labels: tuple[str, ...] | None = None,
+        friction_coefficient: Array | float = 0.0,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -589,6 +674,7 @@ class ThreadlikeActuator(Actuator):
             unit="N",
             label_prefix="muscle_tension",
             labels=labels,
+            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -598,6 +684,7 @@ class ThreadlikeActuator(Actuator):
         *,
         effective_areas: Array,
         labels: tuple[str, ...] | None = None,
+        friction_coefficient: Array | float = 0.0,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -610,6 +697,7 @@ class ThreadlikeActuator(Actuator):
             unit="Pa",
             label_prefix="chamber_pressure",
             labels=labels,
+            friction_coefficient=friction_coefficient,
         )
 
     @property
@@ -649,9 +737,18 @@ class ThreadlikeActuator(Actuator):
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.transmission.routing, robot)
+        _validate_friction_for_robot(
+            self.params.transmission.friction_coefficient, robot
+        )
 
     def _robot_value_validation_tree(self):
-        return self.transmission.routing.params
+        # The friction coefficient must be part of this subtree: validate_for_robot
+        # uses it to detect tracers, and a traced coefficient alongside concrete
+        # routing would otherwise let the eager value checks run on a tracer.
+        return (
+            self.transmission.routing.params,
+            self.params.transmission.friction_coefficient,
+        )
 
     def path_lengths(self, robot, q: Array) -> Array:
         return self.transmission.path_lengths(robot, q)
@@ -664,9 +761,15 @@ class ThreadlikeActuator(Actuator):
 
 
 class ThreadlikeImpedanceParams(BaseSystemParams):
-    """Spring-damper parameters for passive routed paths."""
+    """Spring-damper parameters for passive routed paths.
 
-    routing: BaseThreadlikeRoutingParams
+    The routed path is described by a nested ``transmission``, matching
+    ``ArticulatedTendonImpedanceParams``, so guide friction is declared in one
+    place for active and passive paths alike. Its coordinate scale is one,
+    because a passive path's natural coordinate is its raw length.
+    """
+
+    transmission: ThreadlikeTransmissionParams
     stiffness: Array
     damping: Array
     rest_length: Array
@@ -674,10 +777,15 @@ class ThreadlikeImpedanceParams(BaseSystemParams):
     def __check_init__(self) -> None:
         self.validate_for_update()
 
+    @property
+    def routing(self) -> BaseThreadlikeRoutingParams:
+        """Routing parameters of the passive paths."""
+        return self.transmission.routing
+
     def validate_structure(self) -> None:
         """Validate threadlike impedance parameter structure."""
-        self.routing.validate_structure()
-        count = self.routing.num_paths
+        self.transmission.validate_structure()
+        count = self.transmission.routing.num_paths
         for name in ("stiffness", "damping", "rest_length"):
             value = jnp.asarray(getattr(self, name))
             if value.shape != (count,):
@@ -686,15 +794,15 @@ class ThreadlikeImpedanceParams(BaseSystemParams):
                 )
 
     def validate_values(self) -> None:
-        """Validate eager nested threadlike routing values."""
-        self.routing.validate_values()
+        """Validate eager nested threadlike transmission values."""
+        self.transmission.validate_values()
 
 
 class ThreadlikeImpedance(PassiveElement):
     """Passive spring-damper mechanics along fixed threadlike paths."""
 
     _params: ThreadlikeImpedanceParams
-    routing: ThreadlikeRouting
+    _transmission: ThreadlikeTransmission
     name: str = eqx.field(static=True)
 
     def __init__(
@@ -704,17 +812,24 @@ class ThreadlikeImpedance(PassiveElement):
         stiffness: Array,
         damping: Array,
         rest_length: Array,
+        friction_coefficient: Array | float = 0.0,
         name: str = "passive_threadlike",
     ) -> None:
         routing = ThreadlikeActuator._normalize_routing(routing)
         count = routing.num_paths
         self._params = ThreadlikeImpedanceParams(
-            routing=routing.params,
+            transmission=ThreadlikeTransmissionParams(
+                routing=routing.params,
+                coordinate_scale=jnp.ones((count,)),
+                friction_coefficient=jnp.asarray(friction_coefficient),
+            ),
             stiffness=_channel_array(stiffness, count, "stiffness"),
             damping=_channel_array(damping, count, "damping"),
             rest_length=_channel_array(rest_length, count, "rest_length"),
         )
-        self.routing = routing
+        self._transmission = ThreadlikeTransmission(
+            self._params.transmission, routing=routing
+        )
         self.name = name
 
     @classmethod
@@ -726,10 +841,11 @@ class ThreadlikeImpedance(PassiveElement):
         routing: ThreadlikeRouting,
     ) -> ThreadlikeImpedance:
         return cls(
-            routing=routing.with_params(params.routing),
+            routing=routing.with_params(params.transmission.routing),
             stiffness=params.stiffness,
             damping=params.damping,
             rest_length=params.rest_length,
+            friction_coefficient=params.transmission.friction_coefficient,
             name=name,
         )
 
@@ -737,10 +853,21 @@ class ThreadlikeImpedance(PassiveElement):
     def params(self) -> ThreadlikeImpedanceParams:
         return self._params
 
+    @property
+    def transmission(self) -> ThreadlikeTransmission:
+        return self._transmission
+
+    @property
+    def routing(self) -> ThreadlikeRouting:
+        """Runtime routing object of the passive paths."""
+        return self._transmission.routing
+
     def with_params(self, params: BaseSystemParams) -> ThreadlikeImpedance:
         if not isinstance(params, ThreadlikeImpedanceParams):
             raise TypeError("params must be ThreadlikeImpedanceParams.")
-        self.params.routing.assert_same_topology(params.routing)
+        self.params.transmission.routing.assert_same_topology(
+            params.transmission.routing
+        )
         params.validate_for_update()
         return self._from_params(params, name=self.name, routing=self.routing)
 
@@ -749,35 +876,83 @@ class ThreadlikeImpedance(PassiveElement):
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.routing, robot)
+        _validate_friction_for_robot(
+            self.params.transmission.friction_coefficient, robot
+        )
 
     def _robot_value_validation_tree(self):
-        return self.routing.params
+        # See ThreadlikeActuator._robot_value_validation_tree: the coefficient
+        # belongs here so a traced value is detected by validate_for_robot.
+        return (
+            self.routing.params,
+            self.params.transmission.friction_coefficient,
+        )
 
     def path_lengths(self, robot, q: Array) -> Array:
         """Return the raw lengths of the passive routed paths."""
-        return robot._threadlike_path_lengths(q, self.routing)
+        return self._transmission.path_lengths(robot, q)
 
     def path_velocities(self, robot, q: Array, qd: Array) -> Array:
         """Return the raw length rates of the passive routed paths."""
-        return self._length_jacobian(robot, q) @ qd
+        return self._transmission.path_velocities(robot, q, qd)
 
     def path_poses(self, robot, q: Array, s: Array) -> Array:
         """Return passive routed-path positions at backbone coordinate ``s``."""
-        return robot._threadlike_path_positions(q, s, self.routing)
+        return self._transmission.path_poses(robot, q, s)
 
     def _length_jacobian(self, robot, q: Array) -> Array:
-        return robot._threadlike_moment_matrix(q, self.routing).T
+        """Return the exact kinematic length Jacobian ``dl/dq``.
+
+        Path length is pure geometry, so this is exact at any friction
+        coefficient. The friction-weighted force transmission is
+        :meth:`_transmission_matrix`.
+        """
+        return self._transmission.kinematic_matrix(robot, q).T
+
+    def _transmission_matrix(self, robot, q: Array) -> Array:
+        """Return the Capstan-weighted force transmission map of the paths."""
+        return self._transmission.moment_matrix(robot, q)
 
     def elastic_force(self, robot, q: Array) -> Array:
+        """Return the conservative part of the passive path force.
+
+        This uses the exact kinematic Jacobian, so it stays exactly the
+        gradient of :meth:`elastic_energy` at any friction coefficient. The
+        remainder that friction stops from reaching the backbone is reported by
+        :meth:`nonconservative_force`.
+        """
         lengths = self.path_lengths(robot, q)
         jacobian = self._length_jacobian(robot, q)
         return jacobian.T @ (
             self.params.stiffness * (lengths - self.params.rest_length)
         )
 
-    def damping_matrix(self, robot, q: Array) -> Array:
+    def nonconservative_force(self, robot, q: Array) -> Array:
+        """Return the part of the spring force that friction makes non-potential.
+
+        Guide friction attenuates the spring force transmitted to the backbone
+        without changing the energy stored in the spring, so the transmitted
+        force is not the gradient of anything. Splitting it off keeps
+        :meth:`elastic_force` conservative and the host's ``elastic_energy``
+        custom JVP truthful. It is zero when the friction coefficient is zero.
+        """
+        lengths = self.path_lengths(robot, q)
+        transmission = self._transmission_matrix(robot, q)
         jacobian = self._length_jacobian(robot, q)
-        return jacobian.T @ (self.params.damping[:, None] * jacobian)
+        return (transmission - jacobian.T) @ (
+            self.params.stiffness * (lengths - self.params.rest_length)
+        )
+
+    def damping_matrix(self, robot, q: Array) -> Array:
+        """Return the passive damping contribution of the routed paths.
+
+        Both sides use the Capstan-weighted transmission map, which keeps the
+        result symmetric positive semi-definite and therefore dissipative at
+        any friction coefficient. Reading the rate through the exact Jacobian
+        instead would make the matrix indefinite.
+        """
+        matrix = self._transmission_matrix(robot, q)
+        return matrix @ (self.params.damping[:, None] * matrix.T)
 
     def elastic_energy(self, robot, q: Array) -> Array:
         delta = self.path_lengths(robot, q) - self.params.rest_length

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -150,16 +150,32 @@ class BaseThreadlikeRoutingParams(BaseSystemParams):
 
     @property
     def start_segment_index_array(self) -> Array:
-        """Return the first active segment of every path as an integer array."""
+        """Return the first active segment of every routed path.
+
+        Returns:
+            Start indices with shape ``(self.num_paths,)``.
+        """
         return jnp.asarray(self.start_segment_index, dtype=jnp.int32)
 
     @property
     def end_segment_index_array(self) -> Array:
-        """Return the last active segment of every path as an integer array."""
+        """Return the last active segment of every routed path.
+
+        Returns:
+            End indices with shape ``(self.num_paths,)``.
+        """
         return jnp.asarray(self.end_segment_index, dtype=jnp.int32)
 
     def validate_structure_for_robot(self, num_segments: int) -> None:
-        """Validate path spans against a host robot's segment count."""
+        """Validate path spans against a host robot's segment count.
+
+        Args:
+            num_segments: Number of continuum body segments in the host robot.
+
+        Raises:
+            ValueError: If a path span falls outside the host robot or its start
+                index follows its end index.
+        """
         self.validate_structure()
         for start, end in zip(self.start_segment_index, self.end_segment_index):
             if start < 0 or start > end or end >= num_segments:
@@ -169,7 +185,15 @@ class BaseThreadlikeRoutingParams(BaseSystemParams):
                 )
 
     def assert_same_topology(self, other: BaseThreadlikeRoutingParams) -> None:
-        """Reject a replacement that changes routing type, count, or spans."""
+        """Reject a replacement that changes routing type, count, or spans.
+
+        Args:
+            other: Candidate replacement routing parameters.
+
+        Raises:
+            ValueError: If ``other`` changes the parameter type, number of
+                paths, or segment spans.
+        """
         if type(other) is not type(self):
             raise ValueError("Changing routing type requires reconstruction.")
         if other.num_paths != self.num_paths:
@@ -219,16 +243,6 @@ class LinearThreadlikeRoutingParams(BaseThreadlikeRoutingParams):
     def num_paths(self) -> int:
         """Return the number of linear paths."""
         return int(jnp.asarray(self.intercept).shape[0])
-
-    @property
-    def start_segment_index_array(self) -> Array:
-        """Return the first active segment of every path as an integer array."""
-        return jnp.asarray(self.start_segment_index, dtype=jnp.int32)
-
-    @property
-    def end_segment_index_array(self) -> Array:
-        """Return the last active segment of every path as an integer array."""
-        return jnp.asarray(self.end_segment_index, dtype=jnp.int32)
 
     @classmethod
     def empty(cls) -> LinearThreadlikeRoutingParams:
@@ -281,14 +295,31 @@ class LinearThreadlikeRoutingParams(BaseThreadlikeRoutingParams):
 
 
 def linear_threadlike_routing(params: LinearThreadlikeRoutingParams, s: Array) -> Array:
-    """Return material-frame offsets ``intercept + slope * s``."""
+    """Evaluate linear material-frame routing offsets.
+
+    Args:
+        params: Linear routing parameters for one path or a path batch.
+        s: Scalar backbone abscissa.
+
+    Returns:
+        Material-frame offsets ``params.intercept + params.slope * s`` with
+        shape ``(3,)`` or ``(num_paths, 3)``.
+    """
     return jnp.asarray(params.intercept) + jnp.asarray(params.slope) * jnp.asarray(s)
 
 
 def linear_threadlike_routing_derivative(
     params: LinearThreadlikeRoutingParams, s: Array
 ) -> Array:
-    """Return the arc-length derivative of a linear routing offset."""
+    """Evaluate the first derivative of a linear routing offset.
+
+    Args:
+        params: Linear routing parameters for one path or a path batch.
+        s: Scalar backbone abscissa, used to preserve dtype and tracing.
+
+    Returns:
+        Constant slopes with shape ``(3,)`` or ``(num_paths, 3)``.
+    """
     return jnp.asarray(params.slope) + jnp.zeros_like(
         jnp.asarray(params.slope)
     ) * jnp.asarray(s)
@@ -301,7 +332,7 @@ def linear_threadlike_routing_second_derivative(
 
     Args:
         params: Linear routing parameters for one path or a path batch.
-        s: Backbone coordinate, used only to preserve output dtype and tracing.
+        s: Scalar backbone abscissa, used to preserve output dtype and tracing.
 
     Returns:
         Zeros with the same shape as ``params.slope``.
@@ -332,6 +363,17 @@ class ThreadlikeRouting(eqx.Module):
 
         The final array axis is ``[x, y, z]``. Local x follows the backbone, so
         the x-components of ``intercept`` and ``slope`` must both be zero.
+
+        Args:
+            intercept: Offset at zero backbone abscissa with shape ``(3,)`` or
+                ``(num_paths, 3)``.
+            slope: Constant offset derivative, either scalar or shaped ``(3,)``
+                or ``(num_paths, 3)``.
+            start_segment_index: First segment traversed by each path.
+            end_segment_index: Last segment traversed by each path.
+
+        Returns:
+            Vectorized linear routing family.
         """
         intercept = _path_vector_array(intercept, "intercept")
         count = int(intercept.shape[0])
@@ -364,17 +406,40 @@ class ThreadlikeRouting(eqx.Module):
 
     @property
     def has_analytical_second_derivative(self) -> bool:
-        """Return whether the routing supplies the derivative needed for turn."""
-        return self.second_derivative_fn is not None or isinstance(
-            self.params, LinearThreadlikeRoutingParams
+        """Return whether the routing supplies the derivative needed for turn.
+
+        Returns:
+            Whether an explicit second-derivative function is installed or all
+            routing callbacks are the built-in linear functions.
+        """
+        return self.second_derivative_fn is not None or (
+            isinstance(self.params, LinearThreadlikeRoutingParams)
+            and self.offset_fn is linear_threadlike_routing
+            and self.derivative_fn is linear_threadlike_routing_derivative
         )
 
     def offset(self, path_params: BaseThreadlikeRoutingParams, s: Array) -> Array:
-        """Evaluate one path's material-frame offset at ``s``."""
+        """Evaluate one path's material-frame offset.
+
+        Args:
+            path_params: Parameters of one routed path.
+            s: Scalar backbone abscissa.
+
+        Returns:
+            Material-frame offset with shape ``(3,)``.
+        """
         return self.offset_fn(path_params, s)
 
     def derivative(self, path_params: BaseThreadlikeRoutingParams, s: Array) -> Array:
-        """Evaluate one path's material-frame offset derivative at ``s``."""
+        """Evaluate one path's material-frame offset derivative.
+
+        Args:
+            path_params: Parameters of one routed path.
+            s: Scalar backbone abscissa.
+
+        Returns:
+            First backbone-abscissa derivative with shape ``(3,)``.
+        """
         return self.derivative_fn(path_params, s)
 
     def second_derivative(
@@ -384,17 +449,21 @@ class ThreadlikeRouting(eqx.Module):
 
         Args:
             path_params: Parameters of one routed path.
-            s: Physical backbone coordinate.
+            s: Scalar backbone abscissa.
 
         Returns:
-            The second arc-length derivative of the material offset.
+            Second backbone-abscissa derivative with shape ``(3,)``.
 
         Raises:
             ValueError: If a custom routing does not provide an analytical
                 ``second_derivative_fn``.
         """
         if self.second_derivative_fn is None:
-            if isinstance(path_params, LinearThreadlikeRoutingParams):
+            if (
+                isinstance(path_params, LinearThreadlikeRoutingParams)
+                and self.offset_fn is linear_threadlike_routing
+                and self.derivative_fn is linear_threadlike_routing_derivative
+            ):
                 return linear_threadlike_routing_second_derivative(path_params, s)
             raise ValueError(
                 "custom threadlike routing requires second_derivative_fn for "
@@ -514,24 +583,31 @@ class ThreadlikeTransmission(Transmission):
 
         Args:
             robot: Continuum robot hosting the routing.
-            q: Generalized configuration.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
 
         Returns:
-            One work-conjugate coordinate per path.
+            y_a: Work-conjugate coordinates with shape
+                ``(self.num_channels,)``.
         """
         return self.params.coordinate_scale * robot._threadlike_path_lengths(
             q, self.routing
         )
 
     def coordinate_jacobian(self, robot: SoftRobot, q: Array) -> Array:
-        """Return the Jacobian of scaled path coordinates.
+        """Return the scaled path-coordinate Jacobian.
+
+        The Jacobian maps generalized velocity to actuator-coordinate velocity
+        as ``yd_a = J_a(q) @ qd``.
 
         Args:
             robot: Continuum robot hosting the routing.
-            q: Generalized configuration.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
 
         Returns:
-            Matrix with shape ``(num_channels, robot.num_velocities)``.
+            J_a: Coordinate Jacobian with shape
+                ``(self.num_channels, robot.num_velocities)``.
         """
         raw_jacobian = robot._threadlike_path_length_jacobian(q, self.routing)
         return self.params.coordinate_scale[:, None] * raw_jacobian
@@ -544,10 +620,12 @@ class ThreadlikeTransmission(Transmission):
 
         Args:
             robot: Continuum robot hosting the routing.
-            q: Generalized configuration.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
 
         Returns:
-            Matrix with shape ``(robot.num_velocities, num_channels)``.
+            A: Actuation matrix with shape
+                ``(robot.num_velocities, self.num_channels)``.
         """
         raw_matrix = robot._threadlike_actuation_matrix(
             q, self.routing, friction=self.friction
@@ -555,19 +633,61 @@ class ThreadlikeTransmission(Transmission):
         return raw_matrix * self.params.coordinate_scale[None, :]
 
     def path_lengths(self, robot: SoftRobot, q: Array) -> Array:
-        """Return unscaled physical routed-path lengths."""
+        """Return unscaled physical routed-path lengths.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            Path lengths with shape ``(self.num_channels,)``.
+        """
         return robot._threadlike_path_lengths(q, self.routing)
 
     def path_length_jacobian(self, robot: SoftRobot, q: Array) -> Array:
-        """Return the Jacobian of unscaled physical path lengths."""
+        """Return the unscaled physical path-length Jacobian.
+
+        This Jacobian maps generalized velocity to physical path-length rate.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            J_l: Path-length Jacobian with shape
+                ``(self.num_channels, robot.num_velocities)``.
+        """
         return robot._threadlike_path_length_jacobian(q, self.routing)
 
     def path_velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
-        """Return unscaled physical path-length rates."""
+        """Return unscaled physical path-length rates.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+            qd: Generalized velocities with shape ``(robot.num_velocities,)``.
+
+        Returns:
+            Path-length rates with shape ``(self.num_channels,)``.
+        """
         return self.path_length_jacobian(robot, q) @ qd
 
     def path_poses(self, robot: SoftRobot, q: Array, s: Array) -> Array:
-        """Return routed-path positions at backbone coordinate ``s``."""
+        """Return routed-path positions at a backbone abscissa.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+            s: Scalar backbone abscissa.
+
+        Returns:
+            Path positions with shape ``(self.num_channels, 2)`` for planar
+            hosts or ``(self.num_channels, 3)`` for spatial hosts.
+        """
         return robot._threadlike_path_positions(q, s, self.routing)
 
     def with_params(
@@ -729,7 +849,16 @@ class ThreadlikeActuator(Actuator):
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
     ) -> ThreadlikeActuator:
-        """Construct tension-only tendons with shortening-positive coordinates."""
+        """Construct tension-only tendons with shortening-positive coordinates.
+
+        Args:
+            routings: Fixed material-frame routing geometry.
+            labels: Optional label for each routed path.
+            friction: Optional active effort-loss model.
+
+        Returns:
+            Vectorized tendon actuator with one channel per path.
+        """
         routing = cls._normalize_routing(routings)
         return cls._preset(
             routing,
@@ -750,7 +879,16 @@ class ThreadlikeActuator(Actuator):
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
     ) -> ThreadlikeActuator:
-        """Construct compression push rods with lengthening-positive coordinates."""
+        """Construct compression push rods with lengthening-positive coordinates.
+
+        Args:
+            routings: Fixed material-frame routing geometry.
+            labels: Optional label for each routed path.
+            friction: Optional active effort-loss model.
+
+        Returns:
+            Vectorized push-rod actuator with one channel per path.
+        """
         routing = cls._normalize_routing(routings)
         return cls._preset(
             routing,
@@ -771,7 +909,16 @@ class ThreadlikeActuator(Actuator):
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
     ) -> ThreadlikeActuator:
-        """Construct tensile muscles with shortening-positive coordinates."""
+        """Construct tensile muscles with shortening-positive coordinates.
+
+        Args:
+            routings: Fixed material-frame routing geometry.
+            labels: Optional label for each routed path.
+            friction: Optional active effort-loss model.
+
+        Returns:
+            Vectorized muscle actuator with one channel per path.
+        """
         routing = cls._normalize_routing(routings)
         return cls._preset(
             routing,
@@ -793,7 +940,18 @@ class ThreadlikeActuator(Actuator):
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
     ) -> ThreadlikeActuator:
-        """Construct pressure chambers scaled by their effective areas."""
+        """Construct pressure chambers scaled by their effective areas.
+
+        Args:
+            routings: Fixed material-frame routing geometry.
+            effective_areas: Effective area of each chamber with shape
+                ``(num_paths,)``.
+            labels: Optional label for each routed path.
+            friction: Optional active effort-loss model.
+
+        Returns:
+            Vectorized pressure-chamber actuator with one channel per path.
+        """
         routing = cls._normalize_routing(routings)
         return cls._preset(
             routing,
@@ -829,7 +987,18 @@ class ThreadlikeActuator(Actuator):
         return self._metadata
 
     def with_params(self, params: BaseSystemParams) -> ThreadlikeActuator:
-        """Return a copy carrying replacement actuator parameter leaves."""
+        """Return a copy carrying replacement actuator parameter leaves.
+
+        Args:
+            params: Replacement threadlike-actuator parameters.
+
+        Returns:
+            Actuator with updated differentiable parameter leaves.
+
+        Raises:
+            TypeError: If ``params`` has the wrong parameter type.
+            ValueError: If ``params`` changes the routing topology.
+        """
         if not isinstance(params, ThreadlikeActuatorParams):
             raise TypeError("params must be ThreadlikeActuatorParams.")
         self.params.transmission.routing.assert_same_topology(
@@ -863,15 +1032,45 @@ class ThreadlikeActuator(Actuator):
         )
 
     def path_lengths(self, robot: SoftRobot, q: Array) -> Array:
-        """Return physical routed-path lengths."""
+        """Return physical routed-path lengths.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            Path lengths with shape ``(self.num_channels,)``.
+        """
         return self.transmission.path_lengths(robot, q)
 
     def path_velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
-        """Return physical routed-path length rates."""
+        """Return physical routed-path length rates.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+            qd: Generalized velocities with shape ``(robot.num_velocities,)``.
+
+        Returns:
+            Path-length rates with shape ``(self.num_channels,)``.
+        """
         return self.transmission.path_velocities(robot, q, qd)
 
     def path_poses(self, robot: SoftRobot, q: Array, s: Array) -> Array:
-        """Return routed-path positions at backbone coordinate ``s``."""
+        """Return routed-path positions at a backbone abscissa.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+            s: Scalar backbone abscissa.
+
+        Returns:
+            Path positions with shape ``(self.num_channels, 2)`` for planar
+            hosts or ``(self.num_channels, 3)`` for spatial hosts.
+        """
         return self.transmission.path_poses(robot, q, s)
 
 
@@ -962,7 +1161,18 @@ class ThreadlikeImpedance(PassiveElement):
         return self._params
 
     def with_params(self, params: BaseSystemParams) -> ThreadlikeImpedance:
-        """Return a copy carrying replacement impedance parameters."""
+        """Return a copy carrying replacement impedance parameters.
+
+        Args:
+            params: Replacement threadlike-impedance parameters.
+
+        Returns:
+            Passive element with updated differentiable parameter leaves.
+
+        Raises:
+            TypeError: If ``params`` has the wrong parameter type.
+            ValueError: If ``params`` changes the routing topology.
+        """
         if not isinstance(params, ThreadlikeImpedanceParams):
             raise TypeError("params must be ThreadlikeImpedanceParams.")
         self.params.routing.assert_same_topology(params.routing)
@@ -982,19 +1192,61 @@ class ThreadlikeImpedance(PassiveElement):
         return self.routing.params
 
     def path_lengths(self, robot: SoftRobot, q: Array) -> Array:
-        """Return the raw lengths of the passive routed paths."""
+        """Return the raw lengths of the passive routed paths.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            Path lengths with shape ``(self.routing.num_paths,)``.
+        """
         return robot._threadlike_path_lengths(q, self.routing)
 
     def path_length_jacobian(self, robot: SoftRobot, q: Array) -> Array:
-        """Return the Jacobian of passive physical path lengths."""
+        """Return the Jacobian of passive physical path lengths.
+
+        The Jacobian maps generalized velocity to passive path-length rate.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+
+        Returns:
+            J_l: Path-length Jacobian with shape
+                ``(self.routing.num_paths, robot.num_velocities)``.
+        """
         return robot._threadlike_path_length_jacobian(q, self.routing)
 
     def path_velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
-        """Return the raw length rates of the passive routed paths."""
+        """Return the raw length rates of the passive routed paths.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+            qd: Generalized velocities with shape ``(robot.num_velocities,)``.
+
+        Returns:
+            Path-length rates with shape ``(self.routing.num_paths,)``.
+        """
         return self.path_length_jacobian(robot, q) @ qd
 
     def path_poses(self, robot: SoftRobot, q: Array, s: Array) -> Array:
-        """Return passive routed-path positions at backbone coordinate ``s``."""
+        """Return passive routed-path positions at a backbone abscissa.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized coordinates with shape
+                ``(robot.num_coordinates,)``.
+            s: Scalar backbone abscissa.
+
+        Returns:
+            Path positions with shape ``(self.routing.num_paths, 2)`` for
+            planar hosts or ``(self.routing.num_paths, 3)`` for spatial hosts.
+        """
         return robot._threadlike_path_positions(q, s, self.routing)
 
     def elastic_force(self, robot: SoftRobot, q: Array) -> Array:

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -19,15 +19,11 @@ from .core import (
     Transmission,
 )
 from .friction import (
-    CapstanFriction,
-    Frictionless,
+    BaseThreadlikeFrictionParams,
+    FrictionlessParams,
     ThreadlikeFriction,
+    validate_friction_for_robot,
 )
-
-# Sentinel distinguishing "caller passed nothing" from an explicit friction
-# law, so the deprecated friction_coefficient sugar can be rejected when both
-# spellings are supplied.
-_UNSET: Any = object()
 
 ThreadlikeKind = Literal["tendon", "push_rod", "muscle", "pneumatic", "generic"]
 
@@ -111,65 +107,13 @@ def _channel_array(value: Any, count: int, name: str) -> Array:
     return array
 
 
-def _resolve_friction(
-    friction: ThreadlikeFriction | None,
-    friction_coefficient: Any,
-) -> ThreadlikeFriction:
-    """Resolve the two spellings of a transmission-loss law into one model.
-
-    ``friction_coefficient`` is retained sugar for the common Capstan case and
-    builds a :class:`CapstanFriction`. Supplying both spellings is a mistake
-    rather than a merge, because the two would silently disagree.
-
-    Args:
-        friction: Explicit transmission-loss law, or ``None`` for the default.
-        friction_coefficient: Capstan coefficient sugar, or ``_UNSET``.
-
-    Returns:
-        model: The law to install. Defaults to :class:`Frictionless`.
-
-    Raises:
-        TypeError: If ``friction`` is not a :class:`ThreadlikeFriction`.
-        ValueError: If both spellings are supplied.
-    """
-    if friction_coefficient is not _UNSET:
-        if friction is not None:
-            raise ValueError(
-                "Pass either friction= or friction_coefficient=, not both. "
-                "friction_coefficient is sugar for "
-                "CapstanFriction(coefficient=...)."
-            )
-        return CapstanFriction(coefficient=jnp.asarray(friction_coefficient))
-    if friction is None:
-        return Frictionless()
-    if not isinstance(friction, ThreadlikeFriction):
+def _normalize_friction(friction: Any) -> ThreadlikeFriction | None:
+    if friction is not None and not isinstance(friction, ThreadlikeFriction):
         raise TypeError(
             "friction must be a ThreadlikeFriction instance, got "
             f"{type(friction).__name__}."
         )
     return friction
-
-
-def _validate_friction_for_robot(friction: ThreadlikeFriction, robot) -> None:
-    """Reject a transmission-loss law the host cannot serve.
-
-    A law reading the accumulated turn of the routed path needs a host that
-    implements ``_threadlike_wrap_density``. Hosts without it would silently
-    ignore the law, so it is refused here rather than dropped. Laws that read
-    only host-agnostic geometry, such as a length-based loss, are accepted
-    everywhere. This runs only on concrete values, through the tracer guard in
-    ``validate_for_robot``.
-    """
-    if friction.is_lossless or not friction.requires_wrap_angle:
-        return
-    if not callable(getattr(robot, "_threadlike_wrap_density", None)):
-        raise TypeError(
-            f"{type(robot).__name__} does not implement the threadlike "
-            f"wrap-angle model, so {type(friction).__name__} cannot be "
-            "honoured. Install the component on PCS or PlanarPCS, or choose a "
-            "law that does not require the wrap angle, such as "
-            "ExponentialLengthFriction."
-        )
 
 
 def _path_vector_array(value: Any, name: str, *, count: int | None = None) -> Array:
@@ -404,24 +348,15 @@ class ThreadlikeRouting(eqx.Module):
 
 
 class ThreadlikeTransmissionParams(BaseSystemParams):
-    """Routing parameters, work-coordinate scale, and the transmission loss.
-
-    ``friction`` is the law describing how much of the effort applied at the
-    base of a path survives to arc length ``s``. It weights the integrand of
-    the moment matrix, so a loss accumulates along the path instead of scaling
-    the input. The default :class:`~soromox.actuation.friction.Frictionless`
-    delivers the full effort everywhere and reproduces the frictionless
-    transmission exactly.
-
-    Swapping the law changes the parameter PyTree structure and so triggers a
-    retrace; replacing a value inside a law does not. Identification should
-    therefore start from a lossy law at a zero parameter, such as
-    ``CapstanFriction(coefficient=0.0)``, rather than from ``Frictionless()``.
+    """Routing parameters, constant work-coordinate scale per path, and
+    friction paramters.
     """
 
     routing: BaseThreadlikeRoutingParams
     coordinate_scale: Array
-    friction: ThreadlikeFriction = eqx.field(default_factory=Frictionless)
+    friction: BaseThreadlikeFrictionParams = eqx.field(
+        default_factory=FrictionlessParams
+    )
 
     def __check_init__(self) -> None:
         self.validate_for_update()
@@ -435,16 +370,16 @@ class ThreadlikeTransmissionParams(BaseSystemParams):
                 "coordinate_scale must have shape "
                 f"({self.routing.num_paths},), got {scale.shape}."
             )
-        if not isinstance(self.friction, ThreadlikeFriction):
+        if not isinstance(self.friction, BaseThreadlikeFrictionParams):
             raise TypeError(
-                "friction must be a ThreadlikeFriction instance, got "
+                "friction must be a BaseThreadlikeFrictionParams instance, got "
                 f"{type(self.friction).__name__}."
             )
         self.friction.validate_structure()
-        self.friction.validate_for_paths(self.routing.num_paths)
+        self.friction.validate_structure_compatibility(self.routing.num_paths)
 
     def validate_values(self) -> None:
-        """Validate eager nested routing and transmission-loss values."""
+        """Validate eager nested routing and friction values."""
         self.routing.validate_values()
         self.friction.validate_values()
 
@@ -454,12 +389,14 @@ class ThreadlikeTransmission(Transmission):
 
     params: ThreadlikeTransmissionParams
     routing: ThreadlikeRouting
+    friction: ThreadlikeFriction
 
     def __init__(
         self,
         params: ThreadlikeTransmissionParams,
         *,
         routing: ThreadlikeRouting | None = None,
+        friction: ThreadlikeFriction | None = None,
     ) -> None:
         if not isinstance(params, ThreadlikeTransmissionParams):
             raise TypeError("params must be ThreadlikeTransmissionParams.")
@@ -475,6 +412,16 @@ class ThreadlikeTransmission(Transmission):
         else:
             routing = routing.with_params(params.routing)
         self.routing = routing
+        if friction is None:
+            if not isinstance(params.friction, FrictionlessParams):
+                raise TypeError(
+                    "friction params require their matching "
+                    "ThreadlikeFriction runtime object."
+                )
+            friction = ThreadlikeFriction()
+        else:
+            friction = friction.with_params(params.friction)
+        self.friction = friction
 
     @property
     def num_channels(self) -> int:
@@ -485,11 +432,6 @@ class ThreadlikeTransmission(Transmission):
             q, self.routing
         )
 
-    @property
-    def friction(self) -> ThreadlikeFriction:
-        """Transmission-loss law installed on this path family."""
-        return self.params.friction
-
     def moment_matrix(self, robot, q: Array) -> Array:
         raw_matrix = robot._threadlike_moment_matrix(
             q, self.routing, friction=self.friction
@@ -497,13 +439,7 @@ class ThreadlikeTransmission(Transmission):
         return raw_matrix * self.params.coordinate_scale[None, :]
 
     def kinematic_matrix(self, robot, q: Array) -> Array:
-        """Return the frictionless length gradient ``(dl/dq).T`` of the paths.
-
-        This is the exact geometric Jacobian at any friction coefficient,
-        because path length is pure geometry. It coincides with
-        :meth:`moment_matrix` only when the coefficient is zero and the
-        coordinate scale is one.
-        """
+        """Return the frictionless length gradient ``(dl/dq).T`` of the paths."""
         return robot._threadlike_moment_matrix(q, self.routing)
 
     def path_lengths(self, robot, q: Array) -> Array:
@@ -522,7 +458,9 @@ class ThreadlikeTransmission(Transmission):
             raise TypeError("params must be ThreadlikeTransmissionParams.")
         self.params.routing.assert_same_topology(params.routing)
         params.validate_for_update()
-        return ThreadlikeTransmission(params, routing=self.routing)
+        return ThreadlikeTransmission(
+            params, routing=self.routing, friction=self.friction
+        )
 
     def update_params(self, **updates: Any) -> ThreadlikeTransmission:
         return self.with_params(self.params.replace(**updates))
@@ -569,6 +507,7 @@ class ThreadlikeActuator(Actuator):
         *,
         params: ThreadlikeActuatorParams,
         routing: ThreadlikeRouting | None = None,
+        friction: ThreadlikeFriction | None = None,
         labels: tuple[str, ...],
         units: str | tuple[str, ...],
         name: str,
@@ -580,7 +519,7 @@ class ThreadlikeActuator(Actuator):
             raise ValueError("labels must contain one entry per threadlike path.")
         self._params = params
         self._transmission = ThreadlikeTransmission(
-            params.transmission, routing=routing
+            params.transmission, routing=routing, friction=friction
         )
         self._effort_model = DirectEffort()
         self._metadata = ActuatorMetadata(
@@ -624,9 +563,9 @@ class ThreadlikeActuator(Actuator):
         upper_bounds: Array | float = jnp.inf,
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
+        friction = _normalize_friction(friction)
         count = routing.num_paths
         params = ThreadlikeActuatorParams(
             transmission=ThreadlikeTransmissionParams(
@@ -634,7 +573,9 @@ class ThreadlikeActuator(Actuator):
                 coordinate_scale=_channel_array(
                     coordinate_scale, count, "coordinate_scale"
                 ),
-                friction=_resolve_friction(friction, friction_coefficient),
+                friction=(
+                    friction.params if friction is not None else FrictionlessParams()
+                ),
             ),
             lower_bounds=_channel_array(lower_bounds, count, "lower_bounds"),
             upper_bounds=_channel_array(upper_bounds, count, "upper_bounds"),
@@ -644,6 +585,7 @@ class ThreadlikeActuator(Actuator):
         return cls(
             params=params,
             routing=routing,
+            friction=friction,
             labels=labels,
             units=unit,
             name=name,
@@ -657,7 +599,6 @@ class ThreadlikeActuator(Actuator):
         *,
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -669,7 +610,6 @@ class ThreadlikeActuator(Actuator):
             label_prefix="tendon_tension",
             labels=labels,
             friction=friction,
-            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -679,7 +619,6 @@ class ThreadlikeActuator(Actuator):
         *,
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -691,7 +630,6 @@ class ThreadlikeActuator(Actuator):
             label_prefix="rod_compression",
             labels=labels,
             friction=friction,
-            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -701,7 +639,6 @@ class ThreadlikeActuator(Actuator):
         *,
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -713,7 +650,6 @@ class ThreadlikeActuator(Actuator):
             label_prefix="muscle_tension",
             labels=labels,
             friction=friction,
-            friction_coefficient=friction_coefficient,
         )
 
     @classmethod
@@ -724,7 +660,6 @@ class ThreadlikeActuator(Actuator):
         effective_areas: Array,
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
     ) -> ThreadlikeActuator:
         routing = cls._normalize_routing(routings)
         return cls._preset(
@@ -738,7 +673,6 @@ class ThreadlikeActuator(Actuator):
             label_prefix="chamber_pressure",
             labels=labels,
             friction=friction,
-            friction_coefficient=friction_coefficient,
         )
 
     @property
@@ -767,6 +701,7 @@ class ThreadlikeActuator(Actuator):
         return ThreadlikeActuator(
             params=params,
             routing=self.transmission.routing,
+            friction=self.transmission.friction,
             labels=self.metadata.labels,
             units=self.metadata.units,
             name=self.name,
@@ -778,12 +713,9 @@ class ThreadlikeActuator(Actuator):
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.transmission.routing, robot)
-        _validate_friction_for_robot(self.params.transmission.friction, robot)
+        validate_friction_for_robot(self.transmission.friction, robot)
 
     def _robot_value_validation_tree(self):
-        # The friction coefficient must be part of this subtree: validate_for_robot
-        # uses it to detect tracers, and a traced coefficient alongside concrete
-        # routing would otherwise let the eager value checks run on a tracer.
         return (
             self.transmission.routing.params,
             self.params.transmission.friction,
@@ -800,13 +732,7 @@ class ThreadlikeActuator(Actuator):
 
 
 class ThreadlikeImpedanceParams(BaseSystemParams):
-    """Spring-damper parameters for passive routed paths.
-
-    The routed path is described by a nested ``transmission``, matching
-    ``ArticulatedTendonImpedanceParams``, so guide friction is declared in one
-    place for active and passive paths alike. Its coordinate scale is one,
-    because a passive path's natural coordinate is its raw length.
-    """
+    """Spring-damper parameters for passive routed paths."""
 
     transmission: ThreadlikeTransmissionParams
     stiffness: Array
@@ -852,23 +778,25 @@ class ThreadlikeImpedance(PassiveElement):
         damping: Array,
         rest_length: Array,
         friction: ThreadlikeFriction | None = None,
-        friction_coefficient: Any = _UNSET,
         name: str = "passive_threadlike",
     ) -> None:
         routing = ThreadlikeActuator._normalize_routing(routing)
+        friction = _normalize_friction(friction)
         count = routing.num_paths
         self._params = ThreadlikeImpedanceParams(
             transmission=ThreadlikeTransmissionParams(
                 routing=routing.params,
                 coordinate_scale=jnp.ones((count,)),
-                friction=_resolve_friction(friction, friction_coefficient),
+                friction=(
+                    friction.params if friction is not None else FrictionlessParams()
+                ),
             ),
             stiffness=_channel_array(stiffness, count, "stiffness"),
             damping=_channel_array(damping, count, "damping"),
             rest_length=_channel_array(rest_length, count, "rest_length"),
         )
         self._transmission = ThreadlikeTransmission(
-            self._params.transmission, routing=routing
+            self._params.transmission, routing=routing, friction=friction
         )
         self.name = name
 
@@ -879,13 +807,14 @@ class ThreadlikeImpedance(PassiveElement):
         *,
         name: str,
         routing: ThreadlikeRouting,
+        friction: ThreadlikeFriction,
     ) -> ThreadlikeImpedance:
         return cls(
             routing=routing.with_params(params.transmission.routing),
             stiffness=params.stiffness,
             damping=params.damping,
             rest_length=params.rest_length,
-            friction=params.transmission.friction,
+            friction=friction.with_params(params.transmission.friction),
             name=name,
         )
 
@@ -909,18 +838,21 @@ class ThreadlikeImpedance(PassiveElement):
             params.transmission.routing
         )
         params.validate_for_update()
-        return self._from_params(params, name=self.name, routing=self.routing)
+        return self._from_params(
+            params,
+            name=self.name,
+            routing=self.routing,
+            friction=self._transmission.friction,
+        )
 
     def validate_structure_for_robot(self, robot) -> None:
         _validate_routing_structure_for_robot(self.routing, robot)
 
     def validate_values_for_robot(self, robot) -> None:
         _validate_routing_values_for_robot(self.routing, robot)
-        _validate_friction_for_robot(self.params.transmission.friction, robot)
+        validate_friction_for_robot(self.transmission.friction, robot)
 
     def _robot_value_validation_tree(self):
-        # See ThreadlikeActuator._robot_value_validation_tree: the coefficient
-        # belongs here so a traced value is detected by validate_for_robot.
         return (
             self.routing.params,
             self.params.transmission.friction,
@@ -939,26 +871,13 @@ class ThreadlikeImpedance(PassiveElement):
         return self._transmission.path_poses(robot, q, s)
 
     def _length_jacobian(self, robot, q: Array) -> Array:
-        """Return the exact kinematic length Jacobian ``dl/dq``.
-
-        Path length is pure geometry, so this is exact at any friction
-        coefficient. The friction-weighted force transmission is
-        :meth:`_transmission_matrix`.
-        """
         return self._transmission.kinematic_matrix(robot, q).T
 
     def _transmission_matrix(self, robot, q: Array) -> Array:
-        """Return the Capstan-weighted force transmission map of the paths."""
         return self._transmission.moment_matrix(robot, q)
 
     def elastic_force(self, robot, q: Array) -> Array:
-        """Return the conservative part of the passive path force.
-
-        This uses the exact kinematic Jacobian, so it stays exactly the
-        gradient of :meth:`elastic_energy` at any friction coefficient. The
-        remainder that friction stops from reaching the backbone is reported by
-        :meth:`nonconservative_force`.
-        """
+        """Return the conservative part of the passive path force."""
         lengths = self.path_lengths(robot, q)
         jacobian = self._length_jacobian(robot, q)
         return jacobian.T @ (
@@ -966,14 +885,7 @@ class ThreadlikeImpedance(PassiveElement):
         )
 
     def nonconservative_force(self, robot, q: Array) -> Array:
-        """Return the part of the spring force that friction makes non-potential.
-
-        Guide friction attenuates the spring force transmitted to the backbone
-        without changing the energy stored in the spring, so the transmitted
-        force is not the gradient of anything. Splitting it off keeps
-        :meth:`elastic_force` conservative and the host's ``elastic_energy``
-        custom JVP truthful. It is zero when the friction coefficient is zero.
-        """
+        """Return the part of the spring force that friction makes non-potential."""
         lengths = self.path_lengths(robot, q)
         transmission = self._transmission_matrix(robot, q)
         jacobian = self._length_jacobian(robot, q)
@@ -982,13 +894,6 @@ class ThreadlikeImpedance(PassiveElement):
         )
 
     def damping_matrix(self, robot, q: Array) -> Array:
-        """Return the passive damping contribution of the routed paths.
-
-        Both sides use the Capstan-weighted transmission map, which keeps the
-        result symmetric positive semi-definite and therefore dissipative at
-        any friction coefficient. Reading the rate through the exact Jacobian
-        instead would make the matrix indefinite.
-        """
         matrix = self._transmission_matrix(robot, q)
         return matrix @ (self.params.damping[:, None] * matrix.T)
 

--- a/src/soromox/actuation/threadlike.py
+++ b/src/soromox/actuation/threadlike.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import equinox as eqx
 from jax import Array, vmap
 from jax import numpy as jnp
 
 from soromox.systems.params import BaseSystemParams
+
+if TYPE_CHECKING:
+    from soromox.systems.soft_robot import SoftRobot
 
 from .core import (
     Actuator,
@@ -22,7 +25,7 @@ from .friction import (
     BaseThreadlikeFrictionParams,
     FrictionlessParams,
     ThreadlikeFriction,
-    validate_friction_for_robot,
+    _validate_friction_model,
 )
 
 ThreadlikeKind = Literal["tendon", "push_rod", "muscle", "pneumatic", "generic"]
@@ -32,7 +35,8 @@ def _validate_routing_structure_for_robot(routing: ThreadlikeRouting, robot) -> 
     """Validate routing topology and tracer-safe host compatibility."""
     required_hooks = (
         "_threadlike_path_lengths",
-        "_threadlike_moment_matrix",
+        "_threadlike_path_length_jacobian",
+        "_threadlike_actuation_matrix",
         "_threadlike_path_positions",
     )
     if not all(callable(getattr(robot, name, None)) for name in required_hooks):
@@ -84,6 +88,7 @@ def _validate_routing_values_for_robot(routing: ThreadlikeRouting, robot) -> Non
 
 
 def _index_tuple(value: int | tuple[int, ...] | list[int] | Array) -> tuple[int, ...]:
+    """Normalize one or more segment indices to an immutable tuple."""
     if isinstance(value, int):
         return (int(value),)
     if isinstance(value, tuple):
@@ -99,6 +104,7 @@ def _index_tuple(value: int | tuple[int, ...] | list[int] | Array) -> tuple[int,
 
 
 def _channel_array(value: Any, count: int, name: str) -> Array:
+    """Broadcast a scalar or validate one value per actuation channel."""
     array = jnp.asarray(value)
     if array.ndim == 0:
         array = jnp.full((count,), array)
@@ -108,6 +114,7 @@ def _channel_array(value: Any, count: int, name: str) -> Array:
 
 
 def _normalize_friction(friction: Any) -> ThreadlikeFriction | None:
+    """Validate an optional runtime threadlike-friction object."""
     if friction is not None and not isinstance(friction, ThreadlikeFriction):
         raise TypeError(
             "friction must be a ThreadlikeFriction instance, got "
@@ -138,17 +145,21 @@ class BaseThreadlikeRoutingParams(BaseSystemParams):
 
     @property
     def num_paths(self) -> int:
+        """Return the number of routed paths represented by the parameters."""
         raise NotImplementedError
 
     @property
     def start_segment_index_array(self) -> Array:
+        """Return the first active segment of every path as an integer array."""
         return jnp.asarray(self.start_segment_index, dtype=jnp.int32)
 
     @property
     def end_segment_index_array(self) -> Array:
+        """Return the last active segment of every path as an integer array."""
         return jnp.asarray(self.end_segment_index, dtype=jnp.int32)
 
     def validate_structure_for_robot(self, num_segments: int) -> None:
+        """Validate path spans against a host robot's segment count."""
         self.validate_structure()
         for start, end in zip(self.start_segment_index, self.end_segment_index):
             if start < 0 or start > end or end >= num_segments:
@@ -158,6 +169,7 @@ class BaseThreadlikeRoutingParams(BaseSystemParams):
                 )
 
     def assert_same_topology(self, other: BaseThreadlikeRoutingParams) -> None:
+        """Reject a replacement that changes routing type, count, or spans."""
         if type(other) is not type(self):
             raise ValueError("Changing routing type requires reconstruction.")
         if other.num_paths != self.num_paths:
@@ -200,22 +212,27 @@ class LinearThreadlikeRoutingParams(BaseThreadlikeRoutingParams):
     end_segment_index: tuple[int, ...] = eqx.field(static=True, converter=_index_tuple)
 
     def __check_init__(self) -> None:
+        """Validate newly constructed linear-routing parameters."""
         self.validate_for_update()
 
     @property
     def num_paths(self) -> int:
+        """Return the number of linear paths."""
         return int(jnp.asarray(self.intercept).shape[0])
 
     @property
     def start_segment_index_array(self) -> Array:
+        """Return the first active segment of every path as an integer array."""
         return jnp.asarray(self.start_segment_index, dtype=jnp.int32)
 
     @property
     def end_segment_index_array(self) -> Array:
+        """Return the last active segment of every path as an integer array."""
         return jnp.asarray(self.end_segment_index, dtype=jnp.int32)
 
     @classmethod
     def empty(cls) -> LinearThreadlikeRoutingParams:
+        """Construct an empty linear-routing parameter batch."""
         empty = jnp.zeros((0, 3), dtype=jnp.float64)
         return cls(
             intercept=empty,
@@ -225,6 +242,7 @@ class LinearThreadlikeRoutingParams(BaseThreadlikeRoutingParams):
         )
 
     def validate_structure(self) -> None:
+        """Validate linear-routing array shapes and segment-span topology."""
         intercept = jnp.asarray(self.intercept)
         slope = jnp.asarray(self.slope)
         if intercept.ndim != 2 or intercept.shape[1:] != (3,):
@@ -276,6 +294,21 @@ def linear_threadlike_routing_derivative(
     ) * jnp.asarray(s)
 
 
+def linear_threadlike_routing_second_derivative(
+    params: LinearThreadlikeRoutingParams, s: Array
+) -> Array:
+    """Return the zero second derivative of a linear routing offset.
+
+    Args:
+        params: Linear routing parameters for one path or a path batch.
+        s: Backbone coordinate, used only to preserve output dtype and tracing.
+
+    Returns:
+        Zeros with the same shape as ``params.slope``.
+    """
+    return jnp.zeros_like(jnp.asarray(params.slope)) * jnp.asarray(s)
+
+
 class ThreadlikeRouting(eqx.Module):
     """Runtime routing object for a batched fixed material-frame path family."""
 
@@ -284,6 +317,7 @@ class ThreadlikeRouting(eqx.Module):
     derivative_fn: Callable = eqx.field(
         static=True, default=linear_threadlike_routing_derivative
     )
+    second_derivative_fn: Callable | None = eqx.field(static=True, default=None)
 
     @classmethod
     def linear(
@@ -318,11 +352,22 @@ class ThreadlikeRouting(eqx.Module):
             start_segment_index=starts,
             end_segment_index=ends,
         )
-        return cls(params=params)
+        return cls(
+            params=params,
+            second_derivative_fn=linear_threadlike_routing_second_derivative,
+        )
 
     @property
     def num_paths(self) -> int:
+        """Return the number of paths represented by the routing family."""
         return self.params.num_paths
+
+    @property
+    def has_analytical_second_derivative(self) -> bool:
+        """Return whether the routing supplies the derivative needed for turn."""
+        return self.second_derivative_fn is not None or isinstance(
+            self.params, LinearThreadlikeRoutingParams
+        )
 
     def offset(self, path_params: BaseThreadlikeRoutingParams, s: Array) -> Array:
         """Evaluate one path's material-frame offset at ``s``."""
@@ -332,7 +377,33 @@ class ThreadlikeRouting(eqx.Module):
         """Evaluate one path's material-frame offset derivative at ``s``."""
         return self.derivative_fn(path_params, s)
 
+    def second_derivative(
+        self, path_params: BaseThreadlikeRoutingParams, s: Array
+    ) -> Array:
+        """Evaluate one path's material-frame offset second derivative.
+
+        Args:
+            path_params: Parameters of one routed path.
+            s: Physical backbone coordinate.
+
+        Returns:
+            The second arc-length derivative of the material offset.
+
+        Raises:
+            ValueError: If a custom routing does not provide an analytical
+                ``second_derivative_fn``.
+        """
+        if self.second_derivative_fn is None:
+            if isinstance(path_params, LinearThreadlikeRoutingParams):
+                return linear_threadlike_routing_second_derivative(path_params, s)
+            raise ValueError(
+                "custom threadlike routing requires second_derivative_fn for "
+                "friction calculations."
+            )
+        return self.second_derivative_fn(path_params, s)
+
     def with_params(self, params: BaseThreadlikeRoutingParams) -> ThreadlikeRouting:
+        """Return a routing with new values and unchanged runtime functions."""
         if not isinstance(params, BaseThreadlikeRoutingParams):
             raise TypeError("params must be BaseThreadlikeRoutingParams.")
         self.params.assert_same_topology(params)
@@ -341,16 +412,16 @@ class ThreadlikeRouting(eqx.Module):
             params=params,
             offset_fn=self.offset_fn,
             derivative_fn=self.derivative_fn,
+            second_derivative_fn=self.second_derivative_fn,
         )
 
     def update_params(self, **updates: Any) -> ThreadlikeRouting:
+        """Return a routing with selected parameter leaves replaced."""
         return self.with_params(self.params.replace(**updates))
 
 
 class ThreadlikeTransmissionParams(BaseSystemParams):
-    """Routing parameters, constant work-coordinate scale per path, and
-    friction paramters.
-    """
+    """Routing, work-coordinate scale, and friction parameters per path."""
 
     routing: BaseThreadlikeRoutingParams
     coordinate_scale: Array
@@ -359,6 +430,7 @@ class ThreadlikeTransmissionParams(BaseSystemParams):
     )
 
     def __check_init__(self) -> None:
+        """Validate newly constructed transmission parameters."""
         self.validate_for_update()
 
     def validate_structure(self) -> None:
@@ -385,7 +457,7 @@ class ThreadlikeTransmissionParams(BaseSystemParams):
 
 
 class ThreadlikeTransmission(Transmission):
-    """Transmission whose coordinates are scaled routed-path lengths."""
+    """Map scaled path lengths and anchor efforts to robot coordinates."""
 
     params: ThreadlikeTransmissionParams
     routing: ThreadlikeRouting
@@ -398,6 +470,15 @@ class ThreadlikeTransmission(Transmission):
         routing: ThreadlikeRouting | None = None,
         friction: ThreadlikeFriction | None = None,
     ) -> None:
+        """Construct a runtime transmission from matching parameter objects.
+
+        Args:
+            params: Nested routing, coordinate-scale, and friction parameters.
+            routing: Runtime routing functions. Linear routing is reconstructed
+                automatically when this argument is omitted.
+            friction: Runtime effort-ratio law. Frictionless behavior is
+                reconstructed automatically when this argument is omitted.
+        """
         if not isinstance(params, ThreadlikeTransmissionParams):
             raise TypeError("params must be ThreadlikeTransmissionParams.")
         params.validate_for_update()
@@ -425,35 +506,74 @@ class ThreadlikeTransmission(Transmission):
 
     @property
     def num_channels(self) -> int:
+        """Return the number of independently routed paths."""
         return self.routing.num_paths
 
-    def coordinates(self, robot, q: Array) -> Array:
+    def coordinates(self, robot: SoftRobot, q: Array) -> Array:
+        """Return scaled routed-path lengths.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized configuration.
+
+        Returns:
+            One work-conjugate coordinate per path.
+        """
         return self.params.coordinate_scale * robot._threadlike_path_lengths(
             q, self.routing
         )
 
-    def moment_matrix(self, robot, q: Array) -> Array:
-        raw_matrix = robot._threadlike_moment_matrix(
+    def coordinate_jacobian(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the Jacobian of scaled path coordinates.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized configuration.
+
+        Returns:
+            Matrix with shape ``(num_channels, robot.num_velocities)``.
+        """
+        raw_jacobian = robot._threadlike_path_length_jacobian(q, self.routing)
+        return self.params.coordinate_scale[:, None] * raw_jacobian
+
+    def actuation_matrix(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the anchor-effort to generalized-force map.
+
+        Friction weights each local contribution by its surviving effort ratio,
+        so this matrix need not equal :meth:`coordinate_jacobian` transposed.
+
+        Args:
+            robot: Continuum robot hosting the routing.
+            q: Generalized configuration.
+
+        Returns:
+            Matrix with shape ``(robot.num_velocities, num_channels)``.
+        """
+        raw_matrix = robot._threadlike_actuation_matrix(
             q, self.routing, friction=self.friction
         )
         return raw_matrix * self.params.coordinate_scale[None, :]
 
-    def kinematic_matrix(self, robot, q: Array) -> Array:
-        """Return the frictionless length gradient ``(dl/dq).T`` of the paths."""
-        return robot._threadlike_moment_matrix(q, self.routing)
-
-    def path_lengths(self, robot, q: Array) -> Array:
+    def path_lengths(self, robot: SoftRobot, q: Array) -> Array:
+        """Return unscaled physical routed-path lengths."""
         return robot._threadlike_path_lengths(q, self.routing)
 
-    def path_velocities(self, robot, q: Array, qd: Array) -> Array:
-        return self.kinematic_matrix(robot, q).T @ qd
+    def path_length_jacobian(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the Jacobian of unscaled physical path lengths."""
+        return robot._threadlike_path_length_jacobian(q, self.routing)
 
-    def path_poses(self, robot, q: Array, s: Array) -> Array:
+    def path_velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
+        """Return unscaled physical path-length rates."""
+        return self.path_length_jacobian(robot, q) @ qd
+
+    def path_poses(self, robot: SoftRobot, q: Array, s: Array) -> Array:
+        """Return routed-path positions at backbone coordinate ``s``."""
         return robot._threadlike_path_positions(q, s, self.routing)
 
     def with_params(
         self, params: ThreadlikeTransmissionParams
     ) -> ThreadlikeTransmission:
+        """Return a copy carrying replacement transmission parameter leaves."""
         if not isinstance(params, ThreadlikeTransmissionParams):
             raise TypeError("params must be ThreadlikeTransmissionParams.")
         self.params.routing.assert_same_topology(params.routing)
@@ -463,6 +583,7 @@ class ThreadlikeTransmission(Transmission):
         )
 
     def update_params(self, **updates: Any) -> ThreadlikeTransmission:
+        """Return a copy with replaced transmission parameter leaves."""
         return self.with_params(self.params.replace(**updates))
 
 
@@ -474,6 +595,7 @@ class ThreadlikeActuatorParams(BaseSystemParams):
     upper_bounds: Array
 
     def __check_init__(self) -> None:
+        """Validate newly constructed threadlike-actuator parameters."""
         self.validate_for_update()
 
     def validate_structure(self) -> None:
@@ -513,6 +635,11 @@ class ThreadlikeActuator(Actuator):
         name: str,
         kind: ThreadlikeKind,
     ) -> None:
+        """Construct a vectorized threadlike actuator.
+
+        Prefer the modality-specific constructors such as :meth:`tendons` or
+        :meth:`push_rods` when their effort sign conventions apply.
+        """
         params.validate_for_update()
         count = params.transmission.routing.num_paths
         if len(labels) != count:
@@ -536,6 +663,7 @@ class ThreadlikeActuator(Actuator):
     def _normalize_routing(
         routings: ThreadlikeRouting | BaseThreadlikeRoutingParams,
     ) -> ThreadlikeRouting:
+        """Normalize routing parameters to their runtime routing object."""
         if isinstance(routings, ThreadlikeRouting):
             return routings
         if isinstance(routings, LinearThreadlikeRoutingParams):
@@ -564,6 +692,7 @@ class ThreadlikeActuator(Actuator):
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
     ) -> ThreadlikeActuator:
+        """Construct a modality preset with a prescribed coordinate scale."""
         routing = cls._normalize_routing(routings)
         friction = _normalize_friction(friction)
         count = routing.num_paths
@@ -600,6 +729,7 @@ class ThreadlikeActuator(Actuator):
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
     ) -> ThreadlikeActuator:
+        """Construct tension-only tendons with shortening-positive coordinates."""
         routing = cls._normalize_routing(routings)
         return cls._preset(
             routing,
@@ -620,6 +750,7 @@ class ThreadlikeActuator(Actuator):
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
     ) -> ThreadlikeActuator:
+        """Construct compression push rods with lengthening-positive coordinates."""
         routing = cls._normalize_routing(routings)
         return cls._preset(
             routing,
@@ -640,6 +771,7 @@ class ThreadlikeActuator(Actuator):
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
     ) -> ThreadlikeActuator:
+        """Construct tensile muscles with shortening-positive coordinates."""
         routing = cls._normalize_routing(routings)
         return cls._preset(
             routing,
@@ -661,6 +793,7 @@ class ThreadlikeActuator(Actuator):
         labels: tuple[str, ...] | None = None,
         friction: ThreadlikeFriction | None = None,
     ) -> ThreadlikeActuator:
+        """Construct pressure chambers scaled by their effective areas."""
         routing = cls._normalize_routing(routings)
         return cls._preset(
             routing,
@@ -677,21 +810,26 @@ class ThreadlikeActuator(Actuator):
 
     @property
     def params(self) -> ThreadlikeActuatorParams:
+        """Return the actuator parameter tree."""
         return self._params
 
     @property
     def transmission(self) -> ThreadlikeTransmission:
+        """Return the threadlike transmission."""
         return self._transmission
 
     @property
     def effort_model(self) -> DirectEffort:
+        """Return the direct commanded-effort model."""
         return self._effort_model
 
     @property
     def metadata(self) -> ActuatorMetadata:
+        """Return channel labels, units, kind, and bounds."""
         return self._metadata
 
     def with_params(self, params: BaseSystemParams) -> ThreadlikeActuator:
+        """Return a copy carrying replacement actuator parameter leaves."""
         if not isinstance(params, ThreadlikeActuatorParams):
             raise TypeError("params must be ThreadlikeActuatorParams.")
         self.params.transmission.routing.assert_same_topology(
@@ -708,49 +846,51 @@ class ThreadlikeActuator(Actuator):
             kind=self.kind,
         )
 
-    def validate_structure_for_robot(self, robot) -> None:
+    def validate_structure_for_robot(self, robot: SoftRobot) -> None:
+        """Validate routing and friction structure for the host robot."""
         _validate_routing_structure_for_robot(self.transmission.routing, robot)
+        _validate_friction_model(self.transmission.friction, self.transmission.routing)
 
-    def validate_values_for_robot(self, robot) -> None:
+    def validate_values_for_robot(self, robot: SoftRobot) -> None:
+        """Validate concrete routing and friction values for the host robot."""
         _validate_routing_values_for_robot(self.transmission.routing, robot)
-        validate_friction_for_robot(self.transmission.friction, robot)
 
     def _robot_value_validation_tree(self):
+        """Return routing and friction leaves for robot-specific validation."""
         return (
             self.transmission.routing.params,
             self.params.transmission.friction,
         )
 
-    def path_lengths(self, robot, q: Array) -> Array:
+    def path_lengths(self, robot: SoftRobot, q: Array) -> Array:
+        """Return physical routed-path lengths."""
         return self.transmission.path_lengths(robot, q)
 
-    def path_velocities(self, robot, q: Array, qd: Array) -> Array:
+    def path_velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
+        """Return physical routed-path length rates."""
         return self.transmission.path_velocities(robot, q, qd)
 
-    def path_poses(self, robot, q: Array, s: Array) -> Array:
+    def path_poses(self, robot: SoftRobot, q: Array, s: Array) -> Array:
+        """Return routed-path positions at backbone coordinate ``s``."""
         return self.transmission.path_poses(robot, q, s)
 
 
 class ThreadlikeImpedanceParams(BaseSystemParams):
     """Spring-damper parameters for passive routed paths."""
 
-    transmission: ThreadlikeTransmissionParams
+    routing: BaseThreadlikeRoutingParams
     stiffness: Array
     damping: Array
     rest_length: Array
 
     def __check_init__(self) -> None:
+        """Validate newly constructed impedance parameters."""
         self.validate_for_update()
-
-    @property
-    def routing(self) -> BaseThreadlikeRoutingParams:
-        """Routing parameters of the passive paths."""
-        return self.transmission.routing
 
     def validate_structure(self) -> None:
         """Validate threadlike impedance parameter structure."""
-        self.transmission.validate_structure()
-        count = self.transmission.routing.num_paths
+        self.routing.validate_structure()
+        count = self.routing.num_paths
         for name in ("stiffness", "damping", "rest_length"):
             value = jnp.asarray(getattr(self, name))
             if value.shape != (count,):
@@ -759,15 +899,15 @@ class ThreadlikeImpedanceParams(BaseSystemParams):
                 )
 
     def validate_values(self) -> None:
-        """Validate eager nested threadlike transmission values."""
-        self.transmission.validate_values()
+        """Validate eager nested threadlike routing values."""
+        self.routing.validate_values()
 
 
 class ThreadlikeImpedance(PassiveElement):
     """Passive spring-damper mechanics along fixed threadlike paths."""
 
     _params: ThreadlikeImpedanceParams
-    _transmission: ThreadlikeTransmission
+    routing: ThreadlikeRouting
     name: str = eqx.field(static=True)
 
     def __init__(
@@ -777,27 +917,26 @@ class ThreadlikeImpedance(PassiveElement):
         stiffness: Array,
         damping: Array,
         rest_length: Array,
-        friction: ThreadlikeFriction | None = None,
         name: str = "passive_threadlike",
     ) -> None:
+        """Construct passive spring-damper paths.
+
+        Args:
+            routing: Fixed material-frame routing geometry.
+            stiffness: One axial stiffness per path.
+            damping: One axial damping coefficient per path.
+            rest_length: One undeformed length per path.
+            name: Human-readable passive-element name.
+        """
         routing = ThreadlikeActuator._normalize_routing(routing)
-        friction = _normalize_friction(friction)
         count = routing.num_paths
         self._params = ThreadlikeImpedanceParams(
-            transmission=ThreadlikeTransmissionParams(
-                routing=routing.params,
-                coordinate_scale=jnp.ones((count,)),
-                friction=(
-                    friction.params if friction is not None else FrictionlessParams()
-                ),
-            ),
+            routing=routing.params,
             stiffness=_channel_array(stiffness, count, "stiffness"),
             damping=_channel_array(damping, count, "damping"),
             rest_length=_channel_array(rest_length, count, "rest_length"),
         )
-        self._transmission = ThreadlikeTransmission(
-            self._params.transmission, routing=routing, friction=friction
-        )
+        self.routing = routing
         self.name = name
 
     @classmethod
@@ -807,97 +946,72 @@ class ThreadlikeImpedance(PassiveElement):
         *,
         name: str,
         routing: ThreadlikeRouting,
-        friction: ThreadlikeFriction,
     ) -> ThreadlikeImpedance:
+        """Reconstruct an impedance while preserving its runtime routing law."""
         return cls(
-            routing=routing.with_params(params.transmission.routing),
+            routing=routing.with_params(params.routing),
             stiffness=params.stiffness,
             damping=params.damping,
             rest_length=params.rest_length,
-            friction=friction.with_params(params.transmission.friction),
             name=name,
         )
 
     @property
     def params(self) -> ThreadlikeImpedanceParams:
+        """Return the passive element parameters."""
         return self._params
 
-    @property
-    def transmission(self) -> ThreadlikeTransmission:
-        return self._transmission
-
-    @property
-    def routing(self) -> ThreadlikeRouting:
-        """Runtime routing object of the passive paths."""
-        return self._transmission.routing
-
     def with_params(self, params: BaseSystemParams) -> ThreadlikeImpedance:
+        """Return a copy carrying replacement impedance parameters."""
         if not isinstance(params, ThreadlikeImpedanceParams):
             raise TypeError("params must be ThreadlikeImpedanceParams.")
-        self.params.transmission.routing.assert_same_topology(
-            params.transmission.routing
-        )
+        self.params.routing.assert_same_topology(params.routing)
         params.validate_for_update()
-        return self._from_params(
-            params,
-            name=self.name,
-            routing=self.routing,
-            friction=self._transmission.friction,
-        )
+        return self._from_params(params, name=self.name, routing=self.routing)
 
-    def validate_structure_for_robot(self, robot) -> None:
+    def validate_structure_for_robot(self, robot: SoftRobot) -> None:
+        """Validate routing structure for the host robot."""
         _validate_routing_structure_for_robot(self.routing, robot)
 
-    def validate_values_for_robot(self, robot) -> None:
+    def validate_values_for_robot(self, robot: SoftRobot) -> None:
+        """Validate concrete routing values for the host robot."""
         _validate_routing_values_for_robot(self.routing, robot)
-        validate_friction_for_robot(self.transmission.friction, robot)
 
     def _robot_value_validation_tree(self):
-        return (
-            self.routing.params,
-            self.params.transmission.friction,
-        )
+        """Return routing leaves used by robot-specific eager validation."""
+        return self.routing.params
 
-    def path_lengths(self, robot, q: Array) -> Array:
+    def path_lengths(self, robot: SoftRobot, q: Array) -> Array:
         """Return the raw lengths of the passive routed paths."""
-        return self._transmission.path_lengths(robot, q)
+        return robot._threadlike_path_lengths(q, self.routing)
 
-    def path_velocities(self, robot, q: Array, qd: Array) -> Array:
+    def path_length_jacobian(self, robot: SoftRobot, q: Array) -> Array:
+        """Return the Jacobian of passive physical path lengths."""
+        return robot._threadlike_path_length_jacobian(q, self.routing)
+
+    def path_velocities(self, robot: SoftRobot, q: Array, qd: Array) -> Array:
         """Return the raw length rates of the passive routed paths."""
-        return self._transmission.path_velocities(robot, q, qd)
+        return self.path_length_jacobian(robot, q) @ qd
 
-    def path_poses(self, robot, q: Array, s: Array) -> Array:
+    def path_poses(self, robot: SoftRobot, q: Array, s: Array) -> Array:
         """Return passive routed-path positions at backbone coordinate ``s``."""
-        return self._transmission.path_poses(robot, q, s)
+        return robot._threadlike_path_positions(q, s, self.routing)
 
-    def _length_jacobian(self, robot, q: Array) -> Array:
-        return self._transmission.kinematic_matrix(robot, q).T
-
-    def _transmission_matrix(self, robot, q: Array) -> Array:
-        return self._transmission.moment_matrix(robot, q)
-
-    def elastic_force(self, robot, q: Array) -> Array:
-        """Return the conservative part of the passive path force."""
+    def elastic_force(self, robot: SoftRobot, q: Array) -> Array:
+        """Return conservative generalized spring force from the paths."""
         lengths = self.path_lengths(robot, q)
-        jacobian = self._length_jacobian(robot, q)
+        jacobian = self.path_length_jacobian(robot, q)
         return jacobian.T @ (
             self.params.stiffness * (lengths - self.params.rest_length)
         )
 
-    def nonconservative_force(self, robot, q: Array) -> Array:
-        """Return the part of the spring force that friction makes non-potential."""
-        lengths = self.path_lengths(robot, q)
-        transmission = self._transmission_matrix(robot, q)
-        jacobian = self._length_jacobian(robot, q)
-        return (transmission - jacobian.T) @ (
-            self.params.stiffness * (lengths - self.params.rest_length)
-        )
+    def damping_matrix(self, robot: SoftRobot, q: Array) -> Array:
+        """Return generalized viscous damping from the routed paths."""
+        jacobian = self.path_length_jacobian(robot, q)
+        return jacobian.T @ (self.params.damping[:, None] * jacobian)
 
-    def damping_matrix(self, robot, q: Array) -> Array:
-        matrix = self._transmission_matrix(robot, q)
-        return matrix @ (self.params.damping[:, None] * matrix.T)
-
-    def elastic_energy(self, robot, q: Array) -> Array:
+    def elastic_energy(self, robot: SoftRobot, q: Array) -> Array:
+        """Return elastic energy stored in the routed springs."""
         delta = self.path_lengths(robot, q) - self.params.rest_length
         return 0.5 * jnp.sum(self.params.stiffness * delta**2)
 
@@ -914,4 +1028,5 @@ __all__ = [
     "ThreadlikeTransmissionParams",
     "linear_threadlike_routing",
     "linear_threadlike_routing_derivative",
+    "linear_threadlike_routing_second_derivative",
 ]

--- a/src/soromox/coordinate_transformations/actuation_space.py
+++ b/src/soromox/coordinate_transformations/actuation_space.py
@@ -25,8 +25,8 @@ class ActuationSpaceDynamics(eqx.Module):
     The actuation space dynamics follow the general formulation:
         M_y @ ydd + eta_y @ yd + h_y = A_y @ e
 
-    with ``A_y = J(q)^(-T) @ A_q(q)``. For an ideal transmission this reduces
-    to ``A_y = [[I], [0]]`` and the right-hand side is ``[e, 0]``.
+    with ``A_y = J_y(q)^(-T) @ A_q(q)``. For an ideal transmission this
+    reduces to ``A_y = [[I], [0]]`` and the right-hand side is ``[e, 0]``.
 
     where:
         - M_y: Actuation space inertia matrix
@@ -34,6 +34,8 @@ class ActuationSpaceDynamics(eqx.Module):
         - h_y: Sum of actuation space forces (gravitational, elastic, damping)
         - e: Work-conjugate actuator efforts
         - A_y: Effort-to-generalized-force map in actuation coordinates
+        - J_y: Jacobian mapping configuration velocities to actuation-space
+          coordinate velocities
         - y: Actuation space coordinates = [actuated_coords, unactuated_coords]
 
     The actuated coordinates are obtained from a (generally nonlinear) map from
@@ -302,13 +304,14 @@ class ActuationSpaceDynamics(eqx.Module):
         Compute the full Jacobian from configuration space to actuation space.
 
         The Jacobian is constructed by stacking the actuated and unactuated Jacobians:
-            J = [[J_actuated], [J_unactuated]]
+            J_y = [[J_actuated], [J_unactuated]]
 
         Args:
             q: Generalized coordinates of shape (num_dofs,).
 
         Returns:
-            J: Full Jacobian of shape (num_dofs, num_dofs).
+            J_y: Full actuation-space coordinate Jacobian of shape
+                (num_dofs, num_dofs).
         """
         J_actuated = self.jacobian_actuated(q)
         J_unactuated = self.jacobian_unactuated(q)
@@ -370,10 +373,10 @@ class ActuationSpaceDynamics(eqx.Module):
         Compute the actuation space inertia matrix.
 
         The actuation space inertia matrix is defined as:
-            M_y = J^{-T} @ M @ J^{-1}
+            M_y = J_y^{-T} @ M @ J_y^{-1}
 
-        where M is the configuration space inertia matrix and J is the Jacobian
-        from configuration to actuation space.
+        where M is the configuration space inertia matrix and J_y is the
+        Jacobian from configuration to actuation space.
 
         Args:
             q: Generalized coordinates of shape (num_dofs,).
@@ -395,11 +398,11 @@ class ActuationSpaceDynamics(eqx.Module):
         Compute the actuation space Coriolis/centrifugal matrix.
 
         The actuation space Coriolis matrix is defined as:
-            eta_y = M_y @ (J @ M^{-1} @ C) @ J^{-1}
+            eta_y = M_y @ (J_y @ M^{-1} @ C) @ J_y^{-1}
 
         where:
             - M_y is the actuation space inertia matrix
-            - J is the Jacobian from configuration to actuation space
+            - J_y is the Jacobian from configuration to actuation space
             - M is the configuration space inertia matrix
             - C is the configuration space Coriolis matrix
 
@@ -451,7 +454,7 @@ class ActuationSpaceDynamics(eqx.Module):
         Compute the actuation space damping matrix.
 
         The actuation space damping matrix is defined as:
-            D_y = J^{-T} @ D @ J^{-1}
+            D_y = J_y^{-T} @ D @ J_y^{-1}
 
         where D is the configuration space damping matrix.
 
@@ -479,7 +482,7 @@ class ActuationSpaceDynamics(eqx.Module):
         Compute the actuation space damping force.
 
         The actuation space damping force is defined as:
-            tau_d_y = D_y @ yd = J^{-T} @ D @ qd
+            tau_d_y = D_y @ yd = J_y^{-T} @ D @ qd
 
         Args:
             q: Generalized coordinates of shape (num_dofs,).
@@ -499,7 +502,7 @@ class ActuationSpaceDynamics(eqx.Module):
         Compute the actuation space elastic force.
 
         The actuation space elastic force is defined as:
-            tau_el_y = J^{-T} @ tau_el
+            tau_el_y = J_y^{-T} @ tau_el
 
         where tau_el is the configuration space elastic force.
 
@@ -520,7 +523,7 @@ class ActuationSpaceDynamics(eqx.Module):
         Compute the actuation space gravitational force.
 
         The actuation space gravitational force is defined as:
-            G_y = J^{-T} @ G
+            G_y = J_y^{-T} @ G
 
         where G is the configuration space gravitational force.
 
@@ -591,7 +594,7 @@ class ActuationSpaceDynamics(eqx.Module):
         Compute the actuation matrix in actuation space.
 
         The generalized-force covector transforms as
-        ``A_y = J(q)^(-T) @ A_q(q)``. This reduces to ``[[I], [0]]`` for an
+        ``A_y = J_y(q)^(-T) @ A_q(q)``. This reduces to ``[[I], [0]]`` for an
         ideal transmission whose force map is the transpose of its coordinate
         Jacobian, while preserving explicit losses when those maps differ.
 
@@ -623,11 +626,11 @@ class ActuationSpaceDynamics(eqx.Module):
 
         The transformation is:
             y = [actuated_coordinates(q), unactuated_coordinates(q)]
-            yd = J(q) @ qd
-            ydd = J(q) @ qdd + Jd(q, qd) @ qd
+            yd = J_y(q) @ qd
+            ydd = J_y(q) @ qdd + Jd_y(q, qd) @ qd
 
-        where J is the Jacobian of the coordinate transformation and Jd is its
-        time derivative.
+        where J_y is the Jacobian of the coordinate transformation and Jd_y is
+        its time derivative.
 
         Args:
             reference_trajectory: Reference trajectory in configuration space,

--- a/src/soromox/coordinate_transformations/actuation_space.py
+++ b/src/soromox/coordinate_transformations/actuation_space.py
@@ -20,23 +20,31 @@ class ActuationSpaceDynamics(eqx.Module):
     This class transforms the configuration-space dynamics of a soft robot to actuation
     space using the Jacobian of the coordinate transformation. The actuation space is
     defined by work-conjugate actuator coordinates and unactuated coordinates
-    that span the null space of the actuation matrix.
+    that complete the actuator-coordinate Jacobian.
 
-    The actuation space dynamics follow the formulation:
-        M_y @ ydd + eta_y @ yd + h_y = [tau, 0_{n-m}]
+    The actuation space dynamics follow the general formulation:
+        M_y @ ydd + eta_y @ yd + h_y = A_y @ e
+
+    with ``A_y = J(q)^(-T) @ A_q(q)``. For an ideal transmission this reduces
+    to ``A_y = [[I], [0]]`` and the right-hand side is ``[e, 0]``.
 
     where:
         - M_y: Actuation space inertia matrix
         - eta_y: Actuation space Coriolis/centrifugal matrix
         - h_y: Sum of actuation space forces (gravitational, elastic, damping)
-        - tau: Applied actuator forces (only on the first num_actuators coordinates)
+        - e: Work-conjugate actuator efforts
+        - A_y: Effort-to-generalized-force map in actuation coordinates
         - y: Actuation space coordinates = [actuated_coords, unactuated_coords]
 
     The actuated coordinates are obtained from a (generally nonlinear) map from
     configuration space. They are accessed through the robot's
     `actuator_coordinates` method. The Jacobian of this
-    map is the transpose of the actuation matrix:
-        J_actuated = dy_a/dq = A_at^T
+    map is provided explicitly by the robot:
+        J_actuated = dy_a/dq
+
+    For an ideal transmission, ``J_actuated = A_at^T``. Losses such as
+    threadlike friction can make the generalized-force map ``A_at`` differ
+    from the transpose of the purely kinematic coordinate Jacobian.
 
     The unactuated coordinates can be specified by the user or computed via basis
     expansion using QR decomposition to find a set of linearly independent coordinates.
@@ -54,9 +62,9 @@ class ActuationSpaceDynamics(eqx.Module):
         n_unactuated: Number of unactuated coordinates (equals num_dofs - num_actuators).
 
     Notes:
-        The new actuation matrix in actuation space is:
-            A_y = [[I_{num_actuators}], [0_{num_dofs - num_actuators, num_actuators}]]
-        where only the first num_actuators coordinates are directly actuated.
+        For ideal transmissions, the actuation matrix in actuation space is
+        ``[[I], [0]]``. Lossy transmissions are transformed explicitly and can
+        produce a different matrix.
 
         The robot must implement `actuator_coordinates(q)` and return one
         independent work coordinate per actuator channel.
@@ -97,7 +105,8 @@ class ActuationSpaceDynamics(eqx.Module):
         Args:
             robot: A soft robot implementing the SoftRobot interface.
                 Must have `num_actuators`, `num_internal_dofs`,
-                `actuation_matrix`, and `actuator_coordinates`
+                `actuation_matrix`, `actuator_coordinates`, and
+                `actuator_coordinate_jacobian`
                 attributes/methods.
             H_unactuated: Optional matrix of shape (num_dofs - num_actuators, num_dofs) that
                 maps configurations to unactuated coordinates. If None, the unactuated
@@ -123,11 +132,11 @@ class ActuationSpaceDynamics(eqx.Module):
                 f"num_actuators ({num_actuators}) cannot exceed num_dofs ({num_dofs})"
             )
 
-        # Get the actuation matrix at a reference configuration for basis expansion
-        # A_at has shape (num_dofs, num_actuators)
+        # Use the coordinate differential, rather than a potentially lossy
+        # effort map, to complete the coordinate basis.
         q_ref = jnp.zeros(num_dofs)
-        A_at = self.fixed_base_robot.actuation_matrix(q_ref)
-        rank = int(jnp.linalg.matrix_rank(A_at))
+        coordinate_jacobian = self.fixed_base_robot.actuator_coordinate_jacobian(q_ref)
+        rank = int(jnp.linalg.matrix_rank(coordinate_jacobian))
         if rank != num_actuators:
             raise ValueError(
                 "ActuationSpaceDynamics requires independent actuator coordinates "
@@ -138,7 +147,9 @@ class ActuationSpaceDynamics(eqx.Module):
         # Compute or validate unactuated coordinate mapping
         if H_unactuated is None:
             # Compute via basis expansion using QR decomposition
-            H_unactuated = self._compute_unactuated_coordinates_mapping(A_at)
+            H_unactuated = self._compute_unactuated_coordinates_mapping(
+                coordinate_jacobian.T
+            )
         else:
             H_unactuated = jnp.asarray(H_unactuated)
             expected_shape = (n_unactuated, num_dofs)
@@ -257,10 +268,9 @@ class ActuationSpaceDynamics(eqx.Module):
         """
         Compute the Jacobian of the map from configuration space to actuated coordinates.
 
-        For tendon-actuated robots, this is the transpose of the actuation matrix:
-            J_actuated = A_at^T = d(actuated_coordinates)/dq
-
-        where the actuation matrix A_at maps tendon forces to generalized forces.
+        This is the purely kinematic differential
+        ``d(actuated_coordinates)/dq``. It remains independent of losses in the
+        effort-to-generalized-force map.
 
         Args:
             q: Generalized coordinates of shape (num_dofs,).
@@ -268,8 +278,7 @@ class ActuationSpaceDynamics(eqx.Module):
         Returns:
             J_a: Jacobian of shape (n_actuated, num_dofs).
         """
-        A_at = self.fixed_base_robot.actuation_matrix(q)
-        return A_at.T
+        return self.fixed_base_robot.actuator_coordinate_jacobian(q)
 
     @eqx.filter_jit
     def jacobian_unactuated(self, q: Array) -> Array:
@@ -581,12 +590,10 @@ class ActuationSpaceDynamics(eqx.Module):
         """
         Compute the actuation matrix in actuation space.
 
-        In actuation space, the actuation matrix has a special structure:
-            A_y = [[I_{num_actuators}], [0_{n_unactuated, num_actuators}]]
-
-        This means that actuator forces directly affect only the first num_actuators
-        coordinates (the actuated ones), while the unactuated coordinates receive
-        no direct actuation input.
+        The generalized-force covector transforms as
+        ``A_y = J(q)^(-T) @ A_q(q)``. This reduces to ``[[I], [0]]`` for an
+        ideal transmission whose force map is the transpose of its coordinate
+        Jacobian, while preserving explicit losses when those maps differ.
 
         Args:
             q: Generalized coordinates of shape (num_dofs,) (unused, for API consistency).
@@ -594,18 +601,7 @@ class ActuationSpaceDynamics(eqx.Module):
         Returns:
             A_y: Actuation matrix in actuation space of shape (num_dofs, num_actuators).
         """
-        num_dofs = self.fixed_base_robot.num_internal_dofs
-        num_actuators = self.fixed_base_robot.num_actuators
-
-        # Build the actuation matrix: [[I], [0]]
-        A_y = jnp.vstack(
-            [
-                jnp.eye(num_actuators),
-                jnp.zeros((num_dofs - num_actuators, num_actuators)),
-            ]
-        )
-
-        return A_y
+        return self.jacobian_inverse(q).T @ self.fixed_base_robot.actuation_matrix(q)
 
     # =========================================================================
     # Reference trajectory conversion

--- a/src/soromox/execution/dispatch.py
+++ b/src/soromox/execution/dispatch.py
@@ -122,7 +122,7 @@ def dispatch_actuation_matrix(
     if configured == "warp" and not eligible:
         raise NotImplementedError(
             f"Warp {capabilities.family_name} actuation_matrix requires only "
-            "built-in linear ThreadlikeActuator transmissions."
+            "built-in frictionless linear ThreadlikeActuator transmissions."
         )
     if configured == "warp" and eligible and not capabilities.matrix_enabled:
         raise NotImplementedError(
@@ -174,7 +174,8 @@ def dispatch_actuation_force(
     if configured == "warp" and not eligible:
         raise NotImplementedError(
             f"Warp {capabilities.family_name} actuation_force requires only "
-            "built-in linear ThreadlikeActuator transmissions with DirectEffort."
+            "built-in frictionless linear ThreadlikeActuator transmissions with "
+            "DirectEffort and no non-conservative passive forces."
         )
     if configured == "warp" and eligible and not capabilities.force_enabled:
         raise NotImplementedError(

--- a/src/soromox/execution/dispatch.py
+++ b/src/soromox/execution/dispatch.py
@@ -175,7 +175,7 @@ def dispatch_actuation_force(
         raise NotImplementedError(
             f"Warp {capabilities.family_name} actuation_force requires only "
             "built-in frictionless linear ThreadlikeActuator transmissions with "
-            "DirectEffort and no non-conservative passive forces."
+            "DirectEffort."
         )
     if configured == "warp" and eligible and not capabilities.force_enabled:
         raise NotImplementedError(

--- a/src/soromox/execution/types.py
+++ b/src/soromox/execution/types.py
@@ -294,7 +294,7 @@ class ActuationModel(Protocol):
     num_actuators: int
 
     def _actuation_matrix(self, q: Array) -> Array:
-        """Return the differentiable scalar JAX transmission matrix."""
+        """Return the differentiable scalar JAX actuation matrix."""
 
         ...
 
@@ -308,7 +308,7 @@ class ActuationMatrixEvaluator(Protocol):
     """Scalar matrix evaluator backed by one canonical batched executor."""
 
     def __call__(self, model: ActuationModel, q: Array) -> Array:
-        """Return one transmission matrix with shape ``(D, A)``."""
+        """Return one actuation matrix with shape ``(D, A)``."""
 
         ...
 

--- a/src/soromox/execution/warp/actuation/threadlike.py
+++ b/src/soromox/execution/warp/actuation/threadlike.py
@@ -6,7 +6,7 @@ import equinox as eqx
 import jax.numpy as jnp
 from jax import Array
 
-from soromox.actuation.core import DirectEffort
+from soromox.actuation.core import DirectEffort, PassiveElement
 from soromox.actuation.threadlike import (
     LinearThreadlikeRoutingParams,
     ThreadlikeActuator,
@@ -68,7 +68,7 @@ class LinearThreadlikeActuationData(eqx.Module):
 
 
 def _uses_builtin_linear_routing(actuator) -> bool:
-    """Return whether one actuator has the exact built-in linear runtime."""
+    """Return whether one actuator has the exact frictionless linear runtime."""
 
     if not isinstance(actuator, ThreadlikeActuator):
         return False
@@ -77,21 +77,41 @@ def _uses_builtin_linear_routing(actuator) -> bool:
         isinstance(routing.params, LinearThreadlikeRoutingParams)
         and routing.offset_fn is linear_threadlike_routing
         and routing.derivative_fn is linear_threadlike_routing_derivative
+        and actuator.transmission.friction.is_frictionless
+    )
+
+
+def _has_nonconservative_passive_force(element) -> bool:
+    """Return whether a passive element contributes outside an elastic potential."""
+
+    transmission = getattr(element, "transmission", None)
+    friction = getattr(transmission, "friction", None)
+    if friction is not None:
+        return not friction.is_frictionless
+    return (
+        type(element).nonconservative_force is not PassiveElement.nonconservative_force
     )
 
 
 def supports_linear_threadlike_matrix(model) -> bool:
-    """Return whether all active transmission columns have Warp-linear routing."""
+    """Return whether every active column has frictionless Warp-linear routing."""
 
     actuators = tuple(getattr(model, "actuators", ()))
     return bool(actuators) and all(_uses_builtin_linear_routing(a) for a in actuators)
 
 
 def supports_linear_threadlike_force(model) -> bool:
-    """Return whether the matrix may be fused with direct actuator controls."""
+    """Return whether frictionless direct controls may use the fused Warp force."""
 
-    return supports_linear_threadlike_matrix(model) and all(
-        type(actuator.effort_model) is DirectEffort for actuator in model.actuators
+    return (
+        supports_linear_threadlike_matrix(model)
+        and all(
+            type(actuator.effort_model) is DirectEffort for actuator in model.actuators
+        )
+        and not any(
+            _has_nonconservative_passive_force(element)
+            for element in getattr(model, "passive_elements", ())
+        )
     )
 
 

--- a/src/soromox/execution/warp/actuation/threadlike.py
+++ b/src/soromox/execution/warp/actuation/threadlike.py
@@ -6,12 +6,13 @@ import equinox as eqx
 import jax.numpy as jnp
 from jax import Array
 
-from soromox.actuation.core import DirectEffort, PassiveElement
+from soromox.actuation.core import DirectEffort
 from soromox.actuation.threadlike import (
     LinearThreadlikeRoutingParams,
     ThreadlikeActuator,
     linear_threadlike_routing,
     linear_threadlike_routing_derivative,
+    linear_threadlike_routing_second_derivative,
 )
 
 
@@ -77,19 +78,9 @@ def _uses_builtin_linear_routing(actuator) -> bool:
         isinstance(routing.params, LinearThreadlikeRoutingParams)
         and routing.offset_fn is linear_threadlike_routing
         and routing.derivative_fn is linear_threadlike_routing_derivative
+        and routing.second_derivative_fn
+        in (None, linear_threadlike_routing_second_derivative)
         and actuator.transmission.friction.is_frictionless
-    )
-
-
-def _has_nonconservative_passive_force(element) -> bool:
-    """Return whether a passive element contributes outside an elastic potential."""
-
-    transmission = getattr(element, "transmission", None)
-    friction = getattr(transmission, "friction", None)
-    if friction is not None:
-        return not friction.is_frictionless
-    return (
-        type(element).nonconservative_force is not PassiveElement.nonconservative_force
     )
 
 
@@ -103,15 +94,8 @@ def supports_linear_threadlike_matrix(model) -> bool:
 def supports_linear_threadlike_force(model) -> bool:
     """Return whether frictionless direct controls may use the fused Warp force."""
 
-    return (
-        supports_linear_threadlike_matrix(model)
-        and all(
-            type(actuator.effort_model) is DirectEffort for actuator in model.actuators
-        )
-        and not any(
-            _has_nonconservative_passive_force(element)
-            for element in getattr(model, "passive_elements", ())
-        )
+    return supports_linear_threadlike_matrix(model) and all(
+        type(actuator.effort_model) is DirectEffort for actuator in model.actuators
     )
 
 

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -7,6 +7,10 @@ import jax.numpy as jnp
 from jax import Array, lax, vmap
 
 from soromox.actuation.core import Actuator, PassiveElement
+from soromox.actuation.friction import (
+    ThreadlikeFriction,
+    ThreadlikeQuadratureContext,
+)
 from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
     ThreadlikeRouting,
@@ -5841,7 +5845,7 @@ class GVS(SoftRobot):
             self, q, u, qd, backend=backend, capabilities=GVS_ACTUATION
         )
 
-    def _threadlike_local_basis(
+    def _threadlike_local_geometry(
         self,
         routing: ThreadlikeRouting,
         path_params: BaseThreadlikeRoutingParams,
@@ -5851,8 +5855,15 @@ class GVS(SoftRobot):
         s: Array,
         segment_index: Array,
         point_index: Array,
-    ) -> Array:
-        """Return one spatial routed-path length gradient density."""
+    ) -> ThreadlikeQuadratureContext:
+        """Return one routed-path geometry at a GVS quadrature node.
+
+        Returns:
+            context: Node geometry for one path. ``wrap_angle`` is never
+                populated: GVS strain varies along the arc length, so the
+                accumulated turn is not piecewise linear and would need its own
+                cumulative quadrature.
+        """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
         )
@@ -5861,33 +5872,48 @@ class GVS(SoftRobot):
         if self.scale_rotational_basis_by_length:
             basis = basis.at[:3, :].divide(length)
         strain = basis @ q_link + self.xi_ref_Xs[segment_index, point_index]
-        offset = jnp.append(routing.offset(path_params, s), 1.0)
-        derivative = jnp.append(routing.derivative(path_params, s), 1.0)
-        tangent_unnormalized = (derivative + se3.hat(strain) @ offset)[:-1]
-        tangent = safe_normalize(tangent_unnormalized, eps=self.global_eps)
-        local = jnp.hstack([so3.skew(offset[:-1]) @ tangent, tangent])
-        return active * local
+        offset = routing.offset(path_params, s)
+        offset_derivative = routing.derivative(path_params, s)
+        homogeneous_offset = jnp.append(offset, 1.0)
+        homogeneous_derivative = jnp.append(offset_derivative, 1.0)
+        tangent = (homogeneous_derivative + se3.hat(strain) @ homogeneous_offset)[:-1]
+        return ThreadlikeQuadratureContext(
+            arc_length=jnp.asarray(s),
+            segment_index=jnp.asarray(segment_index),
+            offset=offset,
+            offset_derivative=offset_derivative,
+            tangent_norm=safe_norm(tangent),
+            active=active,
+            unit_tangent=safe_normalize(tangent, eps=self.global_eps),
+            strain=strain,
+        )
+
+    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return one routed-path length gradient density in the GVS basis."""
+        tangent = context.unit_tangent
+        local = jnp.hstack([so3.skew(context.offset) @ tangent, tangent])
+        return context.active * local
 
     def _threadlike_moment_matrix(
         self,
         q: Array,
         routing: ThreadlikeRouting,
-        friction_coefficient: Array | None = None,
+        friction: ThreadlikeFriction | None = None,
     ) -> Array:
-        """Integrate raw routed-length moment arms in the native GVS basis.
+        """Integrate routed-length moment arms in the native GVS basis.
 
         GVS strain varies along the arc length, so the Capstan wrap angle is
-        not piecewise linear and would need its own cumulative quadrature. The
-        wrap-angle model is therefore not implemented for this host and
-        ``friction_coefficient`` is ignored; installing a threadlike component
-        carrying a nonzero coefficient on a GVS robot is refused at
-        construction instead of being silently dropped.
+        not piecewise linear and would need its own cumulative quadrature. This
+        host therefore supplies no ``wrap_angle``, and a law requiring one is
+        refused at construction rather than silently dropped. Laws reading only
+        host-agnostic geometry, such as a length-based loss, are honoured here
+        exactly as on the PCS hosts.
         """
-        del friction_coefficient
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
+        lossy = friction is not None and not friction.is_lossless
         q_gathered = self._min_size_gathered(q)
 
         def segment_matrix(segment_index: Array) -> Array:
@@ -5900,10 +5926,10 @@ class GVS(SoftRobot):
                     self.segment_end_positions[segment_index]
                     + self.integration_points[segment_index, point_index] * length
                 )
-                local = vmap(
-                    self._threadlike_local_basis,
+                context = vmap(
+                    self._threadlike_local_geometry,
                     in_axes=(None, 0, 0, 0, None, None, None, None),
-                    out_axes=1,
+                    out_axes=0,
                 )(
                     routing,
                     params,
@@ -5914,6 +5940,9 @@ class GVS(SoftRobot):
                     segment_index,
                     point_index,
                 )
+                local = vmap(self._threadlike_local_basis, out_axes=1)(context)
+                if lossy:
+                    local = local * friction.transmission_ratio(context)[None, :]
                 basis = self.B_Xs[segment_index, point_index]
                 if self.scale_rotational_basis_by_length:
                     basis = basis.at[:3, :].divide(length)

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -5868,8 +5868,22 @@ class GVS(SoftRobot):
         local = jnp.hstack([so3.skew(offset[:-1]) @ tangent, tangent])
         return active * local
 
-    def _threadlike_moment_matrix(self, q: Array, routing: ThreadlikeRouting) -> Array:
-        """Integrate raw routed-length moment arms in the native GVS basis."""
+    def _threadlike_moment_matrix(
+        self,
+        q: Array,
+        routing: ThreadlikeRouting,
+        friction_coefficient: Array | None = None,
+    ) -> Array:
+        """Integrate raw routed-length moment arms in the native GVS basis.
+
+        GVS strain varies along the arc length, so the Capstan wrap angle is
+        not piecewise linear and would need its own cumulative quadrature. The
+        wrap-angle model is therefore not implemented for this host and
+        ``friction_coefficient`` is ignored; installing a threadlike component
+        carrying a nonzero coefficient on a GVS robot is refused at
+        construction instead of being silently dropped.
+        """
+        del friction_coefficient
         params = routing.params
         count = params.num_paths
         if count == 0:

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -5864,15 +5864,18 @@ class GVS(SoftRobot):
         Args:
             routing: Routed-path family.
             path_params: Parameters of one path.
-            start_segment_index: First segment traversed by the path.
-            end_segment_index: Last segment traversed by the path.
-            q_link: Padded generalized link coordinates.
-            s: Physical backbone coordinate.
-            segment_index: Segment containing ``s``.
-            point_index: Host quadrature-point index.
+            start_segment_index: Scalar index of the path's first segment.
+            end_segment_index: Scalar index of the path's last segment.
+            q_link: Padded generalized link coordinates with shape
+                ``(self.max_dof,)``.
+            s: Scalar backbone abscissa.
+            segment_index: Scalar index of the segment containing ``s``.
+            point_index: Scalar host quadrature-point index.
 
         Returns:
-            Tuple ``(offset, unit_tangent, active)`` for one path.
+            offset: Material-frame routing offset with shape ``(3,)``.
+            unit_tangent: Material-frame unit tangent with shape ``(3,)``.
+            active: Scalar indicating whether the path traverses the segment.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
@@ -5893,12 +5896,13 @@ class GVS(SoftRobot):
         """Return one routed-path length gradient density in the GVS basis.
 
         Args:
-            offset: Material-frame routing offset.
-            unit_tangent: Material-frame unit tangent.
-            active: Whether the path traverses the current segment.
+            offset: Material-frame routing offset with shape ``(3,)``.
+            unit_tangent: Material-frame unit tangent with shape ``(3,)``.
+            active: Scalar indicating whether the path traverses the segment.
 
         Returns:
-            length_gradient_density: Shape ``(6,)``.
+            length_gradient_density: Routed-length gradient density with shape
+                ``(6,)``.
         """
         local = jnp.hstack([so3.skew(offset) @ unit_tangent, unit_tangent])
         return active * local
@@ -5907,65 +5911,66 @@ class GVS(SoftRobot):
         self,
         q_link: Array,
         segment_index: Array,
-        points: Array,
+        s_ps: Array,
     ) -> tuple[Array, Array]:
-        """Evaluate GVS strain and its physical arc-length derivative.
+        """Evaluate GVS strain and its backbone-abscissa derivative.
 
         Args:
-            q_link: Padded generalized link coordinates.
-            segment_index: Segment containing all supplied points.
-            points: Physical backbone coordinates with shape ``(num_points,)``.
+            q_link: Padded generalized link coordinates with shape
+                ``(self.max_dof,)``.
+            segment_index: Segment containing every supplied abscissa.
+            s_ps: Backbone abscissae with shape ``(num_points,)``.
 
         Returns:
-            Tuple of strain and strain derivative arrays, each shaped
-            ``(num_points, 6)``.
+            xi_ps: Strains with shape ``(num_points, 6)``.
+            dxi_ds_ps: Backbone-abscissa strain derivatives with shape
+                ``(num_points, 6)``.
         """
         length = self.segment_lengths[segment_index]
-        normalized = (points - self.segment_end_positions[segment_index]) / length
+        normalized = (s_ps - self.segment_end_positions[segment_index]) / length
         basis = self._eval_B_segment(segment_index, normalized)
         basis_derivative = self._eval_dB_segment(segment_index, normalized)
         if self.scale_rotational_basis_by_length:
             basis = basis.at[:, :3, :].divide(length)
             basis_derivative = basis_derivative.at[:, :3, :].divide(length)
         reference = self.xi_ref_Xs[segment_index, 0]
-        strain = jnp.einsum("pij,j->pi", basis, q_link) + reference
-        strain_derivative = jnp.einsum("pij,j->pi", basis_derivative, q_link) / length
-        return strain, strain_derivative
+        xi_ps = jnp.einsum("pij,j->pi", basis, q_link) + reference
+        dxi_ds_ps = jnp.einsum("pij,j->pi", basis_derivative, q_link) / length
+        return xi_ps, dxi_ds_ps
 
     def _threadlike_turn_rates(
         self,
         q_gathered: Array,
         routing: ThreadlikeRouting,
         segment_index: Array,
-        points: Array,
+        s_ps: Array,
     ) -> Array:
-        """Evaluate analytical GVS path-turn rates at physical points.
+        """Evaluate analytical GVS path-turn rates at backbone abscissae.
 
         Args:
-            q_gathered: Per-segment padded generalized coordinates.
+            q_gathered: Padded generalized coordinates with shape
+                ``(self.num_segments, 2, self.max_dof)``.
             routing: Routed-path family.
-            segment_index: Segment containing every supplied point.
-            points: Physical backbone coordinates with shape ``(num_points,)``.
+            segment_index: Segment containing every supplied abscissa.
+            s_ps: Backbone abscissae with shape ``(num_points,)``.
 
         Returns:
             Turn rates shaped ``(num_points, num_paths)``.
         """
-        strain, strain_derivative = self._threadlike_strain_and_derivative(
-            q_gathered[segment_index, 1], segment_index, points
+        xi_ps, dxi_ds_ps = self._threadlike_strain_and_derivative(
+            q_gathered[segment_index, 1], segment_index, s_ps
         )
 
-        def point_rates(
-            s: Array, current_strain: Array, current_derivative: Array
-        ) -> Array:
-            """Return all path-turn rates at one backbone coordinate."""
+        def point_rates(s: Array, xi: Array, dxi_ds: Array) -> Array:
+            """Return all path-turn rates at one backbone abscissa."""
 
             def path_rate(path_params: BaseThreadlikeRoutingParams) -> Array:
-                """Return one routed path's turn rate at the coordinate."""
+                """Return one routed path's turn rate at the abscissa."""
                 return threadlike_turn_rate(
-                    current_strain[:3],
-                    current_strain[3:],
-                    current_derivative[:3],
-                    current_derivative[3:],
+                    xi[:3],
+                    xi[3:],
+                    dxi_ds[:3],
+                    dxi_ds[3:],
                     routing.offset(path_params, s),
                     routing.derivative(path_params, s),
                     routing.second_derivative(path_params, s),
@@ -5974,7 +5979,7 @@ class GVS(SoftRobot):
 
             return vmap(path_rate)(routing.params)
 
-        return vmap(point_rates)(points, strain, strain_derivative)
+        return vmap(point_rates)(s_ps, xi_ps, dxi_ds_ps)
 
     def _threadlike_boundary_turn(
         self,
@@ -5985,12 +5990,14 @@ class GVS(SoftRobot):
         """Return one-sided path-turn angles at a fixed GVS link interface.
 
         Args:
-            q_gathered: Per-segment padded generalized coordinates.
+            q_gathered: Padded generalized coordinates with shape
+                ``(self.num_segments, 2, self.max_dof)``.
             routing: Routed-path family.
-            left_segment_index: Segment immediately before the interface.
+            left_segment_index: Scalar index of the segment immediately before
+                the interface.
 
         Returns:
-            One unsigned tangent angle per routed path.
+            Unsigned tangent angles with shape ``(routing.num_paths,)``.
         """
         s = self.segment_end_positions[left_segment_index + 1]
         left_strain, _ = self._threadlike_strain_and_derivative(
@@ -6031,16 +6038,17 @@ class GVS(SoftRobot):
         """Integrate unsigned routed-path turn from each anchor through ``s``.
 
         Args:
-            q_gathered: Per-segment padded generalized coordinates.
+            q_gathered: Padded generalized coordinates with shape
+                ``(self.num_segments, 2, self.max_dof)``.
             routing: Routed-path family.
-            s: Physical backbone coordinate.
+            s: Scalar backbone abscissa.
 
         Returns:
-            Accumulated turn in radians for every path.
+            Accumulated turn in radians with shape ``(routing.num_paths,)``.
         """
         return integrate_accumulated_turn(
-            lambda segment_index, physical_points: self._threadlike_turn_rates(
-                q_gathered, routing, segment_index, physical_points
+            lambda segment_index, s_ps: self._threadlike_turn_rates(
+                q_gathered, routing, segment_index, s_ps
             ),
             lambda left_segment_index: self._threadlike_boundary_turn(
                 q_gathered, routing, left_segment_index
@@ -6063,12 +6071,14 @@ class GVS(SoftRobot):
         """Integrate the threadlike anchor-effort map in the GVS basis.
 
         Args:
-            q: Generalized configuration.
+            q: Generalized coordinates with shape
+                ``(self.num_internal_dofs,)``.
             routing: Routed-path family.
             friction: Optional effort-loss model.
 
         Returns:
-            Effort-to-generalized-force matrix shaped ``(num_dofs, num_paths)``.
+            A: Effort-to-generalized-force matrix with shape
+                ``(self.num_internal_dofs, routing.num_paths)``.
         """
         params = routing.params
         count = params.num_paths
@@ -6078,14 +6088,14 @@ class GVS(SoftRobot):
         q_gathered = self._min_size_gathered(q)
         accumulated_turn = None
         if has_friction:
-            physical_points = self.segment_end_positions[:-1, None] + (
+            s_ps = self.segment_end_positions[:-1, None] + (
                 self.segment_lengths[:, None] * self.integration_points
             )
             accumulated_turn = vmap(
-                lambda segment_points: vmap(
+                lambda segment_s_ps: vmap(
                     lambda s: self._threadlike_accumulated_turn(q_gathered, routing, s)
-                )(segment_points)
-            )(physical_points)
+                )(segment_s_ps)
+            )(s_ps)
 
         def segment_matrix(segment_index: Array) -> Array:
             """Integrate the effort map over one GVS body segment."""
@@ -6148,16 +6158,29 @@ class GVS(SoftRobot):
         """Return the Jacobian of unscaled GVS routed-path lengths.
 
         Args:
-            q: Generalized configuration.
+            q: Generalized coordinates with shape
+                ``(self.num_internal_dofs,)``.
             routing: Routed-path family.
 
         Returns:
-            Jacobian shaped ``(num_paths, num_internal_dofs)``.
+            J_l: Path-length Jacobian with shape
+                ``(routing.num_paths, self.num_internal_dofs)``. It maps
+                generalized velocity to unscaled path-length rates as
+                ``path_velocity = J_l @ qd``.
         """
         return self._threadlike_actuation_matrix(q, routing).T
 
     def _threadlike_path_lengths(self, q: Array, routing: ThreadlikeRouting) -> Array:
-        """Integrate raw threadlike path lengths over the GVS quadrature."""
+        """Integrate raw threadlike path lengths over the GVS quadrature.
+
+        Args:
+            q: Generalized coordinates with shape
+                ``(self.num_internal_dofs,)``.
+            routing: Routed-path family.
+
+        Returns:
+            Physical path lengths with shape ``(routing.num_paths,)``.
+        """
         params = routing.params
         if params.num_paths == 0:
             return jnp.zeros((0,), dtype=q.dtype)
@@ -6208,7 +6231,17 @@ class GVS(SoftRobot):
     def _threadlike_path_positions(
         self, q: Array, s: Array, routing: ThreadlikeRouting
     ) -> Array:
-        """Return spatial positions of all routed paths at backbone coordinate ``s``."""
+        """Return spatial routed-path positions at a backbone abscissa.
+
+        Args:
+            q: Generalized coordinates with shape
+                ``(self.num_internal_dofs,)``.
+            s: Scalar backbone abscissa.
+            routing: Routed-path family.
+
+        Returns:
+            Path positions with shape ``(routing.num_paths, 3)``.
+        """
         params = routing.params
         if params.num_paths == 0:
             return jnp.zeros((0, 3), dtype=q.dtype)

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -9,7 +9,10 @@ from jax import Array, lax, vmap
 from soromox.actuation.core import Actuator, PassiveElement
 from soromox.actuation.friction import (
     ThreadlikeFriction,
-    ThreadlikeQuadratureContext,
+    integrate_accumulated_turn,
+    threadlike_tangent,
+    threadlike_turn_rate,
+    threadlike_turning_angle,
 )
 from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
@@ -5855,19 +5858,24 @@ class GVS(SoftRobot):
         s: Array,
         segment_index: Array,
         point_index: Array,
-    ) -> ThreadlikeQuadratureContext:
-        """Return one routed-path geometry at a GVS quadrature node.
+    ) -> tuple[Array, Array, Array]:
+        """Return one GVS routed-path offset, unit tangent, and activity.
+
+        Args:
+            routing: Routed-path family.
+            path_params: Parameters of one path.
+            start_segment_index: First segment traversed by the path.
+            end_segment_index: Last segment traversed by the path.
+            q_link: Padded generalized link coordinates.
+            s: Physical backbone coordinate.
+            segment_index: Segment containing ``s``.
+            point_index: Host quadrature-point index.
 
         Returns:
-            context: Node geometry for one path.
+            Tuple ``(offset, unit_tangent, active)`` for one path.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
-        )
-        path_abscissa = jnp.clip(
-            jnp.asarray(s) - self.segment_end_positions[start_segment_index],
-            0.0,
-            self.segment_end_positions[-1],
         )
         basis = self.B_Xs[segment_index, point_index]
         length = self.segment_lengths[segment_index]
@@ -5876,61 +5884,222 @@ class GVS(SoftRobot):
         strain = basis @ q_link + self.xi_ref_Xs[segment_index, point_index]
         offset = routing.offset(path_params, s)
         offset_derivative = routing.derivative(path_params, s)
-        homogeneous_offset = jnp.append(offset, 1.0)
-        homogeneous_derivative = jnp.append(offset_derivative, 1.0)
-        tangent = (homogeneous_derivative + se3.hat(strain) @ homogeneous_offset)[:-1]
-        return ThreadlikeQuadratureContext(
-            abscissa=jnp.asarray(s),
-            path_abscissa=path_abscissa,
-            segment_index=jnp.asarray(segment_index),
-            offset=offset,
-            offset_derivative=offset_derivative,
-            tangent_norm=safe_norm(tangent),
-            active=active,
-            unit_tangent=safe_normalize(tangent, eps=self.global_eps),
-            strain=strain,
-        )
+        tangent = threadlike_tangent(strain[:3], strain[3:], offset, offset_derivative)
+        return offset, safe_normalize(tangent, eps=self.global_eps), active
 
     def _threadlike_local_length_gradient(
-        self, context: ThreadlikeQuadratureContext
+        self, offset: Array, unit_tangent: Array, active: Array
     ) -> Array:
         """Return one routed-path length gradient density in the GVS basis.
 
         Args:
-            context: Node geometry.
+            offset: Material-frame routing offset.
+            unit_tangent: Material-frame unit tangent.
+            active: Whether the path traverses the current segment.
 
         Returns:
             length_gradient_density: Shape ``(6,)``.
         """
-        tangent = context.unit_tangent
-        local = jnp.hstack([so3.skew(context.offset) @ tangent, tangent])
-        return context.active * local
+        local = jnp.hstack([so3.skew(offset) @ unit_tangent, unit_tangent])
+        return active * local
 
-    def _threadlike_moment_matrix(
+    def _threadlike_strain_and_derivative(
+        self,
+        q_link: Array,
+        segment_index: Array,
+        points: Array,
+    ) -> tuple[Array, Array]:
+        """Evaluate GVS strain and its physical arc-length derivative.
+
+        Args:
+            q_link: Padded generalized link coordinates.
+            segment_index: Segment containing all supplied points.
+            points: Physical backbone coordinates with shape ``(num_points,)``.
+
+        Returns:
+            Tuple of strain and strain derivative arrays, each shaped
+            ``(num_points, 6)``.
+        """
+        length = self.segment_lengths[segment_index]
+        normalized = (points - self.segment_end_positions[segment_index]) / length
+        basis = self._eval_B_segment(segment_index, normalized)
+        basis_derivative = self._eval_dB_segment(segment_index, normalized)
+        if self.scale_rotational_basis_by_length:
+            basis = basis.at[:, :3, :].divide(length)
+            basis_derivative = basis_derivative.at[:, :3, :].divide(length)
+        reference = self.xi_ref_Xs[segment_index, 0]
+        strain = jnp.einsum("pij,j->pi", basis, q_link) + reference
+        strain_derivative = jnp.einsum("pij,j->pi", basis_derivative, q_link) / length
+        return strain, strain_derivative
+
+    def _threadlike_turn_rates(
+        self,
+        q_gathered: Array,
+        routing: ThreadlikeRouting,
+        segment_index: Array,
+        points: Array,
+    ) -> Array:
+        """Evaluate analytical GVS path-turn rates at physical points.
+
+        Args:
+            q_gathered: Per-segment padded generalized coordinates.
+            routing: Routed-path family.
+            segment_index: Segment containing every supplied point.
+            points: Physical backbone coordinates with shape ``(num_points,)``.
+
+        Returns:
+            Turn rates shaped ``(num_points, num_paths)``.
+        """
+        strain, strain_derivative = self._threadlike_strain_and_derivative(
+            q_gathered[segment_index, 1], segment_index, points
+        )
+
+        def point_rates(
+            s: Array, current_strain: Array, current_derivative: Array
+        ) -> Array:
+            """Return all path-turn rates at one backbone coordinate."""
+
+            def path_rate(path_params: BaseThreadlikeRoutingParams) -> Array:
+                """Return one routed path's turn rate at the coordinate."""
+                return threadlike_turn_rate(
+                    current_strain[:3],
+                    current_strain[3:],
+                    current_derivative[:3],
+                    current_derivative[3:],
+                    routing.offset(path_params, s),
+                    routing.derivative(path_params, s),
+                    routing.second_derivative(path_params, s),
+                    eps=self.global_eps,
+                )
+
+            return vmap(path_rate)(routing.params)
+
+        return vmap(point_rates)(points, strain, strain_derivative)
+
+    def _threadlike_boundary_turn(
+        self,
+        q_gathered: Array,
+        routing: ThreadlikeRouting,
+        left_segment_index: Array,
+    ) -> Array:
+        """Return one-sided path-turn angles at a fixed GVS link interface.
+
+        Args:
+            q_gathered: Per-segment padded generalized coordinates.
+            routing: Routed-path family.
+            left_segment_index: Segment immediately before the interface.
+
+        Returns:
+            One unsigned tangent angle per routed path.
+        """
+        s = self.segment_end_positions[left_segment_index + 1]
+        left_strain, _ = self._threadlike_strain_and_derivative(
+            q_gathered[left_segment_index, 1],
+            left_segment_index,
+            jnp.ones((1,)) * s,
+        )
+        right_strain, _ = self._threadlike_strain_and_derivative(
+            q_gathered[left_segment_index + 1, 1],
+            left_segment_index + 1,
+            jnp.ones((1,)) * s,
+        )
+
+        def path_angle(path_params: BaseThreadlikeRoutingParams) -> Array:
+            """Return one routed path's tangent jump at the interface."""
+            offset = routing.offset(path_params, s)
+            offset_derivative = routing.derivative(path_params, s)
+
+            def unit_tangent(strain: Array) -> Array:
+                """Return the path unit tangent for one-sided link strain."""
+                tangent = threadlike_tangent(
+                    strain[:3], strain[3:], offset, offset_derivative
+                )
+                return safe_normalize(tangent, eps=self.global_eps)
+
+            return threadlike_turning_angle(
+                unit_tangent(left_strain[0]), unit_tangent(right_strain[0])
+            )
+
+        return vmap(path_angle)(routing.params)
+
+    def _threadlike_accumulated_turn(
+        self,
+        q_gathered: Array,
+        routing: ThreadlikeRouting,
+        s: Array,
+    ) -> Array:
+        """Integrate unsigned routed-path turn from each anchor through ``s``.
+
+        Args:
+            q_gathered: Per-segment padded generalized coordinates.
+            routing: Routed-path family.
+            s: Physical backbone coordinate.
+
+        Returns:
+            Accumulated turn in radians for every path.
+        """
+        return integrate_accumulated_turn(
+            lambda segment_index, physical_points: self._threadlike_turn_rates(
+                q_gathered, routing, segment_index, physical_points
+            ),
+            lambda left_segment_index: self._threadlike_boundary_turn(
+                q_gathered, routing, left_segment_index
+            ),
+            s,
+            self.segment_end_positions[:-1],
+            self.segment_lengths,
+            self.integration_points,
+            self.integration_weights,
+            routing.params.start_segment_index_array,
+            routing.params.end_segment_index_array,
+        )
+
+    def _threadlike_actuation_matrix(
         self,
         q: Array,
         routing: ThreadlikeRouting,
         friction: ThreadlikeFriction | None = None,
     ) -> Array:
-        """Integrate routed-length moment arms in the native GVS basis."""
+        """Integrate the threadlike anchor-effort map in the GVS basis.
+
+        Args:
+            q: Generalized configuration.
+            routing: Routed-path family.
+            friction: Optional effort-loss model.
+
+        Returns:
+            Effort-to-generalized-force matrix shaped ``(num_dofs, num_paths)``.
+        """
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         has_friction = friction is not None and not friction.is_frictionless
         q_gathered = self._min_size_gathered(q)
+        accumulated_turn = None
+        if has_friction:
+            physical_points = self.segment_end_positions[:-1, None] + (
+                self.segment_lengths[:, None] * self.integration_points
+            )
+            accumulated_turn = vmap(
+                lambda segment_points: vmap(
+                    lambda s: self._threadlike_accumulated_turn(q_gathered, routing, s)
+                )(segment_points)
+            )(physical_points)
 
         def segment_matrix(segment_index: Array) -> Array:
+            """Integrate the effort map over one GVS body segment."""
             length = self.segment_lengths[segment_index]
             q_link = q_gathered[segment_index, 1]
             joint = jnp.zeros((self.max_dof, count), dtype=q.dtype)
 
             def point_matrix(point_index: Array) -> Array:
+                """Return one quadrature node's weighted effort-map density."""
                 s = (
                     self.segment_end_positions[segment_index]
                     + self.integration_points[segment_index, point_index] * length
                 )
-                context = vmap(
+                offset, unit_tangent, active = vmap(
                     self._threadlike_local_geometry,
                     in_axes=(None, 0, 0, 0, None, None, None, None),
                     out_axes=0,
@@ -5945,10 +6114,16 @@ class GVS(SoftRobot):
                     point_index,
                 )
                 local = vmap(self._threadlike_local_length_gradient, out_axes=1)(
-                    context
+                    offset, unit_tangent, active
                 )
                 if has_friction:
-                    local = local * friction.transmission_ratio(context)[None, :]
+                    assert accumulated_turn is not None
+                    local = (
+                        local
+                        * friction.effort_ratio(
+                            accumulated_turn[segment_index, point_index]
+                        )[None, :]
+                    )
                 basis = self.B_Xs[segment_index, point_index]
                 if self.scale_rotational_basis_by_length:
                     basis = basis.at[:3, :].divide(length)
@@ -5966,6 +6141,20 @@ class GVS(SoftRobot):
             self.num_padded_dofs, count
         )
         return self.active_dof_map.T @ full
+
+    def _threadlike_path_length_jacobian(
+        self, q: Array, routing: ThreadlikeRouting
+    ) -> Array:
+        """Return the Jacobian of unscaled GVS routed-path lengths.
+
+        Args:
+            q: Generalized configuration.
+            routing: Routed-path family.
+
+        Returns:
+            Jacobian shaped ``(num_paths, num_internal_dofs)``.
+        """
+        return self._threadlike_actuation_matrix(q, routing).T
 
     def _threadlike_path_lengths(self, q: Array, routing: ThreadlikeRouting) -> Array:
         """Integrate raw threadlike path lengths over the GVS quadrature."""

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -5859,13 +5859,15 @@ class GVS(SoftRobot):
         """Return one routed-path geometry at a GVS quadrature node.
 
         Returns:
-            context: Node geometry for one path. ``wrap_angle`` is never
-                populated: GVS strain varies along the arc length, so the
-                accumulated turn is not piecewise linear and would need its own
-                cumulative quadrature.
+            context: Node geometry for one path.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
+        )
+        path_abscissa = jnp.clip(
+            jnp.asarray(s) - self.segment_end_positions[start_segment_index],
+            0.0,
+            self.segment_end_positions[-1],
         )
         basis = self.B_Xs[segment_index, point_index]
         length = self.segment_lengths[segment_index]
@@ -5878,7 +5880,8 @@ class GVS(SoftRobot):
         homogeneous_derivative = jnp.append(offset_derivative, 1.0)
         tangent = (homogeneous_derivative + se3.hat(strain) @ homogeneous_offset)[:-1]
         return ThreadlikeQuadratureContext(
-            arc_length=jnp.asarray(s),
+            abscissa=jnp.asarray(s),
+            path_abscissa=path_abscissa,
             segment_index=jnp.asarray(segment_index),
             offset=offset,
             offset_derivative=offset_derivative,
@@ -5888,8 +5891,17 @@ class GVS(SoftRobot):
             strain=strain,
         )
 
-    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return one routed-path length gradient density in the GVS basis."""
+    def _threadlike_local_length_gradient(
+        self, context: ThreadlikeQuadratureContext
+    ) -> Array:
+        """Return one routed-path length gradient density in the GVS basis.
+
+        Args:
+            context: Node geometry.
+
+        Returns:
+            length_gradient_density: Shape ``(6,)``.
+        """
         tangent = context.unit_tangent
         local = jnp.hstack([so3.skew(context.offset) @ tangent, tangent])
         return context.active * local
@@ -5900,20 +5912,12 @@ class GVS(SoftRobot):
         routing: ThreadlikeRouting,
         friction: ThreadlikeFriction | None = None,
     ) -> Array:
-        """Integrate routed-length moment arms in the native GVS basis.
-
-        GVS strain varies along the arc length, so the Capstan wrap angle is
-        not piecewise linear and would need its own cumulative quadrature. This
-        host therefore supplies no ``wrap_angle``, and a law requiring one is
-        refused at construction rather than silently dropped. Laws reading only
-        host-agnostic geometry, such as a length-based loss, are honoured here
-        exactly as on the PCS hosts.
-        """
+        """Integrate routed-length moment arms in the native GVS basis."""
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
-        lossy = friction is not None and not friction.is_lossless
+        has_friction = friction is not None and not friction.is_frictionless
         q_gathered = self._min_size_gathered(q)
 
         def segment_matrix(segment_index: Array) -> Array:
@@ -5940,8 +5944,10 @@ class GVS(SoftRobot):
                     segment_index,
                     point_index,
                 )
-                local = vmap(self._threadlike_local_basis, out_axes=1)(context)
-                if lossy:
+                local = vmap(self._threadlike_local_length_gradient, out_axes=1)(
+                    context
+                )
+                if has_friction:
                     local = local * friction.transmission_ratio(context)[None, :]
                 basis = self.B_Xs[segment_index, point_index]
                 if self.scale_rotational_basis_by_length:

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -125,7 +125,6 @@ class PCS(SoftRobot):
     scale_rotational_basis_by_length: bool = eqx.field(static=True)
     backend: ExecutionBackend = eqx.field(static=True)
     backend_params: PCSBackendParams = eqx.field(static=True)
-    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
     xi_ref: Array  # Reference configuration strain
     B_xi_unscaled: Array  # Unscaled strain basis matrix
@@ -364,12 +363,6 @@ class PCS(SoftRobot):
         self.scale_rotational_basis_by_length = bool(
             structure.scale_rotational_basis_by_length
         )
-        self.wrap_angle_smoothing = float(structure.wrap_angle_smoothing)
-        if self.wrap_angle_smoothing < 0.0:
-            raise ValueError(
-                "wrap_angle_smoothing must be non-negative, got "
-                f"{self.wrap_angle_smoothing}."
-            )
 
         # Number of segments
         num_segments = int(params.link.length.shape[0])
@@ -3117,9 +3110,6 @@ class PCS(SoftRobot):
     ) -> ThreadlikeQuadratureContext:
         """Return one spatial routed-path geometry at a quadrature node.
 
-        The routed tangent is ``v + omega x r + r'``, assembled here in
-        homogeneous coordinates.
-
         Args:
             segment_index: Index of the segment containing the node.
             strain: Segment strain of shape ``(6,)``.
@@ -3131,11 +3121,14 @@ class PCS(SoftRobot):
 
         Returns:
             context: Node geometry for one path, consumed by
-                :meth:`_threadlike_local_basis` and by the installed
-                transmission-loss law.
+                :meth:`_threadlike_local_length_gradient` and by the installed
+                friction model.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
+        )
+        path_abscissa = jnp.clip(
+            jnp.asarray(s) - self.L_cum[start_segment_index], 0.0, self.L_cum[-1]
         )
         offset = routing.offset(path_params, s)
         offset_derivative = routing.derivative(path_params, s)
@@ -3143,7 +3136,8 @@ class PCS(SoftRobot):
         homogeneous_derivative = jnp.append(offset_derivative, 1.0)
         tangent = (homogeneous_derivative + se3.hat(strain) @ homogeneous_offset)[:-1]
         return ThreadlikeQuadratureContext(
-            arc_length=jnp.asarray(s),
+            abscissa=jnp.asarray(s),
+            path_abscissa=path_abscissa,
             segment_index=jnp.asarray(segment_index),
             offset=offset,
             offset_derivative=offset_derivative,
@@ -3153,81 +3147,98 @@ class PCS(SoftRobot):
             strain=strain,
         )
 
-    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return one spatial routed-path length gradient density.
+    def _threadlike_local_length_gradient(
+        self, context: ThreadlikeQuadratureContext
+    ) -> Array:
+        """Return one spatial routed-path length gradient density, ``d|t|/dxi``.
 
         Args:
-            context: Node geometry from :meth:`_threadlike_local_geometry`.
+            context: Node geometry.
 
         Returns:
-            phi: Length-gradient density of shape ``(6,)``.
+            length_gradient_density: Shape ``(6,)``.
         """
         tangent = context.unit_tangent
         basis = jnp.hstack([so3.skew(context.offset) @ tangent, tangent])
         return context.active * basis
 
-    def _threadlike_wrap_density(
+    def _threadlike_path_curvature(
         self, strains: Array, routing: ThreadlikeRouting
     ) -> Array:
-        """Return the Capstan wrap-angle density of each segment and path.
+        """Return the curvature of each routed path in each segment.
 
-        The density is ``|omega x u_hat|``, the turning rate of the routed path
-        tangent with its material-frame rotation dropped. Torsion contributes
-        whenever the path is off-axis: for a constant offset at radius ``rho``
-        under pure twist ``kx`` it evaluates to ``kx**2 rho / nu``, the
-        curvature of the resulting helix. In a planar configuration the angular
-        strain is perpendicular to the unit tangent and it reduces to
-        ``|kappa|`` identically, which is what makes the planar and spatial
-        hosts agree.
+        The curvature is ``|omega x u_hat|``, the rate at which the routed-path
+        tangent turns per metre of backbone. Only the component of the angular
+        strain perpendicular to the tangent contributes, so torsion about the
+        axis of the path does not. An off-axis path under twist traces a helix,
+        and this recovers that curvature of the helix.
 
-        The offset is evaluated at the segment midpoint, so the density is
+        The offset is evaluated at the segment midpoint, so the curvature is
         exact for constant-offset routing and first order in the routing slope
         otherwise, matching the accuracy of the dropped material-frame term.
 
         Args:
             strains: Segment strains of shape ``(num_segments, 6)``.
-            routing: Routed-path family whose tangents set the density.
+            routing: Routed-path family whose tangents set the curvature.
 
         Returns:
-            w: Wrap-angle density of shape ``(num_segments, num_paths)``, in
-                radians per metre.
+            path_curvature: Shape ``(num_segments, num_paths)``, in radians per
+                metre.
         """
         params = routing.params
         midpoints = 0.5 * (self.L_cum[:-1] + self.L_cum[1:])
 
-        def density_segment(segment_index: Array, s: Array) -> Array:
+        def curvature_segment(segment_index: Array, s: Array) -> Array:
             strain = strains[segment_index]
             angular = strain[:3]
 
-            def density_path(path_params: BaseThreadlikeRoutingParams) -> Array:
+            def curvature_path(path_params: BaseThreadlikeRoutingParams) -> Array:
                 offset = jnp.append(routing.offset(path_params, s), 1.0)
                 derivative = jnp.append(routing.derivative(path_params, s), 1.0)
                 tangent = (derivative + se3.hat(strain) @ offset)[:-1]
                 unit = safe_normalize(tangent, eps=self.global_eps)
                 return safe_norm(jnp.cross(angular, unit))
 
-            return vmap(density_path)(params)
+            return vmap(curvature_path)(params)
 
-        density = vmap(density_segment)(jnp.arange(self.num_segments), midpoints)
-        if self.wrap_angle_smoothing == 0.0:
-            return density
-        return jnp.sqrt(density**2 + self.wrap_angle_smoothing**2)
+        return vmap(curvature_segment)(jnp.arange(self.num_segments), midpoints)
 
-    def _threadlike_wrap_angle(self, density: Array, s: Array) -> Array:
-        """Accumulate the wrap angle of each path from the base up to ``s``.
+    def _threadlike_safe_wrap_angle(
+        self,
+        path_curvature: Array,
+        s: Array,
+        start_segment_index: Array,
+        eps: Array,
+    ) -> Array:
+        """Integrate path curvature from each path anchor up to ``s``.
 
-        The density is piecewise constant, so the accumulated angle is
-        piecewise linear in ``s`` and therefore exact at every quadrature node.
+        Segments before a path anchor contribute nothing, because the path
+        has not turned there yet. ``safe_norm`` floors the curvature at
+        ``eps`` to keep a Capstan coefficient identifiable near a straight
+        configuration; its zero tangent at the origin reproduces the exact
+        curvature at ``eps == 0`` with a finite gradient, which a plain
+        ``sqrt`` would not.
 
         Args:
-            density: Wrap density of shape ``(num_segments, num_paths)``.
-            s: Scalar arc-length coordinate.
+            path_curvature: Shape ``(num_segments, num_paths)``.
+            s: Scalar abscissa coordinate.
+            start_segment_index: First segment of each path, ``(num_paths,)``.
+            eps: Curvature floor in radians per metre.
 
         Returns:
-            Theta: Accumulated wrap angle of shape ``(num_paths,)``, in radians.
+            wrap_angle: Shape ``(num_paths,)``, in radians.
         """
+        floored = safe_norm(
+            jnp.stack(
+                [path_curvature, jnp.broadcast_to(eps, path_curvature.shape)],
+                axis=-1,
+            ),
+            axis=-1,
+        )
         arc_in_segment = jnp.clip(jnp.asarray(s) - self.L_cum[:-1], 0.0, self.L)
-        return arc_in_segment @ density
+        segments = jnp.arange(self.num_segments)
+        spanned = segments[:, None] >= jnp.asarray(start_segment_index)[None, :]
+        return (spanned * floored * arc_in_segment[:, None]).sum(axis=0)
 
     def _threadlike_moment_matrix(
         self,
@@ -3237,17 +3248,11 @@ class PCS(SoftRobot):
     ) -> Array:
         """Integrate routed-length moment arms in the PCS strain basis.
 
-        When a lossy ``friction`` law is installed, its transmission ratio
-        weights the local basis inside the arc-length integral, because a
-        transmission loss accumulates along the path rather than scaling the
-        applied effort. A lossless law is skipped entirely and reproduces the
-        frictionless matrix exactly.
-
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
             routing: Routed-path family to integrate.
-            friction: Optional transmission-loss law. ``None`` or any law whose
-                ``is_lossless`` is set skips the weighting entirely.
+            friction: Optional friction model. ``None`` or any model whose
+                ``is_frictionless`` is set skips the weighting entirely.
 
         Returns:
             A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
@@ -3258,10 +3263,10 @@ class PCS(SoftRobot):
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 6))
 
-        lossy = friction is not None and not friction.is_lossless
-        wrap_density = None
-        if lossy and friction.requires_wrap_angle:
-            wrap_density = self._threadlike_wrap_density(strains, routing)
+        has_friction = friction is not None and not friction.is_frictionless
+        path_curvature = None
+        if has_friction and friction.requires_wrap_angle:
+            path_curvature = self._threadlike_path_curvature(strains, routing)
 
         def segment_matrix(segment_index: Array) -> Array:
             points, weights = scale_gaussian_quadrature(
@@ -3285,13 +3290,20 @@ class PCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
-                basis = vmap(self._threadlike_local_basis, out_axes=1)(context)
+                basis = vmap(self._threadlike_local_length_gradient, out_axes=1)(
+                    context
+                )
                 weighted = weights[point_index] * basis
-                if not lossy:
+                if not has_friction:
                     return weighted
-                if wrap_density is not None:
+                if path_curvature is not None:
                     context = context.with_wrap_angle(
-                        self._threadlike_wrap_angle(wrap_density, points[point_index])
+                        self._threadlike_safe_wrap_angle(
+                            path_curvature,
+                            points[point_index],
+                            params.start_segment_index_array,
+                            getattr(friction.params, "eps", 0.0),
+                        )
                     )
                 return weighted * friction.transmission_ratio(context)[None, :]
 

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -121,6 +121,7 @@ class PCS(SoftRobot):
     scale_rotational_basis_by_length: bool = eqx.field(static=True)
     backend: ExecutionBackend = eqx.field(static=True)
     backend_params: PCSBackendParams = eqx.field(static=True)
+    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
     xi_ref: Array  # Reference configuration strain
     B_xi_unscaled: Array  # Unscaled strain basis matrix
@@ -359,6 +360,12 @@ class PCS(SoftRobot):
         self.scale_rotational_basis_by_length = bool(
             structure.scale_rotational_basis_by_length
         )
+        self.wrap_angle_smoothing = float(structure.wrap_angle_smoothing)
+        if self.wrap_angle_smoothing < 0.0:
+            raise ValueError(
+                "wrap_angle_smoothing must be non-negative, got "
+                f"{self.wrap_angle_smoothing}."
+            )
 
         # Number of segments
         num_segments = int(params.link.length.shape[0])
@@ -3115,13 +3122,102 @@ class PCS(SoftRobot):
         basis = jnp.hstack([so3.skew(offset[:-1]) @ tangent, tangent])
         return active * basis
 
-    def _threadlike_moment_matrix(self, q: Array, routing: ThreadlikeRouting) -> Array:
-        """Integrate raw routed-length moment arms in the PCS strain basis."""
+    def _threadlike_wrap_density(
+        self, strains: Array, routing: ThreadlikeRouting
+    ) -> Array:
+        """Return the Capstan wrap-angle density of each segment and path.
+
+        The density is ``|omega x u_hat|``, the turning rate of the routed path
+        tangent with its material-frame rotation dropped. Torsion contributes
+        whenever the path is off-axis: for a constant offset at radius ``rho``
+        under pure twist ``kx`` it evaluates to ``kx**2 rho / nu``, the
+        curvature of the resulting helix. In a planar configuration the angular
+        strain is perpendicular to the unit tangent and it reduces to
+        ``|kappa|`` identically, which is what makes the planar and spatial
+        hosts agree.
+
+        The offset is evaluated at the segment midpoint, so the density is
+        exact for constant-offset routing and first order in the routing slope
+        otherwise, matching the accuracy of the dropped material-frame term.
+
+        Args:
+            strains: Segment strains of shape ``(num_segments, 6)``.
+            routing: Routed-path family whose tangents set the density.
+
+        Returns:
+            w: Wrap-angle density of shape ``(num_segments, num_paths)``, in
+                radians per metre.
+        """
+        params = routing.params
+        midpoints = 0.5 * (self.L_cum[:-1] + self.L_cum[1:])
+
+        def density_segment(segment_index: Array, s: Array) -> Array:
+            strain = strains[segment_index]
+            angular = strain[:3]
+
+            def density_path(path_params: BaseThreadlikeRoutingParams) -> Array:
+                offset = jnp.append(routing.offset(path_params, s), 1.0)
+                derivative = jnp.append(routing.derivative(path_params, s), 1.0)
+                tangent = (derivative + se3.hat(strain) @ offset)[:-1]
+                unit = safe_normalize(tangent, eps=self.global_eps)
+                return safe_norm(jnp.cross(angular, unit))
+
+            return vmap(density_path)(params)
+
+        density = vmap(density_segment)(jnp.arange(self.num_segments), midpoints)
+        if self.wrap_angle_smoothing == 0.0:
+            return density
+        return jnp.sqrt(density**2 + self.wrap_angle_smoothing**2)
+
+    def _threadlike_wrap_angle(self, density: Array, s: Array) -> Array:
+        """Accumulate the wrap angle of each path from the base up to ``s``.
+
+        The density is piecewise constant, so the accumulated angle is
+        piecewise linear in ``s`` and therefore exact at every quadrature node.
+
+        Args:
+            density: Wrap density of shape ``(num_segments, num_paths)``.
+            s: Scalar arc-length coordinate.
+
+        Returns:
+            Theta: Accumulated wrap angle of shape ``(num_paths,)``, in radians.
+        """
+        arc_in_segment = jnp.clip(jnp.asarray(s) - self.L_cum[:-1], 0.0, self.L)
+        return arc_in_segment @ density
+
+    def _threadlike_moment_matrix(
+        self,
+        q: Array,
+        routing: ThreadlikeRouting,
+        friction_coefficient: Array | None = None,
+    ) -> Array:
+        """Integrate routed-length moment arms in the PCS strain basis.
+
+        When a ``friction_coefficient`` is supplied, the Capstan transmission
+        ratio ``exp(-mu * Theta(s))`` weights the local basis inside the
+        arc-length integral, because guide friction accumulates along the path
+        rather than scaling the applied effort. A zero coefficient reproduces
+        the frictionless matrix exactly.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+            routing: Routed-path family to integrate.
+            friction_coefficient: Optional Capstan coefficient, scalar or one
+                entry per path. ``None`` skips the weighting entirely.
+
+        Returns:
+            A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
+        """
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 6))
+
+        mu = None
+        if friction_coefficient is not None:
+            mu = jnp.broadcast_to(jnp.asarray(friction_coefficient), (count,))
+            wrap_density = self._threadlike_wrap_density(strains, routing)
 
         def segment_matrix(segment_index: Array) -> Array:
             points, weights = scale_gaussian_quadrature(
@@ -3145,7 +3241,13 @@ class PCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
-                return weights[point_index] * basis
+                weighted = weights[point_index] * basis
+                if mu is None:
+                    return weighted
+                transmission_ratio = jnp.exp(
+                    -mu * self._threadlike_wrap_angle(wrap_density, points[point_index])
+                )
+                return weighted * transmission_ratio[None, :]
 
             return jnp.sum(
                 vmap(point_matrix)(jnp.arange(self.num_integration_points)), axis=0

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -10,7 +10,10 @@ from jax import numpy as jnp
 from soromox.actuation.core import Actuator, PassiveElement
 from soromox.actuation.friction import (
     ThreadlikeFriction,
-    ThreadlikeQuadratureContext,
+    integrate_accumulated_turn,
+    threadlike_tangent,
+    threadlike_turn_rate,
+    threadlike_turning_angle,
 )
 from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
@@ -3107,8 +3110,8 @@ class PCS(SoftRobot):
         path_params: BaseThreadlikeRoutingParams,
         start_segment_index: Array,
         end_segment_index: Array,
-    ) -> ThreadlikeQuadratureContext:
-        """Return one spatial routed-path geometry at a quadrature node.
+    ) -> tuple[Array, Array, Array]:
+        """Return one spatial routed-path offset, unit tangent, and activity.
 
         Args:
             segment_index: Index of the segment containing the node.
@@ -3120,133 +3123,157 @@ class PCS(SoftRobot):
             end_segment_index: Last segment the path spans.
 
         Returns:
-            context: Node geometry for one path, consumed by
-                :meth:`_threadlike_local_length_gradient` and by the installed
-                friction model.
+            Tuple ``(offset, unit_tangent, active)`` for one path.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
         )
-        path_abscissa = jnp.clip(
-            jnp.asarray(s) - self.L_cum[start_segment_index], 0.0, self.L_cum[-1]
-        )
         offset = routing.offset(path_params, s)
         offset_derivative = routing.derivative(path_params, s)
-        homogeneous_offset = jnp.append(offset, 1.0)
-        homogeneous_derivative = jnp.append(offset_derivative, 1.0)
-        tangent = (homogeneous_derivative + se3.hat(strain) @ homogeneous_offset)[:-1]
-        return ThreadlikeQuadratureContext(
-            abscissa=jnp.asarray(s),
-            path_abscissa=path_abscissa,
-            segment_index=jnp.asarray(segment_index),
-            offset=offset,
-            offset_derivative=offset_derivative,
-            tangent_norm=safe_norm(tangent),
-            active=active,
-            unit_tangent=safe_normalize(tangent, eps=self.global_eps),
-            strain=strain,
-        )
+        tangent = threadlike_tangent(strain[:3], strain[3:], offset, offset_derivative)
+        return offset, safe_normalize(tangent, eps=self.global_eps), active
 
     def _threadlike_local_length_gradient(
-        self, context: ThreadlikeQuadratureContext
+        self, offset: Array, unit_tangent: Array, active: Array
     ) -> Array:
         """Return one spatial routed-path length gradient density, ``d|t|/dxi``.
 
         Args:
-            context: Node geometry.
+            offset: Material-frame routing offset.
+            unit_tangent: Material-frame unit tangent of the path.
+            active: Whether the path traverses the current segment.
 
         Returns:
             length_gradient_density: Shape ``(6,)``.
         """
-        tangent = context.unit_tangent
-        basis = jnp.hstack([so3.skew(context.offset) @ tangent, tangent])
-        return context.active * basis
+        basis = jnp.hstack([so3.skew(offset) @ unit_tangent, unit_tangent])
+        return active * basis
 
-    def _threadlike_path_curvature(
-        self, strains: Array, routing: ThreadlikeRouting
-    ) -> Array:
-        """Return the curvature of each routed path in each segment.
-
-        The curvature is ``|omega x u_hat|``, the rate at which the routed-path
-        tangent turns per metre of backbone. Only the component of the angular
-        strain perpendicular to the tangent contributes, so torsion about the
-        axis of the path does not. An off-axis path under twist traces a helix,
-        and this recovers that curvature of the helix.
-
-        The offset is evaluated at the segment midpoint, so the curvature is
-        exact for constant-offset routing and first order in the routing slope
-        otherwise, matching the accuracy of the dropped material-frame term.
-
-        Args:
-            strains: Segment strains of shape ``(num_segments, 6)``.
-            routing: Routed-path family whose tangents set the curvature.
-
-        Returns:
-            path_curvature: Shape ``(num_segments, num_paths)``, in radians per
-                metre.
-        """
-        params = routing.params
-        midpoints = 0.5 * (self.L_cum[:-1] + self.L_cum[1:])
-
-        def curvature_segment(segment_index: Array, s: Array) -> Array:
-            strain = strains[segment_index]
-            angular = strain[:3]
-
-            def curvature_path(path_params: BaseThreadlikeRoutingParams) -> Array:
-                offset = jnp.append(routing.offset(path_params, s), 1.0)
-                derivative = jnp.append(routing.derivative(path_params, s), 1.0)
-                tangent = (derivative + se3.hat(strain) @ offset)[:-1]
-                unit = safe_normalize(tangent, eps=self.global_eps)
-                return safe_norm(jnp.cross(angular, unit))
-
-            return vmap(curvature_path)(params)
-
-        return vmap(curvature_segment)(jnp.arange(self.num_segments), midpoints)
-
-    def _threadlike_safe_wrap_angle(
+    def _threadlike_turn_rates(
         self,
-        path_curvature: Array,
-        s: Array,
-        start_segment_index: Array,
-        eps: Array,
+        strains: Array,
+        routing: ThreadlikeRouting,
+        segment_index: Array,
+        points: Array,
     ) -> Array:
-        """Integrate path curvature from each path anchor up to ``s``.
-
-        Segments before a path anchor contribute nothing, because the path
-        has not turned there yet. ``safe_norm`` floors the curvature at
-        ``eps`` to keep a Capstan coefficient identifiable near a straight
-        configuration; its zero tangent at the origin reproduces the exact
-        curvature at ``eps == 0`` with a finite gradient, which a plain
-        ``sqrt`` would not.
+        """Evaluate analytical spatial-path turn rates at physical points.
 
         Args:
-            path_curvature: Shape ``(num_segments, num_paths)``.
-            s: Scalar abscissa coordinate.
-            start_segment_index: First segment of each path, ``(num_paths,)``.
-            eps: Curvature floor in radians per metre.
+            strains: Piecewise-constant PCS strains.
+            routing: Routed-path family.
+            segment_index: Segment containing every supplied point.
+            points: Physical backbone coordinates with shape ``(num_points,)``.
 
         Returns:
-            wrap_angle: Shape ``(num_paths,)``, in radians.
+            Turn rates shaped ``(num_points, num_paths)``.
         """
-        floored = safe_norm(
-            jnp.stack(
-                [path_curvature, jnp.broadcast_to(eps, path_curvature.shape)],
-                axis=-1,
-            ),
-            axis=-1,
-        )
-        arc_in_segment = jnp.clip(jnp.asarray(s) - self.L_cum[:-1], 0.0, self.L)
-        segments = jnp.arange(self.num_segments)
-        spanned = segments[:, None] >= jnp.asarray(start_segment_index)[None, :]
-        return (spanned * floored * arc_in_segment[:, None]).sum(axis=0)
+        strain = strains[segment_index]
+        zero = jnp.zeros((3,), dtype=strain.dtype)
 
-    def _threadlike_moment_matrix(
+        def point_rates(s: Array) -> Array:
+            """Return all path-turn rates at one backbone coordinate."""
+
+            def path_rate(path_params: BaseThreadlikeRoutingParams) -> Array:
+                """Return one routed path's turn rate at the coordinate."""
+                offset = routing.offset(path_params, s)
+                offset_derivative = routing.derivative(path_params, s)
+                offset_second_derivative = routing.second_derivative(path_params, s)
+                return threadlike_turn_rate(
+                    strain[:3],
+                    strain[3:],
+                    zero,
+                    zero,
+                    offset,
+                    offset_derivative,
+                    offset_second_derivative,
+                    eps=self.global_eps,
+                )
+
+            return vmap(path_rate)(routing.params)
+
+        return vmap(point_rates)(points)
+
+    def _threadlike_boundary_turn(
+        self,
+        strains: Array,
+        routing: ThreadlikeRouting,
+        left_segment_index: Array,
+    ) -> Array:
+        """Return one-sided path-turn angles at a PCS segment boundary.
+
+        Args:
+            strains: Piecewise-constant PCS strains.
+            routing: Routed-path family.
+            left_segment_index: Segment immediately before the boundary.
+
+        Returns:
+            One unsigned tangent angle per routed path.
+        """
+        s = self.L_cum[left_segment_index + 1]
+
+        def path_angle(path_params: BaseThreadlikeRoutingParams) -> Array:
+            """Return one routed path's tangent jump at the boundary."""
+            offset = routing.offset(path_params, s)
+            offset_derivative = routing.derivative(path_params, s)
+
+            def unit_tangent(strain: Array) -> Array:
+                """Return the path unit tangent for one-sided segment strain."""
+                tangent = threadlike_tangent(
+                    strain[:3], strain[3:], offset, offset_derivative
+                )
+                return safe_normalize(tangent, eps=self.global_eps)
+
+            return threadlike_turning_angle(
+                unit_tangent(strains[left_segment_index]),
+                unit_tangent(strains[left_segment_index + 1]),
+            )
+
+        return vmap(path_angle)(routing.params)
+
+    def _threadlike_accumulated_turn(
+        self,
+        strains: Array,
+        routing: ThreadlikeRouting,
+        s: Array,
+    ) -> Array:
+        """Integrate unsigned routed-path turn from each anchor through ``s``.
+
+        Args:
+            strains: Piecewise-constant PCS strains.
+            routing: Routed-path family.
+            s: Physical backbone coordinate.
+
+        Returns:
+            Accumulated turn in radians for every path.
+        """
+        points = jnp.broadcast_to(
+            self.integration_points[None, :],
+            (self.num_segments, self.num_integration_points),
+        )
+        weights = jnp.broadcast_to(self.integration_weights[None, :], points.shape)
+        return integrate_accumulated_turn(
+            lambda segment_index, physical_points: self._threadlike_turn_rates(
+                strains, routing, segment_index, physical_points
+            ),
+            lambda left_segment_index: self._threadlike_boundary_turn(
+                strains, routing, left_segment_index
+            ),
+            s,
+            self.L_cum[:-1],
+            self.L,
+            points,
+            weights,
+            routing.params.start_segment_index_array,
+            routing.params.end_segment_index_array,
+        )
+
+    def _threadlike_actuation_matrix(
         self,
         q: Array,
         routing: ThreadlikeRouting,
         friction: ThreadlikeFriction | None = None,
     ) -> Array:
-        """Integrate routed-length moment arms in the PCS strain basis.
+        """Integrate the threadlike anchor-effort map in the PCS basis.
 
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
@@ -3255,7 +3282,7 @@ class PCS(SoftRobot):
                 ``is_frictionless`` is set skips the weighting entirely.
 
         Returns:
-            A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
+            Effort-to-generalized-force matrix shaped ``(num_dofs, num_paths)``.
         """
         params = routing.params
         count = params.num_paths
@@ -3264,11 +3291,20 @@ class PCS(SoftRobot):
         strains = self.strain(q).reshape((self.num_segments, 6))
 
         has_friction = friction is not None and not friction.is_frictionless
-        path_curvature = None
-        if has_friction and friction.requires_wrap_angle:
-            path_curvature = self._threadlike_path_curvature(strains, routing)
+        accumulated_turn = None
+        if has_friction:
+            physical_points = (
+                self.L_cum[:-1, None]
+                + self.L[:, None] * (self.integration_points[None, :])
+            )
+            accumulated_turn = vmap(
+                lambda segment_points: vmap(
+                    lambda s: self._threadlike_accumulated_turn(strains, routing, s)
+                )(segment_points)
+            )(physical_points)
 
         def segment_matrix(segment_index: Array) -> Array:
+            """Integrate the effort map over one PCS segment."""
             points, weights = scale_gaussian_quadrature(
                 self.integration_points,
                 self.integration_weights,
@@ -3277,7 +3313,8 @@ class PCS(SoftRobot):
             )
 
             def point_matrix(point_index: Array) -> Array:
-                context = vmap(
+                """Return one quadrature node's weighted effort-map density."""
+                offset, unit_tangent, active = vmap(
                     self._threadlike_local_geometry,
                     in_axes=(None, None, None, None, 0, 0, 0),
                     out_axes=0,
@@ -3291,21 +3328,18 @@ class PCS(SoftRobot):
                     params.end_segment_index_array,
                 )
                 basis = vmap(self._threadlike_local_length_gradient, out_axes=1)(
-                    context
+                    offset, unit_tangent, active
                 )
                 weighted = weights[point_index] * basis
                 if not has_friction:
                     return weighted
-                if path_curvature is not None:
-                    context = context.with_wrap_angle(
-                        self._threadlike_safe_wrap_angle(
-                            path_curvature,
-                            points[point_index],
-                            params.start_segment_index_array,
-                            getattr(friction.params, "eps", 0.0),
-                        )
-                    )
-                return weighted * friction.transmission_ratio(context)[None, :]
+                assert accumulated_turn is not None
+                return (
+                    weighted
+                    * friction.effort_ratio(
+                        accumulated_turn[segment_index, point_index]
+                    )[None, :]
+                )
 
             return jnp.sum(
                 vmap(point_matrix)(jnp.arange(self.num_integration_points)), axis=0
@@ -3315,6 +3349,20 @@ class PCS(SoftRobot):
             self.num_strains, count
         )
         return self.B_xi.T @ full_matrix
+
+    def _threadlike_path_length_jacobian(
+        self, q: Array, routing: ThreadlikeRouting
+    ) -> Array:
+        """Return the Jacobian of unscaled PCS routed-path lengths.
+
+        Args:
+            q: Generalized configuration.
+            routing: Routed-path family.
+
+        Returns:
+            Jacobian shaped ``(num_paths, num_internal_dofs)``.
+        """
+        return self._threadlike_actuation_matrix(q, routing).T
 
     def _threadlike_path_lengths(self, q: Array, routing: ThreadlikeRouting) -> Array:
         """Integrate raw threadlike path lengths without signed work scaling."""

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -11,8 +11,8 @@ from soromox.actuation.core import Actuator, PassiveElement
 from soromox.actuation.friction import (
     ThreadlikeFriction,
     integrate_accumulated_turn,
+    threadlike_constant_strain_turn_rate,
     threadlike_tangent,
-    threadlike_turn_rate,
     threadlike_turning_angle,
 )
 from soromox.actuation.threadlike import (
@@ -3114,16 +3114,18 @@ class PCS(SoftRobot):
         """Return one spatial routed-path offset, unit tangent, and activity.
 
         Args:
-            segment_index: Index of the segment containing the node.
-            strain: Segment strain of shape ``(6,)``.
-            s: Backbone coordinate of the node.
+            segment_index: Scalar index of the segment containing the node.
+            strain: PCS strain with shape ``(6,)``.
+            s: Scalar backbone abscissa of the node.
             routing: Routed-path family being integrated.
             path_params: Parameters of the single path.
-            start_segment_index: First segment the path spans.
-            end_segment_index: Last segment the path spans.
+            start_segment_index: Scalar index of the path's first segment.
+            end_segment_index: Scalar index of the path's last segment.
 
         Returns:
-            Tuple ``(offset, unit_tangent, active)`` for one path.
+            offset: Material-frame routing offset with shape ``(3,)``.
+            unit_tangent: Material-frame unit tangent with shape ``(3,)``.
+            active: Scalar indicating whether the path traverses the segment.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
@@ -3139,50 +3141,49 @@ class PCS(SoftRobot):
         """Return one spatial routed-path length gradient density, ``d|t|/dxi``.
 
         Args:
-            offset: Material-frame routing offset.
-            unit_tangent: Material-frame unit tangent of the path.
-            active: Whether the path traverses the current segment.
+            offset: Material-frame routing offset with shape ``(3,)``.
+            unit_tangent: Material-frame unit tangent with shape ``(3,)``.
+            active: Scalar indicating whether the path traverses the segment.
 
         Returns:
-            length_gradient_density: Shape ``(6,)``.
+            length_gradient_density: Routed-length gradient density with shape
+                ``(6,)``.
         """
         basis = jnp.hstack([so3.skew(offset) @ unit_tangent, unit_tangent])
         return active * basis
 
     def _threadlike_turn_rates(
         self,
-        strains: Array,
+        xi: Array,
         routing: ThreadlikeRouting,
         segment_index: Array,
-        points: Array,
+        s_ps: Array,
     ) -> Array:
-        """Evaluate analytical spatial-path turn rates at physical points.
+        """Evaluate analytical spatial-path turn rates at backbone abscissae.
 
         Args:
-            strains: Piecewise-constant PCS strains.
+            xi: Piecewise-constant PCS strains with shape
+                ``(self.num_segments, 6)``.
             routing: Routed-path family.
-            segment_index: Segment containing every supplied point.
-            points: Physical backbone coordinates with shape ``(num_points,)``.
+            segment_index: Segment containing every supplied abscissa.
+            s_ps: Backbone abscissae with shape ``(num_points,)``.
 
         Returns:
-            Turn rates shaped ``(num_points, num_paths)``.
+            Turn rates with shape ``(num_points, routing.num_paths)``.
         """
-        strain = strains[segment_index]
-        zero = jnp.zeros((3,), dtype=strain.dtype)
+        xi_i = xi[segment_index]
 
         def point_rates(s: Array) -> Array:
-            """Return all path-turn rates at one backbone coordinate."""
+            """Return all path-turn rates at one backbone abscissa."""
 
             def path_rate(path_params: BaseThreadlikeRoutingParams) -> Array:
-                """Return one routed path's turn rate at the coordinate."""
+                """Return one routed path's turn rate at the abscissa."""
                 offset = routing.offset(path_params, s)
                 offset_derivative = routing.derivative(path_params, s)
                 offset_second_derivative = routing.second_derivative(path_params, s)
-                return threadlike_turn_rate(
-                    strain[:3],
-                    strain[3:],
-                    zero,
-                    zero,
+                return threadlike_constant_strain_turn_rate(
+                    xi_i[:3],
+                    xi_i[3:],
                     offset,
                     offset_derivative,
                     offset_second_derivative,
@@ -3191,23 +3192,25 @@ class PCS(SoftRobot):
 
             return vmap(path_rate)(routing.params)
 
-        return vmap(point_rates)(points)
+        return vmap(point_rates)(s_ps)
 
     def _threadlike_boundary_turn(
         self,
-        strains: Array,
+        xi: Array,
         routing: ThreadlikeRouting,
         left_segment_index: Array,
     ) -> Array:
         """Return one-sided path-turn angles at a PCS segment boundary.
 
         Args:
-            strains: Piecewise-constant PCS strains.
+            xi: Piecewise-constant PCS strains with shape
+                ``(self.num_segments, 6)``.
             routing: Routed-path family.
-            left_segment_index: Segment immediately before the boundary.
+            left_segment_index: Scalar index of the segment immediately before
+                the boundary.
 
         Returns:
-            One unsigned tangent angle per routed path.
+            Unsigned tangent angles with shape ``(routing.num_paths,)``.
         """
         s = self.L_cum[left_segment_index + 1]
 
@@ -3224,44 +3227,47 @@ class PCS(SoftRobot):
                 return safe_normalize(tangent, eps=self.global_eps)
 
             return threadlike_turning_angle(
-                unit_tangent(strains[left_segment_index]),
-                unit_tangent(strains[left_segment_index + 1]),
+                unit_tangent(xi[left_segment_index]),
+                unit_tangent(xi[left_segment_index + 1]),
             )
 
         return vmap(path_angle)(routing.params)
 
     def _threadlike_accumulated_turn(
         self,
-        strains: Array,
+        xi: Array,
         routing: ThreadlikeRouting,
         s: Array,
     ) -> Array:
         """Integrate unsigned routed-path turn from each anchor through ``s``.
 
         Args:
-            strains: Piecewise-constant PCS strains.
+            xi: Piecewise-constant PCS strains with shape
+                ``(self.num_segments, 6)``.
             routing: Routed-path family.
-            s: Physical backbone coordinate.
+            s: Scalar backbone abscissa.
 
         Returns:
-            Accumulated turn in radians for every path.
+            Accumulated turn in radians with shape ``(routing.num_paths,)``.
         """
-        points = jnp.broadcast_to(
+        normalized_s_ps = jnp.broadcast_to(
             self.integration_points[None, :],
             (self.num_segments, self.num_integration_points),
         )
-        weights = jnp.broadcast_to(self.integration_weights[None, :], points.shape)
+        weights = jnp.broadcast_to(
+            self.integration_weights[None, :], normalized_s_ps.shape
+        )
         return integrate_accumulated_turn(
-            lambda segment_index, physical_points: self._threadlike_turn_rates(
-                strains, routing, segment_index, physical_points
+            lambda segment_index, s_ps: self._threadlike_turn_rates(
+                xi, routing, segment_index, s_ps
             ),
             lambda left_segment_index: self._threadlike_boundary_turn(
-                strains, routing, left_segment_index
+                xi, routing, left_segment_index
             ),
             s,
             self.L_cum[:-1],
             self.L,
-            points,
+            normalized_s_ps,
             weights,
             routing.params.start_segment_index_array,
             routing.params.end_segment_index_array,
@@ -3277,31 +3283,32 @@ class PCS(SoftRobot):
 
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
-            routing: Routed-path family to integrate.
+            routing: Routed-path family with ``routing.num_paths`` paths.
             friction: Optional friction model. ``None`` or any model whose
                 ``is_frictionless`` is set skips the weighting entirely.
 
         Returns:
-            Effort-to-generalized-force matrix shaped ``(num_dofs, num_paths)``.
+            A: Effort-to-generalized-force matrix with shape
+                ``(self.num_internal_dofs, routing.num_paths)``.
         """
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
-        strains = self.strain(q).reshape((self.num_segments, 6))
+        xi = self.strain(q).reshape((self.num_segments, 6))
 
         has_friction = friction is not None and not friction.is_frictionless
         accumulated_turn = None
         if has_friction:
-            physical_points = (
+            s_ps = (
                 self.L_cum[:-1, None]
                 + self.L[:, None] * (self.integration_points[None, :])
             )
             accumulated_turn = vmap(
-                lambda segment_points: vmap(
-                    lambda s: self._threadlike_accumulated_turn(strains, routing, s)
-                )(segment_points)
-            )(physical_points)
+                lambda segment_s_ps: vmap(
+                    lambda s: self._threadlike_accumulated_turn(xi, routing, s)
+                )(segment_s_ps)
+            )(s_ps)
 
         def segment_matrix(segment_index: Array) -> Array:
             """Integrate the effort map over one PCS segment."""
@@ -3320,7 +3327,7 @@ class PCS(SoftRobot):
                     out_axes=0,
                 )(
                     segment_index,
-                    strains[segment_index],
+                    xi[segment_index],
                     points[point_index],
                     routing,
                     params,
@@ -3356,20 +3363,33 @@ class PCS(SoftRobot):
         """Return the Jacobian of unscaled PCS routed-path lengths.
 
         Args:
-            q: Generalized configuration.
+            q: Generalized coordinates with shape
+                ``(self.num_internal_dofs,)``.
             routing: Routed-path family.
 
         Returns:
-            Jacobian shaped ``(num_paths, num_internal_dofs)``.
+            J_l: Path-length Jacobian with shape
+                ``(routing.num_paths, self.num_internal_dofs)``. It maps
+                generalized velocity to unscaled path-length rates as
+                ``path_velocity = J_l @ qd``.
         """
         return self._threadlike_actuation_matrix(q, routing).T
 
     def _threadlike_path_lengths(self, q: Array, routing: ThreadlikeRouting) -> Array:
-        """Integrate raw threadlike path lengths without signed work scaling."""
+        """Integrate raw threadlike path lengths without signed work scaling.
+
+        Args:
+            q: Generalized coordinates with shape
+                ``(self.num_internal_dofs,)``.
+            routing: Routed-path family.
+
+        Returns:
+            Physical path lengths with shape ``(routing.num_paths,)``.
+        """
         params = routing.params
         if params.num_paths == 0:
             return jnp.zeros((0,), dtype=q.dtype)
-        strains = self.strain(q).reshape((self.num_segments, 6))
+        xi = self.strain(q).reshape((self.num_segments, 6))
 
         def segment_density(segment_index: Array) -> Array:
             points, weights = scale_gaussian_quadrature(
@@ -3392,9 +3412,7 @@ class PCS(SoftRobot):
                     )
                     offset = jnp.append(routing.offset(path_params, s), 1.0)
                     derivative = jnp.append(routing.derivative(path_params, s), 1.0)
-                    tangent = (derivative + se3.hat(strains[segment_index]) @ offset)[
-                        :-1
-                    ]
+                    tangent = (derivative + se3.hat(xi[segment_index]) @ offset)[:-1]
                     return active * safe_norm(tangent)
 
                 density = vmap(path_density)(
@@ -3413,7 +3431,17 @@ class PCS(SoftRobot):
     def _threadlike_path_positions(
         self, q: Array, s: Array, routing: ThreadlikeRouting
     ) -> Array:
-        """Return spatial positions of all routed paths at backbone coordinate ``s``."""
+        """Return spatial routed-path positions at a backbone abscissa.
+
+        Args:
+            q: Generalized coordinates with shape
+                ``(self.num_internal_dofs,)``.
+            s: Scalar backbone abscissa.
+            routing: Routed-path family.
+
+        Returns:
+            Path positions with shape ``(routing.num_paths, 3)``.
+        """
         params = routing.params
         if params.num_paths == 0:
             return jnp.zeros((0, 3), dtype=q.dtype)

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -8,6 +8,10 @@ from jax import Array, jvp, lax, vmap
 from jax import numpy as jnp
 
 from soromox.actuation.core import Actuator, PassiveElement
+from soromox.actuation.friction import (
+    ThreadlikeFriction,
+    ThreadlikeQuadratureContext,
+)
 from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
     ThreadlikeRouting,
@@ -3101,7 +3105,7 @@ class PCS(SoftRobot):
             self, q, u, qd, backend=backend, capabilities=PCS_ACTUATION
         )
 
-    def _threadlike_local_basis(
+    def _threadlike_local_geometry(
         self,
         segment_index: Array,
         strain: Array,
@@ -3110,17 +3114,57 @@ class PCS(SoftRobot):
         path_params: BaseThreadlikeRoutingParams,
         start_segment_index: Array,
         end_segment_index: Array,
-    ) -> Array:
-        """Return one spatial routed-path length gradient density."""
+    ) -> ThreadlikeQuadratureContext:
+        """Return one spatial routed-path geometry at a quadrature node.
+
+        The routed tangent is ``v + omega x r + r'``, assembled here in
+        homogeneous coordinates.
+
+        Args:
+            segment_index: Index of the segment containing the node.
+            strain: Segment strain of shape ``(6,)``.
+            s: Backbone coordinate of the node.
+            routing: Routed-path family being integrated.
+            path_params: Parameters of the single path.
+            start_segment_index: First segment the path spans.
+            end_segment_index: Last segment the path spans.
+
+        Returns:
+            context: Node geometry for one path, consumed by
+                :meth:`_threadlike_local_basis` and by the installed
+                transmission-loss law.
+        """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
         )
-        offset = jnp.append(routing.offset(path_params, s), 1.0)
-        offset_derivative = jnp.append(routing.derivative(path_params, s), 1.0)
-        tangent_unnormalized = (offset_derivative + se3.hat(strain) @ offset)[:-1]
-        tangent = safe_normalize(tangent_unnormalized, eps=self.global_eps)
-        basis = jnp.hstack([so3.skew(offset[:-1]) @ tangent, tangent])
-        return active * basis
+        offset = routing.offset(path_params, s)
+        offset_derivative = routing.derivative(path_params, s)
+        homogeneous_offset = jnp.append(offset, 1.0)
+        homogeneous_derivative = jnp.append(offset_derivative, 1.0)
+        tangent = (homogeneous_derivative + se3.hat(strain) @ homogeneous_offset)[:-1]
+        return ThreadlikeQuadratureContext(
+            arc_length=jnp.asarray(s),
+            segment_index=jnp.asarray(segment_index),
+            offset=offset,
+            offset_derivative=offset_derivative,
+            tangent_norm=safe_norm(tangent),
+            active=active,
+            unit_tangent=safe_normalize(tangent, eps=self.global_eps),
+            strain=strain,
+        )
+
+    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return one spatial routed-path length gradient density.
+
+        Args:
+            context: Node geometry from :meth:`_threadlike_local_geometry`.
+
+        Returns:
+            phi: Length-gradient density of shape ``(6,)``.
+        """
+        tangent = context.unit_tangent
+        basis = jnp.hstack([so3.skew(context.offset) @ tangent, tangent])
+        return context.active * basis
 
     def _threadlike_wrap_density(
         self, strains: Array, routing: ThreadlikeRouting
@@ -3189,21 +3233,21 @@ class PCS(SoftRobot):
         self,
         q: Array,
         routing: ThreadlikeRouting,
-        friction_coefficient: Array | None = None,
+        friction: ThreadlikeFriction | None = None,
     ) -> Array:
         """Integrate routed-length moment arms in the PCS strain basis.
 
-        When a ``friction_coefficient`` is supplied, the Capstan transmission
-        ratio ``exp(-mu * Theta(s))`` weights the local basis inside the
-        arc-length integral, because guide friction accumulates along the path
-        rather than scaling the applied effort. A zero coefficient reproduces
-        the frictionless matrix exactly.
+        When a lossy ``friction`` law is installed, its transmission ratio
+        weights the local basis inside the arc-length integral, because a
+        transmission loss accumulates along the path rather than scaling the
+        applied effort. A lossless law is skipped entirely and reproduces the
+        frictionless matrix exactly.
 
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
             routing: Routed-path family to integrate.
-            friction_coefficient: Optional Capstan coefficient, scalar or one
-                entry per path. ``None`` skips the weighting entirely.
+            friction: Optional transmission-loss law. ``None`` or any law whose
+                ``is_lossless`` is set skips the weighting entirely.
 
         Returns:
             A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
@@ -3214,9 +3258,9 @@ class PCS(SoftRobot):
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 6))
 
-        mu = None
-        if friction_coefficient is not None:
-            mu = jnp.broadcast_to(jnp.asarray(friction_coefficient), (count,))
+        lossy = friction is not None and not friction.is_lossless
+        wrap_density = None
+        if lossy and friction.requires_wrap_angle:
             wrap_density = self._threadlike_wrap_density(strains, routing)
 
         def segment_matrix(segment_index: Array) -> Array:
@@ -3228,10 +3272,10 @@ class PCS(SoftRobot):
             )
 
             def point_matrix(point_index: Array) -> Array:
-                basis = vmap(
-                    self._threadlike_local_basis,
+                context = vmap(
+                    self._threadlike_local_geometry,
                     in_axes=(None, None, None, None, 0, 0, 0),
-                    out_axes=1,
+                    out_axes=0,
                 )(
                     segment_index,
                     strains[segment_index],
@@ -3241,13 +3285,15 @@ class PCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
+                basis = vmap(self._threadlike_local_basis, out_axes=1)(context)
                 weighted = weights[point_index] * basis
-                if mu is None:
+                if not lossy:
                     return weighted
-                transmission_ratio = jnp.exp(
-                    -mu * self._threadlike_wrap_angle(wrap_density, points[point_index])
-                )
-                return weighted * transmission_ratio[None, :]
+                if wrap_density is not None:
+                    context = context.with_wrap_angle(
+                        self._threadlike_wrap_angle(wrap_density, points[point_index])
+                    )
+                return weighted * friction.transmission_ratio(context)[None, :]
 
             return jnp.sum(
                 vmap(point_matrix)(jnp.arange(self.num_integration_points)), axis=0

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -10,7 +10,10 @@ from jax import numpy as jnp
 from soromox.actuation.core import Actuator, PassiveElement
 from soromox.actuation.friction import (
     ThreadlikeFriction,
-    ThreadlikeQuadratureContext,
+    integrate_accumulated_turn,
+    threadlike_tangent,
+    threadlike_turn_rate,
+    threadlike_turning_angle,
 )
 from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
@@ -50,7 +53,7 @@ from soromox.utils.integration import (
 )
 from soromox.utils.lie_algebra import se2
 from soromox.utils.lie_algebra.constant_strain import se2 as constant_strain_se2
-from soromox.utils.numerics import safe_divide, safe_norm
+from soromox.utils.numerics import safe_divide, safe_norm, safe_normalize
 
 
 class PlanarPCS(SoftRobot):
@@ -2980,7 +2983,7 @@ class PlanarPCS(SoftRobot):
         path_params: BaseThreadlikeRoutingParams,
         start_segment_index: Array,
         end_segment_index: Array,
-    ) -> ThreadlikeQuadratureContext:
+    ) -> tuple[Array, Array, Array]:
         """Return one planar routed-path geometry at a quadrature node.
 
         The offset is measured along the local ``+y`` axis, so a path at
@@ -3000,15 +3003,10 @@ class PlanarPCS(SoftRobot):
             end_segment_index: Last segment the path spans.
 
         Returns:
-            context: Node geometry for one path, consumed by
-                :meth:`_threadlike_local_length_gradient` and by the installed
-                friction model.
+            Tuple ``(offset, unit_tangent, active)`` for one path.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
-        )
-        path_abscissa = jnp.clip(
-            jnp.asarray(s) - self.L_cum[start_segment_index], 0.0, self.L_cum[-1]
         )
         offset = routing.offset(path_params, s)
         offset_derivative = routing.derivative(path_params, s)
@@ -3021,96 +3019,152 @@ class PlanarPCS(SoftRobot):
                 safe_divide(shear, norm, self.global_eps),
             ]
         )
-        return ThreadlikeQuadratureContext(
-            abscissa=jnp.asarray(s),
-            path_abscissa=path_abscissa,
-            segment_index=jnp.asarray(segment_index),
-            offset=offset,
-            offset_derivative=offset_derivative,
-            tangent_norm=norm,
-            active=active,
-            unit_tangent=unit_tangent,
-            strain=strain,
-        )
+        return offset, unit_tangent, active
 
     def _threadlike_local_length_gradient(
-        self, context: ThreadlikeQuadratureContext
+        self, offset: Array, unit_tangent: Array, active: Array
     ) -> Array:
         """Return one planar routed-path length gradient density, ``d|t|/dxi``.
 
         Args:
-            context: Node geometry.
+            offset: Material-frame routing offset.
+            unit_tangent: Planar material-frame unit tangent.
+            active: Whether the path traverses the current segment.
 
         Returns:
             length_gradient_density: Shape ``(3,)``.
         """
-        offset = context.offset[1]
-        axial_ratio = context.unit_tangent[0]
-        shear_ratio = context.unit_tangent[1]
-        return context.active * jnp.asarray(
-            [-offset * axial_ratio, axial_ratio, shear_ratio]
+        lateral_offset = offset[1]
+        axial_ratio = unit_tangent[0]
+        shear_ratio = unit_tangent[1]
+        return active * jnp.asarray(
+            [-lateral_offset * axial_ratio, axial_ratio, shear_ratio]
         )
 
-    def _threadlike_path_curvature(self, strains: Array) -> Array:
-        """Return the curvature of the routed paths in each segment,
-        ``|omega x u_hat|``.
-
-        In the plane the angular strain is perpendicular to the in-plane unit
-        tangent, so this reduces to ``|kappa|`` identically, for any routing
-        offset and any strain, and is therefore shared by every path.
-
-        Args:
-            strains: Segment strains of shape ``(num_segments, 3)``.
-
-        Returns:
-            path_curvature: Shape ``(num_segments,)``, in radians per metre.
-        """
-        return jnp.abs(strains[:, 0])
-
-    def _threadlike_safe_wrap_angle(
+    def _threadlike_turn_rates(
         self,
-        path_curvature: Array,
-        s: Array,
-        start_segment_index: Array,
-        eps: Array,
+        strains: Array,
+        routing: ThreadlikeRouting,
+        segment_index: Array,
+        points: Array,
     ) -> Array:
-        """Integrate path curvature from each path anchor up to ``s``.
-
-        Segments before a path anchor contribute nothing, because the path
-        has not turned there yet. ``safe_norm`` floors the curvature at
-        ``eps`` to keep a Capstan coefficient identifiable near a straight
-        configuration; its zero tangent at the origin reproduces the exact
-        curvature at ``eps == 0`` with a finite gradient, which a plain
-        ``sqrt`` would not.
+        """Evaluate analytical planar-path turn rates at physical points.
 
         Args:
-            path_curvature: Per-segment curvature of shape ``(num_segments,)``.
-            s: Scalar abscissa coordinate.
-            start_segment_index: First segment of each path, ``(num_paths,)``.
-            eps: Curvature floor in radians per metre.
+            strains: Piecewise-constant planar PCS strains.
+            routing: Routed-path family.
+            segment_index: Segment containing every supplied point.
+            points: Physical backbone coordinates with shape ``(num_points,)``.
 
         Returns:
-            wrap_angle: Shape ``(num_paths,)``, in radians.
+            Turn rates shaped ``(num_points, num_paths)``.
         """
-        floored = safe_norm(
-            jnp.stack(
-                [path_curvature, jnp.broadcast_to(eps, path_curvature.shape)],
-                axis=-1,
-            ),
-            axis=-1,
-        )
-        arc_in_segment = jnp.clip(jnp.asarray(s) - self.L_cum[:-1], 0.0, self.L)
-        segments = jnp.arange(self.num_segments)
-        spanned = segments[None, :] >= jnp.asarray(start_segment_index)[:, None]
-        return (spanned * (floored * arc_in_segment)[None, :]).sum(axis=-1)
+        strain = strains[segment_index]
+        angular = jnp.asarray([0.0, 0.0, strain[0]])
+        linear = jnp.asarray([strain[1], strain[2], 0.0])
+        zero = jnp.zeros((3,), dtype=strain.dtype)
 
-    def _threadlike_moment_matrix(
+        def point_rates(s: Array) -> Array:
+            """Return all path-turn rates at one backbone coordinate."""
+
+            def path_rate(path_params: BaseThreadlikeRoutingParams) -> Array:
+                """Return one routed path's turn rate at the coordinate."""
+                return threadlike_turn_rate(
+                    angular,
+                    linear,
+                    zero,
+                    zero,
+                    routing.offset(path_params, s),
+                    routing.derivative(path_params, s),
+                    routing.second_derivative(path_params, s),
+                    eps=self.global_eps,
+                )
+
+            return vmap(path_rate)(routing.params)
+
+        return vmap(point_rates)(points)
+
+    def _threadlike_boundary_turn(
+        self,
+        strains: Array,
+        routing: ThreadlikeRouting,
+        left_segment_index: Array,
+    ) -> Array:
+        """Return one-sided path-turn angles at a planar PCS boundary.
+
+        Args:
+            strains: Piecewise-constant planar PCS strains.
+            routing: Routed-path family.
+            left_segment_index: Segment immediately before the boundary.
+
+        Returns:
+            One unsigned tangent angle per routed path.
+        """
+        s = self.L_cum[left_segment_index + 1]
+
+        def path_angle(path_params: BaseThreadlikeRoutingParams) -> Array:
+            """Return one routed path's tangent jump at the boundary."""
+            offset = routing.offset(path_params, s)
+            offset_derivative = routing.derivative(path_params, s)
+
+            def unit_tangent(strain: Array) -> Array:
+                """Return the path unit tangent for one-sided segment strain."""
+                angular = jnp.asarray([0.0, 0.0, strain[0]])
+                linear = jnp.asarray([strain[1], strain[2], 0.0])
+                tangent = threadlike_tangent(angular, linear, offset, offset_derivative)
+                return safe_normalize(tangent, eps=self.global_eps)
+
+            return threadlike_turning_angle(
+                unit_tangent(strains[left_segment_index]),
+                unit_tangent(strains[left_segment_index + 1]),
+            )
+
+        return vmap(path_angle)(routing.params)
+
+    def _threadlike_accumulated_turn(
+        self,
+        strains: Array,
+        routing: ThreadlikeRouting,
+        s: Array,
+    ) -> Array:
+        """Integrate unsigned routed-path turn from each anchor through ``s``.
+
+        Args:
+            strains: Piecewise-constant planar PCS strains.
+            routing: Routed-path family.
+            s: Physical backbone coordinate.
+
+        Returns:
+            Accumulated turn in radians for every path.
+        """
+        points = jnp.broadcast_to(
+            self.integration_points[None, :],
+            (self.num_segments, self.num_integration_points),
+        )
+        weights = jnp.broadcast_to(self.integration_weights[None, :], points.shape)
+        return integrate_accumulated_turn(
+            lambda segment_index, physical_points: self._threadlike_turn_rates(
+                strains, routing, segment_index, physical_points
+            ),
+            lambda left_segment_index: self._threadlike_boundary_turn(
+                strains, routing, left_segment_index
+            ),
+            s,
+            self.L_cum[:-1],
+            self.L,
+            points,
+            weights,
+            routing.params.start_segment_index_array,
+            routing.params.end_segment_index_array,
+        )
+
+    def _threadlike_actuation_matrix(
         self,
         q: Array,
         routing: ThreadlikeRouting,
         friction: ThreadlikeFriction | None = None,
     ) -> Array:
-        """Integrate routed-length moment arms in the planar PCS basis.
+        """Integrate the threadlike anchor-effort map in the planar PCS basis.
 
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
@@ -3118,7 +3172,7 @@ class PlanarPCS(SoftRobot):
             friction: Optional friction model.
 
         Returns:
-            A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
+            Effort-to-generalized-force matrix shaped ``(num_dofs, num_paths)``.
         """
         params = routing.params
         count = params.num_paths
@@ -3127,11 +3181,20 @@ class PlanarPCS(SoftRobot):
         strains = self.strain(q).reshape((self.num_segments, 3))
 
         has_friction = friction is not None and not friction.is_frictionless
-        path_curvature = None
-        if has_friction and friction.requires_wrap_angle:
-            path_curvature = self._threadlike_path_curvature(strains)
+        accumulated_turn = None
+        if has_friction:
+            physical_points = (
+                self.L_cum[:-1, None]
+                + self.L[:, None] * (self.integration_points[None, :])
+            )
+            accumulated_turn = vmap(
+                lambda segment_points: vmap(
+                    lambda s: self._threadlike_accumulated_turn(strains, routing, s)
+                )(segment_points)
+            )(physical_points)
 
         def segment_matrix(segment_index: Array) -> Array:
+            """Integrate the effort map over one planar PCS segment."""
             points, weights = scale_gaussian_quadrature(
                 self.integration_points,
                 self.integration_weights,
@@ -3140,7 +3203,8 @@ class PlanarPCS(SoftRobot):
             )
 
             def point_matrix(point_index: Array) -> Array:
-                context = vmap(
+                """Return one quadrature node's weighted effort-map density."""
+                offset, unit_tangent, active = vmap(
                     self._threadlike_local_geometry,
                     in_axes=(None, None, None, None, 0, 0, 0),
                     out_axes=0,
@@ -3154,21 +3218,18 @@ class PlanarPCS(SoftRobot):
                     params.end_segment_index_array,
                 )
                 gradient = vmap(self._threadlike_local_length_gradient, out_axes=1)(
-                    context
+                    offset, unit_tangent, active
                 )
                 weighted = weights[point_index] * gradient
                 if not has_friction:
                     return weighted
-                if path_curvature is not None:
-                    context = context.with_wrap_angle(
-                        self._threadlike_safe_wrap_angle(
-                            path_curvature,
-                            points[point_index],
-                            params.start_segment_index_array,
-                            getattr(friction.params, "eps", 0.0),
-                        )
-                    )
-                return weighted * friction.transmission_ratio(context)[None, :]
+                assert accumulated_turn is not None
+                return (
+                    weighted
+                    * friction.effort_ratio(
+                        accumulated_turn[segment_index, point_index]
+                    )[None, :]
+                )
 
             return jnp.sum(
                 vmap(point_matrix)(jnp.arange(self.num_integration_points)), axis=0
@@ -3178,6 +3239,20 @@ class PlanarPCS(SoftRobot):
             self.num_strains, count
         )
         return self.B_xi.T @ full_matrix
+
+    def _threadlike_path_length_jacobian(
+        self, q: Array, routing: ThreadlikeRouting
+    ) -> Array:
+        """Return the Jacobian of unscaled planar routed-path lengths.
+
+        Args:
+            q: Generalized configuration.
+            routing: Routed-path family.
+
+        Returns:
+            Jacobian shaped ``(num_paths, num_internal_dofs)``.
+        """
+        return self._threadlike_actuation_matrix(q, routing).T
 
     def _threadlike_path_lengths(self, q: Array, routing: ThreadlikeRouting) -> Array:
         """Integrate raw planar threadlike path lengths.

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -130,7 +130,6 @@ class PlanarPCS(SoftRobot):
     )
     _segment_dof_ends: tuple[int, ...] = eqx.field(static=True, default=())
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
-    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
     xi_ref: Array | None = eqx.field(default=None)  # Reference configuration strain
     B_xi_unscaled: Array | None = eqx.field(
@@ -357,12 +356,6 @@ class PlanarPCS(SoftRobot):
         self.scale_rotational_basis_by_length = bool(
             structure.scale_rotational_basis_by_length
         )
-        self.wrap_angle_smoothing = float(structure.wrap_angle_smoothing)
-        if self.wrap_angle_smoothing < 0.0:
-            raise ValueError(
-                "wrap_angle_smoothing must be non-negative, got "
-                f"{self.wrap_angle_smoothing}."
-            )
 
         # Number of segments
         num_segments = int(params.link.length.shape[0])
@@ -3008,11 +3001,14 @@ class PlanarPCS(SoftRobot):
 
         Returns:
             context: Node geometry for one path, consumed by
-                :meth:`_threadlike_local_basis` and by the installed
-                transmission-loss law.
+                :meth:`_threadlike_local_length_gradient` and by the installed
+                friction model.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
+        )
+        path_abscissa = jnp.clip(
+            jnp.asarray(s) - self.L_cum[start_segment_index], 0.0, self.L_cum[-1]
         )
         offset = routing.offset(path_params, s)
         offset_derivative = routing.derivative(path_params, s)
@@ -3026,7 +3022,8 @@ class PlanarPCS(SoftRobot):
             ]
         )
         return ThreadlikeQuadratureContext(
-            arc_length=jnp.asarray(s),
+            abscissa=jnp.asarray(s),
+            path_abscissa=path_abscissa,
             segment_index=jnp.asarray(segment_index),
             offset=offset,
             offset_derivative=offset_derivative,
@@ -3036,14 +3033,16 @@ class PlanarPCS(SoftRobot):
             strain=strain,
         )
 
-    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
-        """Return one planar routed-path length gradient density.
+    def _threadlike_local_length_gradient(
+        self, context: ThreadlikeQuadratureContext
+    ) -> Array:
+        """Return one planar routed-path length gradient density, ``d|t|/dxi``.
 
         Args:
-            context: Node geometry from :meth:`_threadlike_local_geometry`.
+            context: Node geometry.
 
         Returns:
-            phi: Length-gradient density of shape ``(3,)``.
+            length_gradient_density: Shape ``(3,)``.
         """
         offset = context.offset[1]
         axial_ratio = context.unit_tangent[0]
@@ -3052,45 +3051,58 @@ class PlanarPCS(SoftRobot):
             [-offset * axial_ratio, axial_ratio, shear_ratio]
         )
 
-    def _threadlike_wrap_density(self, strains: Array) -> Array:
-        """Return the Capstan wrap-angle density of each segment.
+    def _threadlike_path_curvature(self, strains: Array) -> Array:
+        """Return the curvature of the routed paths in each segment,
+        ``|omega x u_hat|``.
 
-        The density is ``|omega x u_hat|``, the turning rate of the routed path
-        tangent with its material-frame rotation dropped. In the plane the
-        angular strain is perpendicular to the in-plane unit tangent, so this
-        reduces to ``|kappa|`` identically, for any routing offset and any
-        strain, and is therefore shared by every path.
+        In the plane the angular strain is perpendicular to the in-plane unit
+        tangent, so this reduces to ``|kappa|`` identically, for any routing
+        offset and any strain, and is therefore shared by every path.
 
         Args:
             strains: Segment strains of shape ``(num_segments, 3)``.
 
         Returns:
-            w: Wrap-angle density per segment, shape ``(num_segments,)``, in
-                radians per metre.
+            path_curvature: Shape ``(num_segments,)``, in radians per metre.
         """
-        density = jnp.abs(strains[:, 0])
-        if self.wrap_angle_smoothing == 0.0:
-            return density
-        return jnp.sqrt(density**2 + self.wrap_angle_smoothing**2)
+        return jnp.abs(strains[:, 0])
 
-    def _threadlike_wrap_angle(self, density: Array, s: Array) -> Array:
-        """Accumulate the wrap angle from the base up to ``s``.
+    def _threadlike_safe_wrap_angle(
+        self,
+        path_curvature: Array,
+        s: Array,
+        start_segment_index: Array,
+        eps: Array,
+    ) -> Array:
+        """Integrate path curvature from each path anchor up to ``s``.
 
-        The density is piecewise constant, so the accumulated angle is
-        piecewise linear in ``s`` and therefore exact at every quadrature node.
+        Segments before a path anchor contribute nothing, because the path
+        has not turned there yet. ``safe_norm`` floors the curvature at
+        ``eps`` to keep a Capstan coefficient identifiable near a straight
+        configuration; its zero tangent at the origin reproduces the exact
+        curvature at ``eps == 0`` with a finite gradient, which a plain
+        ``sqrt`` would not.
 
         Args:
-            density: Per-segment wrap density of shape ``(num_segments,)``.
-            s: Arc-length coordinate, scalar or shape ``(num_points,)``.
+            path_curvature: Per-segment curvature of shape ``(num_segments,)``.
+            s: Scalar abscissa coordinate.
+            start_segment_index: First segment of each path, ``(num_paths,)``.
+            eps: Curvature floor in radians per metre.
 
         Returns:
-            Theta: Accumulated wrap angle in radians, matching the shape of
-                ``s``.
+            wrap_angle: Shape ``(num_paths,)``, in radians.
         """
-        arc_in_segment = jnp.clip(
-            jnp.asarray(s)[..., None] - self.L_cum[:-1], 0.0, self.L
+        floored = safe_norm(
+            jnp.stack(
+                [path_curvature, jnp.broadcast_to(eps, path_curvature.shape)],
+                axis=-1,
+            ),
+            axis=-1,
         )
-        return jnp.sum(density * arc_in_segment, axis=-1)
+        arc_in_segment = jnp.clip(jnp.asarray(s) - self.L_cum[:-1], 0.0, self.L)
+        segments = jnp.arange(self.num_segments)
+        spanned = segments[None, :] >= jnp.asarray(start_segment_index)[:, None]
+        return (spanned * (floored * arc_in_segment)[None, :]).sum(axis=-1)
 
     def _threadlike_moment_matrix(
         self,
@@ -3100,17 +3112,10 @@ class PlanarPCS(SoftRobot):
     ) -> Array:
         """Integrate routed-length moment arms in the planar PCS basis.
 
-        When a lossy ``friction`` law is installed, its transmission ratio
-        weights the local basis inside the arc-length integral, because a
-        transmission loss accumulates along the path rather than scaling the
-        applied effort. A lossless law is skipped entirely and reproduces the
-        frictionless matrix exactly.
-
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
             routing: Routed-path family to integrate.
-            friction: Optional transmission-loss law. ``None`` or any law whose
-                ``is_lossless`` is set skips the weighting entirely.
+            friction: Optional friction model.
 
         Returns:
             A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
@@ -3121,10 +3126,10 @@ class PlanarPCS(SoftRobot):
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 3))
 
-        lossy = friction is not None and not friction.is_lossless
-        wrap_density = None
-        if lossy and friction.requires_wrap_angle:
-            wrap_density = self._threadlike_wrap_density(strains)
+        has_friction = friction is not None and not friction.is_frictionless
+        path_curvature = None
+        if has_friction and friction.requires_wrap_angle:
+            path_curvature = self._threadlike_path_curvature(strains)
 
         def segment_matrix(segment_index: Array) -> Array:
             points, weights = scale_gaussian_quadrature(
@@ -3148,19 +3153,19 @@ class PlanarPCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
-                basis = vmap(self._threadlike_local_basis, out_axes=1)(context)
-                weighted = weights[point_index] * basis
-                if not lossy:
+                gradient = vmap(self._threadlike_local_length_gradient, out_axes=1)(
+                    context
+                )
+                weighted = weights[point_index] * gradient
+                if not has_friction:
                     return weighted
-                if wrap_density is not None:
-                    # The planar wrap angle is path-independent, so broadcast it
-                    # to one entry per path before the law consumes it.
+                if path_curvature is not None:
                     context = context.with_wrap_angle(
-                        jnp.broadcast_to(
-                            self._threadlike_wrap_angle(
-                                wrap_density, points[point_index]
-                            ),
-                            (count,),
+                        self._threadlike_safe_wrap_angle(
+                            path_curvature,
+                            points[point_index],
+                            params.start_segment_index_array,
+                            getattr(friction.params, "eps", 0.0),
                         )
                     )
                 return weighted * friction.transmission_ratio(context)[None, :]

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -11,8 +11,8 @@ from soromox.actuation.core import Actuator, PassiveElement
 from soromox.actuation.friction import (
     ThreadlikeFriction,
     integrate_accumulated_turn,
+    threadlike_constant_strain_turn_rate,
     threadlike_tangent,
-    threadlike_turn_rate,
     threadlike_turning_angle,
 )
 from soromox.actuation.threadlike import (
@@ -2994,16 +2994,18 @@ class PlanarPCS(SoftRobot):
         obtains from ``v + omega x r + r'``.
 
         Args:
-            segment_index: Index of the segment containing the node.
-            strain: Segment strain of shape ``(3,)``.
-            s: Backbone coordinate of the node.
+            segment_index: Scalar index of the segment containing the node.
+            strain: Planar PCS strain with shape ``(3,)``.
+            s: Scalar backbone abscissa of the node.
             routing: Routed-path family being integrated.
             path_params: Parameters of the single path.
-            start_segment_index: First segment the path spans.
-            end_segment_index: Last segment the path spans.
+            start_segment_index: Scalar index of the path's first segment.
+            end_segment_index: Scalar index of the path's last segment.
 
         Returns:
-            Tuple ``(offset, unit_tangent, active)`` for one path.
+            offset: Material-frame routing offset with shape ``(3,)``.
+            unit_tangent: Planar material-frame unit tangent with shape ``(2,)``.
+            active: Scalar indicating whether the path traverses the segment.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
@@ -3027,12 +3029,13 @@ class PlanarPCS(SoftRobot):
         """Return one planar routed-path length gradient density, ``d|t|/dxi``.
 
         Args:
-            offset: Material-frame routing offset.
-            unit_tangent: Planar material-frame unit tangent.
-            active: Whether the path traverses the current segment.
+            offset: Material-frame routing offset with shape ``(3,)``.
+            unit_tangent: Planar material-frame unit tangent with shape ``(2,)``.
+            active: Scalar indicating whether the path traverses the segment.
 
         Returns:
-            length_gradient_density: Shape ``(3,)``.
+            length_gradient_density: Routed-length gradient density with shape
+                ``(3,)``.
         """
         lateral_offset = offset[1]
         axial_ratio = unit_tangent[0]
@@ -3043,37 +3046,35 @@ class PlanarPCS(SoftRobot):
 
     def _threadlike_turn_rates(
         self,
-        strains: Array,
+        xi: Array,
         routing: ThreadlikeRouting,
         segment_index: Array,
-        points: Array,
+        s_ps: Array,
     ) -> Array:
-        """Evaluate analytical planar-path turn rates at physical points.
+        """Evaluate analytical planar-path turn rates at backbone abscissae.
 
         Args:
-            strains: Piecewise-constant planar PCS strains.
+            xi: Piecewise-constant planar PCS strains with shape
+                ``(self.num_segments, 3)``.
             routing: Routed-path family.
-            segment_index: Segment containing every supplied point.
-            points: Physical backbone coordinates with shape ``(num_points,)``.
+            segment_index: Segment containing every supplied abscissa.
+            s_ps: Backbone abscissae with shape ``(num_points,)``.
 
         Returns:
-            Turn rates shaped ``(num_points, num_paths)``.
+            Turn rates with shape ``(num_points, routing.num_paths)``.
         """
-        strain = strains[segment_index]
-        angular = jnp.asarray([0.0, 0.0, strain[0]])
-        linear = jnp.asarray([strain[1], strain[2], 0.0])
-        zero = jnp.zeros((3,), dtype=strain.dtype)
+        xi_i = xi[segment_index]
+        angular = jnp.asarray([0.0, 0.0, xi_i[0]])
+        linear = jnp.asarray([xi_i[1], xi_i[2], 0.0])
 
         def point_rates(s: Array) -> Array:
-            """Return all path-turn rates at one backbone coordinate."""
+            """Return all path-turn rates at one backbone abscissa."""
 
             def path_rate(path_params: BaseThreadlikeRoutingParams) -> Array:
-                """Return one routed path's turn rate at the coordinate."""
-                return threadlike_turn_rate(
+                """Return one routed path's turn rate at the abscissa."""
+                return threadlike_constant_strain_turn_rate(
                     angular,
                     linear,
-                    zero,
-                    zero,
                     routing.offset(path_params, s),
                     routing.derivative(path_params, s),
                     routing.second_derivative(path_params, s),
@@ -3082,23 +3083,25 @@ class PlanarPCS(SoftRobot):
 
             return vmap(path_rate)(routing.params)
 
-        return vmap(point_rates)(points)
+        return vmap(point_rates)(s_ps)
 
     def _threadlike_boundary_turn(
         self,
-        strains: Array,
+        xi: Array,
         routing: ThreadlikeRouting,
         left_segment_index: Array,
     ) -> Array:
         """Return one-sided path-turn angles at a planar PCS boundary.
 
         Args:
-            strains: Piecewise-constant planar PCS strains.
+            xi: Piecewise-constant planar PCS strains with shape
+                ``(self.num_segments, 3)``.
             routing: Routed-path family.
-            left_segment_index: Segment immediately before the boundary.
+            left_segment_index: Scalar index of the segment immediately before
+                the boundary.
 
         Returns:
-            One unsigned tangent angle per routed path.
+            Unsigned tangent angles with shape ``(routing.num_paths,)``.
         """
         s = self.L_cum[left_segment_index + 1]
 
@@ -3115,44 +3118,47 @@ class PlanarPCS(SoftRobot):
                 return safe_normalize(tangent, eps=self.global_eps)
 
             return threadlike_turning_angle(
-                unit_tangent(strains[left_segment_index]),
-                unit_tangent(strains[left_segment_index + 1]),
+                unit_tangent(xi[left_segment_index]),
+                unit_tangent(xi[left_segment_index + 1]),
             )
 
         return vmap(path_angle)(routing.params)
 
     def _threadlike_accumulated_turn(
         self,
-        strains: Array,
+        xi: Array,
         routing: ThreadlikeRouting,
         s: Array,
     ) -> Array:
         """Integrate unsigned routed-path turn from each anchor through ``s``.
 
         Args:
-            strains: Piecewise-constant planar PCS strains.
+            xi: Piecewise-constant planar PCS strains with shape
+                ``(self.num_segments, 3)``.
             routing: Routed-path family.
-            s: Physical backbone coordinate.
+            s: Scalar backbone abscissa.
 
         Returns:
-            Accumulated turn in radians for every path.
+            Accumulated turn in radians with shape ``(routing.num_paths,)``.
         """
-        points = jnp.broadcast_to(
+        normalized_s_ps = jnp.broadcast_to(
             self.integration_points[None, :],
             (self.num_segments, self.num_integration_points),
         )
-        weights = jnp.broadcast_to(self.integration_weights[None, :], points.shape)
+        weights = jnp.broadcast_to(
+            self.integration_weights[None, :], normalized_s_ps.shape
+        )
         return integrate_accumulated_turn(
-            lambda segment_index, physical_points: self._threadlike_turn_rates(
-                strains, routing, segment_index, physical_points
+            lambda segment_index, s_ps: self._threadlike_turn_rates(
+                xi, routing, segment_index, s_ps
             ),
             lambda left_segment_index: self._threadlike_boundary_turn(
-                strains, routing, left_segment_index
+                xi, routing, left_segment_index
             ),
             s,
             self.L_cum[:-1],
             self.L,
-            points,
+            normalized_s_ps,
             weights,
             routing.params.start_segment_index_array,
             routing.params.end_segment_index_array,
@@ -3168,30 +3174,31 @@ class PlanarPCS(SoftRobot):
 
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
-            routing: Routed-path family to integrate.
+            routing: Routed-path family with ``routing.num_paths`` paths.
             friction: Optional friction model.
 
         Returns:
-            Effort-to-generalized-force matrix shaped ``(num_dofs, num_paths)``.
+            A: Effort-to-generalized-force matrix with shape
+                ``(self.num_internal_dofs, routing.num_paths)``.
         """
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
-        strains = self.strain(q).reshape((self.num_segments, 3))
+        xi = self.strain(q).reshape((self.num_segments, 3))
 
         has_friction = friction is not None and not friction.is_frictionless
         accumulated_turn = None
         if has_friction:
-            physical_points = (
+            s_ps = (
                 self.L_cum[:-1, None]
                 + self.L[:, None] * (self.integration_points[None, :])
             )
             accumulated_turn = vmap(
-                lambda segment_points: vmap(
-                    lambda s: self._threadlike_accumulated_turn(strains, routing, s)
-                )(segment_points)
-            )(physical_points)
+                lambda segment_s_ps: vmap(
+                    lambda s: self._threadlike_accumulated_turn(xi, routing, s)
+                )(segment_s_ps)
+            )(s_ps)
 
         def segment_matrix(segment_index: Array) -> Array:
             """Integrate the effort map over one planar PCS segment."""
@@ -3210,7 +3217,7 @@ class PlanarPCS(SoftRobot):
                     out_axes=0,
                 )(
                     segment_index,
-                    strains[segment_index],
+                    xi[segment_index],
                     points[point_index],
                     routing,
                     params,
@@ -3246,11 +3253,15 @@ class PlanarPCS(SoftRobot):
         """Return the Jacobian of unscaled planar routed-path lengths.
 
         Args:
-            q: Generalized configuration.
+            q: Generalized coordinates with shape
+                ``(self.num_internal_dofs,)``.
             routing: Routed-path family.
 
         Returns:
-            Jacobian shaped ``(num_paths, num_internal_dofs)``.
+            J_l: Path-length Jacobian with shape
+                ``(routing.num_paths, self.num_internal_dofs)``. It maps
+                generalized velocity to unscaled path-length rates as
+                ``path_velocity = J_l @ qd``.
         """
         return self._threadlike_actuation_matrix(q, routing).T
 
@@ -3258,16 +3269,17 @@ class PlanarPCS(SoftRobot):
         """Integrate raw planar threadlike path lengths.
 
         Args:
-            q: Generalized configuration of the robot.
+            q: Generalized coordinates with shape
+                ``(self.num_internal_dofs,)``.
             routing: Threadlike routing whose paths are integrated.
 
         Returns:
-            One physical length for each routed path.
+            Physical path lengths with shape ``(routing.num_paths,)``.
         """
         params = routing.params
         if params.num_paths == 0:
             return jnp.zeros((0,), dtype=q.dtype)
-        strains = self.strain(q).reshape((self.num_segments, 3))
+        xi = self.strain(q).reshape((self.num_segments, 3))
 
         def segment_density(segment_index: Array) -> Array:
             points, weights = scale_gaussian_quadrature(
@@ -3290,10 +3302,8 @@ class PlanarPCS(SoftRobot):
                     )
                     offset = routing.offset(path_params, s)[1]
                     derivative = routing.derivative(path_params, s)[1]
-                    axial = (
-                        strains[segment_index, 1] - offset * strains[segment_index, 0]
-                    )
-                    shear = strains[segment_index, 2] + derivative
+                    axial = xi[segment_index, 1] - offset * xi[segment_index, 0]
+                    shear = xi[segment_index, 2] + derivative
                     return active * safe_norm(jnp.stack([axial, shear]))
 
                 density = vmap(path_density)(
@@ -3312,7 +3322,17 @@ class PlanarPCS(SoftRobot):
     def _threadlike_path_positions(
         self, q: Array, s: Array, routing: ThreadlikeRouting
     ) -> Array:
-        """Return planar positions of all routed paths at backbone coordinate ``s``."""
+        """Return planar routed-path positions at a backbone abscissa.
+
+        Args:
+            q: Generalized coordinates with shape
+                ``(self.num_internal_dofs,)``.
+            s: Scalar backbone abscissa.
+            routing: Routed-path family.
+
+        Returns:
+            Path positions with shape ``(routing.num_paths, 2)``.
+        """
         params = routing.params
         if params.num_paths == 0:
             return jnp.zeros((0, 2), dtype=q.dtype)

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -8,6 +8,10 @@ from jax import Array, jvp, lax, vmap
 from jax import numpy as jnp
 
 from soromox.actuation.core import Actuator, PassiveElement
+from soromox.actuation.friction import (
+    ThreadlikeFriction,
+    ThreadlikeQuadratureContext,
+)
 from soromox.actuation.threadlike import (
     BaseThreadlikeRoutingParams,
     ThreadlikeRouting,
@@ -2974,7 +2978,7 @@ class PlanarPCS(SoftRobot):
             capabilities=PLANAR_PCS_ACTUATION,
         )
 
-    def _threadlike_local_basis(
+    def _threadlike_local_geometry(
         self,
         segment_index: Array,
         strain: Array,
@@ -2983,39 +2987,70 @@ class PlanarPCS(SoftRobot):
         path_params: BaseThreadlikeRoutingParams,
         start_segment_index: Array,
         end_segment_index: Array,
-    ) -> Array:
-        """Return the routed-path length gradient in one planar segment.
+    ) -> ThreadlikeQuadratureContext:
+        """Return one planar routed-path geometry at a quadrature node.
 
-        The planar strain is ordered as ``[kappa_z, sigma_x, sigma_y]`` and
-        the routing offset is positive along material ``+y``. With the
-        backbone directed along material ``+x``, the local path tangent is
-        ``[sigma_x - offset * kappa_z, sigma_y + offset_derivative]``.
+        The offset is measured along the local ``+y`` axis, so a path at
+        positive offset lies on the inside of a positive-curvature bend and
+        shortens as that bend increases. Differentiating the routed position
+        ``p + d Rot(theta) e_y`` gives ``(sigma_x - d kappa)`` along the tangent
+        and ``(sigma_y + d')`` along the normal, which is what the spatial host
+        obtains from ``v + omega x r + r'``.
 
         Args:
-            segment_index: Index of the segment containing ``s``.
-            strain: Planar material strain for the segment.
-            s: Arc-length coordinate in the undeformed backbone.
-            routing: Threadlike routing law.
-            path_params: Parameters for one routed path.
-            start_segment_index: First segment traversed by the path.
-            end_segment_index: Last segment traversed by the path.
+            segment_index: Index of the segment containing the node.
+            strain: Segment strain of shape ``(3,)``.
+            s: Backbone coordinate of the node.
+            routing: Routed-path family being integrated.
+            path_params: Parameters of the single path.
+            start_segment_index: First segment the path spans.
+            end_segment_index: Last segment the path spans.
 
         Returns:
-            The local path-length gradient with respect to planar strain,
-            ordered as ``[kappa_z, sigma_x, sigma_y]``. The result is zero
-            outside the path's inclusive segment range.
+            context: Node geometry for one path, consumed by
+                :meth:`_threadlike_local_basis` and by the installed
+                transmission-loss law.
         """
         active = (start_segment_index <= segment_index) & (
             segment_index <= end_segment_index
         )
-        offset = routing.offset(path_params, s)[1]
-        offset_derivative = routing.derivative(path_params, s)[1]
-        axial = strain[1] - offset * strain[0]
-        shear = strain[2] + offset_derivative
+        offset = routing.offset(path_params, s)
+        offset_derivative = routing.derivative(path_params, s)
+        axial = strain[1] - offset[1] * strain[0]
+        shear = strain[2] + offset_derivative[1]
         norm = safe_norm(jnp.stack([axial, shear]))
-        axial_ratio = safe_divide(axial, norm, self.global_eps)
-        shear_ratio = safe_divide(shear, norm, self.global_eps)
-        return active * jnp.asarray([-offset * axial_ratio, axial_ratio, shear_ratio])
+        unit_tangent = jnp.stack(
+            [
+                safe_divide(axial, norm, self.global_eps),
+                safe_divide(shear, norm, self.global_eps),
+            ]
+        )
+        return ThreadlikeQuadratureContext(
+            arc_length=jnp.asarray(s),
+            segment_index=jnp.asarray(segment_index),
+            offset=offset,
+            offset_derivative=offset_derivative,
+            tangent_norm=norm,
+            active=active,
+            unit_tangent=unit_tangent,
+            strain=strain,
+        )
+
+    def _threadlike_local_basis(self, context: ThreadlikeQuadratureContext) -> Array:
+        """Return one planar routed-path length gradient density.
+
+        Args:
+            context: Node geometry from :meth:`_threadlike_local_geometry`.
+
+        Returns:
+            phi: Length-gradient density of shape ``(3,)``.
+        """
+        offset = context.offset[1]
+        axial_ratio = context.unit_tangent[0]
+        shear_ratio = context.unit_tangent[1]
+        return context.active * jnp.asarray(
+            [-offset * axial_ratio, axial_ratio, shear_ratio]
+        )
 
     def _threadlike_wrap_density(self, strains: Array) -> Array:
         """Return the Capstan wrap-angle density of each segment.
@@ -3061,21 +3096,21 @@ class PlanarPCS(SoftRobot):
         self,
         q: Array,
         routing: ThreadlikeRouting,
-        friction_coefficient: Array | None = None,
+        friction: ThreadlikeFriction | None = None,
     ) -> Array:
         """Integrate routed-length moment arms in the planar PCS basis.
 
-        When a ``friction_coefficient`` is supplied, the Capstan transmission
-        ratio ``exp(-mu * Theta(s))`` weights the local basis inside the
-        arc-length integral, because guide friction accumulates along the path
-        rather than scaling the applied effort. A zero coefficient reproduces
-        the frictionless matrix exactly.
+        When a lossy ``friction`` law is installed, its transmission ratio
+        weights the local basis inside the arc-length integral, because a
+        transmission loss accumulates along the path rather than scaling the
+        applied effort. A lossless law is skipped entirely and reproduces the
+        frictionless matrix exactly.
 
         Args:
             q: Generalized coordinates of shape ``(num_dofs,)``.
             routing: Routed-path family to integrate.
-            friction_coefficient: Optional Capstan coefficient, scalar or one
-                entry per path. ``None`` skips the weighting entirely.
+            friction: Optional transmission-loss law. ``None`` or any law whose
+                ``is_lossless`` is set skips the weighting entirely.
 
         Returns:
             A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
@@ -3086,9 +3121,9 @@ class PlanarPCS(SoftRobot):
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 3))
 
-        mu = None
-        if friction_coefficient is not None:
-            mu = jnp.broadcast_to(jnp.asarray(friction_coefficient), (count,))
+        lossy = friction is not None and not friction.is_lossless
+        wrap_density = None
+        if lossy and friction.requires_wrap_angle:
             wrap_density = self._threadlike_wrap_density(strains)
 
         def segment_matrix(segment_index: Array) -> Array:
@@ -3100,10 +3135,10 @@ class PlanarPCS(SoftRobot):
             )
 
             def point_matrix(point_index: Array) -> Array:
-                basis = vmap(
-                    self._threadlike_local_basis,
+                context = vmap(
+                    self._threadlike_local_geometry,
                     in_axes=(None, None, None, None, 0, 0, 0),
-                    out_axes=1,
+                    out_axes=0,
                 )(
                     segment_index,
                     strains[segment_index],
@@ -3113,13 +3148,22 @@ class PlanarPCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
+                basis = vmap(self._threadlike_local_basis, out_axes=1)(context)
                 weighted = weights[point_index] * basis
-                if mu is None:
+                if not lossy:
                     return weighted
-                transmission_ratio = jnp.exp(
-                    -mu * self._threadlike_wrap_angle(wrap_density, points[point_index])
-                )
-                return weighted * transmission_ratio[None, :]
+                if wrap_density is not None:
+                    # The planar wrap angle is path-independent, so broadcast it
+                    # to one entry per path before the law consumes it.
+                    context = context.with_wrap_angle(
+                        jnp.broadcast_to(
+                            self._threadlike_wrap_angle(
+                                wrap_density, points[point_index]
+                            ),
+                            (count,),
+                        )
+                    )
+                return weighted * friction.transmission_ratio(context)[None, :]
 
             return jnp.sum(
                 vmap(point_matrix)(jnp.arange(self.num_integration_points)), axis=0

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -126,6 +126,7 @@ class PlanarPCS(SoftRobot):
     )
     _segment_dof_ends: tuple[int, ...] = eqx.field(static=True, default=())
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
+    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
     xi_ref: Array | None = eqx.field(default=None)  # Reference configuration strain
     B_xi_unscaled: Array | None = eqx.field(
@@ -352,6 +353,12 @@ class PlanarPCS(SoftRobot):
         self.scale_rotational_basis_by_length = bool(
             structure.scale_rotational_basis_by_length
         )
+        self.wrap_angle_smoothing = float(structure.wrap_angle_smoothing)
+        if self.wrap_angle_smoothing < 0.0:
+            raise ValueError(
+                "wrap_angle_smoothing must be non-negative, got "
+                f"{self.wrap_angle_smoothing}."
+            )
 
         # Number of segments
         num_segments = int(params.link.length.shape[0])
@@ -3010,22 +3017,79 @@ class PlanarPCS(SoftRobot):
         shear_ratio = safe_divide(shear, norm, self.global_eps)
         return active * jnp.asarray([-offset * axial_ratio, axial_ratio, shear_ratio])
 
-    def _threadlike_moment_matrix(self, q: Array, routing: ThreadlikeRouting) -> Array:
-        """Integrate raw routed-length moment arms in the planar PCS basis.
+    def _threadlike_wrap_density(self, strains: Array) -> Array:
+        """Return the Capstan wrap-angle density of each segment.
+
+        The density is ``|omega x u_hat|``, the turning rate of the routed path
+        tangent with its material-frame rotation dropped. In the plane the
+        angular strain is perpendicular to the in-plane unit tangent, so this
+        reduces to ``|kappa|`` identically, for any routing offset and any
+        strain, and is therefore shared by every path.
 
         Args:
-            q: Generalized configuration of the robot.
-            routing: Threadlike routing whose paths are integrated.
+            strains: Segment strains of shape ``(num_segments, 3)``.
 
         Returns:
-            Matrix whose columns are routed-path length gradients with respect
-            to the generalized coordinates.
+            w: Wrap-angle density per segment, shape ``(num_segments,)``, in
+                radians per metre.
+        """
+        density = jnp.abs(strains[:, 0])
+        if self.wrap_angle_smoothing == 0.0:
+            return density
+        return jnp.sqrt(density**2 + self.wrap_angle_smoothing**2)
+
+    def _threadlike_wrap_angle(self, density: Array, s: Array) -> Array:
+        """Accumulate the wrap angle from the base up to ``s``.
+
+        The density is piecewise constant, so the accumulated angle is
+        piecewise linear in ``s`` and therefore exact at every quadrature node.
+
+        Args:
+            density: Per-segment wrap density of shape ``(num_segments,)``.
+            s: Arc-length coordinate, scalar or shape ``(num_points,)``.
+
+        Returns:
+            Theta: Accumulated wrap angle in radians, matching the shape of
+                ``s``.
+        """
+        arc_in_segment = jnp.clip(
+            jnp.asarray(s)[..., None] - self.L_cum[:-1], 0.0, self.L
+        )
+        return jnp.sum(density * arc_in_segment, axis=-1)
+
+    def _threadlike_moment_matrix(
+        self,
+        q: Array,
+        routing: ThreadlikeRouting,
+        friction_coefficient: Array | None = None,
+    ) -> Array:
+        """Integrate routed-length moment arms in the planar PCS basis.
+
+        When a ``friction_coefficient`` is supplied, the Capstan transmission
+        ratio ``exp(-mu * Theta(s))`` weights the local basis inside the
+        arc-length integral, because guide friction accumulates along the path
+        rather than scaling the applied effort. A zero coefficient reproduces
+        the frictionless matrix exactly.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+            routing: Routed-path family to integrate.
+            friction_coefficient: Optional Capstan coefficient, scalar or one
+                entry per path. ``None`` skips the weighting entirely.
+
+        Returns:
+            A: Moment-arm matrix of shape ``(num_dofs, num_paths)``.
         """
         params = routing.params
         count = params.num_paths
         if count == 0:
             return jnp.zeros((self.num_internal_dofs, 0), dtype=q.dtype)
         strains = self.strain(q).reshape((self.num_segments, 3))
+
+        mu = None
+        if friction_coefficient is not None:
+            mu = jnp.broadcast_to(jnp.asarray(friction_coefficient), (count,))
+            wrap_density = self._threadlike_wrap_density(strains)
 
         def segment_matrix(segment_index: Array) -> Array:
             points, weights = scale_gaussian_quadrature(
@@ -3049,7 +3113,13 @@ class PlanarPCS(SoftRobot):
                     params.start_segment_index_array,
                     params.end_segment_index_array,
                 )
-                return weights[point_index] * basis
+                weighted = weights[point_index] * basis
+                if mu is None:
+                    return weighted
+                transmission_ratio = jnp.exp(
+                    -mu * self._threadlike_wrap_angle(wrap_density, points[point_index])
+                )
+                return weighted * transmission_ratio[None, :]
 
             return jnp.sum(
                 vmap(point_matrix)(jnp.arange(self.num_integration_points)), axis=0

--- a/src/soromox/systems/pcs/structures.py
+++ b/src/soromox/systems/pcs/structures.py
@@ -57,11 +57,23 @@ class PCSStructure(eqx.Module):
             ``None`` activates every strain coordinate.
         scale_rotational_basis_by_length: Whether rotational strain coordinates
             are normalized by their link length.
+        wrap_angle_smoothing: Regularizer for the threadlike Capstan wrap
+            angle, in radians per metre. It replaces ``|kappa|`` by
+            ``sqrt(kappa**2 + wrap_angle_smoothing**2)``, which makes the
+            transmission ratio smooth across a straight segment instead of
+            merely continuous, and keeps a friction coefficient identifiable
+            at a straight configuration. It never under-estimates the wrap
+            angle and over-estimates it by at most
+            ``wrap_angle_smoothing * sum(length)``. It is static because it is
+            a numerical choice rather than a physical parameter, so it is
+            neither differentiated nor identified. The default reproduces the
+            exact ``|kappa|``.
     """
 
     num_gauss_points: int = eqx.field(static=True, default=5)
     strain_selector: Array | None = None
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
+    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
 
 class PlanarPCSStructure(eqx.Module):
@@ -73,11 +85,23 @@ class PlanarPCSStructure(eqx.Module):
             ``None`` activates every strain coordinate.
         scale_rotational_basis_by_length: Whether the rotational strain
             coordinate is normalized by its link length.
+        wrap_angle_smoothing: Regularizer for the threadlike Capstan wrap
+            angle, in radians per metre. It replaces ``|kappa|`` by
+            ``sqrt(kappa**2 + wrap_angle_smoothing**2)``, which makes the
+            transmission ratio smooth across a straight segment instead of
+            merely continuous, and keeps a friction coefficient identifiable
+            at a straight configuration. It never under-estimates the wrap
+            angle and over-estimates it by at most
+            ``wrap_angle_smoothing * sum(length)``. It is static because it is
+            a numerical choice rather than a physical parameter, so it is
+            neither differentiated nor identified. The default reproduces the
+            exact ``|kappa|``.
     """
 
     num_gauss_points: int = eqx.field(static=True, default=5)
     strain_selector: Array | None = None
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
+    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
 
 class PlanarHSAStructure(eqx.Module):

--- a/src/soromox/systems/pcs/structures.py
+++ b/src/soromox/systems/pcs/structures.py
@@ -57,23 +57,11 @@ class PCSStructure(eqx.Module):
             ``None`` activates every strain coordinate.
         scale_rotational_basis_by_length: Whether rotational strain coordinates
             are normalized by their link length.
-        wrap_angle_smoothing: Regularizer for the threadlike Capstan wrap
-            angle, in radians per metre. It replaces ``|kappa|`` by
-            ``sqrt(kappa**2 + wrap_angle_smoothing**2)``, which makes the
-            transmission ratio smooth across a straight segment instead of
-            merely continuous, and keeps a friction coefficient identifiable
-            at a straight configuration. It never under-estimates the wrap
-            angle and over-estimates it by at most
-            ``wrap_angle_smoothing * sum(length)``. It is static because it is
-            a numerical choice rather than a physical parameter, so it is
-            neither differentiated nor identified. The default reproduces the
-            exact ``|kappa|``.
     """
 
     num_gauss_points: int = eqx.field(static=True, default=5)
     strain_selector: Array | None = None
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
-    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
 
 class PlanarPCSStructure(eqx.Module):
@@ -85,23 +73,11 @@ class PlanarPCSStructure(eqx.Module):
             ``None`` activates every strain coordinate.
         scale_rotational_basis_by_length: Whether the rotational strain
             coordinate is normalized by its link length.
-        wrap_angle_smoothing: Regularizer for the threadlike Capstan wrap
-            angle, in radians per metre. It replaces ``|kappa|`` by
-            ``sqrt(kappa**2 + wrap_angle_smoothing**2)``, which makes the
-            transmission ratio smooth across a straight segment instead of
-            merely continuous, and keeps a friction coefficient identifiable
-            at a straight configuration. It never under-estimates the wrap
-            angle and over-estimates it by at most
-            ``wrap_angle_smoothing * sum(length)``. It is static because it is
-            a numerical choice rather than a physical parameter, so it is
-            neither differentiated nor identified. The default reproduces the
-            exact ``|kappa|``.
     """
 
     num_gauss_points: int = eqx.field(static=True, default=5)
     strain_selector: Array | None = None
     scale_rotational_basis_by_length: bool = eqx.field(static=True, default=False)
-    wrap_angle_smoothing: float = eqx.field(static=True, default=0.0)
 
 
 class PlanarHSAStructure(eqx.Module):

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -2265,8 +2265,8 @@ class SoftRobot(DynamicalSystem):
         Return the installed transmissions' coordinate velocities.
 
         Velocities are concatenated in actuator and channel order and satisfy
-        ``yd_a = A(q).T @ qd``, where ``A(q)`` is the concatenated actuator
-        transmission matrix.
+        ``yd_a = J_a(q) @ qd``, where ``J_a(q)`` is
+        :meth:`actuator_coordinate_jacobian`.
 
         Args:
             q: Generalized coordinates of shape ``(num_coordinates,)``.
@@ -2277,20 +2277,41 @@ class SoftRobot(DynamicalSystem):
                 ``(num_actuators,)``. An unactuated robot returns an empty
                 array.
         """
+        return self.actuator_coordinate_jacobian(q) @ qd
+
+    def actuator_coordinate_jacobian(self, q: Array) -> Array:
+        """Return the Jacobian of all installed actuator coordinates.
+
+        The singular ``coordinate`` follows the package convention for a
+        Jacobian of the vector returned by :meth:`actuator_coordinates`.
+        Rows are concatenated in actuator and channel order and satisfy
+        ``actuator_velocities(q, qd) = J_a(q) @ qd``.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_coordinates,)``.
+
+        Returns:
+            Coordinate Jacobian ``J_a`` with shape
+            ``(num_actuators, num_velocities)``.
+        """
         if self.floating_base:
             _, q_internal = self.split_configuration(q)
-            _, qd_internal = self.split_velocity(qd)
-            return self._fixed_base_robot_at_pose().actuator_velocities(
-                q_internal, qd_internal
+            internal = self._fixed_base_robot_at_pose().actuator_coordinate_jacobian(
+                q_internal
             )
+            return jnp.pad(internal, ((0, 0), (self.num_base_velocities, 0)))
         if not self.actuators:
-            return jnp.zeros((0,), dtype=q.dtype)
+            return jnp.zeros((0, self.num_velocities), dtype=q.dtype)
         return jnp.concatenate(
-            tuple(actuator.velocities(self, q, qd) for actuator in self.actuators)
+            tuple(
+                actuator.transmission.coordinate_jacobian(self, q)
+                for actuator in self.actuators
+            ),
+            axis=0,
         )
 
     def _actuation_matrix(self, q: Array) -> Array:
-        """Return the protected differentiable JAX transmission matrix."""
+        """Return the protected differentiable JAX actuation matrix."""
 
         if self.floating_base:
             _, q_internal = self.split_configuration(q)
@@ -2301,7 +2322,7 @@ class SoftRobot(DynamicalSystem):
             return jnp.zeros((self.num_velocities, 0), dtype=q.dtype)
         return jnp.concatenate(
             tuple(
-                actuator.transmission.moment_matrix(self, q)
+                actuator.transmission.actuation_matrix(self, q)
                 for actuator in self.actuators
             ),
             axis=1,
@@ -2309,16 +2330,16 @@ class SoftRobot(DynamicalSystem):
 
     def actuation_matrix(self, q: Array, *, backend: str | None = None) -> Array:
         """
-        Return the actuator transmission matrix ``A(q)``.
+        Return the actuation matrix ``A(q)``.
 
-        ``A(q)`` is the concatenated moment-arm matrix of the installed
-        transmissions. It maps work-conjugate actuator efforts ``e`` to
-        generalized forces,
+        ``A(q)`` is the concatenated effort-to-generalized-force map of the
+        installed transmissions:
 
         ``tau_u = A(q) @ e``.
 
-        Equivalently, ``A(q).T`` is the Jacobian of the actuator coordinates
-        with respect to the generalized coordinates.
+        For ideal lossless transmissions, ``A(q)`` equals
+        ``actuator_coordinate_jacobian(q).T``. A lossy transmission can break
+        that equality while preserving the kinematic coordinate Jacobian.
 
         Args:
             q: Generalized coordinates of shape (num_coordinates,).
@@ -2326,7 +2347,7 @@ class SoftRobot(DynamicalSystem):
                 implementation supports JAX execution.
 
         Returns:
-            A: Actuator transmission matrix of shape
+            A: Actuation matrix of shape
                 (num_velocities, num_actuators).
         """
         if backend not in (None, "auto", "jax"):
@@ -2341,7 +2362,7 @@ class SoftRobot(DynamicalSystem):
         u: Array,
         qd: Array | None = None,
         *,
-        actuation_matrix: Array | None = None,
+        coordinate_jacobian: Array | None = None,
     ) -> Array:
         """
         Map user controls to work-conjugate actuator efforts.
@@ -2356,15 +2377,15 @@ class SoftRobot(DynamicalSystem):
             q: Generalized coordinates of shape (num_coordinates,).
             u: Actuator controls of shape (num_actuators,).
             qd: Optional generalized velocities of shape (num_velocities,).
-            actuation_matrix: Optional precomputed actuator transmission matrix
-                with shape ``(num_velocities, num_actuators)``. It is reused for
-                velocity-dependent effort laws.
+            coordinate_jacobian: Optional precomputed actuator-coordinate
+                Jacobian with shape ``(num_actuators, num_velocities)``. It is
+                reused for velocity-dependent effort laws.
 
         Returns:
             e: Work-conjugate actuator efforts of shape (num_actuators,).
 
         Raises:
-            ValueError: If ``u`` or ``actuation_matrix`` has an incompatible
+            ValueError: If ``u`` or ``coordinate_jacobian`` has an incompatible
                 shape.
         """
         if self.floating_base:
@@ -2372,30 +2393,30 @@ class SoftRobot(DynamicalSystem):
             qd_internal = None
             if qd is not None:
                 _, qd_internal = self.split_velocity(qd)
-            internal_matrix = (
+            internal_jacobian = (
                 None
-                if actuation_matrix is None
-                else actuation_matrix[self.num_base_velocities :]
+                if coordinate_jacobian is None
+                else coordinate_jacobian[:, self.num_base_velocities :]
             )
             return self._fixed_base_robot_at_pose().actuator_efforts(
                 q_internal,
                 u,
                 qd=qd_internal,
-                actuation_matrix=internal_matrix,
+                coordinate_jacobian=internal_jacobian,
             )
         u = jnp.asarray(u)
         if u.shape != (self.num_actuators,):
             raise ValueError(
                 f"u must have shape ({self.num_actuators},), got {u.shape}."
             )
-        if actuation_matrix is not None and actuation_matrix.shape != (
-            self.num_velocities,
+        if coordinate_jacobian is not None and coordinate_jacobian.shape != (
             self.num_actuators,
+            self.num_velocities,
         ):
             raise ValueError(
-                "actuation_matrix must have shape "
-                f"({self.num_velocities}, {self.num_actuators}), got "
-                f"{actuation_matrix.shape}."
+                "coordinate_jacobian must have shape "
+                f"({self.num_actuators}, {self.num_velocities}), got "
+                f"{coordinate_jacobian.shape}."
             )
         if not self.actuators:
             return jnp.zeros((0,), dtype=u.dtype)
@@ -2403,8 +2424,8 @@ class SoftRobot(DynamicalSystem):
         start = 0
         for actuator in self.actuators:
             stop = start + actuator.num_channels
-            actuator_transmission_matrix = (
-                None if actuation_matrix is None else actuation_matrix[:, start:stop]
+            actuator_coordinate_jacobian = (
+                None if coordinate_jacobian is None else coordinate_jacobian[start:stop]
             )
             efforts.append(
                 actuator.efforts(
@@ -2412,7 +2433,7 @@ class SoftRobot(DynamicalSystem):
                     q,
                     u[start:stop],
                     qd=qd,
-                    transmission_matrix=actuator_transmission_matrix,
+                    coordinate_jacobian=actuator_coordinate_jacobian,
                 )
             )
             start = stop
@@ -2422,13 +2443,20 @@ class SoftRobot(DynamicalSystem):
         """Return the protected differentiable JAX generalized actuator force."""
 
         actuation_matrix = self._actuation_matrix(q)
+        coordinate_jacobian = (
+            self.actuator_coordinate_jacobian(q)
+            if any(
+                actuator.effort_model.requires_velocity for actuator in self.actuators
+            )
+            else None
+        )
         effort = self.actuator_efforts(
             q,
             u,
             qd=qd,
-            actuation_matrix=actuation_matrix,
+            coordinate_jacobian=coordinate_jacobian,
         )
-        return actuation_matrix @ effort - self.passive_nonconservative_force(q)
+        return actuation_matrix @ effort
 
     def actuation_force(
         self,
@@ -2442,17 +2470,10 @@ class SoftRobot(DynamicalSystem):
         Compute the generalized actuation force.
 
         The installed effort models first map the ordered controls ``u`` to
-        work-conjugate actuator efforts ``e``. The actuator transmission matrix
+        work-conjugate actuator efforts ``e``. The actuation matrix
         then maps those efforts to generalized forces as
 
         ``tau_u = A(q) @ e``.
-
-        Any non-conservative passive force is subtracted here as well, because
-        it has no potential and therefore cannot be carried by
-        :meth:`elastic_force`. It is independent of ``u``, so with such an
-        element installed the returned force is affine in ``u`` rather than
-        linear and ``actuation_force(q, 0)`` is nonzero. Prefer this method
-        over ``actuation_matrix(q) @ e`` wherever passive elements exist.
 
         Args:
             q: Generalized coordinates of shape (num_coordinates,).
@@ -2582,47 +2603,6 @@ class SoftRobot(DynamicalSystem):
         for element in self.passive_elements:
             energy = energy + element.elastic_energy(self, q)
         return energy
-
-    def passive_nonconservative_force(self, q: Array) -> Array:
-        """
-        Return the installed passive elements' non-conservative generalized force.
-
-        This is the part of the passive force that is not the gradient of any
-        potential and therefore cannot live in :meth:`elastic_force` without
-        breaking its energy contract. It is applied through
-        :meth:`actuation_force`, so the total dynamics is unchanged by the
-        split and no system implementation needs to be modified.
-
-        Args:
-            q: Generalized coordinates of shape ``(num_coordinates,)``.
-
-        Returns:
-            tau_nc: Non-conservative passive generalized force of shape
-                ``(num_velocities,)``, in the same sign convention as
-                :meth:`elastic_force`. A robot whose passive elements are all
-                conservative returns zeros.
-        """
-        if self.floating_base:
-            total_input = q.shape[-1] == self.num_coordinates
-            q_internal = (
-                self.split_configuration(q)[1]
-                if total_input
-                else self._check_trailing_dimension(
-                    "q_internal", q, self.num_internal_dofs
-                )
-            )
-            internal = self._fixed_base_robot_at_pose().passive_nonconservative_force(
-                q_internal
-            )
-            return (
-                jnp.pad(internal, (self.num_base_velocities, 0))
-                if total_input
-                else internal
-            )
-        force = jnp.zeros((self.num_velocities,), dtype=q.dtype)
-        for element in self.passive_elements:
-            force = force + element.nonconservative_force(self, q)
-        return force
 
     # -----------------------------------------
     # Energy methods

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -2282,9 +2282,8 @@ class SoftRobot(DynamicalSystem):
     def actuator_coordinate_jacobian(self, q: Array) -> Array:
         """Return the Jacobian of all installed actuator coordinates.
 
-        The singular ``coordinate`` follows the package convention for a
-        Jacobian of the vector returned by :meth:`actuator_coordinates`.
-        Rows are concatenated in actuator and channel order and satisfy
+        Rows are concatenated in actuator and channel order. The Jacobian maps
+        generalized velocities to actuator-coordinate velocities according to
         ``actuator_velocities(q, qd) = J_a(q) @ qd``.
 
         Args:

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -2594,15 +2594,32 @@ class SoftRobot(DynamicalSystem):
         split and no system implementation needs to be modified.
 
         Args:
-            q: Generalized coordinates of shape ``(num_dofs,)``.
+            q: Generalized coordinates of shape ``(num_coordinates,)``.
 
         Returns:
             tau_nc: Non-conservative passive generalized force of shape
-                ``(num_dofs,)``, in the same sign convention as
+                ``(num_velocities,)``, in the same sign convention as
                 :meth:`elastic_force`. A robot whose passive elements are all
                 conservative returns zeros.
         """
-        force = jnp.zeros((self.num_dofs,), dtype=q.dtype)
+        if self.floating_base:
+            total_input = q.shape[-1] == self.num_coordinates
+            q_internal = (
+                self.split_configuration(q)[1]
+                if total_input
+                else self._check_trailing_dimension(
+                    "q_internal", q, self.num_internal_dofs
+                )
+            )
+            internal = self._fixed_base_robot_at_pose().passive_nonconservative_force(
+                q_internal
+            )
+            return (
+                jnp.pad(internal, (self.num_base_velocities, 0))
+                if total_input
+                else internal
+            )
+        force = jnp.zeros((self.num_velocities,), dtype=q.dtype)
         for element in self.passive_elements:
             force = force + element.nonconservative_force(self, q)
         return force

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -2428,7 +2428,7 @@ class SoftRobot(DynamicalSystem):
             qd=qd,
             actuation_matrix=actuation_matrix,
         )
-        return actuation_matrix @ effort
+        return actuation_matrix @ effort - self.passive_nonconservative_force(q)
 
     def actuation_force(
         self,
@@ -2446,6 +2446,13 @@ class SoftRobot(DynamicalSystem):
         then maps those efforts to generalized forces as
 
         ``tau_u = A(q) @ e``.
+
+        Any non-conservative passive force is subtracted here as well, because
+        it has no potential and therefore cannot be carried by
+        :meth:`elastic_force`. It is independent of ``u``, so with such an
+        element installed the returned force is affine in ``u`` rather than
+        linear and ``actuation_force(q, 0)`` is nonzero. Prefer this method
+        over ``actuation_matrix(q) @ e`` wherever passive elements exist.
 
         Args:
             q: Generalized coordinates of shape (num_coordinates,).
@@ -2575,6 +2582,30 @@ class SoftRobot(DynamicalSystem):
         for element in self.passive_elements:
             energy = energy + element.elastic_energy(self, q)
         return energy
+
+    def passive_nonconservative_force(self, q: Array) -> Array:
+        """
+        Return the installed passive elements' non-conservative generalized force.
+
+        This is the part of the passive force that is not the gradient of any
+        potential and therefore cannot live in :meth:`elastic_force` without
+        breaking its energy contract. It is applied through
+        :meth:`actuation_force`, so the total dynamics is unchanged by the
+        split and no system implementation needs to be modified.
+
+        Args:
+            q: Generalized coordinates of shape ``(num_dofs,)``.
+
+        Returns:
+            tau_nc: Non-conservative passive generalized force of shape
+                ``(num_dofs,)``, in the same sign convention as
+                :meth:`elastic_force`. A robot whose passive elements are all
+                conservative returns zeros.
+        """
+        force = jnp.zeros((self.num_dofs,), dtype=q.dtype)
+        for element in self.passive_elements:
+            force = force + element.nonconservative_force(self, q)
+        return force
 
     # -----------------------------------------
     # Energy methods

--- a/tests/actuation/test_joint.py
+++ b/tests/actuation/test_joint.py
@@ -226,12 +226,12 @@ def test_affine_joint_transmission_coordinates_jacobian_and_power():
     assert_allclose(transmission.coordinates(robot, q), expected_coordinate)
     assert_allclose(
         jax.jacrev(transmission.coordinates, argnums=1)(robot, q),
-        transmission.moment_matrix(robot, q).T,
+        transmission.actuation_matrix(robot, q).T,
         rtol=1e-12,
         atol=1e-12,
     )
     yad = transmission.velocities(robot, q, qd)
-    tau = transmission.moment_matrix(robot, q) @ effort
+    tau = transmission.actuation_matrix(robot, q) @ effort
     assert_allclose(qd @ tau, yad @ effort, rtol=1e-12, atol=1e-12)
 
 
@@ -365,7 +365,7 @@ def test_generic_affine_map_accepts_pcs_coordinates_but_tendon_preset_rejects_pc
     q = jnp.linspace(-0.1, 0.2, robot.num_internal_dofs)
 
     assert_allclose(transmission.coordinates(robot, q), matrix @ q + jnp.array([0.2]))
-    assert_allclose(transmission.moment_matrix(robot, q), matrix.T)
+    assert_allclose(transmission.actuation_matrix(robot, q), matrix.T)
 
     with pytest.raises(TypeError, match="serial articulated host"):
         _spatial_pcs(

--- a/tests/actuation/test_mckibben.py
+++ b/tests/actuation/test_mckibben.py
@@ -73,7 +73,7 @@ def test_length_jacobian_gradient_is_finite(coincident: bool):
     """Cover the direction vector, which divides by the displacement norm.
 
     This exercises the private group-local hook directly because the public
-    moment matrix additionally needs an articulated host, which is irrelevant to
+    actuation matrix additionally needs an articulated host, which is irrelevant to
     the degeneracy under test.
     """
     transmission = make_transmission(coincident)
@@ -117,11 +117,13 @@ def test_coordinate_gradient_is_finite(coincident: bool):
 
 
 @pytest.mark.parametrize("coincident", [False, True])
-def test_moment_matrix_gradient_is_finite(coincident: bool):
-    """Exercise the public moment-matrix path through normalized directions."""
+def test_actuation_matrix_gradient_is_finite(coincident: bool):
+    """Exercise the public actuation-matrix path through normalized directions."""
     transmission = make_transmission(coincident)
     robot = SimpleNamespace(num_velocities=2)
 
-    jacobian = jax.jacrev(lambda q: transmission.moment_matrix(robot, q))(jnp.zeros(2))
+    jacobian = jax.jacrev(lambda q: transmission.actuation_matrix(robot, q))(
+        jnp.zeros(2)
+    )
 
     assert jnp.isfinite(jacobian).all()

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -171,12 +171,13 @@ def _updated_threadlike_component_params(actuator, passive):
     updated_actuator = actuator_params.replace(transmission=actuator_transmission)
 
     passive_params = passive.params
-    passive_routing = passive_params.routing.replace(
-        intercept=1.01 * passive_params.routing.intercept,
-        slope=1.02 * passive_params.routing.slope,
+    passive_routing = passive_params.transmission.routing.replace(
+        intercept=1.01 * passive_params.transmission.routing.intercept,
+        slope=1.02 * passive_params.transmission.routing.slope,
     )
+    passive_transmission = passive_params.transmission.replace(routing=passive_routing)
     updated_passive = passive_params.replace(
-        routing=passive_routing,
+        transmission=passive_transmission,
         stiffness=1.03 * passive_params.stiffness,
         damping=1.04 * passive_params.damping,
         rest_length=1.01 * passive_params.rest_length,
@@ -411,11 +412,11 @@ def test_direct_effort_skips_unused_threadlike_state(monkeypatch):
     calls = {"moment_matrix": 0}
     original_moment_matrix = PCS._threadlike_moment_matrix
 
-    def counted_moment_matrix(self, q, routing):
+    def counted_moment_matrix(self, q, routing, friction_coefficient=None):
         calls["moment_matrix"] += 1
         return original_moment_matrix(self, q, routing)
 
-    def unexpected_path_lengths(self, q, routing):
+    def unexpected_path_lengths(self, q, routing, friction_coefficient=None):
         del self, q, routing
         raise AssertionError("DirectEffort must not evaluate actuator coordinates.")
 
@@ -463,11 +464,11 @@ def test_state_dependent_effort_reuses_generalized_force_moment_matrix(monkeypat
     original_moment_matrix = PCS._threadlike_moment_matrix
     original_path_lengths = PCS._threadlike_path_lengths
 
-    def counted_moment_matrix(self, q, routing):
+    def counted_moment_matrix(self, q, routing, friction_coefficient=None):
         calls["moment_matrix"] += 1
         return original_moment_matrix(self, q, routing)
 
-    def counted_path_lengths(self, q, routing):
+    def counted_path_lengths(self, q, routing, friction_coefficient=None):
         calls["path_lengths"] += 1
         return original_path_lengths(self, q, routing)
 

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -172,13 +172,12 @@ def _updated_threadlike_component_params(actuator, passive):
     updated_actuator = actuator_params.replace(transmission=actuator_transmission)
 
     passive_params = passive.params
-    passive_routing = passive_params.transmission.routing.replace(
-        intercept=1.01 * passive_params.transmission.routing.intercept,
-        slope=1.02 * passive_params.transmission.routing.slope,
+    passive_routing = passive_params.routing.replace(
+        intercept=1.01 * passive_params.routing.intercept,
+        slope=1.02 * passive_params.routing.slope,
     )
-    passive_transmission = passive_params.transmission.replace(routing=passive_routing)
     updated_passive = passive_params.replace(
-        transmission=passive_transmission,
+        routing=passive_routing,
         stiffness=1.03 * passive_params.stiffness,
         damping=1.04 * passive_params.damping,
         rest_length=1.01 * passive_params.rest_length,
@@ -362,7 +361,7 @@ def test_identity_unactuated_and_mixed_construction():
         )
     )
     q = jnp.zeros(mixed.num_internal_dofs)
-    raw = mixed._threadlike_moment_matrix(q, routing)
+    raw = mixed._threadlike_actuation_matrix(q, routing)
     assert_allclose(mixed.actuation_matrix(q), jnp.concatenate((-raw, raw), axis=1))
     assert [metadata.kind for metadata in mixed.actuator_input_metadata] == [
         "tendon",
@@ -410,28 +409,28 @@ def test_direct_effort_skips_unused_threadlike_state(monkeypatch):
     qd = jnp.linspace(0.04, -0.01, robot.num_internal_dofs)
     control = jnp.array([3.0, 4.0])
     expected_force = robot.actuation_matrix(q) @ control
-    calls = {"moment_matrix": 0}
-    original_moment_matrix = PCS._threadlike_moment_matrix
+    calls = {"actuation_matrix": 0}
+    original_actuation_matrix = PCS._threadlike_actuation_matrix
 
-    def counted_moment_matrix(self, q, routing, friction=None):
-        calls["moment_matrix"] += 1
-        return original_moment_matrix(self, q, routing)
+    def counted_actuation_matrix(self, q, routing, friction=None):
+        calls["actuation_matrix"] += 1
+        return original_actuation_matrix(self, q, routing, friction=friction)
 
     def unexpected_path_lengths(self, q, routing, friction=None):
         del self, q, routing
         raise AssertionError("DirectEffort must not evaluate actuator coordinates.")
 
-    monkeypatch.setattr(PCS, "_threadlike_moment_matrix", counted_moment_matrix)
+    monkeypatch.setattr(PCS, "_threadlike_actuation_matrix", counted_actuation_matrix)
     monkeypatch.setattr(PCS, "_threadlike_path_lengths", unexpected_path_lengths)
 
     assert_allclose(robot.actuator_efforts(q, control, qd=qd), control)
-    assert calls["moment_matrix"] == 0
+    assert calls["actuation_matrix"] == 0
 
     assert_allclose(
         robot.actuation_force(q, control, qd=qd),
         expected_force,
     )
-    assert calls["moment_matrix"] == 1
+    assert calls["actuation_matrix"] == 1
 
 
 class CoordinateVelocityEffort(EffortModel):
@@ -443,7 +442,7 @@ class CoordinateVelocityEffort(EffortModel):
         return control + coordinate + velocity
 
 
-def test_state_dependent_effort_reuses_generalized_force_moment_matrix(monkeypatch):
+def test_state_dependent_effort_uses_coordinate_jacobian(monkeypatch):
     actuator = ThreadlikeActuator.tendons(_routing())
     actuator = eqx.tree_at(
         lambda current: current._effort_model,
@@ -456,63 +455,72 @@ def test_state_dependent_effort_reuses_generalized_force_moment_matrix(monkeypat
     control = jnp.array([3.0, 4.0])
 
     matrix = robot.actuation_matrix(q)
+    coordinate_jacobian = robot.actuator_coordinate_jacobian(q)
     coordinate = robot.actuator_coordinates(q)
     expected_effort = robot.actuator_efforts(q, control, qd=qd)
-    assert_allclose(expected_effort, control + coordinate + matrix.T @ qd)
+    assert_allclose(expected_effort, control + coordinate + coordinate_jacobian @ qd)
     expected_force = matrix @ expected_effort
 
-    calls = {"moment_matrix": 0, "path_lengths": 0}
-    original_moment_matrix = PCS._threadlike_moment_matrix
+    calls = {"actuation_matrix": 0, "path_lengths": 0}
+    original_actuation_matrix = PCS._threadlike_actuation_matrix
     original_path_lengths = PCS._threadlike_path_lengths
 
-    def counted_moment_matrix(self, q, routing, friction=None):
-        calls["moment_matrix"] += 1
-        return original_moment_matrix(self, q, routing)
+    def counted_actuation_matrix(self, q, routing, friction=None):
+        calls["actuation_matrix"] += 1
+        return original_actuation_matrix(self, q, routing, friction=friction)
 
     def counted_path_lengths(self, q, routing, friction=None):
         calls["path_lengths"] += 1
         return original_path_lengths(self, q, routing)
 
-    monkeypatch.setattr(PCS, "_threadlike_moment_matrix", counted_moment_matrix)
+    monkeypatch.setattr(PCS, "_threadlike_actuation_matrix", counted_actuation_matrix)
     monkeypatch.setattr(PCS, "_threadlike_path_lengths", counted_path_lengths)
 
     assert_allclose(robot.actuation_force(q, control, qd=qd), expected_force)
-    assert calls == {"moment_matrix": 1, "path_lengths": 1}
+    assert calls == {"actuation_matrix": 2, "path_lengths": 1}
 
 
-def test_precomputed_transmission_matrices_require_compatible_shapes():
+def test_precomputed_coordinate_jacobians_require_compatible_shapes():
     actuator = ThreadlikeActuator.tendons(_routing())
     robot = _spatial_pcs(actuators=actuator)
     q = jnp.zeros(robot.num_internal_dofs)
     control = jnp.ones(robot.num_actuators)
 
-    with pytest.raises(ValueError, match="actuation_matrix must have shape"):
+    with pytest.raises(ValueError, match="coordinate_jacobian must have shape"):
         robot.actuator_efforts(
             q,
             control,
-            actuation_matrix=jnp.zeros(
-                (robot.num_internal_dofs, robot.num_actuators + 1)
+            coordinate_jacobian=jnp.zeros(
+                (robot.num_actuators + 1, robot.num_internal_dofs)
             ),
         )
 
-    with pytest.raises(ValueError, match="transmission_matrix must have shape"):
+    with pytest.raises(ValueError, match="coordinate_jacobian must have shape"):
         actuator.efforts(
             robot,
             q,
             control,
-            transmission_matrix=jnp.zeros(
-                (robot.num_internal_dofs, actuator.num_channels + 1)
+            coordinate_jacobian=jnp.zeros(
+                (actuator.num_channels + 1, robot.num_internal_dofs)
             ),
         )
 
 
 @pytest.mark.parametrize("factory", [_spatial_pcs, _planar_pcs, _gvs])
-def test_coordinate_jacobian_equals_moment_matrix_transpose(factory):
+def test_lossless_coordinate_jacobian_equals_actuation_matrix_transpose(factory):
     actuator = ThreadlikeActuator.tendons(_routing())
     robot = factory(actuators=actuator)
     q = jnp.linspace(-0.02, 0.03, robot.num_internal_dofs)
     jacobian = jax.jacrev(robot.actuator_coordinates)(q)
-    assert_allclose(jacobian, robot.actuation_matrix(q).T, rtol=2e-7, atol=2e-9)
+    assert_allclose(
+        jacobian, robot.actuator_coordinate_jacobian(q), rtol=2e-7, atol=2e-9
+    )
+    assert_allclose(
+        robot.actuator_coordinate_jacobian(q),
+        robot.actuation_matrix(q).T,
+        rtol=2e-7,
+        atol=2e-9,
+    )
 
 
 @pytest.mark.parametrize(
@@ -522,9 +530,8 @@ def test_coordinate_jacobian_equals_moment_matrix_transpose(factory):
         (_spatial_pcs, 3, ThreadlikeFriction.capstan(coefficient=0.7)),
         (_planar_pcs, 1, None),
         (_planar_pcs, 1, ThreadlikeFriction.capstan(coefficient=0.7)),
-        # GVS supplies no wrap angle, so it hosts only wrap-angle-free laws.
         (_gvs, 3, None),
-        (_gvs, 3, ThreadlikeFriction.exponential_length(rate=3.0)),
+        (_gvs, 3, ThreadlikeFriction.capstan(coefficient=0.7)),
     ],
 )
 def test_collapsed_threadlike_tangent_has_finite_reverse_mode(

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -515,12 +515,22 @@ def test_coordinate_jacobian_equals_moment_matrix_transpose(factory):
 
 
 @pytest.mark.parametrize(
-    ("factory", "axial_index"),
-    [(_spatial_pcs, 3), (_planar_pcs, 1), (_gvs, 3)],
+    ("factory", "axial_index", "friction_coefficient"),
+    [
+        (_spatial_pcs, 3, 0.0),
+        (_spatial_pcs, 3, 0.7),
+        (_planar_pcs, 1, 0.0),
+        (_planar_pcs, 1, 0.7),
+        (_gvs, 3, 0.0),  # GVS refuses a nonzero coefficient at construction
+    ],
 )
-def test_collapsed_threadlike_tangent_has_finite_reverse_mode(factory, axial_index):
+def test_collapsed_threadlike_tangent_has_finite_reverse_mode(
+    factory, axial_index, friction_coefficient
+):
     """Cover normalization and path density at an exactly zero routing tangent."""
-    actuator = ThreadlikeActuator.tendons(_routing(count=1))
+    actuator = ThreadlikeActuator.tendons(
+        _routing(count=1), friction_coefficient=friction_coefficient
+    )
     robot = factory(actuators=actuator)
     q = jnp.zeros(robot.num_internal_dofs).at[axial_index].set(-1.0)
 

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -304,12 +304,12 @@ class SinusoidalRoutingParams(BaseThreadlikeRoutingParams):
 
 def _sinusoidal_offset(params: SinusoidalRoutingParams, s):
     y = params.amplitude * jnp.sin(params.frequency * s)
-    return jnp.asarray([0.0, y, 0.0])
+    return jnp.stack((jnp.zeros_like(y), y, jnp.zeros_like(y)), axis=-1)
 
 
 def _sinusoidal_derivative(params: SinusoidalRoutingParams, s):
     y_dot = params.amplitude * params.frequency * jnp.cos(params.frequency * s)
-    return jnp.asarray([0.0, y_dot, 0.0])
+    return jnp.stack((jnp.zeros_like(y_dot), y_dot, jnp.zeros_like(y_dot)), axis=-1)
 
 
 def test_linear_routing_uses_full_material_frame_vectors():
@@ -534,19 +534,22 @@ def test_lossless_coordinate_jacobian_equals_actuation_matrix_transpose(factory)
         (_gvs, 3, ThreadlikeFriction.capstan(coefficient=0.7)),
     ],
 )
-def test_collapsed_threadlike_tangent_has_finite_reverse_mode(
+def test_collapsed_threadlike_tangent_has_finite_values_and_derivatives(
     factory, axial_index, friction
 ):
-    """Cover normalization and path density at an exactly zero routing tangent."""
+    """Cover values and both AD modes at an exactly zero routing tangent."""
     actuator = ThreadlikeActuator.tendons(_routing(count=1), friction=friction)
     robot = factory(actuators=actuator)
     q = jnp.zeros(robot.num_internal_dofs).at[axial_index].set(-1.0)
 
-    coordinate_jacobian = jax.jacrev(robot.actuator_coordinates)(q)
-    matrix_jacobian = jax.jacrev(robot.actuation_matrix)(q)
-
-    assert jnp.isfinite(coordinate_jacobian).all()
-    assert jnp.isfinite(matrix_jacobian).all()
+    for function in (
+        robot.actuator_coordinates,
+        robot.actuator_coordinate_jacobian,
+        robot.actuation_matrix,
+    ):
+        assert jnp.isfinite(function(q)).all()
+        assert jnp.isfinite(jax.jacfwd(function)(q)).all()
+        assert jnp.isfinite(jax.jacrev(function)(q)).all()
 
 
 def test_custom_nonlinear_routing_uses_the_common_host_contract():

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -16,7 +16,9 @@ from system_param_builders import (
 
 from soromox.actuation import (
     BaseThreadlikeRoutingParams,
+    CapstanFriction,
     EffortModel,
+    ExponentialLengthFriction,
     IdentityActuator,
     IdentityTransmission,
     ThreadlikeActuator,
@@ -412,11 +414,11 @@ def test_direct_effort_skips_unused_threadlike_state(monkeypatch):
     calls = {"moment_matrix": 0}
     original_moment_matrix = PCS._threadlike_moment_matrix
 
-    def counted_moment_matrix(self, q, routing, friction_coefficient=None):
+    def counted_moment_matrix(self, q, routing, friction=None):
         calls["moment_matrix"] += 1
         return original_moment_matrix(self, q, routing)
 
-    def unexpected_path_lengths(self, q, routing, friction_coefficient=None):
+    def unexpected_path_lengths(self, q, routing, friction=None):
         del self, q, routing
         raise AssertionError("DirectEffort must not evaluate actuator coordinates.")
 
@@ -464,11 +466,11 @@ def test_state_dependent_effort_reuses_generalized_force_moment_matrix(monkeypat
     original_moment_matrix = PCS._threadlike_moment_matrix
     original_path_lengths = PCS._threadlike_path_lengths
 
-    def counted_moment_matrix(self, q, routing, friction_coefficient=None):
+    def counted_moment_matrix(self, q, routing, friction=None):
         calls["moment_matrix"] += 1
         return original_moment_matrix(self, q, routing)
 
-    def counted_path_lengths(self, q, routing, friction_coefficient=None):
+    def counted_path_lengths(self, q, routing, friction=None):
         calls["path_lengths"] += 1
         return original_path_lengths(self, q, routing)
 
@@ -515,22 +517,22 @@ def test_coordinate_jacobian_equals_moment_matrix_transpose(factory):
 
 
 @pytest.mark.parametrize(
-    ("factory", "axial_index", "friction_coefficient"),
+    ("factory", "axial_index", "friction"),
     [
-        (_spatial_pcs, 3, 0.0),
-        (_spatial_pcs, 3, 0.7),
-        (_planar_pcs, 1, 0.0),
-        (_planar_pcs, 1, 0.7),
-        (_gvs, 3, 0.0),  # GVS refuses a nonzero coefficient at construction
+        (_spatial_pcs, 3, None),
+        (_spatial_pcs, 3, CapstanFriction(coefficient=0.7)),
+        (_planar_pcs, 1, None),
+        (_planar_pcs, 1, CapstanFriction(coefficient=0.7)),
+        # GVS supplies no wrap angle, so it hosts only wrap-angle-free laws.
+        (_gvs, 3, None),
+        (_gvs, 3, ExponentialLengthFriction(rate=3.0)),
     ],
 )
 def test_collapsed_threadlike_tangent_has_finite_reverse_mode(
-    factory, axial_index, friction_coefficient
+    factory, axial_index, friction
 ):
     """Cover normalization and path density at an exactly zero routing tangent."""
-    actuator = ThreadlikeActuator.tendons(
-        _routing(count=1), friction_coefficient=friction_coefficient
-    )
+    actuator = ThreadlikeActuator.tendons(_routing(count=1), friction=friction)
     robot = factory(actuators=actuator)
     q = jnp.zeros(robot.num_internal_dofs).at[axial_index].set(-1.0)
 

--- a/tests/actuation/test_threadlike.py
+++ b/tests/actuation/test_threadlike.py
@@ -16,12 +16,11 @@ from system_param_builders import (
 
 from soromox.actuation import (
     BaseThreadlikeRoutingParams,
-    CapstanFriction,
     EffortModel,
-    ExponentialLengthFriction,
     IdentityActuator,
     IdentityTransmission,
     ThreadlikeActuator,
+    ThreadlikeFriction,
     ThreadlikeImpedance,
     ThreadlikeRouting,
 )
@@ -520,12 +519,12 @@ def test_coordinate_jacobian_equals_moment_matrix_transpose(factory):
     ("factory", "axial_index", "friction"),
     [
         (_spatial_pcs, 3, None),
-        (_spatial_pcs, 3, CapstanFriction(coefficient=0.7)),
+        (_spatial_pcs, 3, ThreadlikeFriction.capstan(coefficient=0.7)),
         (_planar_pcs, 1, None),
-        (_planar_pcs, 1, CapstanFriction(coefficient=0.7)),
+        (_planar_pcs, 1, ThreadlikeFriction.capstan(coefficient=0.7)),
         # GVS supplies no wrap angle, so it hosts only wrap-angle-free laws.
         (_gvs, 3, None),
-        (_gvs, 3, ExponentialLengthFriction(rate=3.0)),
+        (_gvs, 3, ThreadlikeFriction.exponential_length(rate=3.0)),
     ],
 )
 def test_collapsed_threadlike_tangent_has_finite_reverse_mode(

--- a/tests/actuation/test_threadlike_friction.py
+++ b/tests/actuation/test_threadlike_friction.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-"""Capstan guide friction on threadlike transmissions."""
+"""Guide friction on threadlike transmissions, and the pluggable loss model."""
 
 import jax
 import pytest
@@ -7,6 +7,7 @@ import pytest
 jax.config.update("jax_enable_x64", True)
 
 import jax.numpy as jnp
+from jax import Array
 from numpy.testing import assert_allclose
 from system_param_builders import (
     pcs_params,
@@ -15,7 +16,15 @@ from system_param_builders import (
     spatial_base_pose,
 )
 
-from soromox.actuation import ThreadlikeActuator, ThreadlikeImpedance, ThreadlikeRouting
+from soromox.actuation import (
+    CapstanFriction,
+    ExponentialLengthFriction,
+    Frictionless,
+    ThreadlikeActuator,
+    ThreadlikeFriction,
+    ThreadlikeImpedance,
+    ThreadlikeRouting,
+)
 from soromox.autodiff import custom_jvp_mode
 from soromox.systems import (
     GVS,
@@ -565,3 +574,204 @@ def test_gvs_rejects_nonzero_friction():
 
     with pytest.raises(TypeError, match="wrap-angle model"):
         _gvs(actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.3))
+
+
+# ---------------------------------------------------------------------------
+# The pluggable transmission-loss model
+# ---------------------------------------------------------------------------
+
+
+class _HyperbolicFriction(ThreadlikeFriction):
+    """A law defined entirely outside soromox, to pin the extension point."""
+
+    a: Array
+
+    def transmission_ratio(self, context):
+        return 1.0 / (1.0 + self.a * context.wrap_angle)
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial])
+def test_default_is_lossless_and_bit_identical(factory):
+    """The shipped default delivers full effort and costs nothing."""
+    routing = _routing([0.02, -0.015])
+    q = jnp.linspace(-0.01, 0.04, factory().num_dofs)
+
+    default = factory(actuators=ThreadlikeActuator.tendons(routing))
+    explicit = factory(
+        actuators=ThreadlikeActuator.tendons(routing, friction=Frictionless())
+    )
+    assert Frictionless.is_lossless
+    assert not Frictionless.requires_wrap_angle
+    assert jnp.array_equal(default.actuation_matrix(q), explicit.actuation_matrix(q))
+    assert isinstance(default.actuators[0].params.transmission.friction, Frictionless)
+
+
+def test_capstan_object_matches_coefficient_sugar():
+    """The two spellings of a Capstan law must not diverge."""
+    routing = _routing([0.02])
+    q = jnp.array([6.0, 0.0, 0.0])
+
+    sugar = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.4)
+    )
+    obj = _planar(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=CapstanFriction(coefficient=0.4)
+        )
+    )
+    assert jnp.array_equal(sugar.actuation_matrix(q), obj.actuation_matrix(q))
+
+    with pytest.raises(ValueError, match="not both"):
+        ThreadlikeActuator.tendons(
+            routing, friction=CapstanFriction(coefficient=0.1), friction_coefficient=0.2
+        )
+    with pytest.raises(TypeError, match="ThreadlikeFriction"):
+        ThreadlikeActuator.tendons(routing, friction="capstan")
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial])
+def test_length_friction_matches_closed_form(factory):
+    """A per-length loss integrates to its own analytic mean over a segment."""
+    rate, length = 3.0, 0.1
+    routing = _routing([0.02])
+    q = jnp.zeros((factory().num_dofs,)).at[0].set(4.0)
+
+    frictionless = factory(actuators=ThreadlikeActuator.tendons(routing))
+    attenuated = factory(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ExponentialLengthFriction(rate=rate)
+        )
+    )
+    decay = rate * length
+    expected = (1.0 - jnp.exp(-decay)) / decay
+
+    reference = frictionless.actuation_matrix(q)
+    row = int(jnp.argmax(jnp.abs(reference[:, 0])))
+    assert_allclose(
+        attenuated.actuation_matrix(q)[row, 0],
+        expected * reference[row, 0],
+        rtol=1e-8,
+    )
+
+
+def test_length_friction_runs_on_gvs():
+    """GVS hosts a wrap-angle-free law, and still refuses a Capstan law."""
+    routing = _routing([0.02])
+    q = jnp.zeros((_gvs().num_dofs,)).at[0].set(3.0)
+
+    frictionless = _gvs(actuators=ThreadlikeActuator.tendons(routing))
+    attenuated = _gvs(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ExponentialLengthFriction(rate=4.0)
+        )
+    )
+    reference = jnp.abs(frictionless.actuation_matrix(q))
+    weighted = jnp.abs(attenuated.actuation_matrix(q))
+    assert jnp.all(weighted <= reference + 1e-15)
+    assert jnp.max(reference - weighted) > 1e-6
+
+    with pytest.raises(TypeError, match="wrap-angle model"):
+        _gvs(
+            actuators=ThreadlikeActuator.tendons(
+                routing, friction=CapstanFriction(coefficient=0.3)
+            )
+        )
+
+
+def test_custom_friction_model_needs_no_soromox_change():
+    """A third-party law installs through the public contract alone."""
+    routing = _routing([0.02])
+    q = jnp.array([6.0, 0.0, 0.0])
+
+    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    custom = _planar(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=_HyperbolicFriction(a=jnp.asarray(0.5))
+        )
+    )
+    reference = frictionless.actuation_matrix(q)
+    weighted = custom.actuation_matrix(q)
+
+    assert jnp.all(jnp.abs(weighted) <= jnp.abs(reference) + 1e-15)
+    assert jnp.max(jnp.abs(reference - weighted)) > 1e-6
+    # The law is not Capstan, so it must not coincide with one.
+    capstan = _planar(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=CapstanFriction(coefficient=0.5)
+        )
+    ).actuation_matrix(q)
+    assert jnp.max(jnp.abs(weighted - capstan)) > 1e-6
+
+
+def test_model_is_traceable_and_identifiable():
+    """Loss parameters stay differentiable leaves under jit, for any law."""
+    routing = _routing([0.02, -0.015])
+    q = jnp.array([4.0, 0.02, -0.01])
+    u = jnp.array([2.0, 1.0])
+
+    def loss_for(build, value):
+        # The robot is built once outside the trace; only the loss parameter is
+        # traced, which is how a law is identified in practice.
+        robot = _planar(
+            actuators=ThreadlikeActuator.tendons(routing, friction=build(value))
+        )
+
+        @jax.jit
+        def loss(parameter):
+            transmission = robot.actuators[0].params.transmission
+            identified = robot.update_actuator_params(
+                0, transmission=transmission.replace(friction=build(parameter))
+            )
+            return jnp.sum(identified.actuation_force(q, u) ** 2)
+
+        return jax.value_and_grad(loss)(jnp.asarray(value))
+
+    for build, value in (
+        (lambda p: CapstanFriction(coefficient=p), 0.3),
+        (lambda p: ExponentialLengthFriction(rate=p), 2.0),
+        (lambda p: _HyperbolicFriction(a=p), 0.4),
+    ):
+        magnitude, gradient = loss_for(build, value)
+        assert jnp.isfinite(magnitude) and jnp.isfinite(gradient)
+        assert jnp.abs(gradient) > 0.0
+
+
+def test_context_fields_agree_across_hosts():
+    """Host-agnostic context fields must match, so portable laws are portable."""
+    routing = _routing([0.02, -0.015])
+    planar = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    spatial = _spatial(actuators=ThreadlikeActuator.tendons(routing))
+
+    curvature, axial, shear = 5.0, 0.02, -0.01
+    planar_strain = jnp.array([curvature, 1.0 + axial, shear])
+    spatial_strain = jnp.array([0.0, 0.0, curvature, 1.0 + axial, shear, 0.0])
+    arc_length = 0.06
+    path_routing = planar.actuators[0].transmission.routing
+
+    def geometry(robot, strain):
+        return jax.vmap(
+            robot._threadlike_local_geometry,
+            in_axes=(None, None, None, None, 0, 0, 0),
+            out_axes=0,
+        )(
+            jnp.asarray(0),
+            strain,
+            jnp.asarray(arc_length),
+            path_routing,
+            path_routing.params,
+            path_routing.params.start_segment_index_array,
+            path_routing.params.end_segment_index_array,
+        )
+
+    planar_context = geometry(planar, planar_strain)
+    spatial_context = geometry(spatial, spatial_strain)
+
+    for field in ("arc_length", "offset", "offset_derivative", "tangent_norm"):
+        assert_allclose(
+            getattr(planar_context, field),
+            getattr(spatial_context, field),
+            rtol=1e-9,
+            atol=1e-12,
+            err_msg=f"host-agnostic field {field} disagrees",
+        )
+    assert jnp.array_equal(planar_context.active, spatial_context.active)

--- a/tests/actuation/test_threadlike_friction.py
+++ b/tests/actuation/test_threadlike_friction.py
@@ -139,11 +139,15 @@ def _settle(robot, u, iterations=30):
     return q
 
 
-def _with_friction(robot, friction_coefficient):
-    transmission = robot.actuators[0].params.transmission.replace(
-        friction_coefficient=friction_coefficient
+def _with_friction(robot, coefficient):
+    """Return a copy of ``robot`` whose Capstan coefficient is ``coefficient``."""
+    transmission = robot.actuators[0].params.transmission
+    return robot.update_actuator_params(
+        0,
+        transmission=transmission.replace(
+            friction=transmission.friction.replace(coefficient=coefficient)
+        ),
     )
-    return robot.update_actuator_params(0, transmission=transmission)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/actuation/test_threadlike_friction.py
+++ b/tests/actuation/test_threadlike_friction.py
@@ -1,0 +1,563 @@
+# ruff: noqa: E402
+"""Capstan guide friction on threadlike transmissions."""
+
+import jax
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+from numpy.testing import assert_allclose
+from system_param_builders import (
+    pcs_params,
+    planar_base_pose,
+    planar_pcs_params,
+    spatial_base_pose,
+)
+
+from soromox.actuation import ThreadlikeActuator, ThreadlikeImpedance, ThreadlikeRouting
+from soromox.autodiff import custom_jvp_mode
+from soromox.systems import (
+    GVS,
+    PCS,
+    GVSSegment,
+    JointSpec,
+    LinkSpec,
+    PCSStructure,
+    PlanarPCS,
+    StrainBasisSpec,
+)
+from soromox.systems.pcs import PlanarPCSStructure
+
+# Pull that bends the reference robot by a few radians per metre.
+TENSION = 0.03
+
+
+def _planar(
+    *,
+    num_segments=1,
+    actuators=None,
+    passive_elements=(),
+    wrap_angle_smoothing=0.0,
+    num_gauss_points=5,
+    gravity=jnp.zeros((2,)),
+):
+    body = planar_pcs_params(
+        base_pose=planar_base_pose(),
+        length=jnp.full((num_segments,), 0.1),
+        radius=jnp.full((num_segments,), 0.02),
+        density=jnp.full((num_segments,), 1000.0),
+        gravity=gravity,
+        young_modulus=jnp.full((num_segments,), 1e3),
+        shear_modulus=jnp.full((num_segments,), 5e2),
+        damping_matrix=1e-3 * jnp.eye(3 * num_segments),
+    )
+    return PlanarPCS(
+        body,
+        PlanarPCSStructure(
+            num_gauss_points=num_gauss_points,
+            wrap_angle_smoothing=wrap_angle_smoothing,
+        ),
+        actuators=actuators,
+        passive_elements=passive_elements,
+    )
+
+
+def _spatial(*, num_segments=1, actuators=None, wrap_angle_smoothing=0.0):
+    body = pcs_params(
+        base_pose=spatial_base_pose(),
+        length=jnp.full((num_segments,), 0.1),
+        radius=jnp.full((num_segments,), 0.02),
+        density=jnp.full((num_segments,), 1000.0),
+        gravity=jnp.zeros((3,)),
+        young_modulus=jnp.full((num_segments,), 1e3),
+        shear_modulus=jnp.full((num_segments,), 5e2),
+        damping_matrix=1e-3 * jnp.eye(6 * num_segments),
+    )
+    return PCS(
+        body,
+        PCSStructure(num_gauss_points=5, wrap_angle_smoothing=wrap_angle_smoothing),
+        actuators=actuators,
+    )
+
+
+def _gvs(*, actuators=None):
+    segment = GVSSegment(
+        link=LinkSpec.circular(
+            young_modulus=3e5,
+            shear_modulus=3e5 / 2.9,
+            density=1300.0,
+            material_damping_coefficient=1e4,
+            length=0.1,
+            radius=0.015,
+            reference_strain=[0, 0, 0, 1, 0, 0],
+        ),
+        joint=JointSpec(type="fixed"),
+        basis=StrainBasisSpec(
+            type="monomial",
+            strain_selector=[1, 1, 1, 1, 0, 0],
+            basis_order=[0, 0, 0, 0, 0, 0],
+        ),
+        num_gauss_points=5,
+    )
+    return GVS.from_segments([segment], gravity=jnp.zeros((3,)), actuators=actuators)
+
+
+def _routing(offsets, *, num_segments=1):
+    count = len(offsets)
+    zeros = jnp.zeros((count,))
+    return ThreadlikeRouting.linear(
+        intercept=jnp.stack((zeros, jnp.asarray(offsets), zeros), axis=-1),
+        start_segment_index=(0,) * count,
+        end_segment_index=(num_segments - 1,) * count,
+    )
+
+
+def _impedance(routing, friction_coefficient=0.0):
+    return ThreadlikeImpedance(
+        routing=routing,
+        stiffness=jnp.array([50.0, 30.0]),
+        damping=jnp.array([0.3, 0.2]),
+        rest_length=jnp.array([0.09, 0.1]),
+        friction_coefficient=friction_coefficient,
+    )
+
+
+def _settle(robot, u, iterations=30):
+    """Return the static equilibrium reached by Newton iteration from rest."""
+
+    def residual(q):
+        return (
+            robot.elastic_force(q)
+            + robot.gravitational_force(q)
+            - robot.actuation_force(q, u)
+        )
+
+    q = jnp.zeros((robot.num_dofs,))
+    for _ in range(iterations):
+        q = q - jnp.linalg.solve(jax.jacobian(residual)(q), residual(q))
+    return q
+
+
+def _with_friction(robot, friction_coefficient):
+    transmission = robot.actuators[0].params.transmission.replace(
+        friction_coefficient=friction_coefficient
+    )
+    return robot.update_actuator_params(0, transmission=transmission)
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial])
+def test_zero_friction_is_bit_identical(factory):
+    routing = _routing([0.02, -0.015])
+    plain = factory(actuators=ThreadlikeActuator.tendons(routing))
+    zero = factory(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.0)
+    )
+    q = jnp.linspace(-0.01, 0.04, plain.num_dofs)
+    assert jnp.array_equal(plain.actuation_matrix(q), zero.actuation_matrix(q))
+
+
+def test_capstan_matches_closed_form():
+    """Attenuation follows the Euler belt law and compounds along the arc."""
+    mu, kappa, length = 0.3, 8.0, 0.1
+    routing = _routing([0.02])
+    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    attenuated = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=mu)
+    )
+    q = jnp.array([kappa, 0.0, 0.0])
+    wrap = mu * kappa * length
+    expected = (1.0 - jnp.exp(-wrap)) / wrap
+    axial_row = 1
+    assert_allclose(
+        attenuated.actuation_matrix(q)[axial_row],
+        expected * frictionless.actuation_matrix(q)[axial_row],
+        rtol=1e-8,
+    )
+
+    # Segment-averaged transmission decreases monotonically toward the tip.
+    num_segments = 3
+    span = _routing([0.02], num_segments=num_segments)
+    chain_0 = _planar(
+        num_segments=num_segments, actuators=ThreadlikeActuator.tendons(span)
+    )
+    chain_mu = _planar(
+        num_segments=num_segments,
+        actuators=ThreadlikeActuator.tendons(span, friction_coefficient=0.4),
+    )
+    q_chain = jnp.zeros((chain_0.num_dofs,)).at[::3].set(jnp.array([6.0, 9.0, 12.0]))
+    rows = jnp.arange(num_segments) * 3 + axial_row
+    ratio = (
+        chain_mu.actuation_matrix(q_chain)[rows, 0]
+        / chain_0.actuation_matrix(q_chain)[rows, 0]
+    )
+    assert jnp.all(ratio[1:] < ratio[:-1])
+    assert jnp.all((ratio > 0.0) & (ratio <= 1.0))
+
+
+def test_torsion_wrap_matches_helix_curvature():
+    """An off-axis path under pure torsion wraps at the helix curvature."""
+    radius, torsion = 0.02, 5.0
+    routing = _routing([radius])
+    robot = _spatial(actuators=ThreadlikeActuator.tendons(routing))
+    q = jnp.zeros((robot.num_dofs,)).at[0].set(torsion)
+    strains = robot.strain(q).reshape((robot.num_segments, 6))
+
+    density = robot._threadlike_wrap_density(
+        strains, robot.actuators[0].transmission.routing
+    )
+    chord = jnp.sqrt(1.0 + (torsion * radius) ** 2)
+    assert_allclose(density, jnp.full_like(density, torsion**2 * radius / chord))
+
+
+# ---------------------------------------------------------------------------
+# Energy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("actuator_friction", "passive_friction"),
+    [(0.0, 0.0), (0.6, 0.0), (0.0, 0.6), (0.6, 0.6)],
+)
+def test_energy_rate_matches_actuation_and_damping_power(
+    actuator_friction, passive_friction
+):
+    """The robot-side energy budget stays exact at any friction coefficient."""
+    routing = _routing([0.02, -0.015])
+    robot = _planar(
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction_coefficient=actuator_friction
+        ),
+        passive_elements=(_impedance(routing, passive_friction),),
+        gravity=jnp.array([0.0, -9.81]),
+    )
+    q = jnp.array([4.0, 0.02, -0.01])
+    qd = jnp.array([0.7, -0.3, 0.5])
+    u = jnp.array([3.0, 1.5])
+
+    state_rate = robot.forward_dynamics(0.0, jnp.concatenate([q, qd]), (u,))
+    qdd = state_rate[robot.num_dofs :]
+
+    def energy(q_, qd_):
+        return robot.kinetic_energy(q_, qd_) + robot.potential_energy(q_)
+
+    energy_rate = jax.grad(energy, 0)(q, qd) @ qd + jax.grad(energy, 1)(q, qd) @ qdd
+    power = qd @ robot.actuation_force(q, u, qd=qd) - qd @ robot.damping_matrix(q) @ qd
+    assert_allclose(energy_rate, power, rtol=1e-9, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("preset", "u", "qd_sign"),
+    [
+        (ThreadlikeActuator.tendons, 4.0, 1.0),
+        (ThreadlikeActuator.tendons, -4.0, -1.0),
+        (ThreadlikeActuator.push_rods, 4.0, -1.0),
+    ],
+)
+def test_driving_effort_dissipates_for_pull_and_push(preset, u, qd_sign):
+    """Guides absorb power whenever the effort drives the path, either way."""
+    routing = _routing([0.02])
+    robot = _planar(actuators=preset(routing, friction_coefficient=0.5))
+    transmission = robot.actuators[0].transmission
+    q = jnp.array([7.0, 0.0, 0.0])
+    qd = jnp.array([qd_sign, 0.0, 0.0])
+    effort = jnp.array([u])
+
+    scale = transmission.params.coordinate_scale
+    supplied = jnp.sum(
+        effort * scale * (transmission.kinematic_matrix(robot, q).T @ qd)
+    )
+    delivered = qd @ (transmission.moment_matrix(robot, q) @ effort)
+
+    assert supplied > 0.0  # the effort drives the path in this direction
+    assert delivered > 0.0
+    assert delivered < supplied
+    assert supplied - delivered > 0.0
+
+
+def test_closed_loop_work_is_nonzero_and_orientation_dependent():
+    """Friction admits no actuation potential, so loop work does not vanish."""
+    routing = _routing([0.02])
+    effort = jnp.array([2.0])
+
+    def loop_work(robot, orientation, num_points=2000):
+        angle = orientation * jnp.linspace(0.0, 2.0 * jnp.pi, num_points)
+        path = jnp.stack(
+            [
+                5.0 + 4.0 * jnp.cos(angle),
+                0.05 * jnp.sin(angle),
+                jnp.zeros_like(angle),
+            ],
+            axis=-1,
+        )
+        force = jax.vmap(lambda q: robot.actuation_matrix(q) @ effort)(path)
+        midpoint = 0.5 * (force[1:] + force[:-1])
+        return jnp.sum(midpoint * jnp.diff(path, axis=0))
+
+    attenuated = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.8)
+    )
+    forward = loop_work(attenuated, 1.0)
+    assert jnp.abs(forward) > 1e-4
+    assert_allclose(loop_work(attenuated, -1.0), -forward, rtol=1e-6)
+
+    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    assert jnp.abs(loop_work(frictionless, 1.0)) < 1e-12
+
+
+@pytest.mark.parametrize("passive_friction", [0.0, 1.0])
+def test_passive_friction_is_the_only_unactuated_energy_source(passive_friction):
+    """An unactuated robot decays monotonically only at zero passive friction."""
+    routing = _routing([0.02, -0.015], num_segments=2)
+    robot = _planar(
+        num_segments=2,
+        passive_elements=(_impedance(routing, passive_friction),),
+        gravity=jnp.array([0.0, -9.81]),
+    )
+    control = jnp.zeros((robot.num_actuators,))
+    key = jax.random.PRNGKey(3)
+
+    def energy_rate(index):
+        keys = jax.random.split(jax.random.fold_in(key, index))
+        q = 4.0 * jax.random.normal(keys[0], (robot.num_dofs,))
+        qd = jax.random.normal(keys[1], (robot.num_dofs,))
+        return (
+            qd @ robot.actuation_force(q, control, qd=qd)
+            - qd @ robot.damping_matrix(q) @ qd
+        )
+
+    rates = jax.vmap(energy_rate)(jnp.arange(200))
+    if passive_friction == 0.0:
+        assert jnp.all(rates <= 0.0)
+    else:
+        assert jnp.any(rates > 0.0)
+
+
+def test_passive_damping_is_psd_under_friction():
+    """The chosen congruence stays dissipative where the rejected form does not."""
+    routing = _routing([0.02, -0.015], num_segments=2)
+    passive = _impedance(routing, 1.2)
+    robot = _planar(num_segments=2, passive_elements=(passive,))
+    q = jnp.array([6.0, 0.02, -0.01, 10.0, 0.02, -0.01])
+
+    damping = passive.damping_matrix(robot, q)
+    assert_allclose(damping, damping.T, atol=1e-18)
+    assert jnp.min(jnp.linalg.eigvalsh(damping)) > -1e-15
+
+    # The rejected A_mu D A_0^T reads the rate through the exact Jacobian.
+    transmission = passive._transmission_matrix(robot, q)
+    jacobian = passive._length_jacobian(robot, q).T
+    rejected = transmission @ (passive.params.damping[:, None] * jacobian.T)
+    symmetric = 0.5 * (rejected + rejected.T)
+    direction = jnp.linalg.eigh(symmetric)[1][:, 0]
+
+    assert direction @ rejected @ direction < 0.0  # would inject energy
+    assert direction @ damping @ direction > 0.0
+
+
+def test_passive_split_preserves_energy_gradient_and_total_dynamics():
+    """Splitting the spring force changes bookkeeping, not physics."""
+    routing = _routing([0.02, -0.015], num_segments=2)
+    passive = _impedance(routing, 0.8)
+    robot = _planar(num_segments=2, passive_elements=(passive,))
+    q = jnp.array([5.0, 0.02, -0.01, -3.0, 0.01, 0.02])
+
+    extension = passive.path_lengths(robot, q) - passive.params.rest_length
+    transmitted = passive._transmission_matrix(robot, q) @ (
+        passive.params.stiffness * extension
+    )
+    assert_allclose(
+        transmitted,
+        passive.elastic_force(robot, q) + passive.nonconservative_force(robot, q),
+        atol=1e-15,
+    )
+
+    for enabled in (True, False):
+        with custom_jvp_mode(enabled):
+            assert_allclose(
+                jax.grad(robot.elastic_energy)(q),
+                robot.elastic_force(q),
+                rtol=1e-9,
+                atol=1e-14,
+            )
+
+
+def test_push_and_pull_share_the_same_transmission_ratio():
+    """The ratio depends on the configuration only, never on the effort."""
+    routing = _routing([0.02])
+    tendon = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.7)
+    )
+    push_rod = _planar(
+        actuators=ThreadlikeActuator.push_rods(routing, friction_coefficient=0.7)
+    )
+    q = jnp.array([6.0, 0.01, 0.0])
+    assert_allclose(
+        tendon.actuation_matrix(q), -push_rod.actuation_matrix(q), atol=1e-18
+    )
+
+
+# ---------------------------------------------------------------------------
+# Planar routed-path offset sign
+# ---------------------------------------------------------------------------
+
+
+def test_pulled_tendon_shortens_and_bends_toward_its_own_side():
+    """A pulled tendon must shorten and curve the backbone onto its own side."""
+    robot = _planar(actuators=ThreadlikeActuator.tendons(_routing([0.02, -0.02])))
+    actuator = robot.actuators[0]
+    rest = 0.1
+
+    q_first = _settle(robot, jnp.array([TENSION, 0.0]))
+    first = actuator.path_lengths(robot, q_first)
+    assert q_first[0] > 0.0
+    assert first[0] < rest < first[1]
+
+    q_second = _settle(robot, jnp.array([0.0, TENSION]))
+    second = actuator.path_lengths(robot, q_second)
+    assert_allclose(q_second[0], -q_first[0], rtol=1e-9)
+    assert_allclose(second, first[::-1], rtol=1e-9)
+
+    q_push = _settle(robot, jnp.array([-TENSION, 0.0]))
+    pushed = actuator.path_lengths(robot, q_push)
+    assert q_push[0] < 0.0
+    assert pushed[0] > rest > pushed[1]
+
+
+def test_planar_path_length_matches_rendered_path():
+    """Path length must equal the arc length of the curve the renderer draws."""
+    robot = _planar(actuators=ThreadlikeActuator.tendons(_routing([0.02])))
+    actuator = robot.actuators[0]
+    q = jnp.array([10.0, 0.0, 0.0])
+
+    samples = jnp.linspace(0.0, float(jnp.sum(robot.L)), 20001)
+    positions = jax.vmap(lambda s: actuator.path_poses(robot, q, s))(samples)
+    polyline = jnp.sum(jnp.linalg.norm(jnp.diff(positions[:, 0], axis=0), axis=-1))
+
+    assert_allclose(actuator.path_lengths(robot, q), jnp.array([0.08]), rtol=1e-6)
+    assert_allclose(polyline, 0.08, rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Invariants and autodiff
+# ---------------------------------------------------------------------------
+
+
+def test_friction_breaks_length_gradient_identity():
+    """Friction deliberately severs moment_matrix from the length gradient."""
+    routing = _routing([0.02, -0.015])
+    q = jnp.array([4.0, 0.02, -0.01])
+
+    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    assert_allclose(
+        jax.jacrev(frictionless.actuator_coordinates)(q),
+        frictionless.actuation_matrix(q).T,
+        rtol=2e-7,
+        atol=2e-9,
+    )
+
+    attenuated = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.6)
+    )
+    gap = (
+        jax.jacrev(attenuated.actuator_coordinates)(q)
+        - attenuated.actuation_matrix(q).T
+    )
+    assert jnp.max(jnp.abs(gap)) > 1e-3
+
+
+def test_friction_coefficient_is_traceable_and_identifiable():
+    """The coefficient stays a differentiable leaf under jit."""
+    routing = _routing([0.02, -0.015])
+    robot = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.2)
+    )
+    q = jnp.array([4.0, 0.02, -0.01])
+    u = jnp.array([2.0, 1.0])
+
+    @jax.jit
+    def loss(friction_coefficient):
+        identified = _with_friction(robot, friction_coefficient)
+        return jnp.sum(identified.actuation_force(q, u) ** 2)
+
+    for start in (0.0, 0.35):
+        value, gradient = jax.value_and_grad(loss)(jnp.asarray(start))
+        assert jnp.isfinite(value) and jnp.isfinite(gradient)
+        assert jnp.abs(gradient) > 0.0
+
+    per_path = jax.grad(loss)(jnp.array([0.1, 0.4]))
+    assert per_path.shape == (2,)
+    assert jnp.all(jnp.isfinite(per_path)) and jnp.all(per_path != 0.0)
+
+
+@pytest.mark.parametrize("wrap_angle_smoothing", [0.0, 0.1])
+def test_friction_gradients_are_finite_at_singular_states(wrap_angle_smoothing):
+    """The |kappa| kink at a straight backbone must not produce NaNs."""
+    robot = _planar(
+        wrap_angle_smoothing=wrap_angle_smoothing,
+        actuators=ThreadlikeActuator.tendons(
+            _routing([0.02]), friction_coefficient=0.3
+        ),
+    )
+    straight = jnp.zeros((robot.num_dofs,))
+
+    assert jnp.isfinite(jax.jacrev(robot.actuation_matrix)(straight)).all()
+    assert jnp.isfinite(jax.jacrev(robot.actuator_coordinates)(straight)).all()
+
+    def matrix_norm(friction_coefficient):
+        identified = _with_friction(robot, friction_coefficient)
+        return jnp.sum(identified.actuation_matrix(straight) ** 2)
+
+    sensitivity = jax.grad(matrix_norm)(jnp.asarray(0.3))
+    assert jnp.isfinite(sensitivity)
+    # Smoothing is what makes the coefficient identifiable at a straight pose.
+    if wrap_angle_smoothing == 0.0:
+        assert sensitivity == 0.0
+    else:
+        assert jnp.abs(sensitivity) > 0.0
+
+
+def test_wrap_angle_smoothing_bias_is_bounded_and_removes_the_kink():
+    """Smoothing only ever over-estimates the wrap angle, by at most eps * L."""
+    q = jnp.array([3.0, 0.0, 0.0, -2.0, 0.0, 0.0])
+    exact = _planar(num_segments=2)
+    total_length = float(jnp.sum(exact.L))
+    reference = exact._threadlike_wrap_angle(
+        exact._threadlike_wrap_density(exact.strain(q).reshape((2, 3))), total_length
+    )
+
+    for smoothing in (0.0, 0.05, 0.4):
+        smoothed = _planar(num_segments=2, wrap_angle_smoothing=smoothing)
+        angle = smoothed._threadlike_wrap_angle(
+            smoothed._threadlike_wrap_density(smoothed.strain(q).reshape((2, 3))),
+            total_length,
+        )
+        assert angle >= reference
+        assert angle - reference <= smoothing * total_length + 1e-12
+
+    routing = _routing([0.02])
+    plain = _planar(
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.5)
+    )
+    unsmoothed = _planar(
+        wrap_angle_smoothing=0.0,
+        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.5),
+    )
+    q_single = jnp.array([3.0, 0.0, 0.0])
+    assert jnp.array_equal(
+        plain.actuation_matrix(q_single), unsmoothed.actuation_matrix(q_single)
+    )
+
+
+def test_gvs_rejects_nonzero_friction():
+    """GVS strain varies along s, so the piecewise-linear wrap angle is invalid."""
+    routing = _routing([0.02])
+    _gvs(actuators=ThreadlikeActuator.tendons(routing))  # zero stays allowed
+
+    with pytest.raises(TypeError, match="wrap-angle model"):
+        _gvs(actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.3))

--- a/tests/actuation/test_threadlike_friction.py
+++ b/tests/actuation/test_threadlike_friction.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-"""Guide friction on threadlike transmissions, and the pluggable loss model."""
+"""Guide friction on threadlike transmissions, and the pluggable model."""
 
 import jax
 import pytest
@@ -17,13 +17,15 @@ from system_param_builders import (
 )
 
 from soromox.actuation import (
-    CapstanFriction,
-    ExponentialLengthFriction,
-    Frictionless,
+    BaseThreadlikeFrictionParams,
+    CapstanFrictionParams,
+    ExponentialLengthFrictionParams,
+    FrictionlessParams,
     ThreadlikeActuator,
     ThreadlikeFriction,
     ThreadlikeImpedance,
     ThreadlikeRouting,
+    capstan_transmission_ratio,
 )
 from soromox.autodiff import custom_jvp_mode
 from soromox.systems import (
@@ -47,12 +49,10 @@ def _planar(
     num_segments=1,
     actuators=None,
     passive_elements=(),
-    wrap_angle_smoothing=0.0,
     num_gauss_points=5,
     gravity=jnp.zeros((2,)),
 ):
     body = planar_pcs_params(
-        base_pose=planar_base_pose(),
         length=jnp.full((num_segments,), 0.1),
         radius=jnp.full((num_segments,), 0.02),
         density=jnp.full((num_segments,), 1000.0),
@@ -63,18 +63,15 @@ def _planar(
     )
     return PlanarPCS(
         body,
-        PlanarPCSStructure(
-            num_gauss_points=num_gauss_points,
-            wrap_angle_smoothing=wrap_angle_smoothing,
-        ),
+        PlanarPCSStructure(num_gauss_points=num_gauss_points),
+        base_pose=planar_base_pose(),
         actuators=actuators,
         passive_elements=passive_elements,
     )
 
 
-def _spatial(*, num_segments=1, actuators=None, wrap_angle_smoothing=0.0):
+def _spatial(*, num_segments=1, actuators=None):
     body = pcs_params(
-        base_pose=spatial_base_pose(),
         length=jnp.full((num_segments,), 0.1),
         radius=jnp.full((num_segments,), 0.02),
         density=jnp.full((num_segments,), 1000.0),
@@ -85,7 +82,8 @@ def _spatial(*, num_segments=1, actuators=None, wrap_angle_smoothing=0.0):
     )
     return PCS(
         body,
-        PCSStructure(num_gauss_points=5, wrap_angle_smoothing=wrap_angle_smoothing),
+        PCSStructure(num_gauss_points=5),
+        base_pose=spatial_base_pose(),
         actuators=actuators,
     )
 
@@ -122,13 +120,46 @@ def _routing(offsets, *, num_segments=1):
     )
 
 
-def _impedance(routing, friction_coefficient=0.0):
+def _anchored_routing(offset, *, start, end):
+    """One path anchored at segment ``start`` and ending at segment ``end``."""
+    return ThreadlikeRouting.linear(
+        intercept=jnp.array([[0.0, offset, 0.0]]),
+        start_segment_index=(start,),
+        end_segment_index=(end,),
+    )
+
+
+def _geometry(robot, path_routing, q, *, s, segment_index):
+    """Evaluate the quadrature context of every path at one node."""
+    strains = robot.strain(q).reshape((robot.num_segments, -1))
+    params = path_routing.params
+    return jax.vmap(
+        robot._threadlike_local_geometry,
+        in_axes=(None, None, None, None, 0, 0, 0),
+        out_axes=0,
+    )(
+        jnp.asarray(segment_index),
+        strains[segment_index],
+        jnp.asarray(s),
+        path_routing,
+        params,
+        params.start_segment_index_array,
+        params.end_segment_index_array,
+    )
+
+
+def _bend_index(factory):
+    """Index of the bending strain within one segment, per host."""
+    return 0 if factory is _planar else 2
+
+
+def _impedance(routing, coefficient=0.0):
     return ThreadlikeImpedance(
         routing=routing,
         stiffness=jnp.array([50.0, 30.0]),
         damping=jnp.array([0.3, 0.2]),
         rest_length=jnp.array([0.09, 0.1]),
-        friction_coefficient=friction_coefficient,
+        friction=ThreadlikeFriction.capstan(coefficient=coefficient),
     )
 
 
@@ -142,7 +173,7 @@ def _settle(robot, u, iterations=30):
             - robot.actuation_force(q, u)
         )
 
-    q = jnp.zeros((robot.num_dofs,))
+    q = jnp.zeros((robot.num_coordinates,))
     for _ in range(iterations):
         q = q - jnp.linalg.solve(jax.jacobian(residual)(q), residual(q))
     return q
@@ -159,6 +190,17 @@ def _with_friction(robot, coefficient):
     )
 
 
+def _with_eps(robot, eps):
+    """Return a copy of ``robot`` whose Capstan curvature floor is ``eps``."""
+    transmission = robot.actuators[0].params.transmission
+    return robot.update_actuator_params(
+        0,
+        transmission=transmission.replace(
+            friction=transmission.friction.replace(eps=eps)
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Model
 # ---------------------------------------------------------------------------
@@ -169,9 +211,11 @@ def test_zero_friction_is_bit_identical(factory):
     routing = _routing([0.02, -0.015])
     plain = factory(actuators=ThreadlikeActuator.tendons(routing))
     zero = factory(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.0)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.0)
+        )
     )
-    q = jnp.linspace(-0.01, 0.04, plain.num_dofs)
+    q = jnp.linspace(-0.01, 0.04, plain.num_coordinates)
     assert jnp.array_equal(plain.actuation_matrix(q), zero.actuation_matrix(q))
 
 
@@ -181,7 +225,9 @@ def test_capstan_matches_closed_form():
     routing = _routing([0.02])
     frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
     attenuated = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=mu)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=mu)
+        )
     )
     q = jnp.array([kappa, 0.0, 0.0])
     wrap = mu * kappa * length
@@ -201,9 +247,13 @@ def test_capstan_matches_closed_form():
     )
     chain_mu = _planar(
         num_segments=num_segments,
-        actuators=ThreadlikeActuator.tendons(span, friction_coefficient=0.4),
+        actuators=ThreadlikeActuator.tendons(
+            span, friction=ThreadlikeFriction.capstan(coefficient=0.4)
+        ),
     )
-    q_chain = jnp.zeros((chain_0.num_dofs,)).at[::3].set(jnp.array([6.0, 9.0, 12.0]))
+    q_chain = (
+        jnp.zeros((chain_0.num_coordinates,)).at[::3].set(jnp.array([6.0, 9.0, 12.0]))
+    )
     rows = jnp.arange(num_segments) * 3 + axial_row
     ratio = (
         chain_mu.actuation_matrix(q_chain)[rows, 0]
@@ -213,19 +263,32 @@ def test_capstan_matches_closed_form():
     assert jnp.all((ratio > 0.0) & (ratio <= 1.0))
 
 
-def test_torsion_wrap_matches_helix_curvature():
-    """An off-axis path under pure torsion wraps at the helix curvature."""
-    radius, torsion = 0.02, 5.0
+def test_path_curvature_is_the_curvature_of_the_routed_path():
+    """``|omega x u_hat|`` must be the curvature the routed path traces."""
+    radius, torsion, bend = 0.02, 5.0, 7.0
     routing = _routing([radius])
-    robot = _spatial(actuators=ThreadlikeActuator.tendons(routing))
-    q = jnp.zeros((robot.num_dofs,)).at[0].set(torsion)
-    strains = robot.strain(q).reshape((robot.num_segments, 6))
+    spatial = _spatial(actuators=ThreadlikeActuator.tendons(routing))
+    path_routing = spatial.actuators[0].transmission.routing
 
-    density = robot._threadlike_wrap_density(
-        strains, robot.actuators[0].transmission.routing
-    )
+    def spatial_curvature(q):
+        strains = spatial.strain(q).reshape((spatial.num_segments, 6))
+        return spatial._threadlike_path_curvature(strains, path_routing)
+
+    # Under pure torsion an off-axis path traces a helix.
+    helix = spatial_curvature(jnp.zeros((spatial.num_coordinates,)).at[0].set(torsion))
     chord = jnp.sqrt(1.0 + (torsion * radius) ** 2)
-    assert_allclose(density, jnp.full_like(density, torsion**2 * radius / chord))
+    assert_allclose(helix, jnp.full_like(helix, torsion**2 * radius / chord))
+
+    # In a planar configuration it reduces to |kappa_z| for any offset, which
+    # is what makes the planar and spatial hosts agree.
+    reduced = spatial_curvature(jnp.zeros((spatial.num_coordinates,)).at[2].set(bend))
+    planar = _planar(actuators=ThreadlikeActuator.tendons(routing))
+    planar_q = jnp.zeros((planar.num_coordinates,)).at[0].set(bend)
+    planar_curvature = planar._threadlike_path_curvature(
+        planar.strain(planar_q).reshape((planar.num_segments, 3))
+    )
+    assert_allclose(reduced, jnp.full_like(reduced, bend), rtol=1e-9)
+    assert_allclose(planar_curvature, jnp.full_like(planar_curvature, bend), rtol=1e-9)
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +307,7 @@ def test_energy_rate_matches_actuation_and_damping_power(
     routing = _routing([0.02, -0.015])
     robot = _planar(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction_coefficient=actuator_friction
+            routing, friction=ThreadlikeFriction.capstan(coefficient=actuator_friction)
         ),
         passive_elements=(_impedance(routing, passive_friction),),
         gravity=jnp.array([0.0, -9.81]),
@@ -254,7 +317,7 @@ def test_energy_rate_matches_actuation_and_damping_power(
     u = jnp.array([3.0, 1.5])
 
     state_rate = robot.forward_dynamics(0.0, jnp.concatenate([q, qd]), (u,))
-    qdd = state_rate[robot.num_dofs :]
+    qdd = state_rate[robot.num_coordinates :]
 
     def energy(q_, qd_):
         return robot.kinetic_energy(q_, qd_) + robot.potential_energy(q_)
@@ -275,7 +338,9 @@ def test_energy_rate_matches_actuation_and_damping_power(
 def test_driving_effort_dissipates_for_pull_and_push(preset, u, qd_sign):
     """Guides absorb power whenever the effort drives the path, either way."""
     routing = _routing([0.02])
-    robot = _planar(actuators=preset(routing, friction_coefficient=0.5))
+    robot = _planar(
+        actuators=preset(routing, friction=ThreadlikeFriction.capstan(coefficient=0.5))
+    )
     transmission = robot.actuators[0].transmission
     q = jnp.array([7.0, 0.0, 0.0])
     qd = jnp.array([qd_sign, 0.0, 0.0])
@@ -313,7 +378,9 @@ def test_closed_loop_work_is_nonzero_and_orientation_dependent():
         return jnp.sum(midpoint * jnp.diff(path, axis=0))
 
     attenuated = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.8)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.8)
+        )
     )
     forward = loop_work(attenuated, 1.0)
     assert jnp.abs(forward) > 1e-4
@@ -337,8 +404,8 @@ def test_passive_friction_is_the_only_unactuated_energy_source(passive_friction)
 
     def energy_rate(index):
         keys = jax.random.split(jax.random.fold_in(key, index))
-        q = 4.0 * jax.random.normal(keys[0], (robot.num_dofs,))
-        qd = jax.random.normal(keys[1], (robot.num_dofs,))
+        q = 4.0 * jax.random.normal(keys[0], (robot.num_coordinates,))
+        qd = jax.random.normal(keys[1], (robot.num_velocities,))
         return (
             qd @ robot.actuation_force(q, control, qd=qd)
             - qd @ robot.damping_matrix(q) @ qd
@@ -349,6 +416,31 @@ def test_passive_friction_is_the_only_unactuated_energy_source(passive_friction)
         assert jnp.all(rates <= 0.0)
     else:
         assert jnp.any(rates > 0.0)
+
+
+def test_floating_passive_nonconservative_force_has_zero_base_prefix():
+    """Passive routing friction acts only on the internal material coordinates."""
+
+    routing = _routing([0.02, -0.015])
+    fixed = _planar(passive_elements=(_impedance(routing, coefficient=0.6),))
+    floating = PlanarPCS(
+        params=fixed.params,
+        structure=PlanarPCSStructure(num_gauss_points=fixed.num_gauss_points),
+        passive_elements=fixed.passive_elements,
+        floating_base=True,
+        backend="jax",
+    )
+    q_internal = jnp.array([4.0, 0.02, -0.01])
+    q = floating.pack_configuration(
+        q_internal,
+        base_pose=jnp.array([0.3, 0.1, -0.2]),
+    )
+    expected = fixed.passive_nonconservative_force(q_internal)
+    actual = floating.passive_nonconservative_force(q)
+
+    assert_allclose(actual[: floating.num_base_velocities], 0.0, atol=0.0)
+    assert_allclose(actual[floating.num_base_velocities :], expected)
+    assert_allclose(floating.passive_nonconservative_force(q_internal), expected)
 
 
 def test_passive_damping_is_psd_under_friction():
@@ -404,10 +496,14 @@ def test_push_and_pull_share_the_same_transmission_ratio():
     """The ratio depends on the configuration only, never on the effort."""
     routing = _routing([0.02])
     tendon = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.7)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.7)
+        )
     )
     push_rod = _planar(
-        actuators=ThreadlikeActuator.push_rods(routing, friction_coefficient=0.7)
+        actuators=ThreadlikeActuator.push_rods(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.7)
+        )
     )
     q = jnp.array([6.0, 0.01, 0.0])
     assert_allclose(
@@ -475,7 +571,9 @@ def test_friction_breaks_length_gradient_identity():
     )
 
     attenuated = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.6)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.6)
+        )
     )
     gap = (
         jax.jacrev(attenuated.actuator_coordinates)(q)
@@ -484,18 +582,20 @@ def test_friction_breaks_length_gradient_identity():
     assert jnp.max(jnp.abs(gap)) > 1e-3
 
 
-def test_friction_coefficient_is_traceable_and_identifiable():
+def test_capstan_coefficient_is_traceable_and_identifiable():
     """The coefficient stays a differentiable leaf under jit."""
     routing = _routing([0.02, -0.015])
     robot = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.2)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.2)
+        )
     )
     q = jnp.array([4.0, 0.02, -0.01])
     u = jnp.array([2.0, 1.0])
 
     @jax.jit
-    def loss(friction_coefficient):
-        identified = _with_friction(robot, friction_coefficient)
+    def loss(coefficient):
+        identified = _with_friction(robot, coefficient)
         return jnp.sum(identified.actuation_force(q, u) ** 2)
 
     for start in (0.0, 0.35):
@@ -508,58 +608,68 @@ def test_friction_coefficient_is_traceable_and_identifiable():
     assert jnp.all(jnp.isfinite(per_path)) and jnp.all(per_path != 0.0)
 
 
-@pytest.mark.parametrize("wrap_angle_smoothing", [0.0, 0.1])
-def test_friction_gradients_are_finite_at_singular_states(wrap_angle_smoothing):
+@pytest.mark.parametrize("eps", [0.0, 0.1])
+def test_friction_gradients_are_finite_at_singular_states(eps):
     """The |kappa| kink at a straight backbone must not produce NaNs."""
     robot = _planar(
-        wrap_angle_smoothing=wrap_angle_smoothing,
         actuators=ThreadlikeActuator.tendons(
-            _routing([0.02]), friction_coefficient=0.3
+            _routing([0.02]),
+            friction=ThreadlikeFriction.capstan(coefficient=0.3, eps=eps),
         ),
     )
-    straight = jnp.zeros((robot.num_dofs,))
+    straight = jnp.zeros((robot.num_coordinates,))
 
     assert jnp.isfinite(jax.jacrev(robot.actuation_matrix)(straight)).all()
     assert jnp.isfinite(jax.jacrev(robot.actuator_coordinates)(straight)).all()
 
-    def matrix_norm(friction_coefficient):
-        identified = _with_friction(robot, friction_coefficient)
+    def matrix_norm(coefficient):
+        identified = _with_friction(robot, coefficient)
         return jnp.sum(identified.actuation_matrix(straight) ** 2)
 
     sensitivity = jax.grad(matrix_norm)(jnp.asarray(0.3))
     assert jnp.isfinite(sensitivity)
-    # Smoothing is what makes the coefficient identifiable at a straight pose.
-    if wrap_angle_smoothing == 0.0:
+    # The curvature floor is what makes the coefficient identifiable straight.
+    if eps == 0.0:
         assert sensitivity == 0.0
-    else:
-        assert jnp.abs(sensitivity) > 0.0
+        return
+    assert jnp.abs(sensitivity) > 0.0
+
+    # The floor is itself a traced leaf, so it can be fitted alongside.
+    def floor_norm(value):
+        return jnp.sum(_with_eps(robot, value).actuation_matrix(straight) ** 2)
+
+    floor_sensitivity = jax.grad(floor_norm)(jnp.asarray(eps))
+    assert jnp.isfinite(floor_sensitivity) and jnp.abs(floor_sensitivity) > 0.0
 
 
-def test_wrap_angle_smoothing_bias_is_bounded_and_removes_the_kink():
-    """Smoothing only ever over-estimates the wrap angle, by at most eps * L."""
+def test_curvature_floor_bias_is_bounded_and_removes_the_kink():
+    """The floor only ever over-estimates the wrap angle, by at most eps * L."""
     q = jnp.array([3.0, 0.0, 0.0, -2.0, 0.0, 0.0])
-    exact = _planar(num_segments=2)
-    total_length = float(jnp.sum(exact.L))
-    reference = exact._threadlike_wrap_angle(
-        exact._threadlike_wrap_density(exact.strain(q).reshape((2, 3))), total_length
+    robot = _planar(num_segments=2)
+    total_length = float(jnp.sum(robot.L))
+    starts = jnp.zeros((1,), dtype=jnp.int32)
+    curvature = robot._threadlike_path_curvature(robot.strain(q).reshape((2, 3)))
+    reference = robot._threadlike_safe_wrap_angle(
+        curvature, total_length, starts, jnp.asarray(0.0)
     )
 
-    for smoothing in (0.0, 0.05, 0.4):
-        smoothed = _planar(num_segments=2, wrap_angle_smoothing=smoothing)
-        angle = smoothed._threadlike_wrap_angle(
-            smoothed._threadlike_wrap_density(smoothed.strain(q).reshape((2, 3))),
-            total_length,
+    for eps in (0.0, 0.05, 0.4):
+        angle = robot._threadlike_safe_wrap_angle(
+            curvature, total_length, starts, jnp.asarray(eps)
         )
-        assert angle >= reference
-        assert angle - reference <= smoothing * total_length + 1e-12
+        assert jnp.all(angle >= reference)
+        assert jnp.all(angle - reference <= eps * total_length + 1e-12)
 
     routing = _routing([0.02])
     plain = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.5)
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.5)
+        )
     )
     unsmoothed = _planar(
-        wrap_angle_smoothing=0.0,
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.5),
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.5, eps=0.0)
+        ),
     )
     q_single = jnp.array([3.0, 0.0, 0.0])
     assert jnp.array_equal(
@@ -573,73 +683,100 @@ def test_gvs_rejects_nonzero_friction():
     _gvs(actuators=ThreadlikeActuator.tendons(routing))  # zero stays allowed
 
     with pytest.raises(TypeError, match="wrap-angle model"):
-        _gvs(actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.3))
+        _gvs(
+            actuators=ThreadlikeActuator.tendons(
+                routing, friction=ThreadlikeFriction.capstan(coefficient=0.3)
+            )
+        )
 
 
 # ---------------------------------------------------------------------------
-# The pluggable transmission-loss model
+# The pluggable friction model
 # ---------------------------------------------------------------------------
 
 
-class _HyperbolicFriction(ThreadlikeFriction):
-    """A law defined entirely outside soromox, to pin the extension point."""
+class _HyperbolicFrictionParams(BaseThreadlikeFrictionParams):
+    """Parameters of a law defined entirely outside soromox."""
 
     a: Array
 
-    def transmission_ratio(self, context):
-        return 1.0 / (1.0 + self.a * context.wrap_angle)
+
+def _hyperbolic_transmission_ratio(params, context):
+    """A law defined entirely outside soromox, to pin the extension point."""
+    return 1.0 / (1.0 + params.a * context.wrap_angle)
+
+
+def _hyperbolic(a):
+    return ThreadlikeFriction(
+        params=_HyperbolicFrictionParams(a=jnp.asarray(a)),
+        ratio_fn=_hyperbolic_transmission_ratio,
+        requires_wrap_angle=True,
+        is_frictionless=False,
+    )
 
 
 @pytest.mark.parametrize("factory", [_planar, _spatial])
-def test_default_is_lossless_and_bit_identical(factory):
+def test_default_is_frictionless_and_bit_identical(factory):
     """The shipped default delivers full effort and costs nothing."""
     routing = _routing([0.02, -0.015])
-    q = jnp.linspace(-0.01, 0.04, factory().num_dofs)
+    q = jnp.linspace(-0.01, 0.04, factory().num_coordinates)
 
     default = factory(actuators=ThreadlikeActuator.tendons(routing))
     explicit = factory(
-        actuators=ThreadlikeActuator.tendons(routing, friction=Frictionless())
+        actuators=ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.frictionless()
+        )
     )
-    assert Frictionless.is_lossless
-    assert not Frictionless.requires_wrap_angle
+    assert ThreadlikeFriction.frictionless().is_frictionless
+    assert not ThreadlikeFriction.frictionless().requires_wrap_angle
     assert jnp.array_equal(default.actuation_matrix(q), explicit.actuation_matrix(q))
-    assert isinstance(default.actuators[0].params.transmission.friction, Frictionless)
+    assert isinstance(
+        default.actuators[0].params.transmission.friction, FrictionlessParams
+    )
 
 
-def test_capstan_object_matches_coefficient_sugar():
-    """The two spellings of a Capstan law must not diverge."""
+def test_params_and_law_stay_paired():
+    """The params leaf and the runtime law must not drift apart."""
     routing = _routing([0.02])
     q = jnp.array([6.0, 0.0, 0.0])
 
-    sugar = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction_coefficient=0.4)
-    )
-    obj = _planar(
+    robot = _planar(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction=CapstanFriction(coefficient=0.4)
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.4)
         )
     )
-    assert jnp.array_equal(sugar.actuation_matrix(q), obj.actuation_matrix(q))
+    transmission = robot.actuators[0].transmission
+    assert isinstance(transmission.params.friction, CapstanFrictionParams)
+    assert transmission.friction.params is transmission.params.friction
 
-    with pytest.raises(ValueError, match="not both"):
-        ThreadlikeActuator.tendons(
-            routing, friction=CapstanFriction(coefficient=0.1), friction_coefficient=0.2
+    # Replacing a value keeps the installed law.
+    replaced = _with_friction(robot, jnp.asarray(0.4))
+    assert replaced.actuators[0].transmission.friction.ratio_fn is (
+        transmission.friction.ratio_fn
+    )
+    assert jnp.array_equal(robot.actuation_matrix(q), replaced.actuation_matrix(q))
+
+    # Swapping the params type behind an installed law is refused, as is
+    # installing anything that is not a law.
+    with pytest.raises(TypeError, match="keep their type"):
+        transmission.friction.with_params(
+            ExponentialLengthFrictionParams(rate=jnp.asarray(1.0))
         )
-    with pytest.raises(TypeError, match="ThreadlikeFriction"):
+    with pytest.raises(TypeError):
         ThreadlikeActuator.tendons(routing, friction="capstan")
 
 
 @pytest.mark.parametrize("factory", [_planar, _spatial])
 def test_length_friction_matches_closed_form(factory):
-    """A per-length loss integrates to its own analytic mean over a segment."""
+    """A per-length friction integrates to its analytic mean over a segment."""
     rate, length = 3.0, 0.1
     routing = _routing([0.02])
-    q = jnp.zeros((factory().num_dofs,)).at[0].set(4.0)
+    q = jnp.zeros((factory().num_coordinates,)).at[0].set(4.0)
 
     frictionless = factory(actuators=ThreadlikeActuator.tendons(routing))
     attenuated = factory(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction=ExponentialLengthFriction(rate=rate)
+            routing, friction=ThreadlikeFriction.exponential_length(rate=rate)
         )
     )
     decay = rate * length
@@ -657,12 +794,12 @@ def test_length_friction_matches_closed_form(factory):
 def test_length_friction_runs_on_gvs():
     """GVS hosts a wrap-angle-free law, and still refuses a Capstan law."""
     routing = _routing([0.02])
-    q = jnp.zeros((_gvs().num_dofs,)).at[0].set(3.0)
+    q = jnp.zeros((_gvs().num_coordinates,)).at[0].set(3.0)
 
     frictionless = _gvs(actuators=ThreadlikeActuator.tendons(routing))
     attenuated = _gvs(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction=ExponentialLengthFriction(rate=4.0)
+            routing, friction=ThreadlikeFriction.exponential_length(rate=4.0)
         )
     )
     reference = jnp.abs(frictionless.actuation_matrix(q))
@@ -673,7 +810,7 @@ def test_length_friction_runs_on_gvs():
     with pytest.raises(TypeError, match="wrap-angle model"):
         _gvs(
             actuators=ThreadlikeActuator.tendons(
-                routing, friction=CapstanFriction(coefficient=0.3)
+                routing, friction=ThreadlikeFriction.capstan(coefficient=0.3)
             )
         )
 
@@ -685,9 +822,7 @@ def test_custom_friction_model_needs_no_soromox_change():
 
     frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
     custom = _planar(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=_HyperbolicFriction(a=jnp.asarray(0.5))
-        )
+        actuators=ThreadlikeActuator.tendons(routing, friction=_hyperbolic(0.5))
     )
     reference = frictionless.actuation_matrix(q)
     weighted = custom.actuation_matrix(q)
@@ -697,20 +832,20 @@ def test_custom_friction_model_needs_no_soromox_change():
     # The law is not Capstan, so it must not coincide with one.
     capstan = _planar(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction=CapstanFriction(coefficient=0.5)
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.5)
         )
     ).actuation_matrix(q)
     assert jnp.max(jnp.abs(weighted - capstan)) > 1e-6
 
 
 def test_model_is_traceable_and_identifiable():
-    """Loss parameters stay differentiable leaves under jit, for any law."""
+    """Friction parameters stay differentiable leaves under jit, for any model."""
     routing = _routing([0.02, -0.015])
     q = jnp.array([4.0, 0.02, -0.01])
     u = jnp.array([2.0, 1.0])
 
     def loss_for(build, value):
-        # The robot is built once outside the trace; only the loss parameter is
+        # The robot is built once outside the trace; only the friction parameter
         # traced, which is how a law is identified in practice.
         robot = _planar(
             actuators=ThreadlikeActuator.tendons(routing, friction=build(value))
@@ -720,16 +855,17 @@ def test_model_is_traceable_and_identifiable():
         def loss(parameter):
             transmission = robot.actuators[0].params.transmission
             identified = robot.update_actuator_params(
-                0, transmission=transmission.replace(friction=build(parameter))
+                0,
+                transmission=transmission.replace(friction=build(parameter).params),
             )
             return jnp.sum(identified.actuation_force(q, u) ** 2)
 
         return jax.value_and_grad(loss)(jnp.asarray(value))
 
     for build, value in (
-        (lambda p: CapstanFriction(coefficient=p), 0.3),
-        (lambda p: ExponentialLengthFriction(rate=p), 2.0),
-        (lambda p: _HyperbolicFriction(a=p), 0.4),
+        (lambda p: ThreadlikeFriction.capstan(coefficient=p), 0.3),
+        (lambda p: ThreadlikeFriction.exponential_length(rate=p), 2.0),
+        (lambda p: _hyperbolic(p), 0.4),
     ):
         magnitude, gradient = loss_for(build, value)
         assert jnp.isfinite(magnitude) and jnp.isfinite(gradient)
@@ -745,7 +881,7 @@ def test_context_fields_agree_across_hosts():
     curvature, axial, shear = 5.0, 0.02, -0.01
     planar_strain = jnp.array([curvature, 1.0 + axial, shear])
     spatial_strain = jnp.array([0.0, 0.0, curvature, 1.0 + axial, shear, 0.0])
-    arc_length = 0.06
+    abscissa = 0.06
     path_routing = planar.actuators[0].transmission.routing
 
     def geometry(robot, strain):
@@ -756,7 +892,7 @@ def test_context_fields_agree_across_hosts():
         )(
             jnp.asarray(0),
             strain,
-            jnp.asarray(arc_length),
+            jnp.asarray(abscissa),
             path_routing,
             path_routing.params,
             path_routing.params.start_segment_index_array,
@@ -766,7 +902,13 @@ def test_context_fields_agree_across_hosts():
     planar_context = geometry(planar, planar_strain)
     spatial_context = geometry(spatial, spatial_strain)
 
-    for field in ("arc_length", "offset", "offset_derivative", "tangent_norm"):
+    for field in (
+        "abscissa",
+        "path_abscissa",
+        "offset",
+        "offset_derivative",
+        "tangent_norm",
+    ):
         assert_allclose(
             getattr(planar_context, field),
             getattr(spatial_context, field),
@@ -775,3 +917,129 @@ def test_context_fields_agree_across_hosts():
             err_msg=f"host-agnostic field {field} disagrees",
         )
     assert jnp.array_equal(planar_context.active, spatial_context.active)
+
+
+@pytest.mark.parametrize(
+    ("build", "field"),
+    [
+        (lambda v: CapstanFrictionParams(coefficient=jnp.asarray(v)), "coefficient"),
+        (lambda v: CapstanFrictionParams(eps=jnp.asarray(v)), "eps"),
+        (lambda v: ExponentialLengthFrictionParams(rate=jnp.asarray(v)), "rate"),
+    ],
+)
+@pytest.mark.parametrize("value", [-1.0, jnp.nan, jnp.inf])
+def test_friction_parameters_reject_negative_and_non_finite_values(build, field, value):
+    """A ratio outside (0, 1] would let a transmission generate effort."""
+    with pytest.raises(ValueError, match=field):
+        build(value)
+
+
+def test_friction_parameters_reject_a_wrong_per_path_shape():
+    """A per-path parameter must carry one entry per routed path."""
+    with pytest.raises(ValueError, match="coefficient"):
+        ThreadlikeActuator.tendons(
+            _routing([0.02, -0.015]),
+            friction=ThreadlikeFriction.capstan(coefficient=jnp.zeros((3,))),
+        )
+
+
+def test_a_friction_model_may_not_claim_to_be_frictionless():
+    """is_frictionless skips the model, so a friction model must not set it."""
+    with pytest.raises(ValueError, match="is_frictionless"):
+        ThreadlikeFriction(
+            params=CapstanFrictionParams(coefficient=jnp.asarray(0.3)),
+            ratio_fn=capstan_transmission_ratio,
+            requires_wrap_angle=True,
+            is_frictionless=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Friction accumulates from the path anchor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial])
+def test_friction_is_measured_from_the_path_anchor(factory):
+    """A path anchored mid-robot must not pay for what happens below it."""
+    robot = factory(num_segments=3)
+    anchored = _anchored_routing(0.02, start=1, end=2)
+    path_routing = ThreadlikeActuator.tendons(anchored).transmission.routing
+    starts = anchored.params.start_segment_index_array
+    anchor, tip = float(robot.L_cum[1]), float(jnp.sum(robot.L))
+
+    # Bend only the first segment, which the path does not span.
+    q = jnp.zeros((robot.num_coordinates,)).at[_bend_index(factory)].set(9.0)
+    strains = robot.strain(q).reshape((robot.num_segments, -1))
+    curvature = (
+        robot._threadlike_path_curvature(strains)
+        if factory is _planar
+        else robot._threadlike_path_curvature(strains, anchored)
+    )
+
+    # The wrap angle ignores that turning,
+    anchored_angle = robot._threadlike_safe_wrap_angle(
+        curvature, tip, starts, jnp.asarray(0.0)
+    )
+    assert_allclose(anchored_angle, jnp.zeros_like(anchored_angle), atol=1e-12)
+    # which the same pose measured from the robot base does not.
+    base_angle = robot._threadlike_safe_wrap_angle(
+        curvature, tip, jnp.zeros_like(starts), jnp.asarray(0.0)
+    )
+    assert jnp.all(base_angle > 1e-3)
+
+    # The traversed length is anchor-relative too, so a length law transmits in
+    # full at the anchor and decays only beyond it.
+    at_anchor = _geometry(robot, path_routing, q, s=anchor, segment_index=1)
+    assert_allclose(
+        at_anchor.path_abscissa, jnp.zeros_like(at_anchor.path_abscissa), atol=1e-12
+    )
+    ratio = ThreadlikeFriction.exponential_length(rate=5.0).transmission_ratio(
+        at_anchor
+    )
+    assert_allclose(ratio, jnp.ones_like(ratio), rtol=1e-12)
+
+    travelled = 0.03
+    beyond = _geometry(robot, path_routing, q, s=anchor + travelled, segment_index=1)
+    assert_allclose(
+        beyond.path_abscissa, jnp.full_like(beyond.path_abscissa, travelled)
+    )
+    # while the backbone coordinate still counts from the robot base.
+    assert_allclose(beyond.abscissa, jnp.full_like(beyond.abscissa, anchor + travelled))
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial])
+def test_capstan_friction_is_unaffected_by_curvature_before_the_anchor(factory):
+    """Attenuation of a mid-robot path must not depend on the segments below."""
+    anchored = _anchored_routing(0.02, start=1, end=2)
+    frictional = factory(
+        num_segments=3,
+        actuators=ThreadlikeActuator.tendons(
+            anchored, friction=ThreadlikeFriction.capstan(coefficient=0.6)
+        ),
+    )
+    reference = factory(num_segments=3, actuators=ThreadlikeActuator.tendons(anchored))
+    per_segment, bend = frictional.num_internal_dofs // 3, _bend_index(factory)
+
+    def attenuation(base_curvature):
+        # Bend the two segments the path spans, so it is genuinely attenuated,
+        # and vary only the curvature of the segment below its anchor.
+        q = (
+            jnp.zeros((frictional.num_coordinates,))
+            .at[bend]
+            .set(base_curvature)
+            .at[per_segment + bend]
+            .set(8.0)
+            .at[2 * per_segment + bend]
+            .set(-6.0)
+        )
+        reference_matrix = reference.actuation_matrix(q)
+        carried = jnp.abs(reference_matrix) > 1e-9
+        return frictional.actuation_matrix(q)[carried] / reference_matrix[carried]
+
+    straight_below = attenuation(0.0)
+    bent_below = attenuation(11.0)
+    assert straight_below.size > 0
+    # The path is attenuated, but by its own turning only.
+    assert jnp.all(straight_below < 1.0)
+    assert_allclose(straight_below, bent_below, rtol=1e-9, atol=1e-12)

--- a/tests/actuation/test_threadlike_friction.py
+++ b/tests/actuation/test_threadlike_friction.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E402
-"""Guide friction on threadlike transmissions, and the pluggable model."""
+"""Continuum Capstan friction for threadlike actuator transmissions."""
 
+import equinox as eqx
 import jax
 import pytest
 
@@ -18,16 +19,20 @@ from system_param_builders import (
 
 from soromox.actuation import (
     BaseThreadlikeFrictionParams,
+    BaseThreadlikeRoutingParams,
     CapstanFrictionParams,
-    ExponentialLengthFrictionParams,
-    FrictionlessParams,
     ThreadlikeActuator,
     ThreadlikeFriction,
     ThreadlikeImpedance,
     ThreadlikeRouting,
-    capstan_transmission_ratio,
+    capstan_effort_ratio,
+    threadlike_tangent,
+    threadlike_turn_rate,
 )
-from soromox.autodiff import custom_jvp_mode
+from soromox.coordinate_transformations import ActuationSpaceDynamics
+from soromox.execution.warp.actuation.threadlike import (
+    supports_linear_threadlike_matrix,
+)
 from soromox.systems import (
     GVS,
     PCS,
@@ -39,38 +44,32 @@ from soromox.systems import (
     StrainBasisSpec,
 )
 from soromox.systems.pcs import PlanarPCSStructure
-
-# Pull that bends the reference robot by a few radians per metre.
-TENSION = 0.03
+from soromox.utils.lie_algebra import so3
 
 
-def _planar(
-    *,
-    num_segments=1,
-    actuators=None,
-    passive_elements=(),
-    num_gauss_points=5,
-    gravity=jnp.zeros((2,)),
-):
+def _planar(*, num_segments: int = 1, actuators=None) -> PlanarPCS:
+    """Construct a planar PCS fixture with all strain coordinates active."""
     body = planar_pcs_params(
         length=jnp.full((num_segments,), 0.1),
         radius=jnp.full((num_segments,), 0.02),
         density=jnp.full((num_segments,), 1000.0),
-        gravity=gravity,
+        gravity=jnp.zeros((2,)),
         young_modulus=jnp.full((num_segments,), 1e3),
         shear_modulus=jnp.full((num_segments,), 5e2),
         damping_matrix=1e-3 * jnp.eye(3 * num_segments),
     )
     return PlanarPCS(
         body,
-        PlanarPCSStructure(num_gauss_points=num_gauss_points),
+        PlanarPCSStructure(num_gauss_points=7),
         base_pose=planar_base_pose(),
         actuators=actuators,
-        passive_elements=passive_elements,
     )
 
 
-def _spatial(*, num_segments=1, actuators=None):
+def _spatial(
+    *, num_segments: int = 1, actuators=None, num_gauss_points: int = 7
+) -> PCS:
+    """Construct a spatial PCS fixture with all strain coordinates active."""
     body = pcs_params(
         length=jnp.full((num_segments,), 0.1),
         radius=jnp.full((num_segments,), 0.02),
@@ -82,13 +81,14 @@ def _spatial(*, num_segments=1, actuators=None):
     )
     return PCS(
         body,
-        PCSStructure(num_gauss_points=5),
+        PCSStructure(num_gauss_points=num_gauss_points),
         base_pose=spatial_base_pose(),
         actuators=actuators,
     )
 
 
-def _gvs(*, actuators=None):
+def _gvs(*, actuators=None, basis_order=0) -> GVS:
+    """Construct a one-link GVS fixture with fixed base and joint."""
     segment = GVSSegment(
         link=LinkSpec.circular(
             young_modulus=3e5,
@@ -102,944 +102,391 @@ def _gvs(*, actuators=None):
         joint=JointSpec(type="fixed"),
         basis=StrainBasisSpec(
             type="monomial",
-            strain_selector=[1, 1, 1, 1, 0, 0],
-            basis_order=[0, 0, 0, 0, 0, 0],
+            strain_selector=[0, 0, 1, 1, 0, 0],
+            basis_order=[0, 0, basis_order, 0, 0, 0],
         ),
-        num_gauss_points=5,
+        num_gauss_points=7,
     )
     return GVS.from_segments([segment], gravity=jnp.zeros((3,)), actuators=actuators)
 
 
-def _routing(offsets, *, num_segments=1):
-    count = len(offsets)
-    zeros = jnp.zeros((count,))
+def _routing(
+    offset: float = 0.02,
+    *,
+    start_segment: int = 0,
+    end_segment: int = 0,
+) -> ThreadlikeRouting:
+    """Construct one constant-offset material-frame path."""
     return ThreadlikeRouting.linear(
-        intercept=jnp.stack((zeros, jnp.asarray(offsets), zeros), axis=-1),
-        start_segment_index=(0,) * count,
-        end_segment_index=(num_segments - 1,) * count,
+        intercept=jnp.array([0.0, offset, 0.0]),
+        start_segment_index=(start_segment,),
+        end_segment_index=(end_segment,),
     )
 
 
-def _anchored_routing(offset, *, start, end):
-    """One path anchored at segment ``start`` and ending at segment ``end``."""
-    return ThreadlikeRouting.linear(
-        intercept=jnp.array([[0.0, offset, 0.0]]),
-        start_segment_index=(start,),
-        end_segment_index=(end,),
-    )
+def _constant_bending_configuration(robot, curvature: float) -> Array:
+    """Return a pure positive-z bending configuration for a fixture host."""
+    if isinstance(robot, PlanarPCS):
+        return jnp.array([curvature, 0.0, 0.0])
+    if isinstance(robot, PCS):
+        return jnp.array([0.0, 0.0, curvature, 0.0, 0.0, 0.0])
+    return jnp.array([curvature, 0.0])
 
 
-def _geometry(robot, path_routing, q, *, s, segment_index):
-    """Evaluate the quadrature context of every path at one node."""
-    strains = robot.strain(q).reshape((robot.num_segments, -1))
-    params = path_routing.params
-    return jax.vmap(
-        robot._threadlike_local_geometry,
-        in_axes=(None, None, None, None, 0, 0, 0),
-        out_axes=0,
-    )(
-        jnp.asarray(segment_index),
-        strains[segment_index],
-        jnp.asarray(s),
-        path_routing,
-        params,
-        params.start_segment_index_array,
-        params.end_segment_index_array,
-    )
-
-
-def _bend_index(factory):
-    """Index of the bending strain within one segment, per host."""
-    return 0 if factory is _planar else 2
-
-
-def _impedance(routing, coefficient=0.0):
-    return ThreadlikeImpedance(
-        routing=routing,
-        stiffness=jnp.array([50.0, 30.0]),
-        damping=jnp.array([0.3, 0.2]),
-        rest_length=jnp.array([0.09, 0.1]),
-        friction=ThreadlikeFriction.capstan(coefficient=coefficient),
-    )
-
-
-def _settle(robot, u, iterations=30):
-    """Return the static equilibrium reached by Newton iteration from rest."""
-
-    def residual(q):
-        return (
-            robot.elastic_force(q)
-            + robot.gravitational_force(q)
-            - robot.actuation_force(q, u)
-        )
-
-    q = jnp.zeros((robot.num_coordinates,))
-    for _ in range(iterations):
-        q = q - jnp.linalg.solve(jax.jacobian(residual)(q), residual(q))
-    return q
-
-
-def _with_friction(robot, coefficient):
-    """Return a copy of ``robot`` whose Capstan coefficient is ``coefficient``."""
-    transmission = robot.actuators[0].params.transmission
-    return robot.update_actuator_params(
-        0,
-        transmission=transmission.replace(
-            friction=transmission.friction.replace(coefficient=coefficient)
-        ),
-    )
-
-
-def _with_eps(robot, eps):
-    """Return a copy of ``robot`` whose Capstan curvature floor is ``eps``."""
-    transmission = robot.actuators[0].params.transmission
-    return robot.update_actuator_params(
-        0,
-        transmission=transmission.replace(
-            friction=transmission.friction.replace(eps=eps)
-        ),
-    )
-
-
-# ---------------------------------------------------------------------------
-# Model
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("factory", [_planar, _spatial])
-def test_zero_friction_is_bit_identical(factory):
-    routing = _routing([0.02, -0.015])
-    plain = factory(actuators=ThreadlikeActuator.tendons(routing))
-    zero = factory(
+@pytest.mark.parametrize("factory", [_planar, _spatial, _gvs])
+def test_zero_coefficient_matches_frictionless_transmission(factory):
+    """Keep the zero-loss result identical for every continuum host."""
+    routing = _routing()
+    ideal = factory(actuators=ThreadlikeActuator.tendons(routing))
+    zero_loss = factory(
         actuators=ThreadlikeActuator.tendons(
             routing, friction=ThreadlikeFriction.capstan(coefficient=0.0)
         )
     )
-    q = jnp.linspace(-0.01, 0.04, plain.num_coordinates)
-    assert jnp.array_equal(plain.actuation_matrix(q), zero.actuation_matrix(q))
+    q = _constant_bending_configuration(ideal, 3.0)
 
-
-def test_capstan_matches_closed_form():
-    """Attenuation follows the Euler belt law and compounds along the arc."""
-    mu, kappa, length = 0.3, 8.0, 0.1
-    routing = _routing([0.02])
-    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
-    attenuated = _planar(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.capstan(coefficient=mu)
-        )
-    )
-    q = jnp.array([kappa, 0.0, 0.0])
-    wrap = mu * kappa * length
-    expected = (1.0 - jnp.exp(-wrap)) / wrap
-    axial_row = 1
+    assert jnp.array_equal(ideal.actuation_matrix(q), zero_loss.actuation_matrix(q))
     assert_allclose(
-        attenuated.actuation_matrix(q)[axial_row],
-        expected * frictionless.actuation_matrix(q)[axial_row],
-        rtol=1e-8,
+        ideal.actuator_coordinate_jacobian(q),
+        zero_loss.actuator_coordinate_jacobian(q),
     )
 
-    # Segment-averaged transmission decreases monotonically toward the tip.
-    num_segments = 3
-    span = _routing([0.02], num_segments=num_segments)
-    chain_0 = _planar(
-        num_segments=num_segments, actuators=ThreadlikeActuator.tendons(span)
-    )
-    chain_mu = _planar(
-        num_segments=num_segments,
+
+@pytest.mark.parametrize("factory", [_planar, _spatial, _gvs])
+def test_constant_curvature_capstan_matrix_matches_closed_form(factory):
+    """Match the continuum integral for a constant-offset circular path."""
+    coefficient = 0.6
+    curvature = 4.0
+    offset = 0.02
+    routing = _routing(offset)
+    robot = factory(
         actuators=ThreadlikeActuator.tendons(
-            span, friction=ThreadlikeFriction.capstan(coefficient=0.4)
-        ),
-    )
-    q_chain = (
-        jnp.zeros((chain_0.num_coordinates,)).at[::3].set(jnp.array([6.0, 9.0, 12.0]))
-    )
-    rows = jnp.arange(num_segments) * 3 + axial_row
-    ratio = (
-        chain_mu.actuation_matrix(q_chain)[rows, 0]
-        / chain_0.actuation_matrix(q_chain)[rows, 0]
-    )
-    assert jnp.all(ratio[1:] < ratio[:-1])
-    assert jnp.all((ratio > 0.0) & (ratio <= 1.0))
-
-
-def test_path_curvature_is_the_curvature_of_the_routed_path():
-    """``|omega x u_hat|`` must be the curvature the routed path traces."""
-    radius, torsion, bend = 0.02, 5.0, 7.0
-    routing = _routing([radius])
-    spatial = _spatial(actuators=ThreadlikeActuator.tendons(routing))
-    path_routing = spatial.actuators[0].transmission.routing
-
-    def spatial_curvature(q):
-        strains = spatial.strain(q).reshape((spatial.num_segments, 6))
-        return spatial._threadlike_path_curvature(strains, path_routing)
-
-    # Under pure torsion an off-axis path traces a helix.
-    helix = spatial_curvature(jnp.zeros((spatial.num_coordinates,)).at[0].set(torsion))
-    chord = jnp.sqrt(1.0 + (torsion * radius) ** 2)
-    assert_allclose(helix, jnp.full_like(helix, torsion**2 * radius / chord))
-
-    # In a planar configuration it reduces to |kappa_z| for any offset, which
-    # is what makes the planar and spatial hosts agree.
-    reduced = spatial_curvature(jnp.zeros((spatial.num_coordinates,)).at[2].set(bend))
-    planar = _planar(actuators=ThreadlikeActuator.tendons(routing))
-    planar_q = jnp.zeros((planar.num_coordinates,)).at[0].set(bend)
-    planar_curvature = planar._threadlike_path_curvature(
-        planar.strain(planar_q).reshape((planar.num_segments, 3))
-    )
-    assert_allclose(reduced, jnp.full_like(reduced, bend), rtol=1e-9)
-    assert_allclose(planar_curvature, jnp.full_like(planar_curvature, bend), rtol=1e-9)
-
-
-# ---------------------------------------------------------------------------
-# Energy
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("actuator_friction", "passive_friction"),
-    [(0.0, 0.0), (0.6, 0.0), (0.0, 0.6), (0.6, 0.6)],
-)
-def test_energy_rate_matches_actuation_and_damping_power(
-    actuator_friction, passive_friction
-):
-    """The robot-side energy budget stays exact at any friction coefficient."""
-    routing = _routing([0.02, -0.015])
-    robot = _planar(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.capstan(coefficient=actuator_friction)
-        ),
-        passive_elements=(_impedance(routing, passive_friction),),
-        gravity=jnp.array([0.0, -9.81]),
-    )
-    q = jnp.array([4.0, 0.02, -0.01])
-    qd = jnp.array([0.7, -0.3, 0.5])
-    u = jnp.array([3.0, 1.5])
-
-    state_rate = robot.forward_dynamics(0.0, jnp.concatenate([q, qd]), (u,))
-    qdd = state_rate[robot.num_coordinates :]
-
-    def energy(q_, qd_):
-        return robot.kinetic_energy(q_, qd_) + robot.potential_energy(q_)
-
-    energy_rate = jax.grad(energy, 0)(q, qd) @ qd + jax.grad(energy, 1)(q, qd) @ qdd
-    power = qd @ robot.actuation_force(q, u, qd=qd) - qd @ robot.damping_matrix(q) @ qd
-    assert_allclose(energy_rate, power, rtol=1e-9, atol=1e-12)
-
-
-@pytest.mark.parametrize(
-    ("preset", "u", "qd_sign"),
-    [
-        (ThreadlikeActuator.tendons, 4.0, 1.0),
-        (ThreadlikeActuator.tendons, -4.0, -1.0),
-        (ThreadlikeActuator.push_rods, 4.0, -1.0),
-    ],
-)
-def test_driving_effort_dissipates_for_pull_and_push(preset, u, qd_sign):
-    """Guides absorb power whenever the effort drives the path, either way."""
-    routing = _routing([0.02])
-    robot = _planar(
-        actuators=preset(routing, friction=ThreadlikeFriction.capstan(coefficient=0.5))
-    )
-    transmission = robot.actuators[0].transmission
-    q = jnp.array([7.0, 0.0, 0.0])
-    qd = jnp.array([qd_sign, 0.0, 0.0])
-    effort = jnp.array([u])
-
-    scale = transmission.params.coordinate_scale
-    supplied = jnp.sum(
-        effort * scale * (transmission.kinematic_matrix(robot, q).T @ qd)
-    )
-    delivered = qd @ (transmission.moment_matrix(robot, q) @ effort)
-
-    assert supplied > 0.0  # the effort drives the path in this direction
-    assert delivered > 0.0
-    assert delivered < supplied
-    assert supplied - delivered > 0.0
-
-
-def test_closed_loop_work_is_nonzero_and_orientation_dependent():
-    """Friction admits no actuation potential, so loop work does not vanish."""
-    routing = _routing([0.02])
-    effort = jnp.array([2.0])
-
-    def loop_work(robot, orientation, num_points=2000):
-        angle = orientation * jnp.linspace(0.0, 2.0 * jnp.pi, num_points)
-        path = jnp.stack(
-            [
-                5.0 + 4.0 * jnp.cos(angle),
-                0.05 * jnp.sin(angle),
-                jnp.zeros_like(angle),
-            ],
-            axis=-1,
+            routing,
+            friction=ThreadlikeFriction.capstan(coefficient=coefficient),
         )
-        force = jax.vmap(lambda q: robot.actuation_matrix(q) @ effort)(path)
-        midpoint = 0.5 * (force[1:] + force[:-1])
-        return jnp.sum(midpoint * jnp.diff(path, axis=0))
+    )
+    q = _constant_bending_configuration(robot, curvature)
+    length = 0.1
+    weighted_length = -jnp.expm1(-coefficient * curvature * length) / (
+        coefficient * curvature
+    )
 
-    attenuated = _planar(
+    expected = jnp.zeros((robot.num_velocities, 1))
+    if isinstance(robot, (PlanarPCS, GVS)):
+        expected = expected.at[0, 0].set(offset * weighted_length)
+        expected = expected.at[1, 0].set(-weighted_length)
+    else:
+        expected = expected.at[2, 0].set(offset * weighted_length)
+        expected = expected.at[3, 0].set(-weighted_length)
+
+    assert_allclose(robot.actuation_matrix(q), expected, rtol=5e-8, atol=5e-10)
+
+
+def test_turn_rate_formula_matches_autodiff_of_spatial_unit_tangent():
+    """Verify the analytical production formula against a test-only JVP."""
+    angular = jnp.array([0.7, -0.3, 1.1])
+    linear = jnp.array([1.0, 0.2, -0.1])
+    angular_derivative = jnp.array([0.2, 0.1, -0.4])
+    linear_derivative = jnp.array([-0.1, 0.3, 0.2])
+    offset = jnp.array([0.0, 0.03, -0.02])
+    offset_derivative = jnp.array([0.0, -0.2, 0.1])
+    offset_second_derivative = jnp.array([0.0, 0.4, -0.15])
+
+    analytical = threadlike_turn_rate(
+        angular,
+        linear,
+        angular_derivative,
+        linear_derivative,
+        offset,
+        offset_derivative,
+        offset_second_derivative,
+        eps=1e-12,
+    )
+
+    def spatial_unit_tangent(delta: Array) -> Array:
+        """Construct a local spatial tangent curve for test differentiation."""
+        omega = angular + delta * angular_derivative
+        velocity = linear + delta * linear_derivative
+        current_offset = (
+            offset
+            + delta * offset_derivative
+            + 0.5 * delta**2 * offset_second_derivative
+        )
+        current_offset_derivative = offset_derivative + delta * offset_second_derivative
+        tangent = threadlike_tangent(
+            omega, velocity, current_offset, current_offset_derivative
+        )
+        unit = tangent / jnp.linalg.norm(tangent)
+        return so3.exp(delta * angular) @ unit
+
+    _, derivative = jax.jvp(
+        spatial_unit_tangent, (jnp.asarray(0.0),), (jnp.asarray(1.0),)
+    )
+    assert_allclose(analytical, jnp.linalg.norm(derivative), rtol=2e-12, atol=2e-12)
+
+
+class SinusoidalRoutingParams(BaseThreadlikeRoutingParams):
+    """Parameters for an analytical sinusoidal test routing."""
+
+    amplitude: Array
+    frequency: Array
+    start_segment_index: tuple[int, ...] = eqx.field(static=True)
+    end_segment_index: tuple[int, ...] = eqx.field(static=True)
+
+    @property
+    def num_paths(self) -> int:
+        """Return the number of sinusoidal paths."""
+        return int(self.amplitude.shape[0])
+
+    def validate_structure(self) -> None:
+        """Validate amplitude and frequency shapes."""
+        if self.frequency.shape != self.amplitude.shape:
+            raise ValueError("frequency must match amplitude shape.")
+
+
+def _sinusoidal_offset(params: SinusoidalRoutingParams, s: Array) -> Array:
+    """Return a sinusoidal material-``y`` routing offset."""
+    y = params.amplitude * jnp.sin(params.frequency * s)
+    return jnp.asarray([0.0, y, 0.0])
+
+
+def _sinusoidal_derivative(params: SinusoidalRoutingParams, s: Array) -> Array:
+    """Return the analytical first derivative of the sinusoidal offset."""
+    y = params.amplitude * params.frequency * jnp.cos(params.frequency * s)
+    return jnp.asarray([0.0, y, 0.0])
+
+
+def _sinusoidal_second_derivative(params: SinusoidalRoutingParams, s: Array) -> Array:
+    """Return the analytical second derivative of the sinusoidal offset."""
+    y = -(params.frequency**2) * params.amplitude * jnp.sin(params.frequency * s)
+    return jnp.asarray([0.0, y, 0.0])
+
+
+def test_custom_routing_analytical_turn_matches_dense_numerical_reference():
+    """Include material-tangent variation in accumulated continuum turn."""
+    params = SinusoidalRoutingParams(
+        amplitude=jnp.array([0.015]),
+        frequency=jnp.array([18.0]),
+        start_segment_index=(0,),
+        end_segment_index=(0,),
+    )
+    routing = ThreadlikeRouting(
+        params=params,
+        offset_fn=_sinusoidal_offset,
+        derivative_fn=_sinusoidal_derivative,
+        second_derivative_fn=_sinusoidal_second_derivative,
+    )
+    robot = _spatial(num_gauss_points=17)
+    q = jnp.array([0.2, -0.4, 2.0, 0.1, 0.05, -0.03])
+    strains = robot.strain(q).reshape((1, 6))
+    accumulated = robot._threadlike_accumulated_turn(strains, routing, robot.length)[0]
+
+    points = jnp.linspace(0.0, robot.length, 20001)
+    rates = robot._threadlike_turn_rates(strains, routing, jnp.asarray(0), points)[:, 0]
+    reference = jnp.trapezoid(rates, points)
+    assert_allclose(accumulated, reference, rtol=5e-5, atol=5e-8)
+
+
+def test_gvs_varying_strain_turn_rate_uses_analytical_basis_derivative():
+    """Match GVS turn rate to test-only differentiation of its strain field."""
+    routing = _routing()
+    robot = _gvs(basis_order=1)
+    q = jnp.array([1.2, -0.7, 0.1])
+    gathered = robot._min_size_gathered(q)
+    point = jnp.asarray(0.063)
+    actual = robot._threadlike_turn_rates(
+        gathered, routing, jnp.asarray(0), point[None]
+    )[0, 0]
+
+    def spatial_unit_tangent(s: Array) -> Array:
+        """Evaluate the world path tangent for test-only differentiation."""
+        strain, _ = robot._threadlike_strain_and_derivative(
+            gathered[0, 1], jnp.asarray(0), s[None]
+        )
+        current = strain[0]
+        offset = routing.offset(routing.params, s)[0]
+        derivative = routing.derivative(routing.params, s)[0]
+        tangent = threadlike_tangent(current[:3], current[3:], offset, derivative)
+        unit = tangent / jnp.linalg.norm(tangent)
+        rotation = robot.forward_kinematics(q, s)[:3, :3]
+        return rotation @ unit
+
+    _, derivative = jax.jvp(spatial_unit_tangent, (point,), (jnp.asarray(1.0),))
+    assert_allclose(actual, jnp.linalg.norm(derivative), rtol=5e-6, atol=2e-7)
+
+
+@pytest.mark.parametrize("factory", [_planar, _spatial, _gvs])
+def test_friction_separates_coordinate_jacobian_from_actuation_matrix(factory):
+    """Keep kinematics geometric while attenuating generalized force."""
+    routing = _routing()
+    robot = factory(
         actuators=ThreadlikeActuator.tendons(
             routing, friction=ThreadlikeFriction.capstan(coefficient=0.8)
         )
     )
-    forward = loop_work(attenuated, 1.0)
-    assert jnp.abs(forward) > 1e-4
-    assert_allclose(loop_work(attenuated, -1.0), -forward, rtol=1e-6)
+    q = _constant_bending_configuration(robot, 5.0)
+    coordinate_jacobian = robot.actuator_coordinate_jacobian(q)
 
-    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
-    assert jnp.abs(loop_work(frictionless, 1.0)) < 1e-12
-
-
-@pytest.mark.parametrize("passive_friction", [0.0, 1.0])
-def test_passive_friction_is_the_only_unactuated_energy_source(passive_friction):
-    """An unactuated robot decays monotonically only at zero passive friction."""
-    routing = _routing([0.02, -0.015], num_segments=2)
-    robot = _planar(
-        num_segments=2,
-        passive_elements=(_impedance(routing, passive_friction),),
-        gravity=jnp.array([0.0, -9.81]),
-    )
-    control = jnp.zeros((robot.num_actuators,))
-    key = jax.random.PRNGKey(3)
-
-    def energy_rate(index):
-        keys = jax.random.split(jax.random.fold_in(key, index))
-        q = 4.0 * jax.random.normal(keys[0], (robot.num_coordinates,))
-        qd = jax.random.normal(keys[1], (robot.num_velocities,))
-        return (
-            qd @ robot.actuation_force(q, control, qd=qd)
-            - qd @ robot.damping_matrix(q) @ qd
-        )
-
-    rates = jax.vmap(energy_rate)(jnp.arange(200))
-    if passive_friction == 0.0:
-        assert jnp.all(rates <= 0.0)
-    else:
-        assert jnp.any(rates > 0.0)
-
-
-def test_floating_passive_nonconservative_force_has_zero_base_prefix():
-    """Passive routing friction acts only on the internal material coordinates."""
-
-    routing = _routing([0.02, -0.015])
-    fixed = _planar(passive_elements=(_impedance(routing, coefficient=0.6),))
-    floating = PlanarPCS(
-        params=fixed.params,
-        structure=PlanarPCSStructure(num_gauss_points=fixed.num_gauss_points),
-        passive_elements=fixed.passive_elements,
-        floating_base=True,
-        backend="jax",
-    )
-    q_internal = jnp.array([4.0, 0.02, -0.01])
-    q = floating.pack_configuration(
-        q_internal,
-        base_pose=jnp.array([0.3, 0.1, -0.2]),
-    )
-    expected = fixed.passive_nonconservative_force(q_internal)
-    actual = floating.passive_nonconservative_force(q)
-
-    assert_allclose(actual[: floating.num_base_velocities], 0.0, atol=0.0)
-    assert_allclose(actual[floating.num_base_velocities :], expected)
-    assert_allclose(floating.passive_nonconservative_force(q_internal), expected)
-
-
-def test_passive_damping_is_psd_under_friction():
-    """The chosen congruence stays dissipative where the rejected form does not."""
-    routing = _routing([0.02, -0.015], num_segments=2)
-    passive = _impedance(routing, 1.2)
-    robot = _planar(num_segments=2, passive_elements=(passive,))
-    q = jnp.array([6.0, 0.02, -0.01, 10.0, 0.02, -0.01])
-
-    damping = passive.damping_matrix(robot, q)
-    assert_allclose(damping, damping.T, atol=1e-18)
-    assert jnp.min(jnp.linalg.eigvalsh(damping)) > -1e-15
-
-    # The rejected A_mu D A_0^T reads the rate through the exact Jacobian.
-    transmission = passive._transmission_matrix(robot, q)
-    jacobian = passive._length_jacobian(robot, q).T
-    rejected = transmission @ (passive.params.damping[:, None] * jacobian.T)
-    symmetric = 0.5 * (rejected + rejected.T)
-    direction = jnp.linalg.eigh(symmetric)[1][:, 0]
-
-    assert direction @ rejected @ direction < 0.0  # would inject energy
-    assert direction @ damping @ direction > 0.0
-
-
-def test_passive_split_preserves_energy_gradient_and_total_dynamics():
-    """Splitting the spring force changes bookkeeping, not physics."""
-    routing = _routing([0.02, -0.015], num_segments=2)
-    passive = _impedance(routing, 0.8)
-    robot = _planar(num_segments=2, passive_elements=(passive,))
-    q = jnp.array([5.0, 0.02, -0.01, -3.0, 0.01, 0.02])
-
-    extension = passive.path_lengths(robot, q) - passive.params.rest_length
-    transmitted = passive._transmission_matrix(robot, q) @ (
-        passive.params.stiffness * extension
-    )
     assert_allclose(
-        transmitted,
-        passive.elastic_force(robot, q) + passive.nonconservative_force(robot, q),
-        atol=1e-15,
+        coordinate_jacobian,
+        jax.jacrev(robot.actuator_coordinates)(q),
+        rtol=3e-7,
+        atol=3e-9,
     )
-
-    for enabled in (True, False):
-        with custom_jvp_mode(enabled):
-            assert_allclose(
-                jax.grad(robot.elastic_energy)(q),
-                robot.elastic_force(q),
-                rtol=1e-9,
-                atol=1e-14,
-            )
+    assert not jnp.allclose(coordinate_jacobian, robot.actuation_matrix(q).T)
 
 
-def test_push_and_pull_share_the_same_transmission_ratio():
-    """The ratio depends on the configuration only, never on the effort."""
-    routing = _routing([0.02])
-    tendon = _planar(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.capstan(coefficient=0.7)
-        )
-    )
-    push_rod = _planar(
-        actuators=ThreadlikeActuator.push_rods(
-            routing, friction=ThreadlikeFriction.capstan(coefficient=0.7)
-        )
-    )
-    q = jnp.array([6.0, 0.01, 0.0])
-    assert_allclose(
-        tendon.actuation_matrix(q), -push_rod.actuation_matrix(q), atol=1e-18
-    )
-
-
-# ---------------------------------------------------------------------------
-# Planar routed-path offset sign
-# ---------------------------------------------------------------------------
-
-
-def test_pulled_tendon_shortens_and_bends_toward_its_own_side():
-    """A pulled tendon must shorten and curve the backbone onto its own side."""
-    robot = _planar(actuators=ThreadlikeActuator.tendons(_routing([0.02, -0.02])))
-    actuator = robot.actuators[0]
-    rest = 0.1
-
-    q_first = _settle(robot, jnp.array([TENSION, 0.0]))
-    first = actuator.path_lengths(robot, q_first)
-    assert q_first[0] > 0.0
-    assert first[0] < rest < first[1]
-
-    q_second = _settle(robot, jnp.array([0.0, TENSION]))
-    second = actuator.path_lengths(robot, q_second)
-    assert_allclose(q_second[0], -q_first[0], rtol=1e-9)
-    assert_allclose(second, first[::-1], rtol=1e-9)
-
-    q_push = _settle(robot, jnp.array([-TENSION, 0.0]))
-    pushed = actuator.path_lengths(robot, q_push)
-    assert q_push[0] < 0.0
-    assert pushed[0] > rest > pushed[1]
-
-
-def test_planar_path_length_matches_rendered_path():
-    """Path length must equal the arc length of the curve the renderer draws."""
-    robot = _planar(actuators=ThreadlikeActuator.tendons(_routing([0.02])))
-    actuator = robot.actuators[0]
-    q = jnp.array([10.0, 0.0, 0.0])
-
-    samples = jnp.linspace(0.0, float(jnp.sum(robot.L)), 20001)
-    positions = jax.vmap(lambda s: actuator.path_poses(robot, q, s))(samples)
-    polyline = jnp.sum(jnp.linalg.norm(jnp.diff(positions[:, 0], axis=0), axis=-1))
-
-    assert_allclose(actuator.path_lengths(robot, q), jnp.array([0.08]), rtol=1e-6)
-    assert_allclose(polyline, 0.08, rtol=1e-6)
-
-
-# ---------------------------------------------------------------------------
-# Invariants and autodiff
-# ---------------------------------------------------------------------------
-
-
-def test_friction_breaks_length_gradient_identity():
-    """Friction deliberately severs moment_matrix from the length gradient."""
-    routing = _routing([0.02, -0.015])
-    q = jnp.array([4.0, 0.02, -0.01])
-
-    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
-    assert_allclose(
-        jax.jacrev(frictionless.actuator_coordinates)(q),
-        frictionless.actuation_matrix(q).T,
-        rtol=2e-7,
-        atol=2e-9,
-    )
-
-    attenuated = _planar(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.capstan(coefficient=0.6)
-        )
-    )
-    gap = (
-        jax.jacrev(attenuated.actuator_coordinates)(q)
-        - attenuated.actuation_matrix(q).T
-    )
-    assert jnp.max(jnp.abs(gap)) > 1e-3
-
-
-def test_capstan_coefficient_is_traceable_and_identifiable():
-    """The coefficient stays a differentiable leaf under jit."""
-    routing = _routing([0.02, -0.015])
+def test_actuation_space_preserves_the_lossy_force_map():
+    """Transform effort covectors with ``J^-T A`` instead of assuming identity."""
+    routing = _routing()
     robot = _planar(
         actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.capstan(coefficient=0.2)
+            routing, friction=ThreadlikeFriction.capstan(coefficient=0.8)
         )
     )
-    q = jnp.array([4.0, 0.02, -0.01])
-    u = jnp.array([2.0, 1.0])
+    transform = ActuationSpaceDynamics(robot)
+    q = _constant_bending_configuration(robot, 5.0)
+    expected = transform.jacobian_inverse(q).T @ robot.actuation_matrix(q)
 
-    @jax.jit
-    def loss(coefficient):
-        identified = _with_friction(robot, coefficient)
-        return jnp.sum(identified.actuation_force(q, u) ** 2)
-
-    for start in (0.0, 0.35):
-        value, gradient = jax.value_and_grad(loss)(jnp.asarray(start))
-        assert jnp.isfinite(value) and jnp.isfinite(gradient)
-        assert jnp.abs(gradient) > 0.0
-
-    per_path = jax.grad(loss)(jnp.array([0.1, 0.4]))
-    assert per_path.shape == (2,)
-    assert jnp.all(jnp.isfinite(per_path)) and jnp.all(per_path != 0.0)
-
-
-@pytest.mark.parametrize("eps", [0.0, 0.1])
-def test_friction_gradients_are_finite_at_singular_states(eps):
-    """The |kappa| kink at a straight backbone must not produce NaNs."""
-    robot = _planar(
-        actuators=ThreadlikeActuator.tendons(
-            _routing([0.02]),
-            friction=ThreadlikeFriction.capstan(coefficient=0.3, eps=eps),
-        ),
-    )
-    straight = jnp.zeros((robot.num_coordinates,))
-
-    assert jnp.isfinite(jax.jacrev(robot.actuation_matrix)(straight)).all()
-    assert jnp.isfinite(jax.jacrev(robot.actuator_coordinates)(straight)).all()
-
-    def matrix_norm(coefficient):
-        identified = _with_friction(robot, coefficient)
-        return jnp.sum(identified.actuation_matrix(straight) ** 2)
-
-    sensitivity = jax.grad(matrix_norm)(jnp.asarray(0.3))
-    assert jnp.isfinite(sensitivity)
-    # The curvature floor is what makes the coefficient identifiable straight.
-    if eps == 0.0:
-        assert sensitivity == 0.0
-        return
-    assert jnp.abs(sensitivity) > 0.0
-
-    # The floor is itself a traced leaf, so it can be fitted alongside.
-    def floor_norm(value):
-        return jnp.sum(_with_eps(robot, value).actuation_matrix(straight) ** 2)
-
-    floor_sensitivity = jax.grad(floor_norm)(jnp.asarray(eps))
-    assert jnp.isfinite(floor_sensitivity) and jnp.abs(floor_sensitivity) > 0.0
-
-
-def test_curvature_floor_bias_is_bounded_and_removes_the_kink():
-    """The floor only ever over-estimates the wrap angle, by at most eps * L."""
-    q = jnp.array([3.0, 0.0, 0.0, -2.0, 0.0, 0.0])
-    robot = _planar(num_segments=2)
-    total_length = float(jnp.sum(robot.L))
-    starts = jnp.zeros((1,), dtype=jnp.int32)
-    curvature = robot._threadlike_path_curvature(robot.strain(q).reshape((2, 3)))
-    reference = robot._threadlike_safe_wrap_angle(
-        curvature, total_length, starts, jnp.asarray(0.0)
-    )
-
-    for eps in (0.0, 0.05, 0.4):
-        angle = robot._threadlike_safe_wrap_angle(
-            curvature, total_length, starts, jnp.asarray(eps)
-        )
-        assert jnp.all(angle >= reference)
-        assert jnp.all(angle - reference <= eps * total_length + 1e-12)
-
-    routing = _routing([0.02])
-    plain = _planar(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.capstan(coefficient=0.5)
-        )
-    )
-    unsmoothed = _planar(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.capstan(coefficient=0.5, eps=0.0)
-        ),
-    )
-    q_single = jnp.array([3.0, 0.0, 0.0])
-    assert jnp.array_equal(
-        plain.actuation_matrix(q_single), unsmoothed.actuation_matrix(q_single)
+    assert_allclose(transform.actuation_matrix(q), expected)
+    assert not jnp.allclose(
+        transform.actuation_matrix(q), jnp.array([[1.0], [0.0], [0.0]])
     )
 
 
-def test_gvs_rejects_nonzero_friction():
-    """GVS strain varies along s, so the piecewise-linear wrap angle is invalid."""
-    routing = _routing([0.02])
-    _gvs(actuators=ThreadlikeActuator.tendons(routing))  # zero stays allowed
+class HyperbolicFrictionParams(BaseThreadlikeFrictionParams):
+    """Parameter of a custom hyperbolic effort-loss law."""
 
-    with pytest.raises(TypeError, match="wrap-angle model"):
-        _gvs(
-            actuators=ThreadlikeActuator.tendons(
-                routing, friction=ThreadlikeFriction.capstan(coefficient=0.3)
-            )
-        )
+    coefficient: Array
+
+    def validate_values(self) -> None:
+        """Reject negative custom coefficients."""
+        if bool(jnp.any(self.coefficient < 0.0)):
+            raise ValueError("coefficient must be non-negative.")
 
 
-# ---------------------------------------------------------------------------
-# The pluggable friction model
-# ---------------------------------------------------------------------------
+def _hyperbolic_effort_ratio(
+    params: HyperbolicFrictionParams, accumulated_turn: Array
+) -> Array:
+    """Return a custom effort ratio using only explicit accumulated turn."""
+    return 1.0 / (1.0 + params.coefficient * accumulated_turn)
 
 
-class _HyperbolicFrictionParams(BaseThreadlikeFrictionParams):
-    """Parameters of a law defined entirely outside soromox."""
-
-    a: Array
-
-
-def _hyperbolic_transmission_ratio(params, context):
-    """A law defined entirely outside soromox, to pin the extension point."""
-    return 1.0 / (1.0 + params.a * context.wrap_angle)
-
-
-def _hyperbolic(a):
-    return ThreadlikeFriction(
-        params=_HyperbolicFrictionParams(a=jnp.asarray(a)),
-        ratio_fn=_hyperbolic_transmission_ratio,
-        requires_wrap_angle=True,
+def test_custom_effort_ratio_needs_no_quadrature_context():
+    """Keep custom friction laws independent of host geometry containers."""
+    routing = _routing()
+    friction = ThreadlikeFriction(
+        params=HyperbolicFrictionParams(coefficient=jnp.asarray(0.5)),
+        effort_ratio_fn=_hyperbolic_effort_ratio,
         is_frictionless=False,
     )
+    robot = _spatial(actuators=ThreadlikeActuator.tendons(routing, friction=friction))
+    q = _constant_bending_configuration(robot, 4.0)
 
-
-@pytest.mark.parametrize("factory", [_planar, _spatial])
-def test_default_is_frictionless_and_bit_identical(factory):
-    """The shipped default delivers full effort and costs nothing."""
-    routing = _routing([0.02, -0.015])
-    q = jnp.linspace(-0.01, 0.04, factory().num_coordinates)
-
-    default = factory(actuators=ThreadlikeActuator.tendons(routing))
-    explicit = factory(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.frictionless()
-        )
-    )
-    assert ThreadlikeFriction.frictionless().is_frictionless
-    assert not ThreadlikeFriction.frictionless().requires_wrap_angle
-    assert jnp.array_equal(default.actuation_matrix(q), explicit.actuation_matrix(q))
-    assert isinstance(
-        default.actuators[0].params.transmission.friction, FrictionlessParams
-    )
-
-
-def test_params_and_law_stay_paired():
-    """The params leaf and the runtime law must not drift apart."""
-    routing = _routing([0.02])
-    q = jnp.array([6.0, 0.0, 0.0])
-
-    robot = _planar(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.capstan(coefficient=0.4)
-        )
-    )
-    transmission = robot.actuators[0].transmission
-    assert isinstance(transmission.params.friction, CapstanFrictionParams)
-    assert transmission.friction.params is transmission.params.friction
-
-    # Replacing a value keeps the installed law.
-    replaced = _with_friction(robot, jnp.asarray(0.4))
-    assert replaced.actuators[0].transmission.friction.ratio_fn is (
-        transmission.friction.ratio_fn
-    )
-    assert jnp.array_equal(robot.actuation_matrix(q), replaced.actuation_matrix(q))
-
-    # Swapping the params type behind an installed law is refused, as is
-    # installing anything that is not a law.
-    with pytest.raises(TypeError, match="keep their type"):
-        transmission.friction.with_params(
-            ExponentialLengthFrictionParams(rate=jnp.asarray(1.0))
-        )
-    with pytest.raises(TypeError):
-        ThreadlikeActuator.tendons(routing, friction="capstan")
-
-
-@pytest.mark.parametrize("factory", [_planar, _spatial])
-def test_length_friction_matches_closed_form(factory):
-    """A per-length friction integrates to its analytic mean over a segment."""
-    rate, length = 3.0, 0.1
-    routing = _routing([0.02])
-    q = jnp.zeros((factory().num_coordinates,)).at[0].set(4.0)
-
-    frictionless = factory(actuators=ThreadlikeActuator.tendons(routing))
-    attenuated = factory(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.exponential_length(rate=rate)
-        )
-    )
-    decay = rate * length
-    expected = (1.0 - jnp.exp(-decay)) / decay
-
-    reference = frictionless.actuation_matrix(q)
-    row = int(jnp.argmax(jnp.abs(reference[:, 0])))
-    assert_allclose(
-        attenuated.actuation_matrix(q)[row, 0],
-        expected * reference[row, 0],
-        rtol=1e-8,
-    )
-
-
-def test_length_friction_runs_on_gvs():
-    """GVS hosts a wrap-angle-free law, and still refuses a Capstan law."""
-    routing = _routing([0.02])
-    q = jnp.zeros((_gvs().num_coordinates,)).at[0].set(3.0)
-
-    frictionless = _gvs(actuators=ThreadlikeActuator.tendons(routing))
-    attenuated = _gvs(
-        actuators=ThreadlikeActuator.tendons(
-            routing, friction=ThreadlikeFriction.exponential_length(rate=4.0)
-        )
-    )
-    reference = jnp.abs(frictionless.actuation_matrix(q))
-    weighted = jnp.abs(attenuated.actuation_matrix(q))
-    assert jnp.all(weighted <= reference + 1e-15)
-    assert jnp.max(reference - weighted) > 1e-6
-
-    with pytest.raises(TypeError, match="wrap-angle model"):
-        _gvs(
-            actuators=ThreadlikeActuator.tendons(
-                routing, friction=ThreadlikeFriction.capstan(coefficient=0.3)
-            )
-        )
-
-
-def test_custom_friction_model_needs_no_soromox_change():
-    """A third-party law installs through the public contract alone."""
-    routing = _routing([0.02])
-    q = jnp.array([6.0, 0.0, 0.0])
-
-    frictionless = _planar(actuators=ThreadlikeActuator.tendons(routing))
-    custom = _planar(
-        actuators=ThreadlikeActuator.tendons(routing, friction=_hyperbolic(0.5))
-    )
-    reference = frictionless.actuation_matrix(q)
-    weighted = custom.actuation_matrix(q)
-
-    assert jnp.all(jnp.abs(weighted) <= jnp.abs(reference) + 1e-15)
-    assert jnp.max(jnp.abs(reference - weighted)) > 1e-6
-    # The law is not Capstan, so it must not coincide with one.
-    capstan = _planar(
+    capstan = _spatial(
         actuators=ThreadlikeActuator.tendons(
             routing, friction=ThreadlikeFriction.capstan(coefficient=0.5)
         )
-    ).actuation_matrix(q)
-    assert jnp.max(jnp.abs(weighted - capstan)) > 1e-6
+    )
+    assert jnp.isfinite(robot.actuation_matrix(q)).all()
+    assert not jnp.allclose(robot.actuation_matrix(q), capstan.actuation_matrix(q))
 
 
-def test_model_is_traceable_and_identifiable():
-    """Friction parameters stay differentiable leaves under jit, for any model."""
-    routing = _routing([0.02, -0.015])
-    q = jnp.array([4.0, 0.02, -0.01])
-    u = jnp.array([2.0, 1.0])
-
-    def loss_for(build, value):
-        # The robot is built once outside the trace; only the friction parameter
-        # traced, which is how a law is identified in practice.
-        robot = _planar(
-            actuators=ThreadlikeActuator.tendons(routing, friction=build(value))
-        )
-
-        @jax.jit
-        def loss(parameter):
-            transmission = robot.actuators[0].params.transmission
-            identified = robot.update_actuator_params(
-                0,
-                transmission=transmission.replace(friction=build(parameter).params),
-            )
-            return jnp.sum(identified.actuation_force(q, u) ** 2)
-
-        return jax.value_and_grad(loss)(jnp.asarray(value))
-
-    for build, value in (
-        (lambda p: ThreadlikeFriction.capstan(coefficient=p), 0.3),
-        (lambda p: ThreadlikeFriction.exponential_length(rate=p), 2.0),
-        (lambda p: _hyperbolic(p), 0.4),
-    ):
-        magnitude, gradient = loss_for(build, value)
-        assert jnp.isfinite(magnitude) and jnp.isfinite(gradient)
-        assert jnp.abs(gradient) > 0.0
+def test_capstan_effort_ratio_name_and_values():
+    """Expose a modality-neutral ratio name for all threadlike actuators."""
+    params = CapstanFrictionParams(coefficient=jnp.array([0.0, 0.5]))
+    turn = jnp.array([2.0, 2.0])
+    assert_allclose(capstan_effort_ratio(params, turn), jnp.array([1.0, jnp.exp(-1.0)]))
 
 
-def test_context_fields_agree_across_hosts():
-    """Host-agnostic context fields must match, so portable laws are portable."""
-    routing = _routing([0.02, -0.015])
-    planar = _planar(actuators=ThreadlikeActuator.tendons(routing))
-    spatial = _spatial(actuators=ThreadlikeActuator.tendons(routing))
+def test_friction_is_measured_from_each_path_anchor():
+    """Exclude curvature before a path enters its configured segment span."""
+    routing = _routing(start_segment=1, end_segment=1)
+    actuator = ThreadlikeActuator.tendons(
+        routing, friction=ThreadlikeFriction.capstan(coefficient=0.7)
+    )
+    robot = _planar(num_segments=2, actuators=actuator)
+    q = jnp.array([8.0, 0.0, 0.0, 2.0, 0.0, 0.0])
+    strains = robot.strain(q).reshape((2, 3))
 
-    curvature, axial, shear = 5.0, 0.02, -0.01
-    planar_strain = jnp.array([curvature, 1.0 + axial, shear])
-    spatial_strain = jnp.array([0.0, 0.0, curvature, 1.0 + axial, shear, 0.0])
-    abscissa = 0.06
-    path_routing = planar.actuators[0].transmission.routing
-
-    def geometry(robot, strain):
-        return jax.vmap(
-            robot._threadlike_local_geometry,
-            in_axes=(None, None, None, None, 0, 0, 0),
-            out_axes=0,
-        )(
-            jnp.asarray(0),
-            strain,
-            jnp.asarray(abscissa),
-            path_routing,
-            path_routing.params,
-            path_routing.params.start_segment_index_array,
-            path_routing.params.end_segment_index_array,
-        )
-
-    planar_context = geometry(planar, planar_strain)
-    spatial_context = geometry(spatial, spatial_strain)
-
-    for field in (
-        "abscissa",
-        "path_abscissa",
-        "offset",
-        "offset_derivative",
-        "tangent_norm",
-    ):
-        assert_allclose(
-            getattr(planar_context, field),
-            getattr(spatial_context, field),
-            rtol=1e-9,
-            atol=1e-12,
-            err_msg=f"host-agnostic field {field} disagrees",
-        )
-    assert jnp.array_equal(planar_context.active, spatial_context.active)
+    assert_allclose(
+        robot._threadlike_accumulated_turn(strains, routing, jnp.asarray(0.1)),
+        jnp.zeros((1,)),
+        atol=1e-12,
+    )
+    assert_allclose(
+        robot._threadlike_accumulated_turn(strains, routing, jnp.asarray(0.2)),
+        jnp.array([0.2]),
+        rtol=5e-8,
+        atol=1e-10,
+    )
 
 
-@pytest.mark.parametrize(
-    ("build", "field"),
-    [
-        (lambda v: CapstanFrictionParams(coefficient=jnp.asarray(v)), "coefficient"),
-        (lambda v: CapstanFrictionParams(eps=jnp.asarray(v)), "eps"),
-        (lambda v: ExponentialLengthFrictionParams(rate=jnp.asarray(v)), "rate"),
-    ],
-)
-@pytest.mark.parametrize("value", [-1.0, jnp.nan, jnp.inf])
-def test_friction_parameters_reject_negative_and_non_finite_values(build, field, value):
-    """A ratio outside (0, 1] would let a transmission generate effort."""
-    with pytest.raises(ValueError, match=field):
-        build(value)
+def test_accumulated_turn_includes_piecewise_host_tangent_jumps():
+    """Include genuine tangent jumps introduced by the host discretization."""
+    routing = _routing(offset=0.0, end_segment=1)
+    robot = _planar(num_segments=2)
+    strains = jnp.array([[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+
+    assert_allclose(
+        robot._threadlike_accumulated_turn(strains, routing, jnp.asarray(0.2)),
+        jnp.array([0.5 * jnp.pi]),
+        rtol=1e-12,
+        atol=1e-12,
+    )
 
 
-def test_friction_parameters_reject_a_wrong_per_path_shape():
-    """A per-path parameter must carry one entry per routed path."""
+def test_custom_routing_requires_analytical_second_derivative_for_friction():
+    """Reject production autodiff fallbacks for custom routing geometry."""
+    params = SinusoidalRoutingParams(
+        amplitude=jnp.array([0.01]),
+        frequency=jnp.array([10.0]),
+        start_segment_index=(0,),
+        end_segment_index=(0,),
+    )
+    routing = ThreadlikeRouting(
+        params=params,
+        offset_fn=_sinusoidal_offset,
+        derivative_fn=_sinusoidal_derivative,
+    )
+    actuator = ThreadlikeActuator.tendons(
+        routing, friction=ThreadlikeFriction.capstan(coefficient=0.4)
+    )
+
+    with pytest.raises(ValueError, match="second_derivative_fn"):
+        _spatial(actuators=actuator)
+
+
+@pytest.mark.parametrize("value", [-0.1, jnp.inf, jnp.nan])
+def test_capstan_parameters_reject_invalid_values(value):
+    """Reject coefficients that could create effort or poison numerics."""
     with pytest.raises(ValueError, match="coefficient"):
-        ThreadlikeActuator.tendons(
-            _routing([0.02, -0.015]),
-            friction=ThreadlikeFriction.capstan(coefficient=jnp.zeros((3,))),
+        CapstanFrictionParams(coefficient=jnp.asarray(value))
+
+
+def test_capstan_parameters_reject_wrong_per_path_shape():
+    """Require one coefficient per routed path when an array is supplied."""
+    routing = ThreadlikeRouting.linear(
+        intercept=jnp.array([[0.0, 0.01, 0.0], [0.0, -0.01, 0.0]])
+    )
+    friction = ThreadlikeFriction.capstan(coefficient=jnp.ones((3,)))
+    with pytest.raises(ValueError, match="coefficient must be a scalar or"):
+        ThreadlikeActuator.tendons(routing, friction=friction)
+
+
+def test_friction_is_active_only_and_disables_warp_matrix_path():
+    """Keep passive impedance conservative and gate unsupported Warp friction."""
+    routing = _routing()
+    friction = ThreadlikeFriction.capstan(coefficient=0.3)
+    actuator = ThreadlikeActuator.tendons(routing, friction=friction)
+    robot = _spatial(actuators=actuator)
+
+    assert not supports_linear_threadlike_matrix(robot)
+    with pytest.raises(TypeError, match="unexpected keyword argument 'friction'"):
+        ThreadlikeImpedance(
+            routing=routing,
+            stiffness=jnp.ones((1,)),
+            damping=jnp.ones((1,)),
+            rest_length=jnp.ones((1,)),
+            friction=friction,
         )
-
-
-def test_a_friction_model_may_not_claim_to_be_frictionless():
-    """is_frictionless skips the model, so a friction model must not set it."""
-    with pytest.raises(ValueError, match="is_frictionless"):
-        ThreadlikeFriction(
-            params=CapstanFrictionParams(coefficient=jnp.asarray(0.3)),
-            ratio_fn=capstan_transmission_ratio,
-            requires_wrap_angle=True,
-            is_frictionless=True,
-        )
-
-
-# ---------------------------------------------------------------------------
-# Friction accumulates from the path anchor
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("factory", [_planar, _spatial])
-def test_friction_is_measured_from_the_path_anchor(factory):
-    """A path anchored mid-robot must not pay for what happens below it."""
-    robot = factory(num_segments=3)
-    anchored = _anchored_routing(0.02, start=1, end=2)
-    path_routing = ThreadlikeActuator.tendons(anchored).transmission.routing
-    starts = anchored.params.start_segment_index_array
-    anchor, tip = float(robot.L_cum[1]), float(jnp.sum(robot.L))
-
-    # Bend only the first segment, which the path does not span.
-    q = jnp.zeros((robot.num_coordinates,)).at[_bend_index(factory)].set(9.0)
-    strains = robot.strain(q).reshape((robot.num_segments, -1))
-    curvature = (
-        robot._threadlike_path_curvature(strains)
-        if factory is _planar
-        else robot._threadlike_path_curvature(strains, anchored)
-    )
-
-    # The wrap angle ignores that turning,
-    anchored_angle = robot._threadlike_safe_wrap_angle(
-        curvature, tip, starts, jnp.asarray(0.0)
-    )
-    assert_allclose(anchored_angle, jnp.zeros_like(anchored_angle), atol=1e-12)
-    # which the same pose measured from the robot base does not.
-    base_angle = robot._threadlike_safe_wrap_angle(
-        curvature, tip, jnp.zeros_like(starts), jnp.asarray(0.0)
-    )
-    assert jnp.all(base_angle > 1e-3)
-
-    # The traversed length is anchor-relative too, so a length law transmits in
-    # full at the anchor and decays only beyond it.
-    at_anchor = _geometry(robot, path_routing, q, s=anchor, segment_index=1)
-    assert_allclose(
-        at_anchor.path_abscissa, jnp.zeros_like(at_anchor.path_abscissa), atol=1e-12
-    )
-    ratio = ThreadlikeFriction.exponential_length(rate=5.0).transmission_ratio(
-        at_anchor
-    )
-    assert_allclose(ratio, jnp.ones_like(ratio), rtol=1e-12)
-
-    travelled = 0.03
-    beyond = _geometry(robot, path_routing, q, s=anchor + travelled, segment_index=1)
-    assert_allclose(
-        beyond.path_abscissa, jnp.full_like(beyond.path_abscissa, travelled)
-    )
-    # while the backbone coordinate still counts from the robot base.
-    assert_allclose(beyond.abscissa, jnp.full_like(beyond.abscissa, anchor + travelled))
-
-
-@pytest.mark.parametrize("factory", [_planar, _spatial])
-def test_capstan_friction_is_unaffected_by_curvature_before_the_anchor(factory):
-    """Attenuation of a mid-robot path must not depend on the segments below."""
-    anchored = _anchored_routing(0.02, start=1, end=2)
-    frictional = factory(
-        num_segments=3,
-        actuators=ThreadlikeActuator.tendons(
-            anchored, friction=ThreadlikeFriction.capstan(coefficient=0.6)
-        ),
-    )
-    reference = factory(num_segments=3, actuators=ThreadlikeActuator.tendons(anchored))
-    per_segment, bend = frictional.num_internal_dofs // 3, _bend_index(factory)
-
-    def attenuation(base_curvature):
-        # Bend the two segments the path spans, so it is genuinely attenuated,
-        # and vary only the curvature of the segment below its anchor.
-        q = (
-            jnp.zeros((frictional.num_coordinates,))
-            .at[bend]
-            .set(base_curvature)
-            .at[per_segment + bend]
-            .set(8.0)
-            .at[2 * per_segment + bend]
-            .set(-6.0)
-        )
-        reference_matrix = reference.actuation_matrix(q)
-        carried = jnp.abs(reference_matrix) > 1e-9
-        return frictional.actuation_matrix(q)[carried] / reference_matrix[carried]
-
-    straight_below = attenuation(0.0)
-    bent_below = attenuation(11.0)
-    assert straight_below.size > 0
-    # The path is attenuated, but by its own turning only.
-    assert jnp.all(straight_below < 1.0)
-    assert_allclose(straight_below, bent_below, rtol=1e-9, atol=1e-12)

--- a/tests/actuation/test_threadlike_friction.py
+++ b/tests/actuation/test_threadlike_friction.py
@@ -26,9 +26,11 @@ from soromox.actuation import (
     ThreadlikeImpedance,
     ThreadlikeRouting,
     capstan_effort_ratio,
+    threadlike_constant_strain_turn_rate,
     threadlike_tangent,
     threadlike_turn_rate,
 )
+from soromox.actuation.friction import threadlike_turning_angle
 from soromox.coordinate_transformations import ActuationSpaceDynamics
 from soromox.execution.warp.actuation.threadlike import (
     supports_linear_threadlike_matrix,
@@ -225,6 +227,36 @@ def test_turn_rate_formula_matches_autodiff_of_spatial_unit_tangent():
     assert_allclose(analytical, jnp.linalg.norm(derivative), rtol=2e-12, atol=2e-12)
 
 
+def test_constant_strain_turn_rate_matches_full_analytical_formula():
+    """Verify the PCS specialization of the general tangent derivative."""
+    angular = jnp.array([0.7, -0.3, 1.1])
+    linear = jnp.array([1.0, 0.2, -0.1])
+    offset = jnp.array([0.0, 0.03, -0.02])
+    offset_derivative = jnp.array([0.0, -0.2, 0.1])
+    offset_second_derivative = jnp.array([0.0, 0.4, -0.15])
+
+    specialized = threadlike_constant_strain_turn_rate(
+        angular,
+        linear,
+        offset,
+        offset_derivative,
+        offset_second_derivative,
+        eps=1e-12,
+    )
+    general = threadlike_turn_rate(
+        angular,
+        linear,
+        jnp.zeros((3,)),
+        jnp.zeros((3,)),
+        offset,
+        offset_derivative,
+        offset_second_derivative,
+        eps=1e-12,
+    )
+
+    assert_allclose(specialized, general, rtol=2e-12, atol=2e-12)
+
+
 class SinusoidalRoutingParams(BaseThreadlikeRoutingParams):
     """Parameters for an analytical sinusoidal test routing."""
 
@@ -247,19 +279,36 @@ class SinusoidalRoutingParams(BaseThreadlikeRoutingParams):
 def _sinusoidal_offset(params: SinusoidalRoutingParams, s: Array) -> Array:
     """Return a sinusoidal material-``y`` routing offset."""
     y = params.amplitude * jnp.sin(params.frequency * s)
-    return jnp.asarray([0.0, y, 0.0])
+    return jnp.stack((jnp.zeros_like(y), y, jnp.zeros_like(y)), axis=-1)
 
 
 def _sinusoidal_derivative(params: SinusoidalRoutingParams, s: Array) -> Array:
     """Return the analytical first derivative of the sinusoidal offset."""
     y = params.amplitude * params.frequency * jnp.cos(params.frequency * s)
-    return jnp.asarray([0.0, y, 0.0])
+    return jnp.stack((jnp.zeros_like(y), y, jnp.zeros_like(y)), axis=-1)
 
 
 def _sinusoidal_second_derivative(params: SinusoidalRoutingParams, s: Array) -> Array:
     """Return the analytical second derivative of the sinusoidal offset."""
     y = -(params.frequency**2) * params.amplitude * jnp.sin(params.frequency * s)
-    return jnp.asarray([0.0, y, 0.0])
+    return jnp.stack((jnp.zeros_like(y), y, jnp.zeros_like(y)), axis=-1)
+
+
+def test_custom_routing_callbacks_preserve_the_path_axis():
+    """Keep vectorized callback output shaped ``(num_paths, 3)``."""
+    params = SinusoidalRoutingParams(
+        amplitude=jnp.array([0.01, 0.02]),
+        frequency=jnp.array([8.0, 12.0]),
+        start_segment_index=(0, 0),
+        end_segment_index=(0, 0),
+    )
+
+    for callback in (
+        _sinusoidal_offset,
+        _sinusoidal_derivative,
+        _sinusoidal_second_derivative,
+    ):
+        assert callback(params, jnp.asarray(0.04)).shape == (2, 3)
 
 
 def test_custom_routing_analytical_turn_matches_dense_numerical_reference():
@@ -455,6 +504,99 @@ def test_custom_routing_requires_analytical_second_derivative_for_friction():
 
     with pytest.raises(ValueError, match="second_derivative_fn"):
         _spatial(actuators=actuator)
+
+
+def test_custom_callbacks_with_linear_params_require_a_second_derivative():
+    """Do not infer linear behavior from the parameter class alone."""
+    params = ThreadlikeRouting.linear(
+        intercept=jnp.array([0.0, 0.01, 0.0]),
+        slope=jnp.array([0.0, 0.02, 0.0]),
+    ).params
+
+    def nonlinear_offset(path_params, s):
+        """Return a nonlinear offset using linear-routing storage."""
+        return path_params.intercept + s**2 * path_params.slope
+
+    def nonlinear_derivative(path_params, s):
+        """Return the first derivative of the nonlinear offset."""
+        return 2.0 * s * path_params.slope
+
+    routing = ThreadlikeRouting(
+        params=params,
+        offset_fn=nonlinear_offset,
+        derivative_fn=nonlinear_derivative,
+    )
+    actuator = ThreadlikeActuator.tendons(
+        routing, friction=ThreadlikeFriction.capstan(coefficient=0.4)
+    )
+
+    assert not routing.has_analytical_second_derivative
+    with pytest.raises(ValueError, match="second_derivative_fn"):
+        _spatial(actuators=actuator)
+
+
+def test_builtin_linear_callbacks_supply_zero_second_derivative():
+    """Retain the implicit analytical derivative for built-in linear routing."""
+    linear = ThreadlikeRouting.linear(intercept=jnp.array([0.0, 0.01, 0.0]))
+    routing = ThreadlikeRouting(params=linear.params)
+
+    assert routing.has_analytical_second_derivative
+    assert_allclose(
+        routing.second_derivative(routing.params, jnp.asarray(0.04)),
+        jnp.zeros((1, 3)),
+    )
+
+
+@pytest.mark.parametrize(
+    "right_unit_tangent",
+    [jnp.zeros((3,)), jnp.array([1.0, 0.0, 0.0]), jnp.array([-1.0, 0.0, 0.0])],
+)
+def test_turning_angle_has_finite_values_and_derivatives(right_unit_tangent):
+    """Keep boundary-angle values and both differentiation modes finite."""
+
+    def angle(tangents: Array) -> Array:
+        """Evaluate the angle from packed left and right tangents."""
+        return threadlike_turning_angle(tangents[:3], tangents[3:])
+
+    tangents = jnp.concatenate((jnp.zeros((3,)), right_unit_tangent))
+    assert jnp.isfinite(angle(tangents))
+    assert jnp.isfinite(jax.jacfwd(angle)(tangents)).all()
+    assert jnp.isfinite(jax.jacrev(angle)(tangents)).all()
+
+
+@pytest.mark.parametrize(
+    "turn_rate",
+    [threadlike_turn_rate, threadlike_constant_strain_turn_rate],
+)
+def test_turn_rate_has_finite_values_and_derivatives_at_collapsed_tangent(turn_rate):
+    """Keep analytical turn-rate singularity handling differentiable."""
+    zeros = jnp.zeros((3,))
+
+    def rate(linear_strain: Array) -> Array:
+        """Evaluate either turn-rate formula at a collapsed path tangent."""
+        if turn_rate is threadlike_turn_rate:
+            return turn_rate(
+                zeros,
+                linear_strain,
+                zeros,
+                zeros,
+                zeros,
+                zeros,
+                zeros,
+                eps=1e-12,
+            )
+        return turn_rate(
+            zeros,
+            linear_strain,
+            zeros,
+            zeros,
+            zeros,
+            eps=1e-12,
+        )
+
+    assert jnp.isfinite(rate(zeros))
+    assert jnp.isfinite(jax.jacfwd(rate)(zeros)).all()
+    assert jnp.isfinite(jax.jacrev(rate)(zeros)).all()
 
 
 @pytest.mark.parametrize("value", [-0.1, jnp.inf, jnp.nan])

--- a/tests/coordinate_transformations/test_actuation_space_dynamics.py
+++ b/tests/coordinate_transformations/test_actuation_space_dynamics.py
@@ -307,18 +307,18 @@ class TestCoordinateTransformations:
 class TestJacobians:
     """Tests for Jacobian computations."""
 
-    def test_jacobian_actuated_equals_actuation_matrix_transpose(
+    def test_jacobian_actuated_equals_robot_coordinate_jacobian(
         self, underactuated_pendulum
     ):
-        """Test that jacobian_actuated equals A_at^T."""
+        """Test that the transformed Jacobian uses coordinate kinematics."""
         robot = underactuated_pendulum
         asd = ActuationSpaceDynamics(robot)
 
         q = jnp.array([0.1, 0.2, 0.3])
         J_a = asd.jacobian_actuated(q)
-        A_at = robot.actuation_matrix(q)
+        expected = robot.actuator_coordinate_jacobian(q)
 
-        assert_allclose(J_a, A_at.T, rtol=1e-10)
+        assert_allclose(J_a, expected, rtol=1e-10)
 
     def test_jacobian_unactuated_equals_h_unactuated(self, underactuated_pendulum):
         """Test that jacobian_unactuated equals H_unactuated."""
@@ -507,7 +507,7 @@ class TestActuationMatrix:
         A_y = asd.actuation_matrix(q)
 
         # For fully actuated: A_y = I
-        assert_allclose(A_y, jnp.eye(robot.num_internal_dofs), rtol=1e-10)
+        assert_allclose(A_y, jnp.eye(robot.num_internal_dofs), rtol=1e-10, atol=1e-12)
 
     def test_actuation_matrix_structure_underactuated(self, underactuated_pendulum):
         """Test actuation matrix structure for underactuated system."""
@@ -522,10 +522,10 @@ class TestActuationMatrix:
         n_u = asd.n_unactuated
 
         # Top block should be identity
-        assert_allclose(A_y[:n_a, :n_a], jnp.eye(n_a), rtol=1e-10)
+        assert_allclose(A_y[:n_a, :n_a], jnp.eye(n_a), rtol=1e-10, atol=1e-12)
 
         # Bottom block should be zeros
-        assert_allclose(A_y[n_a:, :], jnp.zeros((n_u, n_a)), rtol=1e-10)
+        assert_allclose(A_y[n_a:, :], jnp.zeros((n_u, n_a)), rtol=1e-10, atol=1e-12)
 
     def test_actuation_matrix_shape(self, underactuated_pendulum):
         """Test actuation matrix has correct shape."""
@@ -945,15 +945,15 @@ class TestActuationSpaceDynamicsSystemIndependent:
 
         assert J_a.shape == (asd.n_actuated, robot.num_internal_dofs)
 
-    def test_jacobian_actuated_equals_actuation_matrix_transpose(self, robot):
-        """Test that jacobian_actuated equals A_at^T."""
+    def test_jacobian_actuated_equals_robot_coordinate_jacobian(self, robot):
+        """Test that jacobian_actuated uses the robot coordinate Jacobian."""
         asd = ActuationSpaceDynamics(robot)
         q = random_configuration(robot)
 
         J_a = asd.jacobian_actuated(q)
-        A_at = robot.actuation_matrix(q)
+        expected = robot.actuator_coordinate_jacobian(q)
 
-        assert_allclose(J_a, A_at.T, rtol=1e-10)
+        assert_allclose(J_a, expected, rtol=1e-10)
 
     def test_jacobian_stacks_correctly(self, robot):
         """Test that jacobian stacks actuated and unactuated Jacobians."""
@@ -1088,11 +1088,11 @@ class TestActuationSpaceDynamicsSystemIndependent:
         n_u = asd.n_unactuated
 
         # Top block should be identity
-        assert_allclose(A_y[:n_a, :n_a], jnp.eye(n_a), rtol=1e-10)
+        assert_allclose(A_y[:n_a, :n_a], jnp.eye(n_a), rtol=1e-10, atol=1e-12)
 
         # Bottom block should be zeros (if underactuated)
         if n_u > 0:
-            assert_allclose(A_y[n_a:, :], jnp.zeros((n_u, n_a)), rtol=1e-10)
+            assert_allclose(A_y[n_a:, :], jnp.zeros((n_u, n_a)), rtol=1e-10, atol=1e-12)
 
     def test_actuation_matrix_fully_actuated_is_identity(self, fully_actuated_robot):
         """Test actuation matrix is identity for fully actuated system."""
@@ -1102,7 +1102,7 @@ class TestActuationSpaceDynamicsSystemIndependent:
 
         A_y = asd.actuation_matrix(q)
 
-        assert_allclose(A_y, jnp.eye(robot.num_internal_dofs), rtol=1e-10)
+        assert_allclose(A_y, jnp.eye(robot.num_internal_dofs), rtol=1e-10, atol=1e-12)
 
     # -----------------------
     # Reference trajectory conversion tests

--- a/tests/coordinate_transformations/test_actuation_space_dynamics.py
+++ b/tests/coordinate_transformations/test_actuation_space_dynamics.py
@@ -320,8 +320,10 @@ class TestJacobians:
 
         assert_allclose(J_a, expected, rtol=1e-10)
 
-    def test_jacobian_unactuated_equals_h_unactuated(self, underactuated_pendulum):
-        """Test that jacobian_unactuated equals H_unactuated."""
+    def test_unactuated_coordinate_jacobian_matches_configured_mapping(
+        self, underactuated_pendulum
+    ):
+        """Test the unactuated-coordinate Jacobian against its configured map."""
         robot = underactuated_pendulum
         asd = ActuationSpaceDynamics(robot)
 

--- a/tests/execution/warp/actuation/test_threadlike.py
+++ b/tests/execution/warp/actuation/test_threadlike.py
@@ -11,7 +11,6 @@ from numpy.testing import assert_allclose
 from soromox.actuation import (
     ThreadlikeActuator,
     ThreadlikeFriction,
-    ThreadlikeImpedance,
     ThreadlikeRouting,
 )
 from soromox.execution.warp import loader
@@ -710,7 +709,7 @@ def test_warp_gate_rejects_unimplemented_active_friction() -> None:
     base = _build_system("pcs", 2, 4)
     actuator = ThreadlikeActuator.tendons(
         _routing(2, 4, planar=False),
-        friction=ThreadlikeFriction.exponential_length(rate=2.0),
+        friction=ThreadlikeFriction.capstan(coefficient=0.2),
     )
     model = _rebuild_with_actuators(base, actuator)
     q = jnp.zeros((model.num_coordinates,))
@@ -722,36 +721,6 @@ def test_warp_gate_rejects_unimplemented_active_friction() -> None:
         model.actuation_matrix(q, backend="warp")
     with pytest.raises(NotImplementedError, match="frictionless"):
         model.actuation_force(q, controls, backend="warp")
-
-
-def test_warp_force_gate_rejects_nonconservative_passive_friction() -> None:
-    """Prevent fused Warp force evaluation from dropping passive friction."""
-
-    base = _build_system("pcs", 2, 4)
-    routing = _routing(2, 4, planar=False)
-
-    def rebuild(friction):
-        passive = ThreadlikeImpedance(
-            routing=routing,
-            stiffness=jnp.ones((4,)),
-            damping=jnp.ones((4,)),
-            rest_length=jnp.full((4,), 0.2),
-            friction=friction,
-        )
-        return PCS(
-            params=base.params,
-            structure=PCSStructure(num_gauss_points=base.num_gauss_points),
-            base_pose=base.fixed_base_pose,
-            actuators=base.actuators,
-            passive_elements=(passive,),
-            backend="jax",
-        )
-
-    conservative = rebuild(None)
-    nonconservative = rebuild(ThreadlikeFriction.exponential_length(rate=2.0))
-    assert supports_linear_threadlike_matrix(nonconservative)
-    assert supports_linear_threadlike_force(conservative)
-    assert not supports_linear_threadlike_force(nonconservative)
 
 
 def test_pcs_explicit_warp_matrix_uses_warp_on_cpu(

--- a/tests/execution/warp/actuation/test_threadlike.py
+++ b/tests/execution/warp/actuation/test_threadlike.py
@@ -8,8 +8,17 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from soromox.actuation import ThreadlikeActuator, ThreadlikeRouting
+from soromox.actuation import (
+    ThreadlikeActuator,
+    ThreadlikeFriction,
+    ThreadlikeImpedance,
+    ThreadlikeRouting,
+)
 from soromox.execution.warp import loader
+from soromox.execution.warp.actuation.threadlike import (
+    supports_linear_threadlike_force,
+    supports_linear_threadlike_matrix,
+)
 from soromox.execution.warp.gvs.actuation.operands import (
     GVSThreadlikeOperands,
     GVSThreadlikeShapes,
@@ -693,6 +702,56 @@ def test_public_gate_uses_only_benchmark_qualified_warp_paths(family: str) -> No
             model.actuation_matrix(q, backend="warp")
     with pytest.raises(NotImplementedError, match="low-level Warp-native"):
         model.actuation_force(q, controls, backend="warp")
+
+
+def test_warp_gate_rejects_unimplemented_active_friction() -> None:
+    """Keep frictional matrices and forces on the differentiable JAX path."""
+
+    base = _build_system("pcs", 2, 4)
+    actuator = ThreadlikeActuator.tendons(
+        _routing(2, 4, planar=False),
+        friction=ThreadlikeFriction.exponential_length(rate=2.0),
+    )
+    model = _rebuild_with_actuators(base, actuator)
+    q = jnp.zeros((model.num_coordinates,))
+    controls = jnp.ones((model.num_actuators,))
+
+    assert not supports_linear_threadlike_matrix(model)
+    assert not supports_linear_threadlike_force(model)
+    with pytest.raises(NotImplementedError, match="frictionless"):
+        model.actuation_matrix(q, backend="warp")
+    with pytest.raises(NotImplementedError, match="frictionless"):
+        model.actuation_force(q, controls, backend="warp")
+
+
+def test_warp_force_gate_rejects_nonconservative_passive_friction() -> None:
+    """Prevent fused Warp force evaluation from dropping passive friction."""
+
+    base = _build_system("pcs", 2, 4)
+    routing = _routing(2, 4, planar=False)
+
+    def rebuild(friction):
+        passive = ThreadlikeImpedance(
+            routing=routing,
+            stiffness=jnp.ones((4,)),
+            damping=jnp.ones((4,)),
+            rest_length=jnp.full((4,), 0.2),
+            friction=friction,
+        )
+        return PCS(
+            params=base.params,
+            structure=PCSStructure(num_gauss_points=base.num_gauss_points),
+            base_pose=base.fixed_base_pose,
+            actuators=base.actuators,
+            passive_elements=(passive,),
+            backend="jax",
+        )
+
+    conservative = rebuild(None)
+    nonconservative = rebuild(ThreadlikeFriction.exponential_length(rate=2.0))
+    assert supports_linear_threadlike_matrix(nonconservative)
+    assert supports_linear_threadlike_force(conservative)
+    assert not supports_linear_threadlike_force(nonconservative)
 
 
 def test_pcs_explicit_warp_matrix_uses_warp_on_cpu(

--- a/tests/systems/test_isupport.py
+++ b/tests/systems/test_isupport.py
@@ -388,7 +388,7 @@ def test_isupport_matches_pr116_threadlike_pressure_mapping():
     pressure = jnp.array([1.0e4, 2.0e4, 3.0e4])
 
     routing = robot.actuators[0].transmission.routing
-    raw_path_matrix = robot._threadlike_moment_matrix(q, routing)
+    raw_path_matrix = robot._threadlike_actuation_matrix(q, routing)
     pressure_area = jnp.repeat(
         params.chamber_effective_pressure_area,
         robot.num_chambers_per_segment,

--- a/tests/systems/test_pcs_2d_vs_3d_coherence.py
+++ b/tests/systems/test_pcs_2d_vs_3d_coherence.py
@@ -477,3 +477,41 @@ def test_threadlike_actuation_coherence(num_segments):
 if __name__ == "__main__":
     # run pytest with activated stdout
     pytest.main([__file__])
+
+
+@pytest.mark.parametrize("num_segments", [1, 2, 3])
+@pytest.mark.parametrize("friction_coefficient", [0.0, 0.7])
+def test_threadlike_actuation_coherence(num_segments, friction_coefficient):
+    """The planar and spatial hosts must route and attenuate identically."""
+    routing = ThreadlikeRouting.linear(
+        intercept=jnp.array([[0.0, 2e-2, 0.0], [0.0, -1.5e-2, 0.0]]),
+        start_segment_index=(0, 0),
+        end_segment_index=(num_segments - 1,) * 2,
+    )
+
+    def tendons(coefficient):
+        return ThreadlikeActuator.tendons(routing, friction_coefficient=coefficient)
+
+    planar = make_planar_model(num_segments, actuators=tendons(friction_coefficient))
+    spatial = make_spatial_model(num_segments, actuators=tendons(friction_coefficient))
+
+    q_planar = jnp.concatenate(
+        [jnp.array([4.0 + 2.0 * seg, 2e-2, -1e-2]) for seg in range(num_segments)]
+    )
+    q_spatial = lift_planar_configuration(planar, spatial, q_planar)
+    indices = spatial_planar_indices(num_segments)
+
+    planar_matrix = planar.actuation_matrix(q_planar)
+    assert_allclose(
+        planar_matrix,
+        spatial.actuation_matrix(q_spatial)[indices],
+        rtol=RTOL,
+        atol=ATOL,
+    )
+
+    if friction_coefficient > 0.0:
+        frictionless = make_planar_model(num_segments, actuators=tendons(0.0))
+        attenuated = jnp.abs(planar_matrix)
+        reference = jnp.abs(frictionless.actuation_matrix(q_planar))
+        assert jnp.all(attenuated <= reference + ATOL)
+        assert jnp.max(reference - attenuated) > 1e-4

--- a/tests/systems/test_pcs_2d_vs_3d_coherence.py
+++ b/tests/systems/test_pcs_2d_vs_3d_coherence.py
@@ -10,7 +10,11 @@ from system_param_builders import (
     spatial_base_pose,
 )
 
-from soromox.actuation import ThreadlikeActuator, ThreadlikeRouting
+from soromox.actuation import (
+    ThreadlikeActuator,
+    ThreadlikeFriction,
+    ThreadlikeRouting,
+)
 from soromox.systems import PCS, PCSStructure, PlanarPCS, PlanarPCSStructure
 from soromox.utils.tolerance import Tolerance
 
@@ -480,8 +484,8 @@ if __name__ == "__main__":
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-@pytest.mark.parametrize("friction_coefficient", [0.0, 0.7])
-def test_threadlike_actuation_coherence(num_segments, friction_coefficient):
+@pytest.mark.parametrize("coefficient", [0.0, 0.7])
+def test_threadlike_actuation_coherence(num_segments, coefficient):
     """The planar and spatial hosts must route and attenuate identically."""
     routing = ThreadlikeRouting.linear(
         intercept=jnp.array([[0.0, 2e-2, 0.0], [0.0, -1.5e-2, 0.0]]),
@@ -489,11 +493,13 @@ def test_threadlike_actuation_coherence(num_segments, friction_coefficient):
         end_segment_index=(num_segments - 1,) * 2,
     )
 
-    def tendons(coefficient):
-        return ThreadlikeActuator.tendons(routing, friction_coefficient=coefficient)
+    def tendons(value):
+        return ThreadlikeActuator.tendons(
+            routing, friction=ThreadlikeFriction.capstan(coefficient=value)
+        )
 
-    planar = make_planar_model(num_segments, actuators=tendons(friction_coefficient))
-    spatial = make_spatial_model(num_segments, actuators=tendons(friction_coefficient))
+    planar = make_planar_model(num_segments, actuators=tendons(coefficient))
+    spatial = make_spatial_model(num_segments, actuators=tendons(coefficient))
 
     q_planar = jnp.concatenate(
         [jnp.array([4.0 + 2.0 * seg, 2e-2, -1e-2]) for seg in range(num_segments)]
@@ -509,7 +515,7 @@ def test_threadlike_actuation_coherence(num_segments, friction_coefficient):
         atol=ATOL,
     )
 
-    if friction_coefficient > 0.0:
+    if coefficient > 0.0:
         frictionless = make_planar_model(num_segments, actuators=tendons(0.0))
         attenuated = jnp.abs(planar_matrix)
         reference = jnp.abs(frictionless.actuation_matrix(q_planar))

--- a/tests/systems/test_pcs_2d_vs_3d_coherence.py
+++ b/tests/systems/test_pcs_2d_vs_3d_coherence.py
@@ -449,7 +449,7 @@ def test_forward_dynamics_coherence(num_segments):
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
-def test_threadlike_actuation_coherence(num_segments):
+def test_sloped_threadlike_actuation_coherence(num_segments):
     """Match planar routing to the corresponding in-plane spatial routing."""
     routing = ThreadlikeRouting.linear(
         intercept=jnp.array([0.0, 0.012, 0.0]),
@@ -476,11 +476,6 @@ def test_threadlike_actuation_coherence(num_segments):
         rtol=RTOL,
         atol=ATOL,
     )
-
-
-if __name__ == "__main__":
-    # run pytest with activated stdout
-    pytest.main([__file__])
 
 
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
@@ -521,3 +516,8 @@ def test_threadlike_actuation_coherence(num_segments, coefficient):
         reference = jnp.abs(frictionless.actuation_matrix(q_planar))
         assert jnp.all(attenuated <= reference + ATOL)
         assert jnp.max(reference - attenuated) > 1e-4
+
+
+if __name__ == "__main__":
+    # run pytest with activated stdout
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

This PR supersedes #190 with a continuum formulation of Capstan effort loss
for fixed material-frame threadlike routing. It is based on
`feature/tendon_friction_model_pcs` and targets `main`.

It depends on #202 for the standalone `PlanarPCS` threadlike sign correction.
That fix was split out so it can merge independently.

- apply a Capstan effort ratio continuously at the host quadrature nodes for
  `PlanarPCS`, `PCS`, and `GVS`
- derive routed-path turn from the spatial unit tangent, including analytical
  strain and material-routing derivatives
- keep friction active-only; passive `ThreadlikeImpedance` continues to own
  routing geometry and conservative spring-damper mechanics
- remove `ThreadlikeQuadratureContext` in favor of explicit
  `accumulated_turn` arguments for friction laws
- distinguish the actuator-coordinate Jacobian from the effort-to-force
  actuation matrix throughout the package
- keep frictional threadlike actuation on JAX while retaining Warp execution
  for built-in frictionless linear routing

## Relation to the cited paper

The implementation is inspired by the spacer-disk tendon model in
[Feliu-Talegon et al. (2025)](https://doi.org/10.1109/TMECH.2025.3581774).
That paper applies the established Capstan relation at discrete guide disks,

$$
T_i=T_{i-1}e^{-\mu\varphi_i},
\qquad
T_n=T_0\exp\!\left(-\mu\sum_i\varphi_i\right).
$$

SoRoMoX does not model those disks. Instead, it adapts the same exponential
effort-loss relation to distributed contact along an embedded continuum path.
The current API has no discrete guide locations, radii, or reactions and does
not support a discrete-guide mode.

## Continuum derivation

Let:

- $s$ be the backbone abscissa in the undeformed configuration and $s_0$ the routed path's anchor;
- $R(s)\in SO(3)$ and $p(s)\in\mathbb{R}^3$ be the backbone material
  orientation and position;
- $\xi(s)=(\omega(s),v(s))$ be angular and linear Cosserat strain;
- $r(s)\in\mathbb{R}^3$ be the path offset expressed in the material frame;
- a prime denote differentiation with respect to $s$; and
- $[\omega]_\times$ denote the skew matrix satisfying
  $[\omega]_\times r=\omega\times r$.

The Cosserat kinematics and spatial routed path are

$$
R'=R[\omega]_\times,
\qquad
p'=Rv,
\qquad
x=p+Rr.
$$

Differentiating $x$ gives

$$
x'=Ra,
\qquad
a=v+\omega\times r+r'.
$$

Here $a$ is the path tangent expressed in the material frame. Define its norm
$\nu=\lVert a\rVert$, its material unit tangent $u=a/\nu$, and its spatial
unit tangent $\hat t=Ru$. Analytical differentiation gives

$$
a'=v'+\omega'\times r+\omega\times r'+r'',
$$

and therefore

$$
u'=\frac{(I-uu^T)a'}{\nu}.
$$

Using $R'=R[\omega]_\times$,

$$
\frac{d\hat t}{ds}=R(\omega\times u+u').
$$

Because rotation preserves the Euclidean norm, the unsigned spatial turn rate
is

$$
\rho(s)=\left\lVert\omega\times u+u'\right\rVert.
$$

### Constant-strain specialization

PCS and PlanarPCS assume that $\xi=(\omega,v)$ is constant within each
segment. Consequently, $\omega'=v'=0$ there and the general material-tangent
derivative specializes to

$$
a'=\omega\times r'+r''.
$$

Both constant-strain hosts evaluate this reduced expression directly. The
routing may still vary with the backbone abscissa, so $r'$ and $r''$ can make
$u'$ nonzero even though the segment strain is constant. GVS does not make this
simplification: it retains
$a'=v'+\omega'\times r+\omega\times r'+r''$ and obtains $\omega'$ and
$v'$ analytically from the derivative of the installed strain basis, including
the normalized-coordinate-to-backbone-abscissa scaling. Production code uses
these analytical formulas; test-only JVPs independently verify the general and
constant-strain implementations.

Accumulated turn is

$$
\Theta(s)=\int_{s_0}^{s}\rho(\sigma)\,d\sigma.
$$

The host's quadrature integrates this quantity over complete and partial
segments. If a piecewise host discretization introduces a genuine one-sided
tangent jump, its unsigned angle is included at that interface. These
interfaces are part of the continuum discretization; they are not configurable
friction disks.

The surviving anchor-effort fraction is

$$
\eta(s)=\frac{e(s)}{e(s_0)}=e^{-\mu\Theta(s)},
$$

where $\mu\ge 0$ is the Capstan friction coefficient. The public helper is
named `capstan_effort_ratio` because threadlike actuation also represents push
rods, simplified muscles, and pressure chambers, even though tendons are the
primary application.

For the local spatial strain, the unscaled routed-length gradient density is

$$
g_\xi=\begin{bmatrix}r\times u\\u\end{bmatrix}.
$$

If $B(s)$ maps generalized coordinates to strain and $c$ is the modality's
signed or scaled work-coordinate factor, the active effort-to-force map is

$$
A_\mu(q)=c\int_{s_0}^{s_1}
\eta(q,s)B(s)^Tg_\xi(q,s)\,ds.
$$

Applying $\eta$ to every local contribution is the continuum adaptation; a
single post-integration scalar would not represent distributed loss.

## Coordinate and force-map convention

`Transmission` now exposes two explicit matrices:

$$
\dot y_a=J_a(q)\dot q,
\qquad
\tau_u=A(q)e,
$$

where:

- `coordinate_jacobian(...)` returns
  $J_a=\partial y_a/\partial q$ with shape
  `(num_channels, num_velocities)`; and
- `actuation_matrix(...)` returns $A$ with shape
  `(num_velocities, num_channels)`.

The robot aggregate is `actuator_coordinate_jacobian(...)`.

For an ideal transmission, virtual work gives $A=J_a^T$. Friction leaves path
coordinates and velocities geometric while changing the force map, so in
general $A\ne J_a^T$. `ActuationSpaceDynamics` consequently uses $J_a$ for its
coordinate transformation and transforms the physical force map as
$A_y=J^{-T}A$. Existing collocated actuation-space controllers still assume
the ideal $A=J_a^T$ case; this limitation is now explicit in the documentation.

This is a breaking replacement of `Transmission.moment_matrix(...)`; no
compatibility alias is retained.

## Friction API and scope

`ThreadlikeFriction.capstan(coefficient=...)` installs the continuum model.
Custom laws receive explicit `(params, accumulated_turn)` arguments. Custom
routing laws provide analytical `offset_fn`, `derivative_fn`, and
`second_derivative_fn`; production code does not use autodiff to recover the
material-tangent derivative.

Friction is intentionally limited to active transmissions. Passive
`ThreadlikeImpedance` keeps its `.routing` attribute and conservative
spring-damper force, damping, and energy contracts. The implementation does not
add length-proportional exponential loss, sticking, backdriving direction,
hysteresis, slack, or discrete guides.

## Validation

- Ruff lint and formatting checks: passed
- Zensical documentation build: passed
- full non-system suite before the final boundary-turn regression was added:
  `1384 passed, 26 skipped`
- review-targeted threadlike and actuation-space regression suite:
  `228 passed`
- Warp threadlike actuation suite: `50 passed, 14 skipped`
- targeted PlanarPCS/PCS coherence, floating-base, and GVS public-actuation
  regressions: `12 passed`
- `git diff --check`: passed

