### PR TITLE
Fix gravity for rotated and floating-base systems

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -26,6 +26,8 @@ and include benchmark baseline and measurement context for performance claims.
   controller and optimizer settings, strict device selection,
   regenerated figures, and distinct optimized-best and initial-median animations
   with a shared gravity-down camera.
+- Unified fixed- and floating-base gravity with shared analytical point-mass
+  quadrature, avoiding runtime autodiff and full spatial gravity contractions.
 - Open3D and Viser swept backbones now preserve circular, elliptical, and
   rectangular cross-sections, including dimensions that vary with abscissa.
 
@@ -44,6 +46,8 @@ and include benchmark baseline and measurement context for performance claims.
 
 ### Fixed
 
+- Fixed analytical gravitational forces for rotated mounts in
+  `ArticulatedSoftRobot` and `PlanarHSA`.
 - Fixed `DynamicalSystem` API documentation to avoid assuming second-order
   `[q, qd]` states or configuration-only projection.
 - Made Viser discrete cross-section markers consistent with Open3D: circular,

--- a/src/soromox/systems/articulated/articulated_soft_robot.py
+++ b/src/soromox/systems/articulated/articulated_soft_robot.py
@@ -88,7 +88,7 @@ class ArticulatedSoftRobot(SoftRobot):
         m: Link masses, shape `(num_links,)`.
         I_com: Link inertia matrices about each COM, expressed in the post-joint
             link frame, shape `(num_links, 3, 3)`.
-        g: Gravity acceleration vector in the base frame, shape `(3,)`.
+        g: Gravity acceleration vector in the world frame, shape `(3,)`.
         K: Joint stiffness matrix, shape `(num_links, num_links)`.
         D: Joint damping matrix, shape `(num_links, num_links)`.
         q_ref_k: Rest configuration for the joint springs, shape `(num_links,)`.
@@ -801,45 +801,60 @@ class ArticulatedSoftRobot(SoftRobot):
         Compute gravitational potential energy.
 
         Args:
-            q: Joint coordinates, shape `(num_links,)`.
+            q: Fixed-base joint coordinates or total floating-base
+                configuration.
 
         Returns:
             Gravitational potential energy as a scalar.
         """
+        if self.floating_base:
+            _, q_internal = self.split_configuration(q)
+            _, _, com_frames, _ = self._kinematic_frames(q_internal)
+            return self._gravitational_energy_from_base_relative_points(
+                q, com_frames[:, :3, 3], self.m
+            )
+
         g_coms = self.forward_kinematics_coms(q)
         p_coms = g_coms[:, :3, 3]
         return -jnp.sum(self.m * (p_coms @ self.g))
 
     @eqx.filter_jit
-    def _floating_gravitational_energy(self, q: Array) -> Array:
-        """
-        Compute absolute floating-base gravitational potential energy.
-
-        Args:
-            q: Total floating-base configuration with shape
-                ``(num_coordinates,)``.
-
-        Returns:
-            Absolute gravitational potential energy as a scalar.
-        """
-        _, q_internal = self.split_configuration(q)
-        _, _, com_frames, _ = self._kinematic_frames(q_internal)
-        return self._floating_gravitational_energy_from_points(
-            q, com_frames[:, :3, 3], self.m
-        )
-
-    @eqx.filter_jit
     def _gravitational_force(self, q: Array) -> Array:
         """
-        Compute generalized gravitational forces.
+        Compute generalized gravitational forces analytically from COM Jacobians.
 
         Args:
-            q: Joint coordinates, shape `(num_links,)`.
+            q: Fixed-base joint coordinates or total floating-base
+                configuration.
 
         Returns:
-            Gravity vector, shape `(num_links,)`.
+            Gravity vector in generalized-velocity coordinates.
         """
-        return jax.grad(self._gravitational_energy)(q)
+        q_internal = self.split_configuration(q)[1] if self.floating_base else q
+        _, com_frames, screws = self._com_chain_kinematics(q_internal)
+        jacobians = self._jacobian_for_points(
+            screws,
+            jnp.arange(self.num_links),
+            com_frames[:, :3, 3],
+        )
+        positions = com_frames[:, :3, 3]
+        linear_jacobians = jacobians[:, 3:, :]
+
+        if not self.floating_base:
+            base_transform = self.base_transform_from_configuration(q)
+            base_rotation_transpose = base_transform[:3, :3].T
+            positions = jnp.einsum(
+                "ij,nj->ni",
+                base_rotation_transpose,
+                positions - base_transform[:3, 3],
+            )
+            linear_jacobians = jnp.einsum(
+                "ij,njk->nik", base_rotation_transpose, linear_jacobians
+            )
+
+        return self._gravitational_force_from_base_relative_points(
+            q, positions, self.m, linear_jacobians
+        )
 
     @eqx.filter_jit
     def stiffness_matrix(self) -> Array:
@@ -1016,9 +1031,16 @@ class ArticulatedSoftRobot(SoftRobot):
             qdd_i = (u_i - U_i @ a_i) / d_i
             return a_i + S_i * qdd_i, qdd_i
 
+        # The ABA recursion is expressed in the robot's mounting frame, whereas
+        # ``self.g`` follows the world-frame convention used by gravitational
+        # potential energy and the dense dynamics path.  Rotating gravity into
+        # the mounting frame is essential for non-identity fixed-base poses.
+        # Translation does not affect a uniform gravity field.
+        gravity_base = self.base_transform[:3, :3].T @ self.g
+
         _, qdd = lax.scan(
             _acceleration_step,
-            jnp.concatenate([jnp.zeros(3, dtype=q.dtype), -self.g]),
+            jnp.concatenate([jnp.zeros(3, dtype=q.dtype), -gravity_base]),
             (Xup, S, c, U, d, u),
         )
 

--- a/src/soromox/systems/gvs/core.py
+++ b/src/soromox/systems/gvs/core.py
@@ -2253,24 +2253,6 @@ class GVS(SoftRobot):
         eta = J @ qd
         return weight * (J.T @ (M @ Jd_qd + se3.coadjoint(eta) @ M @ eta))
 
-    def _gravity_integrand(self, weight: Array, g: Array, J: Array, M: Array) -> Array:
-        """
-        Compute one quadrature contribution to generalized gravity.
-
-        Args:
-            weight: Length-scaled quadrature weight, shape ``()``.
-            g: Homogeneous SE(3) pose at the quadrature node, shape ``(4, 4)``.
-            J: Body-frame Jacobian at the quadrature node, shape
-                ``(6, self.num_internal_dofs)``.
-            M: Local spatial mass matrix at the quadrature node, shape
-                ``(6, 6)``.
-
-        Returns:
-            G_ij: Generalized gravity contribution, shape
-            ``(self.num_internal_dofs,)``.
-        """
-        return -weight * J.T @ M @ se3.adjoint_inverse(g) @ self.g
-
     # =========================================================================
     @eqx.filter_jit
     def _forward_kinematics_gauss(self, q_gathered: Array) -> Array:
@@ -3089,7 +3071,8 @@ class GVS(SoftRobot):
         Compute the pose and body-frame Jacobian at ``s`` in one scan.
 
         Args:
-            q (Array): generalized coordinates of shape (num_dofs,).
+            q (Array): Fixed-base generalized coordinates or total floating-base
+                configuration.
             s (Array): point coordinate along the robot in the interval [0, L].
 
         Returns:
@@ -5630,6 +5613,41 @@ class GVS(SoftRobot):
 
         return G_full
 
+    def _gravity_quadrature_kinematics(
+        self, q: Array, *, with_jacobians: bool
+    ) -> tuple[Array, Array, Array | None]:
+        """
+        Return quadrature mass points in the active kinematics frame.
+
+        Args:
+            q (Array): Fixed-base generalized coordinates or total floating-base
+                configuration.
+            with_jacobians (bool): Whether to compute the analytical linear
+                Jacobians at the quadrature points.
+
+        Returns:
+            point_positions (Array): Quadrature-point positions in the inertial
+                frame for a fixed base or the base frame for a floating base.
+            weighted_masses (Array): Quadrature-weighted point masses.
+            linear_jacobians (Array | None): Linear Jacobians in the same frame
+                as ``point_positions``, or ``None`` when not requested.
+        """
+        q_internal = self.split_configuration(q)[1] if self.floating_base else q
+        weighted_masses = self.inner_weighted_mass_diagonals[..., 3]
+        if not with_jacobians:
+            poses = self._forward_kinematics_gauss(self._min_size_gathered(q_internal))[
+                :, 1 : self.max_num_integration_points - 1
+            ]
+            return poses[..., :3, 3], weighted_masses, None
+
+        _, poses, jacobians_body = self._integration_pose_jacobians(q_internal)
+        linear_jacobians = jnp.einsum(
+            "...ij,...jk->...ik",
+            poses[..., :3, :3],
+            jacobians_body[..., 3:, :],
+        )
+        return poses[..., :3, 3], weighted_masses, linear_jacobians
+
     @eqx.filter_jit
     def _gravitational_force(self, q: Array) -> Array:
         """
@@ -5639,20 +5657,22 @@ class GVS(SoftRobot):
             q (Array): generalized coordinates of shape (num_dofs,).
 
         Returns:
-            G (Array): Gravitational force vector, shape (num_dofs, 1)
+            G (Array): Gravitational force in generalized-velocity coordinates.
         """
-        weights, g_quads, J_quads = self._integration_pose_jacobians(q)
-        Ms_inner = self._inner_mass_matrices()
-
-        def segment_terms(i: Array) -> Array:
-            def point_term(j: Array) -> Array:
-                return self._gravity_integrand(
-                    weights[i, j], g_quads[i, j], J_quads[i, j], Ms_inner[i, j]
-                )
-
-            return vmap(point_term)(jnp.arange(self.max_num_integration_points - 2))
-
-        return jnp.sum(vmap(segment_terms)(jnp.arange(self.num_segments)), axis=(0, 1))
+        point_positions, weighted_masses, linear_jacobians = (
+            self._gravity_quadrature_kinematics(q, with_jacobians=True)
+        )
+        assert linear_jacobians is not None
+        if not self.floating_base:
+            return -jnp.einsum(
+                "...,...ij,i->j", weighted_masses, linear_jacobians, self.g[3:]
+            )
+        return self._gravitational_force_from_base_relative_points(
+            q,
+            point_positions,
+            weighted_masses,
+            linear_jacobians,
+        )
 
     @eqx.filter_jit
     def _stiffness_full_matrix(self) -> Array:
@@ -5744,63 +5764,19 @@ class GVS(SoftRobot):
         not use runtime autodiff.
 
         Args:
-            q (Array): generalized coordinates of shape ``(num_dofs,)``.
+            q (Array): Fixed-base generalized coordinates or total floating-base
+                configuration.
 
         Returns:
             U_g (Array): Gravitational potential energy as a scalar array.
         """
-        q_gathered = self._min_size_gathered(q)
-        g_list = self._forward_kinematics_gauss(q_gathered)
-        gravity_linear = self.g[3:]
-
-        def U_G_i(i: Array) -> Array:
-            """Compute the gravitational energy contribution of one segment."""
-            length_i = self.segment_lengths[i]
-            weights = self.integration_weights[
-                i, 1 : self.max_num_integration_points - 1
-            ]
-            mass_density = (
-                jnp.trace(
-                    self.mass_matrices[
-                        i, 1 : self.max_num_integration_points - 1, 3:, 3:
-                    ],
-                    axis1=-2,
-                    axis2=-1,
-                )
-                / 3.0
-            )
-            positions = g_list[i, 1 : self.max_num_integration_points - 1, :3, 3]
-            height_along_gravity = positions @ gravity_linear
-            return -length_i * jnp.sum(weights * mass_density * height_along_gravity)
-
-        return jnp.sum(vmap(U_G_i)(jnp.arange(self.num_segments)))
-
-    @eqx.filter_jit
-    def _floating_gravitational_energy(self, q: Array) -> Array:
-        """
-        Compute absolute floating-base gravitational potential energy.
-
-        This follows the position-only Gauss recurrence and contracts cached
-        scalar mass densities directly. No Jacobians or spatial inertia
-        matrices are assembled.
-
-        Args:
-            q: Total floating-base configuration with shape
-                ``(num_coordinates,)``.
-
-        Returns:
-            Absolute gravitational potential energy as a scalar.
-        """
-        _, q_internal = self.split_configuration(q)
-        relative_poses = self._forward_kinematics_gauss(
-            self._min_size_gathered(q_internal)
-        )[:, 1 : self.max_num_integration_points - 1]
-        relative_positions = relative_poses[..., :3, 3]
-        weighted_masses = (
-            self.inner_integration_weights * self.inner_mass_diagonals[..., 3]
+        point_positions, weighted_masses, _ = self._gravity_quadrature_kinematics(
+            q, with_jacobians=False
         )
-        return self._floating_gravitational_energy_from_points(
-            q, relative_positions, weighted_masses
+        if not self.floating_base:
+            return -jnp.sum(weighted_masses * (point_positions @ self.g[3:]))
+        return self._gravitational_energy_from_base_relative_points(
+            q, point_positions, weighted_masses
         )
 
     def actuation_matrix(

--- a/src/soromox/systems/params.py
+++ b/src/soromox/systems/params.py
@@ -207,12 +207,7 @@ class BaseSystemParams(eqx.Module):
 
 
 class BaseSoftRobotParams(BaseSystemParams):
-    """Common dynamic parameters for soft robot systems.
-
-    Physical parameter trees contain gravity but deliberately do not contain a
-    mounting or initial floating pose. Fixed mounting is model state and
-    floating pose is runtime configuration state.
-    """
+    """Common dynamic parameters, with gravity expressed in the world frame."""
 
     is_planar: ClassVar[bool | None] = None
 

--- a/src/soromox/systems/pcs/pcs.py
+++ b/src/soromox/systems/pcs/pcs.py
@@ -2848,84 +2848,58 @@ class PCS(SoftRobot):
 
         return C
 
-    @eqx.filter_jit
-    def _gravitational_full_force(self, q: Array) -> Array:
+    def _gravity_quadrature_kinematics(
+        self, q: Array, *, with_jacobians: bool
+    ) -> tuple[Array, Array, Array | None]:
         """
-        Compute the full gravitational force acting on the robot.
+        Return quadrature mass points in the active kinematics frame.
 
         Args:
-            q (Array): generalized coordinates of shape (num_active_strains,).
+            q (Array): Fixed-base generalized coordinates or total floating-base
+                configuration.
+            with_jacobians (bool): Whether to compute the analytical linear
+                Jacobians at the quadrature points.
 
         Returns:
-            G (Array): Full gravitational force of shape (num_strains,).
+            point_positions (Array): Quadrature-point positions in the inertial
+                frame for a fixed base or the base frame for a floating base.
+            weighted_masses (Array): Quadrature-weighted point masses.
+            linear_jacobians (Array | None): Linear Jacobians in the same frame
+                as ``point_positions``, or ``None`` when not requested.
         """
-        # compute the gauss quadrature points and weights for each segment
-        Xs_scaled, Ws_scaled = vmap(
-            scale_gaussian_quadrature, in_axes=(None, None, 0, 0)
-        )(
-            self.integration_points,
-            self.integration_weights,
-            self.L_cum[:-1],
-            self.L_cum[1:],
-        )  # shape (num_segments, num_gauss_points) for both Xs_scaled and Ws_scaled
+        q_internal = self.split_configuration(q)[1] if self.floating_base else q
+        kinematics_robot = self._fixed_base_robot_at_pose()
+        points = self.dynamics_local_points[:, :-1] + self.L_cum[:-1, None]
+        num_points = points.shape[1]
+        points_flat = points.reshape(-1)
+        point_poses = kinematics_robot._forward_kinematics_abscissa_batched(
+            q_internal, points_flat
+        ).reshape(self.num_segments, num_points, 4, 4)
+        point_positions = point_poses[..., :3, 3]
+        weighted_masses = self.weighted_mass_diagonals[..., 3]
+        if not with_jacobians:
+            return point_positions, weighted_masses, None
 
-        # compute the forward kinematics for each quadrature point
-        g_ps = self._forward_kinematics_abscissa_batched(
-            q, Xs_scaled.flatten()
-        )  # shape (num_segments * num_gauss_points, 4, 4)
-        g_ps = g_ps.reshape(
-            self.num_segments, self.num_integration_points, 4, 4
-        )  # shape (num_segments, num_gauss_points, 4, 4)
-
-        # compute the jacobian for each quadrature point
-        J_ps = self._J_local_abscissa_batched(
-            q, Xs_scaled.flatten()
-        )  # shape (num_segments * num_gauss_points, 6, num_active_strains)
-        J_ps = J_ps.reshape(
-            self.num_segments, self.num_integration_points, *J_ps.shape[1:]
-        )  # shape (num_segments, num_gauss_points, 6, num_active_strains)
-
-        def G_i(i: Array) -> Array:
-            M_i = self._local_mass_matrix(i)
-
-            def G_ij(j: Array) -> Array:
-                # select the j-th quadrature weight
-                Ws_ij = Ws_scaled[i][j]
-                # select the j-th Cartesian pose
-                g_ij = g_ps[i, j]
-                # select the j-th jacobian and its time-derivative
-                J_ij = J_ps[i, j]
-
-                # compute the inverse Adjoint transformation matrix at point s
-                Ad_g_inv_ij = se3.adjoint_inverse(g_ij)
-
-                G_ij = -Ws_ij * J_ij.T @ M_i @ Ad_g_inv_ij @ self.g
-                return G_ij
-
-            # we can skip the first and last quadrature points since their weight is zero
-            G_blocks_segment_i = vmap(G_ij)(
-                jnp.arange(1, self.num_integration_points - 1)
-            )
-
-            # # For debugging purposes, you can uncomment the following line to see the step-by-step computation
-            # G_blocks_segment_i = jnp.stack(
-            #     [G_j(j) for j in range(self.num_integration_points)], axis=0
-            # )
-
-            return G_blocks_segment_i
-
-        G_blocks_tot = vmap(G_i)(jnp.arange(self.num_segments))
-
-        # # For debugging purposes, you can uncomment the following line to see the step-by-step computation
-        # G_blocks_tot = jnp.stack(
-        #     [G_i(i) for i in range(self.num_segments)], axis=0
-        # )
-
-        G_full = jnp.sum(
-            G_blocks_tot, axis=(0, 1)
-        )  # Sum over links and quadrature points
-
-        return G_full
+        jacobians_body_full = kinematics_robot._J_local_abscissa_batched(
+            q_internal, points_flat
+        ).reshape(
+            self.num_segments,
+            num_points,
+            6,
+            self.num_strains,
+        )
+        jacobians_body = jnp.einsum("...ij,jk->...ik", jacobians_body_full, self.B_xi)
+        linear_jacobians = jnp.einsum(
+            "...ij,...jk->...ik",
+            point_poses[..., :3, :3],
+            jacobians_body[..., 3:, :],
+        ).reshape(
+            self.num_segments,
+            num_points,
+            3,
+            self.num_internal_dofs,
+        )
+        return point_positions, weighted_masses, linear_jacobians
 
     @eqx.filter_jit
     def _gravitational_force(self, q: Array) -> Array:
@@ -2933,16 +2907,26 @@ class PCS(SoftRobot):
         Compute the gravitational force acting on the robot.
 
         Args:
-            q (Array): generalized coordinates of shape (num_active_strains,).
+            q (Array): Fixed-base generalized coordinates or total floating-base
+                configuration.
 
         Returns:
-            G (Array): Gravitational force of shape (num_active_strains,).
+            G (Array): Gravitational force in generalized-velocity coordinates.
         """
-        G_full = self._gravitational_full_force(q)
-
-        G = self.B_xi.T @ G_full
-
-        return G
+        point_positions, weighted_masses, linear_jacobians = (
+            self._gravity_quadrature_kinematics(q, with_jacobians=True)
+        )
+        assert linear_jacobians is not None
+        if not self.floating_base:
+            return -jnp.einsum(
+                "...,...ij,i->j", weighted_masses, linear_jacobians, self.g[3:]
+            )
+        return self._gravitational_force_from_base_relative_points(
+            q,
+            point_positions,
+            weighted_masses,
+            linear_jacobians,
+        )
 
     def _material_operators(self) -> tuple[Array, Array, Array]:
         """Return unit Young, shear, and material-damping link matrices."""
@@ -3237,104 +3221,19 @@ class PCS(SoftRobot):
         Compute the gravitational energy of the robot.
 
         Args:
-            q (Array): generalized coordinates of shape (num_active_strains,).
+            q (Array): Fixed-base generalized coordinates or total floating-base
+                configuration.
 
         Returns:
-            U_G (float): Gravitational energy of the robot.
+            U_G (Array): Gravitational energy of the robot.
         """
-        # compute the gauss quadrature points and weights for each segment
-        Xs_scaled, Ws_scaled = vmap(
-            scale_gaussian_quadrature, in_axes=(None, None, 0, 0)
-        )(
-            self.integration_points,
-            self.integration_weights,
-            self.L_cum[:-1],
-            self.L_cum[1:],
-        )  # shape (num_segments, num_gauss_points) for both Xs_scaled and Ws_scaled
-
-        # compute the forward kinematics for each quadrature point
-        g_ps = self._forward_kinematics_abscissa_batched(
-            q, Xs_scaled.flatten()
-        )  # shape (num_segments * num_gauss_points, 4, 4)
-        g_ps = g_ps.reshape(
-            self.num_segments, self.num_integration_points, 4, 4
-        )  # shape (num_segments, num_gauss_points, 4, 4)
-
-        def U_G_i(i: Array) -> Array:
-            rho_i = self.rho[i]
-            A_i = self._local_cross_sectional_area(i)  # Cross-sectional area
-
-            def U_G_ij(j: Array) -> Array:
-                # select the j-th quadrature weight
-                Ws_ij = Ws_scaled[i][j]
-                # select the j-th Cartesian pose
-                g_ij = g_ps[i, j]
-
-                p_j = jnp.concatenate(
-                    [jnp.zeros(3), g_ij[:3, 3]]
-                )  # Add zeros for the orientation angles
-                U_G_ij = -Ws_ij * rho_i * A_i * jnp.dot(p_j, self.g)
-                return U_G_ij
-
-            # we can skip the first and last quadrature points since their weight is zero
-            U_G_blocks_segment_i = vmap(U_G_ij)(
-                jnp.arange(1, self.num_integration_points - 1)
-            )
-
-            # # For debugging purposes, you can uncomment the following line to see the step-by-step computation
-            # U_G_blocks_segment_i = jnp.stack(
-            #     [U_G_j(j) for j in range(self.num_integration_points)], axis=0
-            # )
-
-            return U_G_blocks_segment_i
-
-        U_G_blocks_tot = vmap(U_G_i)(jnp.arange(self.num_segments))
-
-        # # For debugging purposes, you can uncomment the following line to see the step-by-step computation
-        # U_G_blocks_tot = jnp.stack(
-        #     [U_G_i(i) for i in range(self.num_segments)], axis=0
-        # )
-
-        U_G = jnp.sum(U_G_blocks_tot, axis=(0, 1))  # Sum over segments and Gauss points
-
-        return U_G
-
-    @eqx.filter_jit
-    def _floating_gravitational_energy(self, q: Array) -> Array:
-        """
-        Compute absolute floating-base gravitational potential energy.
-
-        Args:
-            q: Total floating-base configuration with shape
-                ``(num_coordinates,)``.
-
-        Returns:
-            Absolute gravitational potential energy as a scalar.
-        """
-        _, q_internal = self.split_configuration(q)
-        points, weights = vmap(scale_gaussian_quadrature, in_axes=(None, None, 0, 0))(
-            self.integration_points,
-            self.integration_weights,
-            self.L_cum[:-1],
-            self.L_cum[1:],
+        point_positions, weighted_masses, _ = self._gravity_quadrature_kinematics(
+            q, with_jacobians=False
         )
-        relative_poses = (
-            self._fixed_base_robot_at_pose()._forward_kinematics_abscissa_batched(
-                q_internal, points.reshape(-1)
-            )
-        )
-        relative_positions = relative_poses.reshape(
-            self.num_segments, self.num_integration_points, 4, 4
-        )[..., :3, 3]
-        weighted_masses = (
-            weights
-            * self.rho[:, None]
-            * vmap(self._local_cross_sectional_area)(
-                jnp.arange(self.num_segments, dtype=jnp.int32)
-            )[:, None]
-        )
-        return self._floating_gravitational_energy_from_points(
-            q, relative_positions, weighted_masses
+        if not self.floating_base:
+            return -jnp.sum(weighted_masses * (point_positions @ self.g[3:]))
+        return self._gravitational_energy_from_base_relative_points(
+            q, point_positions, weighted_masses
         )
 
     @eqx.filter_jit

--- a/src/soromox/systems/pcs/planar_hsa.py
+++ b/src/soromox/systems/pcs/planar_hsa.py
@@ -964,15 +964,6 @@ class PlanarHSA(PlanarPCS):
         )
         return Jd_ps, Jd_tips
 
-    def _integration_kinematics_gravity(
-        self, q: Array
-    ) -> tuple[Array, Array, Array, Array, Array]:
-        """Return only pose/Jacobian data needed by gravitational forces."""
-        Ws_scaled, g_ps, J_ps, _, _, _, _, g_tips, J_tips = (
-            self._integration_geometry_full(q)
-        )
-        return Ws_scaled, g_ps, J_ps, g_tips, J_tips
-
     def _mass_geometry_from_integration(
         self, geometry: tuple[Array, ...], full: bool
     ) -> tuple[Array, ...]:
@@ -1821,26 +1812,25 @@ class PlanarHSA(PlanarPCS):
             gravity @ (payload_cog - base_translation)
         )
 
-    def _gravitational_energy(self, q: Array) -> Array:
-        """Return gravitational potential energy for active coordinates."""
-        return self._gravitational_energy_full_from_xi(self.strain(q))
-
     @eqx.filter_jit
-    def _floating_gravitational_energy(self, q: Array) -> Array:
+    def _gravitational_energy(self, q: Array) -> Array:
         """
-        Compute absolute floating-base HSA gravitational potential energy.
+        Compute fixed- or floating-base HSA gravitational potential energy.
 
-        The implementation contracts native rod densities and discrete platform
-        masses with positions directly. It does not evaluate Jacobians or build
-        spatial inertia matrices.
+        Floating models contract native rod densities and discrete platform
+        masses with world positions directly. They do not evaluate Jacobians or
+        build spatial inertia matrices.
 
         Args:
-            q: Total floating-base configuration with shape
-                ``(num_coordinates,)``.
+            q: Fixed-base active coordinates or total floating-base
+                configuration.
 
         Returns:
             Absolute gravitational potential energy as a scalar.
         """
+        if not self.floating_base:
+            return self._gravitational_energy_full_from_xi(self.strain(q))
+
         _, q_internal = self.split_configuration(q)
         xi = self.strain(q_internal)
         points, weights = self._quadrature()
@@ -1873,77 +1863,81 @@ class PlanarHSA(PlanarPCS):
                 vmap(rod_energy)(jnp.arange(self.num_rods_per_segment, dtype=jnp.int32))
             )
             mass, _, relative_cog = self._platform_mass_properties(segment_index)
-            tip = self._forward_backbone_from_xi(xi, self.L_cum[segment_index + 1])
-            cosine, sine = jnp.cos(tip[0]), jnp.sin(tip[0])
-            cog = tip[1:] + jnp.array(
-                [
-                    cosine * relative_cog[0] - sine * relative_cog[1],
-                    sine * relative_cog[0] + cosine * relative_cog[1],
-                ]
-            )
+            tip_transform = self._backbone_transform(xi, self.L_cum[segment_index + 1])
+            cog = (
+                tip_transform
+                @ jnp.concatenate(
+                    [relative_cog, jnp.ones((1,), dtype=relative_cog.dtype)]
+                )
+            )[:2]
             return rods - mass * (world_position(cog) @ gravity)
 
         energy = jnp.sum(
             vmap(segment_energy)(jnp.arange(self.num_segments, dtype=jnp.int32))
         )
-        end_effector = self._forward_end_effector_from_xi(xi)
-        cosine, sine = jnp.cos(end_effector[0]), jnp.sin(end_effector[0])
-        payload_cog = end_effector[1:] + jnp.array(
-            [
-                cosine * self.platform_center_of_gravity[0]
-                - sine * self.platform_center_of_gravity[1],
-                sine * self.platform_center_of_gravity[0]
-                + cosine * self.platform_center_of_gravity[1],
-            ]
-        )
+        _, tip_transforms = self._segment_bases_and_tips(xi)
+        payload_cog = (tip_transforms[-1] @ self.payload_transform)[:2, 2]
         return energy - self.platform_mass * (world_position(payload_cog) @ gravity)
 
     def _assemble_gravity_force(self, q: Array, *, full: bool = False) -> Array:
-        """Assemble gravity from pose/Jacobian data only."""
-        Ws, g_ps, J_full, g_tips, J_tips = self._integration_kinematics_gravity(q)
-        basis = jnp.eye(self.num_strains, dtype=J_full.dtype) if full else self.B_xi
-        J_ps = jnp.einsum("sqab,bd->sqad", J_full, basis)
-        rod_transforms = self.rod_transforms
-        rod_adjoint_inverses = self.rod_adjoint_inverses
-        J_rods = jnp.einsum("srab,sqbd->sqrad", rod_adjoint_inverses, J_ps)
-        g_rods = jnp.einsum("sqab,srbc->sqrac", g_ps, rod_transforms)
-        rod_local_gravity = jnp.einsum(
-            "sqrab,b->sqra",
-            vmap(vmap(vmap(se2.adjoint_inverse)))(g_rods),
-            self.g,
-        )
-        rod_gravity_wrench = jnp.einsum(
-            "srab,sqrb->sqra", self.rod_mass_matrices, rod_local_gravity
-        )
-        G_rods = -jnp.einsum("sq,sqrad,sqra->d", Ws, J_rods, rod_gravity_wrench)
+        """Assemble fixed- or floating-base gravity from one geometry pass."""
+        if self.floating_base and full:
+            raise ValueError("Full-strain gravity is only defined for fixed-base HSA.")
+        q = self.normalize_configuration(q)
+        q_internal = self.split_configuration(q)[1] if self.floating_base else q
+        geometry = self._integration_geometry_full(q_internal)
+        (
+            weights,
+            rod_transforms,
+            rod_jacobians,
+            rod_mass_matrices,
+            cog_transforms,
+            cog_jacobians,
+            masses,
+            _,
+            payload_jacobian,
+            payload_transform,
+            payload_mass_matrix,
+        ) = self._mass_geometry_from_integration(geometry, full=full)
 
-        tip_indices = jnp.arange(self.num_segments, dtype=jnp.int32)
-        J_tips = J_tips[tip_indices, tip_indices]
-        J_tips = jnp.einsum("sab,bd->sad", J_tips, basis)
-        J_cogs = jnp.einsum("sab,sbd->sad", self.cog_adjoint_inverses, J_tips)
-        g_cogs = jnp.einsum("sab,sbc->sac", g_tips, self.cog_transforms)
-        cog_matrices = jnp.zeros((*self.segment_masses.shape, 3, 3), dtype=Ws.dtype)
-        cog_matrices = cog_matrices.at[:, 0, 0].set(self.segment_inertias)
-        cog_matrices = cog_matrices.at[:, 1, 1].set(self.segment_masses)
-        cog_matrices = cog_matrices.at[:, 2, 2].set(self.segment_masses)
-        cog_gravity_wrench = jnp.einsum(
-            "sab,sb->sa",
-            cog_matrices,
-            jnp.einsum(
-                "sab,b->sa",
-                vmap(se2.adjoint_inverse)(g_cogs),
-                self.g,
-            ),
-        )
-        G_cogs = -jnp.einsum("sad,sa->d", J_cogs, cog_gravity_wrench)
+        def project_gravity(
+            transforms: Array,
+            point_masses: Array,
+            jacobians_body: Array,
+        ) -> Array:
+            linear_jacobians = jnp.einsum(
+                "...ij,...jk->...ik",
+                transforms[..., :2, :2],
+                jacobians_body[..., 1:, :],
+            )
+            if not self.floating_base:
+                return -jnp.einsum(
+                    "...,...ij,i->j", point_masses, linear_jacobians, self.g[1:]
+                )
+            return self._gravitational_force_from_base_relative_points(
+                q,
+                transforms[..., :2, 2],
+                point_masses,
+                linear_jacobians,
+            )
 
-        J_payload = self.payload_adjoint_inverse @ J_tips[-1]
-        g_payload = g_tips[-1] @ self.payload_transform
-        payload_gravity_wrench = self.payload_mass_matrix @ (
-            se2.adjoint_inverse(g_payload) @ self.g
+        rod_weighted_masses = weights[..., None] * rod_mass_matrices[:, None, :, 1, 1]
+        gravity_rods = project_gravity(
+            rod_transforms,
+            rod_weighted_masses,
+            rod_jacobians,
         )
-        G_payload = -J_payload.T @ payload_gravity_wrench
-        return G_rods + G_cogs + G_payload
+        gravity_cogs = project_gravity(
+            cog_transforms,
+            masses,
+            cog_jacobians,
+        )
+        gravity_payload = project_gravity(
+            payload_transform,
+            payload_mass_matrix[1, 1],
+            payload_jacobian,
+        )
+        return gravity_rods + gravity_cogs + gravity_payload
 
     def inertia_matrix(self, q: Array) -> Array:
         """Return the active-coordinate generalized inertia matrix.

--- a/src/soromox/systems/pcs/planar_pcs.py
+++ b/src/soromox/systems/pcs/planar_pcs.py
@@ -920,7 +920,8 @@ class PlanarPCS(SoftRobot):
         longitudinal backbone direction.
 
         Args:
-            q (Array): generalized coordinates of shape (num_active_strains,).
+            q (Array): Fixed-base generalized coordinates or total floating-base
+                configuration.
 
         Returns:
             xi (Array): strain vector of shape (num_active_strains,)
@@ -2744,60 +2745,59 @@ class PlanarPCS(SoftRobot):
 
         return C
 
-    @eqx.filter_jit
-    def _gravitational_full_force(self, q: Array) -> Array:
+    def _gravity_quadrature_kinematics(
+        self, q: Array, *, with_jacobians: bool
+    ) -> tuple[Array, Array, Array | None]:
         """
-        Compute the full gravitational force acting on the robot.
+        Return quadrature mass points in the active kinematics frame.
 
         Args:
-            q (Array): generalized coordinates of shape (num_active_strains,).
+            q (Array): Fixed-base generalized coordinates or total floating-base
+                configuration.
+            with_jacobians (bool): Whether to compute the analytical linear
+                Jacobians at the quadrature points.
 
         Returns:
-            G (Array): Full gravitational force of shape (num_strains,).
+            point_positions (Array): Quadrature-point positions in the inertial
+                frame for a fixed base or the base frame for a floating base.
+            weighted_masses (Array): Quadrature-weighted point masses.
+            linear_jacobians (Array | None): Linear Jacobians in the same frame
+                as ``point_positions``, or ``None`` when not requested.
         """
-        Xs_scaled, Ws_scaled = vmap(
-            scale_gaussian_quadrature, in_axes=(None, None, 0, 0)
-        )(
-            self.integration_points,
-            self.integration_weights,
-            self.L_cum[:-1],
-            self.L_cum[1:],
+        q_internal = self.split_configuration(q)[1] if self.floating_base else q
+        kinematics_robot = self._fixed_base_robot_at_pose()
+        assert self.dynamics_local_points is not None
+        assert self.weighted_mass_diagonals is not None
+        points = self.dynamics_local_points[:, :-1] + self.L_cum[:-1, None]
+        num_points = points.shape[1]
+        points_flat = points.reshape(-1)
+        point_poses = kinematics_robot._forward_kinematics_abscissa_batched(
+            q_internal, points_flat
+        ).reshape(self.num_segments, num_points, 3)
+        point_positions = point_poses[..., 1:]
+        weighted_masses = self.weighted_mass_diagonals[..., 1]
+        if not with_jacobians:
+            return point_positions, weighted_masses, None
+
+        jacobians_body_full = kinematics_robot._J_local_abscissa_batched(
+            q_internal, points_flat
+        ).reshape(
+            self.num_segments,
+            num_points,
+            3,
+            self.num_strains,
         )
-
-        chi_ps = self._forward_kinematics_abscissa_batched(q, Xs_scaled.flatten())
-        g_ps = vmap(poses.planar_pose_to_transform)(chi_ps.reshape(-1, 3))
-        g_ps = g_ps.reshape(self.num_segments, self.num_integration_points, 3, 3)
-
-        J_ps = self._J_local_abscissa_batched(q, Xs_scaled.flatten())
-        J_ps = J_ps.reshape(
-            self.num_segments, self.num_integration_points, *J_ps.shape[1:]
+        jacobians_body = jnp.einsum("...ij,jk->...ik", jacobians_body_full, self.B_xi)
+        rotations = vmap(vmap(poses.planar_pose_to_transform))(point_poses)[..., :2, :2]
+        linear_jacobians = jnp.einsum(
+            "...ij,...jk->...ik", rotations, jacobians_body[..., 1:, :]
+        ).reshape(
+            self.num_segments,
+            num_points,
+            2,
+            self.num_internal_dofs,
         )
-
-        def G_i(i: Array) -> Array:
-            M_i = self._local_mass_matrix(i)
-
-            def G_ij(j: Array) -> Array:
-                Ws_ij = Ws_scaled[i][j]
-                g_ij = g_ps[i, j]
-                J_ij = J_ps[i, j]
-
-                Ad_g_inv_ij = se2.adjoint_inverse(g_ij)
-
-                return -Ws_ij * J_ij.T @ M_i @ Ad_g_inv_ij @ self.g
-
-            G_blocks_segment_i = vmap(G_ij)(
-                jnp.arange(1, self.num_integration_points - 1)
-            )
-
-            return G_blocks_segment_i
-
-        G_blocks_tot = vmap(G_i)(jnp.arange(self.num_segments))
-
-        G_full = jnp.sum(
-            G_blocks_tot, axis=(0, 1)
-        )  # Sum over links and quadrature points
-
-        return G_full
+        return point_positions, weighted_masses, linear_jacobians
 
     @eqx.filter_jit
     def _gravitational_force(self, q: Array) -> Array:
@@ -2808,13 +2808,22 @@ class PlanarPCS(SoftRobot):
             q (Array): generalized coordinates of shape (num_active_strains,).
 
         Returns:
-            G (Array): Gravitational force of shape (num_active_strains,).
+            G (Array): Gravitational force in generalized-velocity coordinates.
         """
-        G_full = self._gravitational_full_force(q)
-
-        G = self.B_xi.T @ G_full
-
-        return G
+        point_positions, weighted_masses, linear_jacobians = (
+            self._gravity_quadrature_kinematics(q, with_jacobians=True)
+        )
+        assert linear_jacobians is not None
+        if not self.floating_base:
+            return -jnp.einsum(
+                "...,...ij,i->j", weighted_masses, linear_jacobians, self.g[1:]
+            )
+        return self._gravitational_force_from_base_relative_points(
+            q,
+            point_positions,
+            weighted_masses,
+            linear_jacobians,
+        )
 
     def _material_operators(self) -> tuple[Array, Array, Array]:
         """Return unit Young, shear, and material-damping link matrices."""
@@ -3151,85 +3160,19 @@ class PlanarPCS(SoftRobot):
         Compute the gravitational energy of the robot.
 
         Args:
-            q (Array): generalized coordinates of shape (num_active_strains,).
+            q (Array): Fixed-base generalized coordinates or total floating-base
+                configuration.
 
         Returns:
-            U_G (float): Gravitational energy of the robot.
+            U_G (Array): Gravitational energy of the robot.
         """
-        Xs_scaled, Ws_scaled = vmap(
-            scale_gaussian_quadrature, in_axes=(None, None, 0, 0)
-        )(
-            self.integration_points,
-            self.integration_weights,
-            self.L_cum[:-1],
-            self.L_cum[1:],
+        point_positions, weighted_masses, _ = self._gravity_quadrature_kinematics(
+            q, with_jacobians=False
         )
-
-        chi_ps = self._forward_kinematics_abscissa_batched(q, Xs_scaled.flatten())
-        chi_ps = chi_ps.reshape(self.num_segments, self.num_integration_points, 3)
-
-        def U_G_i(i: Array) -> Array:
-            rho_i = self.rho[i]
-            A_i = self._local_cross_sectional_area(i)
-
-            def U_G_ij(j: Array) -> Array:
-                Ws_ij = Ws_scaled[i][j]
-                chi_ij = chi_ps[i, j]
-                p_j = chi_ij.at[0].set(0.0)
-
-                return -Ws_ij * rho_i * A_i * jnp.dot(p_j, self.g)
-
-            U_G_blocks_segment_i = vmap(U_G_ij)(
-                jnp.arange(1, self.num_integration_points - 1)
-            )
-
-            return U_G_blocks_segment_i
-
-        U_G_blocks_tot = vmap(U_G_i)(jnp.arange(self.num_segments))
-
-        U_G = jnp.sum(U_G_blocks_tot, axis=(0, 1))  # Sum over segments and Gauss points
-
-        return U_G
-
-    @eqx.filter_jit
-    def _floating_gravitational_energy(self, q: Array) -> Array:
-        """
-        Compute absolute floating-base gravitational potential energy.
-
-        The quadrature recurrence evaluates positions only. It does not build
-        Jacobians or spatial inertia matrices.
-
-        Args:
-            q: Total floating-base configuration with shape
-                ``(num_coordinates,)``.
-
-        Returns:
-            Absolute gravitational potential energy as a scalar.
-        """
-        _, q_internal = self.split_configuration(q)
-        points, weights = vmap(scale_gaussian_quadrature, in_axes=(None, None, 0, 0))(
-            self.integration_points,
-            self.integration_weights,
-            self.L_cum[:-1],
-            self.L_cum[1:],
-        )
-        relative_poses = (
-            self._fixed_base_robot_at_pose()._forward_kinematics_abscissa_batched(
-                q_internal, points.reshape(-1)
-            )
-        )
-        relative_positions = relative_poses.reshape(
-            self.num_segments, self.num_integration_points, 3
-        )[..., 1:]
-        weighted_masses = (
-            weights
-            * self.rho[:, None]
-            * vmap(self._local_cross_sectional_area)(
-                jnp.arange(self.num_segments, dtype=jnp.int32)
-            )[:, None]
-        )
-        return self._floating_gravitational_energy_from_points(
-            q, relative_positions, weighted_masses
+        if not self.floating_base:
+            return -jnp.sum(weighted_masses * (point_positions @ self.g[1:]))
+        return self._gravitational_energy_from_base_relative_points(
+            q, point_positions, weighted_masses
         )
 
     @eqx.filter_jit

--- a/src/soromox/systems/pendulum/pendulum.py
+++ b/src/soromox/systems/pendulum/pendulum.py
@@ -984,6 +984,15 @@ class Pendulum(SoftRobot):
         Returns:
             G (Array): Generalized gravity vector, shape (N,) [N⋅m]
         """
+        if self.floating_base:
+            _, q_internal = self.split_configuration(q)
+            return self._gravitational_force_from_base_relative_points(
+                q,
+                self._com_positions(q_internal),
+                self.m,
+                self._linear_jacobian_coms(q_internal),
+            )
+
         Jv = self._linear_jacobian_coms(
             q
         )  # (N,2,N) -> indices (link, component, joint)
@@ -1118,32 +1127,21 @@ class Pendulum(SoftRobot):
         where p_com_i is the center of mass position of link i.
 
         Args:
-            q (Array): Joint angles, shape (N,) [rad]
+            q: Fixed-base joint angles or total floating-base configuration.
 
         Returns:
             U_g (Array): Gravitational potential energy [J] (scalar)
         """
+        if self.floating_base:
+            _, q_internal = self.split_configuration(q)
+            return self._gravitational_energy_from_base_relative_points(
+                q, self._com_positions(q_internal), self.m
+            )
+
         p_coms = self._com_positions(q)  # (n, 2)
         # U_G = -Σ_i m_i * g^T @ p_com_i
         U_g = -jnp.sum(self.m * jnp.dot(p_coms, self.g))
         return U_g
-
-    @eqx.filter_jit
-    def _floating_gravitational_energy(self, q: Array) -> Array:
-        """
-        Compute absolute floating-base gravitational potential energy.
-
-        Args:
-            q: Total floating-base configuration with shape
-                ``(num_coordinates,)``.
-
-        Returns:
-            Absolute gravitational potential energy as a scalar.
-        """
-        _, q_internal = self.split_configuration(q)
-        return self._floating_gravitational_energy_from_points(
-            q, self._com_positions(q_internal), self.m
-        )
 
     @eqx.filter_jit
     def _elastic_energy(self, q: Array) -> Array:

--- a/src/soromox/systems/soft_robot.py
+++ b/src/soromox/systems/soft_robot.py
@@ -1735,7 +1735,9 @@ class SoftRobot(DynamicalSystem):
             )
         return jnp.concatenate([jacobians_base, jacobians_internal_world], axis=-1)
 
-    def _floating_world_positions(self, q: Array, relative_positions: Array) -> Array:
+    def _world_positions_from_base_relative(
+        self, q: Array, relative_positions: Array
+    ) -> Array:
         """
         Transform base-relative points into the inertial frame.
 
@@ -1744,8 +1746,8 @@ class SoftRobot(DynamicalSystem):
         matrices.
 
         Args:
-            q: Total floating-base configuration with shape
-                ``(num_coordinates,)``.
+            q: Fixed-base internal coordinates or total floating-base
+                configuration, with shape ``(num_coordinates,)``.
             relative_positions: Base-relative points with trailing dimension two
                 for planar systems or three for spatial systems.
 
@@ -1759,19 +1761,19 @@ class SoftRobot(DynamicalSystem):
         translation = transform[:linear_dimension, linear_dimension]
         return jnp.einsum("ij,...j->...i", rotation, relative_positions) + translation
 
-    def _floating_gravitational_energy_from_points(
+    def _gravitational_energy_from_base_relative_points(
         self, q: Array, relative_positions: Array, masses: Array
     ) -> Array:
         """
-        Compute floating-base gravitational energy from point masses.
+        Compute gravitational energy from base-relative point masses.
 
         Quadrature weights must already be folded into ``masses``. This direct
         contraction is intended for system-specific energy paths and never
         constructs Jacobians or spatial inertia matrices.
 
         Args:
-            q: Total floating-base configuration with shape
-                ``(num_coordinates,)``.
+            q: Fixed-base internal coordinates or total floating-base
+                configuration, with shape ``(num_coordinates,)``.
             relative_positions: Base-relative mass locations with trailing
                 dimension two or three.
             masses: Scalar masses broadcastable to the leading point axes.
@@ -1779,10 +1781,84 @@ class SoftRobot(DynamicalSystem):
         Returns:
             Absolute gravitational potential energy as a scalar.
         """
-        positions = self._floating_world_positions(q, relative_positions)
+        positions = self._world_positions_from_base_relative(q, relative_positions)
         linear_dimension = positions.shape[-1]
         gravity = jnp.asarray(self.g[-linear_dimension:], dtype=q.dtype)
         return -jnp.sum(masses * (positions @ gravity))
+
+    def _gravitational_force_from_base_relative_points(
+        self,
+        q: Array,
+        relative_positions: Array,
+        masses: Array,
+        linear_jacobians_internal: Array,
+    ) -> Array:
+        """Project point-mass gravity through analytical linear Jacobians.
+
+        The point locations and internal Jacobians are expressed in the robot
+        base frame. For fixed models, only the internal Jacobians are rotated
+        into the world frame. For floating models, the rigid-base rotational
+        and translational columns are prepended analytically.
+
+        Args:
+            q: Fixed-base internal coordinates or total floating-base
+                configuration.
+            relative_positions: Base-relative mass locations with trailing
+                dimension two or three.
+            masses: Scalar masses broadcastable to the leading point axes.
+            linear_jacobians_internal: Base-frame linear Jacobians with the
+                same leading point axes and trailing shape
+                ``(linear_dimension, num_internal_dofs)``.
+
+        Returns:
+            Gravitational generalized force in generalized-velocity
+            coordinates.
+        """
+        transform = self.base_transform_from_configuration(q)
+        linear_dimension = 2 if self.is_planar else 3
+        rotation = transform[:linear_dimension, :linear_dimension]
+        jacobians_internal_world = jnp.einsum(
+            "ij,...jk->...ik", rotation, linear_jacobians_internal
+        )
+
+        if self.floating_base:
+            world_offsets = jnp.einsum("ij,...j->...i", rotation, relative_positions)
+            if self.is_planar:
+                jacobians_base = jnp.zeros(
+                    (*relative_positions.shape[:-1], 2, 3),
+                    dtype=linear_jacobians_internal.dtype,
+                )
+                jacobians_base = jacobians_base.at[..., 0, 0].set(
+                    -world_offsets[..., 1]
+                )
+                jacobians_base = jacobians_base.at[..., 1, 0].set(world_offsets[..., 0])
+                jacobians_base = jacobians_base.at[..., 0, 1].set(1.0)
+                jacobians_base = jacobians_base.at[..., 1, 2].set(1.0)
+            else:
+                offset_x = world_offsets[..., 0]
+                offset_y = world_offsets[..., 1]
+                offset_z = world_offsets[..., 2]
+                jacobians_base = jnp.zeros(
+                    (*relative_positions.shape[:-1], 3, 6),
+                    dtype=linear_jacobians_internal.dtype,
+                )
+                jacobians_base = jacobians_base.at[..., 0, 1].set(offset_z)
+                jacobians_base = jacobians_base.at[..., 0, 2].set(-offset_y)
+                jacobians_base = jacobians_base.at[..., 1, 0].set(-offset_z)
+                jacobians_base = jacobians_base.at[..., 1, 2].set(offset_x)
+                jacobians_base = jacobians_base.at[..., 2, 0].set(offset_y)
+                jacobians_base = jacobians_base.at[..., 2, 1].set(-offset_x)
+                jacobians_base = jacobians_base.at[..., 0, 3].set(1.0)
+                jacobians_base = jacobians_base.at[..., 1, 4].set(1.0)
+                jacobians_base = jacobians_base.at[..., 2, 5].set(1.0)
+            jacobians_world = jnp.concatenate(
+                [jacobians_base, jacobians_internal_world], axis=-1
+            )
+        else:
+            jacobians_world = jacobians_internal_world
+
+        gravity = jnp.asarray(self.g[-linear_dimension:], dtype=q.dtype)
+        return -jnp.einsum("...,...ij,i->j", masses, jacobians_world, gravity)
 
     def _augment_floating_body_kinematics(
         self,
@@ -1888,29 +1964,6 @@ class SoftRobot(DynamicalSystem):
         """
         raise NotImplementedError(
             f"{type(self).__name__} does not implement fused floating-base dynamics."
-        )
-
-    def _floating_gravitational_energy(self, q: Array) -> Array:
-        """
-        Compute absolute floating-base gravitational potential energy.
-
-        Concrete systems must implement a direct position/mass contraction and
-        must not route this operation through augmented dynamics assembly.
-
-        Args:
-            q: Total floating-base configuration with shape
-                ``(num_coordinates,)``.
-
-        Returns:
-            Absolute gravitational potential energy as a scalar.
-
-        Raises:
-            NotImplementedError: If the concrete system does not implement a
-                direct floating-base energy path.
-        """
-        raise NotImplementedError(
-            f"{type(self).__name__} does not implement floating-base gravitational "
-            "energy."
         )
 
     def _floating_internal_inertia_addition(self, q_internal: Array) -> Array:
@@ -2197,9 +2250,6 @@ class SoftRobot(DynamicalSystem):
         Returns:
             G: Gravitational force of shape (num_velocities,).
         """
-        if self.floating_base:
-            zeros = jnp.zeros((self.num_velocities,), dtype=q.dtype)
-            return self._assemble_floating_dynamics_terms(q, zeros)[2]
         return self._gravitational_force(q)
 
     def potential_force(self, q: Array) -> Array:
@@ -2220,11 +2270,15 @@ class SoftRobot(DynamicalSystem):
         """
         Protected gravitational-force hook.
 
-        The default implementation differentiates the protected
-        :meth:`_gravitational_energy` hook. Subclasses may override this method
-        with an analytical or fused implementation. Differentiating the
-        protected energy hook avoids recursively invoking the public
-        custom-JVP energy wrapper.
+        The default implementation differentiates the unified protected
+        :meth:`_gravitational_energy` hook. For a spatial floating base, its
+        quaternion coordinate gradient is pulled back to the six-dimensional
+        generalized-velocity space through :meth:`configuration_derivative`.
+        This position-only path does not assemble inertia or Coriolis terms.
+
+        This generic fallback uses runtime autodiff. Performance-sensitive
+        subclasses should override it with an analytical implementation for
+        both fixed- and floating-base configurations.
 
         Args:
             q: Generalized coordinates of shape ``(num_coordinates,)``.
@@ -2232,7 +2286,17 @@ class SoftRobot(DynamicalSystem):
         Returns:
             G: Gravitational generalized force of shape ``(num_velocities,)``.
         """
-        return grad(lambda q_: self._gravitational_energy(q_))(q)
+        if not self.floating_base:
+            return grad(lambda q_: self._gravitational_energy(q_))(q)
+
+        q = self.normalize_configuration(q)
+        coordinate_gradient = grad(lambda q_: self._gravitational_energy(q_))(q)
+        zero_velocity = jnp.zeros((self.num_velocities,), dtype=q.dtype)
+        _, pullback = jax.vjp(
+            lambda velocity: self.configuration_derivative(q, velocity),
+            zero_velocity,
+        )
+        return pullback(coordinate_gradient)[0]
 
     def actuator_coordinates(self, q: Array) -> Array:
         """
@@ -2703,7 +2767,7 @@ class SoftRobot(DynamicalSystem):
             U_g: Gravitational potential energy (scalar).
         """
         if self.floating_base:
-            return self._floating_gravitational_energy(q)
+            return self._gravitational_energy(q)
         if custom_jvp_enabled():
             return SoftRobot._gravitational_energy_custom_jvp(self, q)
         return self._gravitational_energy(q)
@@ -2713,7 +2777,9 @@ class SoftRobot(DynamicalSystem):
         Protected primal gravitational-energy hook for custom autodiff wrappers.
 
         Subclasses that inherit the public SoftRobot gravitational_energy method
-        should override this hook.
+        should override this hook for both fixed- and floating-base
+        configurations. Since ``floating_base`` is static, implementations may
+        branch without tracing or evaluating the inactive path.
         """
         raise NotImplementedError(
             f"{type(self).__name__} must implement _gravitational_energy."

--- a/tests/execution/warp/conftest.py
+++ b/tests/execution/warp/conftest.py
@@ -87,6 +87,10 @@ def make_gvs_model() -> ModelFactory:
 
         return GVS.from_segments(
             segments,
+            base_pose=jnp.asarray(
+                [0.0, 2**-0.5, 0.0, 2**-0.5, 0.03, -0.02, 0.01],
+                dtype=jnp.float64,
+            ),
             gravity=jnp.asarray([0.2, -0.1, -9.81], dtype=jnp.float64),
             scale_rotational_basis_by_length=True,
             backend=backend,
@@ -110,6 +114,10 @@ def make_pcs_model() -> ModelFactory:
 
         return PCS.from_links(
             links,
+            base_pose=jnp.asarray(
+                [0.0, 2**-0.5, 0.0, 2**-0.5, 0.03, -0.02, 0.01],
+                dtype=jnp.float64,
+            ),
             gravity=jnp.asarray([0.2, -0.1, -9.81], dtype=jnp.float64),
             structure=PCSStructure(
                 num_gauss_points=num_gauss_points,
@@ -137,6 +145,7 @@ def make_planar_pcs_model() -> ModelFactory:
 
         return PlanarPCS.from_links(
             links,
+            base_pose=jnp.asarray([0.73, 0.03, -0.02], dtype=jnp.float64),
             gravity=jnp.asarray([0.2, -9.81], dtype=jnp.float64),
             structure=PlanarPCSStructure(
                 num_gauss_points=num_gauss_points,

--- a/tests/systems/test_articulated_soft_robot.py
+++ b/tests/systems/test_articulated_soft_robot.py
@@ -369,6 +369,34 @@ def test_spatial_mixed_axis_chain_matches_dense_matrix_equation():
     assert_allclose(qdd, qdd_dense, rtol=Tolerance.rtol(), atol=Tolerance.atol())
 
 
+def test_rotated_fixed_base_forward_dynamics_matches_dense_matrix_equation():
+    robot = make_spatial_robot().with_fixed_base_pose(
+        jnp.array([0.0, 2**-0.5, 0.0, 2**-0.5, 0.2, -0.1, 0.7])
+    )
+    q = jnp.array([0.2, -0.3, 0.4])
+    qd = jnp.array([0.5, -0.2, 0.3])
+    u = jnp.array([0.1, -0.05, 0.2])
+    tau_ext = jnp.array([0.02, 0.01, -0.03])
+
+    y = jnp.concatenate([q, qd])
+    _, qdd = jnp.split(
+        robot.forward_dynamics(jnp.array(0.0), y, (u, tau_ext)),
+        2,
+    )
+    inertia, coriolis_velocity, gravity = robot.dynamics_terms(q, qd)
+    rhs = (
+        robot.actuation_force(q, u)
+        + tau_ext
+        - coriolis_velocity
+        - gravity
+        - robot.elastic_force(q)
+        - robot.damping_matrix(q) @ qd
+    )
+    qdd_dense = jnp.linalg.solve(inertia, rhs)
+
+    assert_allclose(qdd, qdd_dense, rtol=Tolerance.rtol(), atol=Tolerance.atol())
+
+
 @pytest.mark.parametrize("num_links", [2, 3])
 def test_batched_kinematics_and_jacobian_match_pointwise_evaluation(num_links):
     robot = make_articulated_robot(num_links)

--- a/tests/systems/test_floating_base.py
+++ b/tests/systems/test_floating_base.py
@@ -33,6 +33,7 @@ from soromox.systems import (
     PlanarPCSStructure,
     StrainBasisSpec,
 )
+from soromox.systems.soft_robot import SoftRobot
 from soromox.systems.system_state import SystemState
 
 jax.config.update("jax_enable_x64", True)
@@ -229,6 +230,191 @@ def test_articulated_floating_state_and_dynamics_contract(factory) -> None:
     assert_allclose(elastic_force[:num_base], 0.0, atol=0.0)
     assert_allclose(damping_matrix[:num_base], 0.0, atol=0.0)
     assert_allclose(damping_matrix[:, :num_base], 0.0, atol=0.0)
+
+
+@pytest.mark.parametrize(
+    "factory", [_spatial_pcs, _planar_pcs, _gvs, _planar_hsa, _articulated, _pendulum]
+)
+def test_floating_gravity_matches_raw_energy_tangent(factory) -> None:
+    robot = factory()
+    base_pose = (
+        jnp.array([0.0, 2**-0.5, 0.0, 2**-0.5, 0.03, -0.02, 0.01])
+        if not robot.is_planar
+        else jnp.array([0.73, 0.03, -0.02])
+    )
+    q = robot.pack_configuration(
+        jnp.zeros((robot.num_internal_dofs,), dtype=jnp.float64),
+        base_pose=base_pose,
+    )
+    zero_velocity = jnp.zeros((robot.num_velocities,), dtype=jnp.float64)
+    configuration_velocity_map = jax.jacfwd(
+        lambda velocity: robot.configuration_derivative(q, velocity)
+    )(zero_velocity)
+    expected = configuration_velocity_map.T @ jax.grad(robot._gravitational_energy)(q)
+    actual = robot.gravitational_force(q)
+    _, _, assembled = robot.dynamics_terms(q, zero_velocity)
+
+    assert_allclose(robot.gravitational_energy(q), robot._gravitational_energy(q))
+    assert_allclose(actual, expected, rtol=1.0e-9, atol=1.0e-11)
+    assert_allclose(actual, assembled, rtol=1.0e-9, atol=1.0e-11)
+    _, gravity_tangent = jvp(
+        robot.gravitational_force,
+        (q,),
+        (jnp.linspace(-0.02, 0.03, robot.num_coordinates),),
+    )
+    assert bool(jnp.all(jnp.isfinite(gravity_tangent)))
+
+
+@pytest.mark.parametrize(
+    "factory", [_spatial_pcs, _planar_pcs, _gvs, _planar_hsa, _articulated, _pendulum]
+)
+def test_floating_gravity_uses_analytical_force_path(
+    factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    robot = factory()
+    base_pose = (
+        jnp.array([0.0, 2**-0.5, 0.0, 2**-0.5, 0.03, -0.02, 0.01])
+        if not robot.is_planar
+        else jnp.array([0.73, 0.03, -0.02])
+    )
+    q = robot.pack_configuration(
+        jnp.zeros((robot.num_internal_dofs,), dtype=jnp.float64),
+        base_pose=base_pose,
+    )
+
+    def fail_if_called(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("generic autodiff or complete dynamics path was used")
+
+    monkeypatch.setattr(type(robot), "dynamics_terms", fail_if_called)
+    monkeypatch.setattr(SoftRobot, "_gravitational_force", fail_if_called)
+
+    gravity = robot.gravitational_force(q)
+
+    assert gravity.shape == (robot.num_velocities,)
+    assert bool(jnp.all(jnp.isfinite(gravity)))
+
+
+@pytest.mark.parametrize("factory", [_spatial_pcs, _planar_pcs])
+@pytest.mark.parametrize("floating_base", [False, True])
+def test_pcs_gravity_reuses_one_pose_pass_and_energy_skips_jacobians(
+    factory,
+    floating_base: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    robot = factory()
+    base_pose = (
+        jnp.array([0.0, 2**-0.5, 0.0, 2**-0.5, 0.03, -0.02, 0.01])
+        if not robot.is_planar
+        else jnp.array([0.73, 0.03, -0.02])
+    )
+    if floating_base:
+        q = robot.pack_configuration(
+            jnp.zeros((robot.num_internal_dofs,), dtype=jnp.float64),
+            base_pose=base_pose,
+        )
+    else:
+        robot = robot._fixed_base_robot_at_pose(base_pose)
+        q = jnp.zeros((robot.num_internal_dofs,), dtype=jnp.float64)
+
+    robot_type = type(robot)
+    original_forward = robot_type._forward_kinematics_abscissa_batched
+    calls = 0
+
+    def counted_forward(self, q_, points):
+        nonlocal calls
+        calls += 1
+        return original_forward(self, q_, points)
+
+    monkeypatch.setattr(
+        robot_type, "_forward_kinematics_abscissa_batched", counted_forward
+    )
+    with jax.disable_jit():
+        gravity = robot.gravitational_force(q)
+    assert bool(jnp.all(jnp.isfinite(gravity)))
+    assert calls == 1
+
+    def fail_if_called(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("gravitational energy assembled Jacobians")
+
+    monkeypatch.setattr(robot_type, "_J_local_abscissa_batched", fail_if_called)
+    with jax.disable_jit():
+        energy = robot.gravitational_energy(q)
+    assert bool(jnp.isfinite(energy))
+
+
+@pytest.mark.parametrize("floating_base", [False, True])
+def test_gvs_gravity_reuses_one_pose_pass_and_energy_skips_jacobians(
+    floating_base: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    robot = _gvs()
+    base_pose = jnp.array([0.0, 2**-0.5, 0.0, 2**-0.5, 0.03, -0.02, 0.01])
+    if floating_base:
+        q = robot.pack_configuration(
+            jnp.zeros((robot.num_internal_dofs,), dtype=jnp.float64),
+            base_pose=base_pose,
+        )
+    else:
+        robot = robot._fixed_base_robot_at_pose(base_pose)
+        q = jnp.zeros((robot.num_internal_dofs,), dtype=jnp.float64)
+
+    robot_type = type(robot)
+    original_kinematics = robot_type._integration_pose_jacobians
+    calls = 0
+
+    def counted_kinematics(self, q_):
+        nonlocal calls
+        calls += 1
+        return original_kinematics(self, q_)
+
+    monkeypatch.setattr(robot_type, "_integration_pose_jacobians", counted_kinematics)
+    with jax.disable_jit():
+        gravity = robot.gravitational_force(q)
+    assert bool(jnp.all(jnp.isfinite(gravity)))
+    assert calls == 1
+
+    def fail_if_called(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("gravitational energy assembled Jacobians")
+
+    monkeypatch.setattr(robot_type, "_integration_pose_jacobians", fail_if_called)
+    with jax.disable_jit():
+        energy = robot.gravitational_energy(q)
+    assert bool(jnp.isfinite(energy))
+
+
+@pytest.mark.parametrize("floating_base", [False, True])
+def test_planar_hsa_gravity_uses_one_geometry_pass(
+    floating_base: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    robot = _planar_hsa()
+    base_pose = jnp.array([0.73, 0.03, -0.02])
+    if floating_base:
+        q = robot.pack_configuration(
+            jnp.zeros((robot.num_internal_dofs,), dtype=jnp.float64),
+            base_pose=base_pose,
+        )
+    else:
+        robot = robot._fixed_base_robot_at_pose(base_pose)
+        q = jnp.zeros((robot.num_internal_dofs,), dtype=jnp.float64)
+
+    robot_type = type(robot)
+    original_geometry = robot_type._integration_geometry_full
+    calls = 0
+
+    def counted_geometry(self, q_):
+        nonlocal calls
+        calls += 1
+        return original_geometry(self, q_)
+
+    monkeypatch.setattr(robot_type, "_integration_geometry_full", counted_geometry)
+    with jax.disable_jit():
+        gravity = robot.gravitational_force(q)
+    assert bool(jnp.all(jnp.isfinite(gravity)))
+    assert calls == 1
 
 
 def test_spatial_quaternion_derivative_and_retraction_are_consistent() -> None:

--- a/tests/systems/test_gvs.py
+++ b/tests/systems/test_gvs.py
@@ -89,11 +89,7 @@ def build_matched_gvs_pcs(
     Build a GVS model with constant-strain basis (monomial order 0) and fixed joints
     and a PCS model with the same physical parameters, so their predictions match.
 
-    Note on gravity/signs:
-    - PCS uses G = -∫ J^T M Ad_g^{-1} g ds
-    - GVS uses G =  ∫ J^T M Ad_g^{-1} g ds
-    For equivalent physical gravity (downwards), pass g=[0,0,-9.81] to PCS and
-    g=[0,0, 9.81] to GVS so the resulting generalized gravity forces match.
+    Both models consume the same world-frame gravitational acceleration vector.
     """
     # Physical parameters (kept simple, identical for each segment)
     Ls = 0.2 * jnp.ones((num_segments,))
@@ -1824,6 +1820,17 @@ def test_gvs_gravitational_energy_gradient_matches_force() -> None:
     q = random_q(robot, jax.random.PRNGKey(313), scale=0.02)
 
     dU_dq = jax.grad(lambda q_: robot.gravitational_energy(q_))(q)
+
+    assert_allclose(dU_dq, robot.gravitational_force(q), rtol=RTOL, atol=ATOL)
+
+
+def test_rotated_fixed_base_gravity_matches_raw_potential_gradient() -> None:
+    robot = build_varied_basis_gvs(num_segments=1).with_fixed_base_pose(
+        jnp.array([0.0, 2**-0.5, 0.0, 2**-0.5, 0.03, -0.02, 0.01])
+    )
+    q = random_q(robot, jax.random.PRNGKey(314), scale=0.02)
+
+    dU_dq = jax.grad(robot._gravitational_energy)(q)
 
     assert_allclose(dU_dq, robot.gravitational_force(q), rtol=RTOL, atol=ATOL)
 

--- a/tests/systems/test_pcs.py
+++ b/tests/systems/test_pcs.py
@@ -1355,6 +1355,18 @@ def test_pcs_gravitational_energy_gradient_matches_force() -> None:
     assert_allclose(dU_dq, model.gravitational_force(q), rtol=RTOL, atol=ATOL)
 
 
+def test_rotated_fixed_base_gravity_matches_raw_potential_gradient() -> None:
+    model, _ = make_pcs(num_segments=1)
+    model = model.with_fixed_base_pose(
+        jnp.array([0.0, 2**-0.5, 0.0, 2**-0.5, 0.03, -0.02, 0.01])
+    )
+    q = random_q(model, jax.random.PRNGKey(315), scale=0.02)
+
+    dU_dq = jax.grad(model._gravitational_energy)(q)
+
+    assert_allclose(dU_dq, model.gravitational_force(q), rtol=RTOL, atol=ATOL)
+
+
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
 def test_forward_dynamics_matches_manual_computation(num_segments: int):
     model, _ = make_pcs(num_segments=num_segments, total_length=PCS_TOTAL_LENGTH)

--- a/tests/systems/test_pendulum.py
+++ b/tests/systems/test_pendulum.py
@@ -395,6 +395,20 @@ def test_gravity_matches_potential_gradient(N):
     assert_allclose(G, dU_dq, rtol=Tolerance.rtol(), atol=Tolerance.atol())
 
 
+def test_rotated_fixed_base_gravity_matches_raw_potential_gradient() -> None:
+    robot = make_pendulum(3).with_fixed_base_pose(jnp.array([0.73, 0.03, -0.02]))
+    q = jnp.array([-0.25, 0.1, 0.5])
+
+    dU_dq = jax.grad(robot._gravitational_energy)(q)
+
+    assert_allclose(
+        dU_dq,
+        robot.gravitational_force(q),
+        rtol=Tolerance.rtol(),
+        atol=Tolerance.atol(),
+    )
+
+
 @pytest.mark.parametrize("N", [2, 3])
 def test_forward_dynamics_rest_with_zero_forces(N):
     robot = make_pendulum(N)

--- a/tests/systems/test_planar_hsa.py
+++ b/tests/systems/test_planar_hsa.py
@@ -387,6 +387,15 @@ def test_gravitational_energy(seed: int = 0):
             )
 
 
+def test_rotated_fixed_base_gravity_matches_raw_potential_gradient() -> None:
+    robot = _create_robot().with_fixed_base_pose(jnp.array([0.73, 0.03, -0.02]))
+    q = jnp.array([-0.1, 0.02, 0.1])
+
+    dU_dq = grad(robot._gravitational_energy)(q)
+
+    assert_allclose(dU_dq, robot.gravitational_force(q), rtol=1e-9, atol=1e-11)
+
+
 def test_kinetic_energy(seed: int = 0):
     """
     Test the kinetic energy computation.

--- a/tests/systems/test_planar_pcs.py
+++ b/tests/systems/test_planar_pcs.py
@@ -1536,6 +1536,16 @@ def test_planar_pcs_gravitational_energy_gradient_matches_force() -> None:
     assert_allclose(dU_dq, model.gravitational_force(q), rtol=RTOL, atol=ATOL)
 
 
+def test_rotated_fixed_base_gravity_matches_raw_potential_gradient() -> None:
+    model, _ = make_planar_pcs(num_segments=1)
+    model = model.with_fixed_base_pose(jnp.array([0.73, 0.03, -0.02]))
+    q = random_q(model, jax.random.PRNGKey(316), scale=0.02)
+
+    dU_dq = jax.grad(model._gravitational_energy)(q)
+
+    assert_allclose(dU_dq, model.gravitational_force(q), rtol=RTOL, atol=ATOL)
+
+
 @pytest.mark.parametrize("num_segments", [1, 2, 3])
 def test_forward_dynamics_matches_manual_computation(num_segments: int):
     model, _ = make_planar_pcs(


### PR DESCRIPTION
## Summary
- treat configured gravity consistently as a world-frame vector for rotated mounts
- unify fixed- and floating-base gravitational force and energy paths
- use analytical point-mass Jacobian projection in performance-sensitive systems instead of runtime autodiff or full dynamics assembly
- share quadrature geometry while avoiding Jacobian work for energy-only evaluation
- add rotated-mount and floating-base regression coverage across articulated, GVS, PCS, PlanarPCS, PlanarHSA, and pendulum systems

## Validation
- 26 targeted gravity tests passed on this standalone branch
- the same gravity changes passed the broader 292-test system suite before the PR split
- Ruff passed