### PR TITLE
Restrict semi-implicit Euler to soft robots

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -36,6 +36,8 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Fixed
 
+- Fixed `DynamicalSystem` API documentation to avoid assuming second-order
+  `[q, qd]` states or configuration-only projection.
 - Made Viser discrete cross-section markers consistent with Open3D: circular,
   rectangular, and elliptical sections now use spheres, boxes, and ellipsoids,
   respectively.

--- a/src/soromox/simulation/integrators.py
+++ b/src/soromox/simulation/integrators.py
@@ -14,7 +14,7 @@ from diffrax import (
     LocalLinearInterpolation,
 )
 
-from soromox.systems.dynamical_system import DynamicalSystem
+from soromox.systems.soft_robot import SoftRobot
 
 
 class SemiImplicitEuler(AbstractSolver):
@@ -28,7 +28,7 @@ class SemiImplicitEuler(AbstractSolver):
     ``qd_{n+1} = qd_n + dt * qdd_n`` and
     ``q_{n+1} = retract(q_n, dt * qd_{n+1})``.
 
-    The solver is intended for :class:`soromox.systems.DynamicalSystem`
+    The solver is intended for :class:`soromox.systems.SoftRobot`
     rollouts. It uses the supplied system's state helpers rather than splitting
     the state in half, so unequal floating-base configuration and velocity
     dimensions, manifold retraction, and trailing system auxiliary states are
@@ -36,11 +36,11 @@ class SemiImplicitEuler(AbstractSolver):
     with explicit Euler.
 
     Attributes:
-        system: Soromox system that supplies ``split_state``, ``pack_state``,
+        system: Soft robot system that supplies ``split_state``, ``pack_state``,
             and ``retract_configuration``.
     """
 
-    system: DynamicalSystem
+    system: SoftRobot
     term_structure: ClassVar = AbstractTerm
     interpolation_cls: ClassVar[Callable[..., LocalLinearInterpolation]] = (
         LocalLinearInterpolation

--- a/src/soromox/systems/dynamical_system.py
+++ b/src/soromox/systems/dynamical_system.py
@@ -55,12 +55,13 @@ class DynamicalSystem(eqx.Module):
         """
         Compute the forward dynamics of the system.
 
-        This method computes the state derivative yd = [qd, qdd] given the
-        current time, state, and actuation inputs.
+        This method computes the state derivative ``yd`` given the current
+        time, state, and actuation inputs. No particular decomposition or order
+        of the state is assumed.
 
         Args:
             t (Array): Current time.
-            y (Array): State vector containing configuration and velocity.
+            y (Array): State vector.
             actuation_args (Optional[Tuple]): Tuple of actuation inputs, typically (u, tau_ext) where
                 u is the control input and tau_ext is the external force/torque.
 
@@ -118,11 +119,11 @@ class DynamicalSystem(eqx.Module):
         return base_tau_ext + tau_environment
 
     def project_state(self, y: Array) -> Array:
-        """Project state storage onto the system configuration manifold.
+        """Project state storage onto the system state manifold.
 
         The generic implementation is an identity operation. Systems with a
-        constrained configuration representation can override this hook. It is
-        invoked before rollout callbacks and on saved trajectories.
+        constrained state representation can override this hook. It is invoked
+        before rollout callbacks and on saved trajectories.
 
         Args:
             y: System state with the state dimension on the trailing axis.


### PR DESCRIPTION
## Summary

- type `SemiImplicitEuler.system` as `SoftRobot`, which defines the state helpers used by the integrator
- clarify that `DynamicalSystem.forward_dynamics` does not assume a particular state decomposition or system order
- describe `DynamicalSystem.project_state` in terms of the generic state manifold instead of a configuration manifold

## Validation

- `ruff check src/soromox/simulation/integrators.py src/soromox/systems/dynamical_system.py`
- `ruff format --check src/soromox/simulation/integrators.py src/soromox/systems/dynamical_system.py`
- `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 pytest -q tests/simulation` (7 passed)
